### PR TITLE
Tweak Input focusBorderColor API

### DIFF
--- a/packages/chakra-ui/src/Input/examples.js
+++ b/packages/chakra-ui/src/Input/examples.js
@@ -1,9 +1,13 @@
 import { storiesOf } from "@storybook/react";
+import { withKnobs, select } from "@storybook/addon-knobs";
 import React from "react";
 import Box from "../Box";
 import Input from "../Input";
 
+const colors = ["blue.500", "red.200", "orange.300", "teal.600"];
+
 const stories = storiesOf("Input", module);
+
 stories.addDecorator(story => {
   return (
     <Box maxWidth="lg" mx="auto" mt={6} p={6}>
@@ -24,4 +28,56 @@ stories.add("Readonly", () => (
     focusBorderColor="cyan"
     isReadOnly
   />
+));
+
+const variantStories = storiesOf("Input/Variants");
+variantStories.addDecorator(withKnobs);
+
+variantStories.add("Filled", () => (
+  <Input variant="filled" placeholder="Text goes here"></Input>
+));
+
+variantStories.add("Filled, custom focusBorderColor", () => {
+  const colorKnob = select("focusBorderColor", colors, "blue.500");
+  return (
+    <Input
+      variant="filled"
+      focusBorderColor={colorKnob}
+      placeholder="Text goes here"
+    ></Input>
+  );
+});
+
+variantStories.add("Flushed", () => (
+  <Input variant="flushed" placeholder="Text goes here"></Input>
+));
+
+variantStories.add("Flushed, custom focusBorderColor", () => {
+  const colorKnob = select("focusBorderColor", colors, "blue.500");
+  return (
+    <Input
+      variant="flushed"
+      focusBorderColor={colorKnob}
+      placeholder="Text goes here"
+    ></Input>
+  );
+});
+
+variantStories.add("Outline", () => (
+  <Input variant="outline" placeholder="Text goes here"></Input>
+));
+
+variantStories.add("Outline, custom focusBorderColor", () => {
+  const colorKnob = select("focusBorderColor", colors, "blue.500");
+  return (
+    <Input
+      variant="outline"
+      focusBorderColor={colorKnob}
+      placeholder="Text goes here"
+    ></Input>
+  );
+});
+
+variantStories.add("Unstyled", () => (
+  <Input variant="unstyled" placeholder="Text goes here"></Input>
 ));

--- a/packages/chakra-ui/src/Input/examples.js
+++ b/packages/chakra-ui/src/Input/examples.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/react";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { withKnobs, select, boolean } from "@storybook/addon-knobs";
 import React from "react";
 import Box from "../Box";
 import Input from "../Input";
@@ -37,12 +37,18 @@ variantStories.add("Filled", () => (
   <Input variant="filled" placeholder="Text goes here"></Input>
 ));
 
-variantStories.add("Filled, custom focusBorderColor", () => {
-  const colorKnob = select("focusBorderColor", colors, "blue.500");
+variantStories.add("Filled, custom border colors", () => {
+  const errorColorKnob = select("errorBorderColor", colors, "red.200");
+  const focusColorKnob = select("focusBorderColor", colors, "blue.500");
+
+  const invalidKnob = boolean("isInvalid", false);
+
   return (
     <Input
       variant="filled"
-      focusBorderColor={colorKnob}
+      isInvalid={invalidKnob}
+      errorBorderColor={errorColorKnob}
+      focusBorderColor={focusColorKnob}
       placeholder="Text goes here"
     ></Input>
   );
@@ -52,12 +58,17 @@ variantStories.add("Flushed", () => (
   <Input variant="flushed" placeholder="Text goes here"></Input>
 ));
 
-variantStories.add("Flushed, custom focusBorderColor", () => {
-  const colorKnob = select("focusBorderColor", colors, "blue.500");
+variantStories.add("Flushed, custom border colors", () => {
+  const errorColorKnob = select("errorBorderColor", colors, "red.200");
+  const focusColorKnob = select("focusBorderColor", colors, "blue.500");
+
+  const invalidKnob = boolean("isInvalid", false);
   return (
     <Input
       variant="flushed"
-      focusBorderColor={colorKnob}
+      isInvalid={invalidKnob}
+      errorBorderColor={errorColorKnob}
+      focusBorderColor={focusColorKnob}
       placeholder="Text goes here"
     ></Input>
   );
@@ -67,12 +78,17 @@ variantStories.add("Outline", () => (
   <Input variant="outline" placeholder="Text goes here"></Input>
 ));
 
-variantStories.add("Outline, custom focusBorderColor", () => {
-  const colorKnob = select("focusBorderColor", colors, "blue.500");
+variantStories.add("Outline, custom border colors", () => {
+  const errorColorKnob = select("errorBorderColor", colors, "red.200");
+  const focusColorKnob = select("focusBorderColor", colors, "blue.500");
+
+  const invalidKnob = boolean("isInvalid", false);
   return (
     <Input
       variant="outline"
-      focusBorderColor={colorKnob}
+      isInvalid={invalidKnob}
+      errorBorderColor={errorColorKnob}
+      focusBorderColor={focusColorKnob}
       placeholder="Text goes here"
     ></Input>
   );

--- a/packages/chakra-ui/src/Input/index.d.ts
+++ b/packages/chakra-ui/src/Input/index.d.ts
@@ -53,9 +53,16 @@ export interface IInput<T = HTMLInputElement> {
   /**
    * The border color when the input is focused. Use color keys in `theme.colors`
    * @example
-   * focusBorderColor = "blue"
+   * focusBorderColor = "blue.500"
    */
   focusBorderColor?: string;
+
+  /**
+   * The border color when the input is invalid. Use color keys in `theme.colors`
+   * @example
+   * errorBorderColor = "red.500"
+   */
+  errorBorderColor?: string;
 }
 
 type OmittedTypes =

--- a/packages/chakra-ui/src/Input/index.js
+++ b/packages/chakra-ui/src/Input/index.js
@@ -48,7 +48,7 @@ Input.defaultProps = {
   as: "input",
   variant: "outline",
   isFullWidth: true,
-  focusBorderColor: "blue",
+  focusBorderColor: "blue.500",
 };
 
 export default Input;

--- a/packages/chakra-ui/src/Input/index.js
+++ b/packages/chakra-ui/src/Input/index.js
@@ -18,6 +18,7 @@ const Input = forwardRef((props, ref) => {
     isInvalid,
     isRequired,
     focusBorderColor,
+    errorBorderColor,
     ...rest
   } = props;
 
@@ -49,6 +50,7 @@ Input.defaultProps = {
   variant: "outline",
   isFullWidth: true,
   focusBorderColor: "blue.500",
+  errorBorderColor: "red.500",
 };
 
 export default Input;

--- a/packages/chakra-ui/src/Input/styles.js
+++ b/packages/chakra-ui/src/Input/styles.js
@@ -1,7 +1,12 @@
 import { useTheme } from "../ThemeProvider";
 import { useColorMode } from "../ColorModeProvider";
 
-const outlinedStyle = ({ theme: { colors }, colorMode, focusBorderColor }) => {
+const outlinedStyle = ({
+  theme: { colors },
+  colorMode,
+  focusBorderColor,
+  errorBorderColor,
+}) => {
   const bg = { light: "white", dark: "whiteAlpha.100" };
   const borderColor = { light: "inherit", dark: "whiteAlpha.50" };
   const hoverColor = { light: "gray.300", dark: "whiteAlpha.200" };
@@ -9,7 +14,7 @@ const outlinedStyle = ({ theme: { colors }, colorMode, focusBorderColor }) => {
   const boxShadow = colors[focusBorderColor] && colors[focusBorderColor][500];
 
   const invalidColor = { light: "red.500", dark: "red.300" };
-  const invalidBoxShadow = { light: colors.red[500], dark: colors.red[300] };
+  const invalidBoxShadow = { light: errorBorderColor, dark: errorBorderColor };
 
   return {
     ...readOnly,
@@ -42,10 +47,10 @@ const readOnly = {
   },
 };
 
-const filledStyle = ({ focusBorderColor, colorMode }) => {
+const filledStyle = ({ focusBorderColor, errorBorderColor, colorMode }) => {
   const bg = { light: "gray.100", dark: "whiteAlpha.50" };
   const hoverColor = { light: "gray.200", dark: "whiteAlpha.100" };
-  const invalidColor = { light: "red.500", dark: "red.300" };
+  const invalidColor = { light: errorBorderColor, dark: errorBorderColor };
   const focusColor = {
     light: focusBorderColor,
     dark: focusBorderColor,
@@ -73,9 +78,9 @@ const filledStyle = ({ focusBorderColor, colorMode }) => {
   };
 };
 
-const flushedStyle = ({ colorMode, focusBorderColor }) => {
+const flushedStyle = ({ colorMode, focusBorderColor, errorBorderColor }) => {
   const focusColor = { light: focusBorderColor, dark: focusBorderColor };
-  const errorColor = { light: "red.500", dark: "red.300" };
+  const errorColor = { light: errorBorderColor, dark: errorBorderColor };
 
   return {
     ...readOnly,

--- a/packages/chakra-ui/src/Input/styles.js
+++ b/packages/chakra-ui/src/Input/styles.js
@@ -1,11 +1,7 @@
 import { useTheme } from "../ThemeProvider";
 import { useColorMode } from "../ColorModeProvider";
 
-const outlinedStyle = ({
-  focusBorderColor = "blue",
-  theme: { colors },
-  colorMode,
-}) => {
+const outlinedStyle = ({ theme: { colors }, colorMode, focusBorderColor }) => {
   const bg = { light: "white", dark: "whiteAlpha.100" };
   const borderColor = { light: "inherit", dark: "whiteAlpha.50" };
   const hoverColor = { light: "gray.300", dark: "whiteAlpha.200" };
@@ -28,7 +24,7 @@ const outlinedStyle = ({
       cursor: "not-allowed",
     },
     _focus: {
-      borderColor: `${focusBorderColor}.500`,
+      borderColor: focusBorderColor,
       boxShadow: `0 0 0 1px ${boxShadow}`,
     },
     _invalid: {
@@ -51,8 +47,8 @@ const filledStyle = ({ focusBorderColor, colorMode }) => {
   const hoverColor = { light: "gray.200", dark: "whiteAlpha.100" };
   const invalidColor = { light: "red.500", dark: "red.300" };
   const focusColor = {
-    light: `${focusBorderColor}.500`,
-    dark: `${focusBorderColor}.300`,
+    light: focusBorderColor,
+    dark: focusBorderColor,
   };
 
   return {
@@ -77,8 +73,8 @@ const filledStyle = ({ focusBorderColor, colorMode }) => {
   };
 };
 
-const flushedStyle = ({ colorMode }) => {
-  const focusColor = { light: "blue.500", dark: "blue.300" };
+const flushedStyle = ({ colorMode, focusBorderColor }) => {
+  const focusColor = { light: focusBorderColor, dark: focusBorderColor };
   const errorColor = { light: "red.500", dark: "red.300" };
 
   return {


### PR DESCRIPTION
As per https://github.com/chakra-ui/chakra-ui/issues/91, this PR proposes a few adjustments to the `Input` component's API.

One discrepancy that I've noted throughout the codebase is the ambiguity of the `color` prop. In some cases, users are expected to pass a "partial" color string, e.g., `teal`. In other cases, users are expected to pass a fully-formed color string that corresponds with a key in the `colors` object that powers the UI, e.g., `teal.500`.

I'm partial to the latter approach, but ultimately I care more about consistency. To that end, I've tweaked the `Input` API accordingly.

1. Change the default value of `focusBorderColor` from `blue` to `blue.500`, so as to avoid unnecessary string interpolation in the input style generator.
2. Applied the value of the `focusBorderColor` prop to the `flushed` variant, which was otherwise ignored before.

I do have a few open questions, though –

1. Should we expose a prop for `errorColor`? It feels odd to allow users to customize the focus state, but not the error state.
2. I noticed that we were treating `focusBorderColor` differently when the dark mode was applied (dropping the color from `500` to `300`). Is there any reason for this? Should we defer this opinion to users, allowing them to pass whatever `focusBorderColor` they want as a function of whether the app is in dark mode or not?

Hope this is helpful, thanks for letting me share my thoughts!