### PR TITLE
[Toast] Fix toast typescript defs

### DIFF
--- a/packages/chakra-ui/src/Toast/index.d.ts
+++ b/packages/chakra-ui/src/Toast/index.d.ts
@@ -1,6 +1,15 @@
-import { IAlert, AlertProps } from "../Alert";
+import { IAlert, AlertProps as BaseAlertProps } from "../Alert";
 import { BoxProps } from "../Box";
+import { Omit } from "../common-types";
+import { Position } from "toasted-notes";
 import * as React from "react";
+
+type AlertProps = Omit<BaseAlertProps, "position"> & {
+  /**
+   * One of toasted-notes positions.
+   */
+  position?: keyof typeof Position;
+};
 
 export interface IToast extends AlertProps {
   /**
@@ -20,15 +29,9 @@ export interface IToast extends AlertProps {
    */
   description?: string;
   /**
-   * Position
+   * Duration before dismiss in milliseconds, or `null` to never dismiss.
    */
-  position?:
-    | "top-left"
-    | "top"
-    | "top-right"
-    | "bottom-left"
-    | "bottom"
-    | "bottom-right";
+  duration?: number | null;
 }
 
 export type ToastProps = IToast;


### PR DESCRIPTION
This expands on the `toast` TypeScript definitions fixes from my comment in https://github.com/chakra-ui/chakra-ui/pull/66#issuecomment-530232556.

It fixes a type error from the conflicting `styled-system` `position` prop, and adds the `duration` prop.