### PR TITLE
[Theme] Add missing exports from theme

### DIFF
--- a/packages/chakra-ui/src/index.d.ts
+++ b/packages/chakra-ui/src/index.d.ts
@@ -89,6 +89,7 @@ export { default as Textarea } from "./Textarea";
 export { default as useToast } from "./Toast";
 export { default as Tooltip } from "./Tooltip";
 export { default as theme } from "./theme";
+export * from "./theme";
 export { default as ThemeProvider } from "./ThemeProvider";
 export * from "./ThemeProvider";
 


### PR DESCRIPTION
The `ITheme` interface was missing from exports. This PR adds `export *` to allow all named exports from the theme folder to be available externally.