### PR TITLE
yarn build -> yarn core:build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ git clone git@github.com:chakra-ui/chakra-ui.git
 cd chakra-ui
 yarn install
 yarn bootstrap
-yarn build
+yarn core:build
 ```
 
 ## Root Repo Scripts:


### PR DESCRIPTION
There is no `build` script in `package.json`, so executing the commands in `CONTRIBUTING.md` ('*Before doing anything else, run these commands:*') will not work.

I changed `yarn build` to `yarn core:build` to prevent `Module not found: Can't resolve '@chakra-ui/core'` when working on the docs and such.

Thanks for the great project.