### PR TITLE
Fix http links to avoid secure content warnings

### DIFF
--- a/packages/chakra-ui-docs/pages/Box.mdx
+++ b/packages/chakra-ui-docs/pages/Box.mdx
@@ -39,7 +39,7 @@ import { Box } from "@chakra-ui/core";
 
 function AirbnbExample() {
   const property = {
-    imageUrl: "http://bit.ly/2Z4KKcF",
+    imageUrl: "https://bit.ly/2Z4KKcF",
     imageAlt: "Rear view of modern home with pool",
     beds: 3,
     baths: 2,

--- a/packages/chakra-ui-docs/pages/aspectratiobox.mdx
+++ b/packages/chakra-ui-docs/pages/aspectratiobox.mdx
@@ -47,7 +47,7 @@ Here's how to embed an image that has a 4 by 3 aspect ratio.
 
 ```jsx
 <AspectRatioBox maxW="400px" ratio={4 / 3}>
-  <Image src="http://bit.ly/naruto-sage" alt="naruto" objectFit="cover" />
+  <Image src="https://bit.ly/naruto-sage" alt="naruto" objectFit="cover" />
 </AspectRatioBox>
 ```
 

--- a/packages/chakra-ui-docs/pages/avatar.mdx
+++ b/packages/chakra-ui-docs/pages/avatar.mdx
@@ -28,13 +28,13 @@ import { Avatar, AvatarBadge } from "@chakra-ui/core";
 
 ```jsx
 <Stack isInline>
-  <Avatar name="Dan Abrahmov" src="http://bit.ly/dan-abramov" />
-  <Avatar name="Kola Tioluwani" src="http://bit.ly/tioluwani-kolawole" />
-  <Avatar name="Kent Dodds" src="http://bit.ly/kent-c-dodds" />
-  <Avatar name="Ryan Florence" src="http://bit.ly/ryan-florence" />
-  <Avatar name="Prosper Otemuyiwa" src="http://bit.ly/prosper-baba" />
-  <Avatar name="Christian Nwamba" src="http://bit.ly/code-beast" />
-  <Avatar name="Segun Adebayo" src="http://bit.ly/sage-adebayo" />
+  <Avatar name="Dan Abrahmov" src="https://bit.ly/dan-abramov" />
+  <Avatar name="Kola Tioluwani" src="https://bit.ly/tioluwani-kolawole" />
+  <Avatar name="Kent Dodds" src="https://bit.ly/kent-c-dodds" />
+  <Avatar name="Ryan Florence" src="https://bit.ly/ryan-florence" />
+  <Avatar name="Prosper Otemuyiwa" src="https://bit.ly/prosper-baba" />
+  <Avatar name="Christian Nwamba" src="https://bit.ly/code-beast" />
+  <Avatar name="Segun Adebayo" src="https://bit.ly/sage-adebayo" />
 </Stack>
 ```
 
@@ -44,17 +44,21 @@ The Avatar component comes in 7 sizes
 
 ```jsx
 <Stack isInline>
-  <Avatar size="2xs" name="Dan Abrahmov" src="http://bit.ly/dan-abramov" />
+  <Avatar size="2xs" name="Dan Abrahmov" src="https://bit.ly/dan-abramov" />
   <Avatar
     size="xs"
     name="Kola Tioluwani"
-    src="http://bit.ly/tioluwani-kolawole"
+    src="https://bit.ly/tioluwani-kolawole"
   />
-  <Avatar size="sm" name="Kent Dodds" src="http://bit.ly/kent-c-dodds" />
-  <Avatar size="md" name="Ryan Florence" src="http://bit.ly/ryan-florence" />
-  <Avatar size="lg" name="Prosper Otemuyiwa" src="http://bit.ly/prosper-baba" />
-  <Avatar size="xl" name="Christian Nwamba" src="http://bit.ly/code-beast" />
-  <Avatar size="2xl" name="Segun Adebayo" src="http://bit.ly/sage-adebayo" />
+  <Avatar size="sm" name="Kent Dodds" src="https://bit.ly/kent-c-dodds" />
+  <Avatar size="md" name="Ryan Florence" src="https://bit.ly/ryan-florence" />
+  <Avatar
+    size="lg"
+    name="Prosper Otemuyiwa"
+    src="https://bit.ly/prosper-baba"
+  />
+  <Avatar size="xl" name="Christian Nwamba" src="https://bit.ly/code-beast" />
+  <Avatar size="2xl" name="Segun Adebayo" src="https://bit.ly/sage-adebayo" />
 </Stack>
 ```
 
@@ -68,9 +72,9 @@ If there was an error loading the `src` of the avatar, there are 2 fallbacks:
 
 ```jsx
 <Stack isInline>
-  <Avatar name="Oshigaki Kisame" src="http://bit.ly/broken-link" />
-  <Avatar name="Sasuke Uchiha" src="http://bit.ly/broken-link" />
-  <Avatar src="http://bit.ly/broken-link" />
+  <Avatar name="Oshigaki Kisame" src="https://bit.ly/broken-link" />
+  <Avatar name="Sasuke Uchiha" src="https://bit.ly/broken-link" />
+  <Avatar src="https://bit.ly/broken-link" />
 </Stack>
 ```
 
@@ -107,11 +111,11 @@ component.
 
 ```jsx
 <AvatarGroup size="md" max={2}>
-  <Avatar name="Ryan Florence" src="http://bit.ly/ryan-florence" />
-  <Avatar name="Segun Adebayo" src="http://bit.ly/sage-adebayo" />
-  <Avatar name="Kent Dodds" src="http://bit.ly/kent-c-dodds" />
-  <Avatar name="Prosper Otemuyiwa" src="http://bit.ly/prosper-baba" />
-  <Avatar name="Christian Nwamba" src="http://bit.ly/code-beast" />
+  <Avatar name="Ryan Florence" src="https://bit.ly/ryan-florence" />
+  <Avatar name="Segun Adebayo" src="https://bit.ly/sage-adebayo" />
+  <Avatar name="Kent Dodds" src="https://bit.ly/kent-c-dodds" />
+  <Avatar name="Prosper Otemuyiwa" src="https://bit.ly/prosper-baba" />
+  <Avatar name="Christian Nwamba" src="https://bit.ly/code-beast" />
 </AvatarGroup>
 ```
 

--- a/packages/chakra-ui-docs/pages/contributing.mdx
+++ b/packages/chakra-ui-docs/pages/contributing.mdx
@@ -104,7 +104,8 @@ members of the project's leadership.
 ### Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+version 1.4, available at
+[https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/packages/chakra-ui-docs/pages/drawer.mdx
+++ b/packages/chakra-ui-docs/pages/drawer.mdx
@@ -153,7 +153,7 @@ function DrawerExample() {
             <Box>
               <FormLabel htmlFor="url">Url</FormLabel>
               <InputGroup>
-                <InputLeftAddon>http://</InputLeftAddon>
+                <InputLeftAddon>https://</InputLeftAddon>
                 <Input
                   type="url"
                   id="url"

--- a/packages/chakra-ui-docs/pages/image.mdx
+++ b/packages/chakra-ui-docs/pages/image.mdx
@@ -15,7 +15,7 @@ import { Image } from "@chakra-ui/core";
 
 ```jsx
 <Box size="sm">
-  <Image src="http://bit.ly/sage-adebayo" alt="Segun Adebayo" />
+  <Image src="https://bit.ly/sage-adebayo" alt="Segun Adebayo" />
 </Box>
 ```
 
@@ -28,16 +28,16 @@ The size of the image can be adjusted using the `size` prop.
   <Image
     size="100px"
     objectFit="cover"
-    src="http://bit.ly/sage-adebayo"
+    src="https://bit.ly/sage-adebayo"
     alt="Segun Adebayo"
   />
   <Image
     size="150px"
     objectFit="cover"
-    src="http://bit.ly/dan-abramov"
+    src="https://bit.ly/dan-abramov"
     alt="Dan Abramov"
   />
-  <Image size="200px" src="http://bit.ly/dan-abramov" alt="Dan Abramov" />
+  <Image size="200px" src="https://bit.ly/dan-abramov" alt="Dan Abramov" />
 </Stack>
 ```
 
@@ -47,7 +47,7 @@ The size of the image can be adjusted using the `size` prop.
 <Image
   rounded="full"
   size="150px"
-  src="http://bit.ly/sage-adebayo"
+  src="https://bit.ly/sage-adebayo"
   alt="Segun Adebayo"
 />
 ```

--- a/packages/chakra-ui-docs/pages/index.js
+++ b/packages/chakra-ui-docs/pages/index.js
@@ -50,7 +50,7 @@ const sampleCode = `
 // Sample component from airbnb.com
 
 <Box>
-  <Image rounded="md" src="http://bit.ly/2k1H1t6"/>
+  <Image rounded="md" src="https://bit.ly/2k1H1t6"/>
   <Flex align="baseline" mt={2}>
     <Badge variantColor="pink">Plus</Badge>
     <Text

--- a/packages/chakra-ui-docs/pages/responsive-styles.mdx
+++ b/packages/chakra-ui-docs/pages/responsive-styles.mdx
@@ -92,7 +92,7 @@ browser to see it in action)**:
     <Image
       rounded="lg"
       width={{ md: 40 }}
-      src="http://bit.ly/2jYM25F"
+      src="https://bit.ly/2jYM25F"
       alt="Woman paying for a purchase"
     />
   </Box>

--- a/packages/chakra-ui-docs/pages/tag.mdx
+++ b/packages/chakra-ui-docs/pages/tag.mdx
@@ -86,7 +86,7 @@ import { Tag, TagIcon, TagLabel, TagCloseButton } from "@chakra-ui/core";
 ```jsx
 <Tag variantColor="red" rounded="full">
   <Avatar
-    src="http://bit.ly/sage-adebayo"
+    src="https://bit.ly/sage-adebayo"
     size="xs"
     name="Segun Adebayo"
     ml={-1}

--- a/packages/chakra-ui/src/Avatar/examples.js
+++ b/packages/chakra-ui/src/Avatar/examples.js
@@ -18,7 +18,7 @@ stories.add("Default", () => (
         mr={2}
         size={size}
         name="Uchiha Itachi"
-        src="http://bit.ly/uchiha-itachi"
+        src="https://bit.ly/uchiha-itachi"
       >
         <AvatarBadge size="1.25em" bg="green.500" />
       </Avatar>
@@ -28,7 +28,7 @@ stories.add("Default", () => (
 
 stories.add("Avatar Group", () => (
   <AvatarGroup size="md" max={2}>
-    <Avatar name="Uchiha Itachi" src="http://bit.ly/uchiha-itachi" />
+    <Avatar name="Uchiha Itachi" src="https://bit.ly/uchiha-itachi" />
     <Avatar
       name="Uchiha Sasuke"
       src="https://vignette.wikia.nocookie.net/naruto/images/2/21/Sasuke_Part_1.png/revision/latest?cb=20170716092103"

--- a/packages/chakra-ui/src/IconButton/index.d.ts
+++ b/packages/chakra-ui/src/IconButton/index.d.ts
@@ -8,7 +8,7 @@ type PropsFromButton = Pick<
 
 interface IIconButton extends PropsFromButton {
   /**
-   * The icon to be used. Refer to the [Icons](http://chakra-ui.com/icon/) section
+   * The icon to be used. Refer to the [Icons](https://chakra-ui.com/icon/) section
    * of the docs for the available icon options.
    */
   icon?: string;


### PR DESCRIPTION
Many of the images use unsecure http urls, which causes browser security warnings even though the website is served over https. This PR addresses that issue.

<img width="327" alt="image" src="https://user-images.githubusercontent.com/24194291/65380693-73fea800-dcae-11e9-9ef6-90245adcb6b3.png">