### PR TITLE
[Button] Fixes for `xs` size

### DIFF
--- a/packages/chakra-ui/src/Button/index.d.ts
+++ b/packages/chakra-ui/src/Button/index.d.ts
@@ -6,7 +6,7 @@ export interface IButton {
   /**
    * The size of the button
    */
-  size?: "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg";
   /**
    * If `true`, the button will show a spinner.
    */

--- a/packages/chakra-ui/src/Button/styles.js
+++ b/packages/chakra-ui/src/Button/styles.js
@@ -176,7 +176,7 @@ const sizes = {
   xs: {
     height: 6,
     minWidth: 6,
-    fontSize: "sm",
+    fontSize: "xs",
     px: 2,
   },
 };


### PR DESCRIPTION
The `xs` size was missing from the type enum.

The `fontSize` for it was also set to `sm`, rather than `xs`.