### PR TITLE
[Docs-Modal] Update modal docs

### DIFF
--- a/packages/chakra-ui-docs/components/components.js
+++ b/packages/chakra-ui-docs/components/components.js
@@ -27,6 +27,7 @@ const components = [
   "Link",
   "List",
   "Menu",
+  "Modal",
   "NumberInput",
   "Popover",
   "Progress",

--- a/packages/chakra-ui-docs/pages/modal.mdx
+++ b/packages/chakra-ui-docs/pages/modal.mdx
@@ -5,7 +5,7 @@ the page.
 
 ## Usage
 
-Below is an example of how to use the ModalDialog component.
+Below is an example of how to use the `Modal` component.
 
 ### Basic
 
@@ -49,11 +49,11 @@ function ExampleBasic() {
 
 | Name            | Type                   | Default | Description                                                   |
 | --------------- | ---------------------- | ------- | ------------------------------------------------------------- |
-| isOpen          | `boolean`              |         | If true, the `AlertDialog` will open                          |
-| onClose         | `function`             |         | The function to close the `AlertDialog`                       |
-| size            | `xs`, `sm`, `md`, `lg` | `md`    | The maximum width of the AlertDialog                          |
-| isCentered      | `boolean`              |         | If`true`, the`AlertDialog` will be centered on screen         |
+| isOpen          | `boolean`              |         | If true, the `Modal` will open                                |
+| onClose         | `function`             |         | The function to close the `Modal`                             |
+| size            | `xs`, `sm`, `md`, `lg` | `md`    | The maximum width of the Modal                                |
+| isCentered      | `boolean`              |         | If `true`, the `Modal` will be centered on screen             |
 | initialFocusRef | `React.Ref`            |         | The least destructive action to get focus when dialog is open |
 
-- ModalHeader and ModalBody composes `Box` component
-- ModalFooter composes `Flex` component
+- `ModalHeader` and `ModalBody` composes `Box` component
+- `ModalFooter` composes `Flex` component


### PR DESCRIPTION
The `Modal` component is missing from the docs sidebar. I only found it because it's linked to from the `CloseButton` docs page.

There's also a few incorrect references to `AlertDialog` in the props table.