### PR TITLE
Fixes #55

### DIFF
--- a/packages/chakra-ui/src/ColorModeProvider/index.d.ts
+++ b/packages/chakra-ui/src/ColorModeProvider/index.d.ts
@@ -10,8 +10,8 @@ declare const ColorModeProvider: React.FC<IColorModeProvider>;
 export default ColorModeProvider;
 
 export interface IUseColorMode {
-  readonly mode?: "light" | "dark";
-  toggle?: () => void;
+  readonly colorMode?: "light" | "dark";
+  toggleColorMode?: () => void;
 }
 export function useColorMode(): IUseColorMode;
 


### PR DESCRIPTION
Updated the types in `ColorModeProvider`, more specifically the `useColorMode` hook to use correct naming so that it is usable with TypeScript.