### PR TITLE
Fixes issue #8: Slider not working on touch devices

### DIFF
--- a/packages/chakra-ui-docs/pages/slider.mdx
+++ b/packages/chakra-ui-docs/pages/slider.mdx
@@ -66,27 +66,27 @@ customize its styles.
 The `Slider` component wraps all it's children in the [Box](/box) component, so you
 can pass all `Box` props to change it's style.
 
-| Name               | Type                       | Default | Description                                                               |
-| ------------------ | -------------------------- | ------- | ------------------------------------------------------------------------- |
-| `value`            | `number`                   |         | The value of the slider.                                                  |
-| `defaultValue`     | `number`                   |         | The initial value of the slider.                                          |
-| `max`              | `number`                   |         | Standard `input` max attribute.                                           |
-| `min`              | `number`                   |         | Standard `input` min attribute.                                           |
-| `step`             | `number`                   |         | Standard `input` step attribute.                                          |
-| `onChange`         | `(value: number): void`    |         | Callback fired when the value of the slider changes.                      |
-| `onFocus`          | `React.FocusEventHander`   |         | Callback fired when the thumb receives focus                              |
-| `onBlur`           | `React.FocusEventHander`   |         | Callback fired when the thumb is blurred                                  |
-| `onMouseDown`      | `React.MouseEventHander`   |         | Callback fired when the you mousedown on any part of the slider           |
-| `aria-label`       | `string`                   |         | The accessible label.                                                     |
-| `aria-labelledby`  | `string`                   |         | The `id` of the element that labels the sliders                           |
-| `aria-valuetext`   | `string`                   |         | The aria-valuetext of the switch for accessibility.                       |
-| `orientation`      | `string`                   |         | The orientation of the slider, only `horizontal` is supported for now.    |
-| `getAriaValueText` | `(value: number ): string` |         | The callback to format the `aria-valuetext`.                              |
-| `size`             | `sm`, `md`, `lg`           |         | The size of the slider.                                                   |
-| `color`            | `string`                   |         | The color scheme to use for the slider. Use a color key in `theme.colors` |
-| `name`             | `string`                   |         | The name of the slider component when used in a form.                     |
-| `id`               | `string`                   |         | The id of the slider component when used in a form.                       |
-| `children`         | `React.ReactNode`          |         | The children of the slider.                                               |
+| Name               | Type                                               | Default | Description                                                               |
+| ------------------ | -------------------------------------------------- | ------- | ------------------------------------------------------------------------- |
+| `value`            | `number`                                           |         | The value of the slider.                                                  |
+| `defaultValue`     | `number`                                           |         | The initial value of the slider.                                          |
+| `max`              | `number`                                           |         | Standard `input` max attribute.                                           |
+| `min`              | `number`                                           |         | Standard `input` min attribute.                                           |
+| `step`             | `number`                                           |         | Standard `input` step attribute.                                          |
+| `onChange`         | `(value: number): void`                            |         | Callback fired when the value of the slider changes.                      |
+| `onFocus`          | `React.FocusEventHander`                           |         | Callback fired when the thumb receives focus                              |
+| `onBlur`           | `React.FocusEventHander`                           |         | Callback fired when the thumb is blurred                                  |
+| `onMouseDown`      | `React.MouseEventHander | React.TouchEventHandler` |         | Callback fired when the you mousedown on any part of the slider           |
+| `aria-label`       | `string`                                           |         | The accessible label.                                                     |
+| `aria-labelledby`  | `string`                                           |         | The `id` of the element that labels the sliders                           |
+| `aria-valuetext`   | `string`                                           |         | The aria-valuetext of the switch for accessibility.                       |
+| `orientation`      | `string`                                           |         | The orientation of the slider, only `horizontal` is supported for now.    |
+| `getAriaValueText` | `(value: number ): string`                         |         | The callback to format the `aria-valuetext`.                              |
+| `size`             | `sm`, `md`, `lg`                                   |         | The size of the slider.                                                   |
+| `color`            | `string`                                           |         | The color scheme to use for the slider. Use a color key in `theme.colors` |
+| `name`             | `string`                                           |         | The name of the slider component when used in a form.                     |
+| `id`               | `string`                                           |         | The id of the slider component when used in a form.                       |
+| `children`         | `React.ReactNode`                                  |         | The children of the slider.                                               |
 
 ### SliderThumb Props
 

--- a/packages/chakra-ui/src/Slider/index.js
+++ b/packages/chakra-ui/src/Slider/index.js
@@ -176,7 +176,7 @@ const Slider = forwardRef(
     const getNewValue = event => {
       if (trackRef.current) {
         const { left, width } = trackRef.current.getBoundingClientRect();
-        const { clientX } = event;
+        const { clientX } = event.touches ? event.touches[0] : event;
         let diffX = clientX - left;
         let percent = diffX / width;
         let newValue = percentToValue(percent, min, max);
@@ -254,7 +254,9 @@ const Slider = forwardRef(
 
     const handleMouseUp = () => {
       document.body.removeEventListener("mousemove", handleMouseMove);
+      document.body.removeEventListener("touchmove", handleMouseMove);
       document.body.removeEventListener("mouseup", handleMouseUp);
+      document.body.removeEventListener("touchend", handleMouseUp);
     };
 
     // TODO: Optimize this mouseMove event
@@ -275,7 +277,9 @@ const Slider = forwardRef(
       }
 
       document.body.addEventListener("mousemove", handleMouseMove);
+      document.body.addEventListener("touchmove", handleMouseMove);
       document.body.addEventListener("mouseup", handleMouseUp);
+      document.body.addEventListener("touchend", handleMouseUp);
       thumbRef.current && thumbRef.current.focus();
     };
 
@@ -306,7 +310,9 @@ const Slider = forwardRef(
           role="presentation"
           tabIndex="-1"
           onMouseDown={handleMouseDown}
+          onTouchStart={handleMouseDown}
           onMouseLeave={handleMouseUp}
+          onTouchEnd={handleMouseUp}
           onBlur={event => {
             handleMouseUp();
             onBlur && onBlur(event);
@@ -314,6 +320,7 @@ const Slider = forwardRef(
           py={3}
           aria-disabled={isDisabled}
           ref={ref}
+          css={{ touchAction: "none" }}
           {...rootStyle}
           {...rest}
         >


### PR DESCRIPTION
Fixes #8 

It's tested on chrome android and also on chrome desktop's touch emulator, the slider works fine in both. Note that this is a quick fix, it's not heavily tested but it should mostly work everywhere.

You can test slider with this PR ~[here](http://chakra-ui-pr-18.surge.sh/?path=/story/slider--default)~ [here](https://deploy-preview-18--chakra-ui.netlify.com/?path=/story/slider--default) (I was a little faster than netlify bot :P)

I've also updated the docs for slider props to be `onMouseDown: React.MouseEventHander | React.TouchEventHandler` instead of `onMouseDown: React.MouseEventHander`