### PR TITLE
Prevent page scroll from RadioButtonGroup key nav

### DIFF
--- a/packages/chakra-ui/src/RadioButtonGroup/index.js
+++ b/packages/chakra-ui/src/RadioButtonGroup/index.js
@@ -36,6 +36,9 @@ const RadioButtonGroup = ({
   };
 
   const handleKeyDown = event => {
+    // Disable page scrolling while navigating with keys
+    event.preventDefault();
+
     const count = focusableValues.length;
     let enabledCheckedIndex = focusableValues.indexOf(_value);
 


### PR DESCRIPTION
When navigating through the elements of a RadioButtonGroup with keyboard, the page could be scrolled accidentally. This fix disables key-based scrolling inside the keyboard navigation context.