### PR TITLE
Fix a typo

### DIFF
--- a/packages/chakra-ui-docs/pages/alert.mdx
+++ b/packages/chakra-ui-docs/pages/alert.mdx
@@ -50,7 +50,7 @@ color scheme and icon used. Alert supports `error`, `success`, `warning`, and
 <Stack spacing={3}>
   <Alert status="error">
     <AlertIcon />
-    There was an error processes your request
+    There was an error processing your request
   </Alert>
 
   <Alert status="success">


### PR DESCRIPTION
Hello! I found this tiny typo:

<img width="752" alt="image" src="https://user-images.githubusercontent.com/10660468/65530469-02994200-dec6-11e9-91df-b4a2b73dd856.png">

Have a nice day :v: