### PR TITLE
fix: resolve yarn v2 pnp issues

### DIFF
--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -19,6 +19,7 @@
     "version": "yarn build"
   },
   "dependencies": {
+    "@babel/runtime": "^7.6.2",
     "@reach/auto-id": "0.2.0",
     "@styled-system/css": "5.0.13",
     "@styled-system/should-forward-prop": "5.0.12",
@@ -30,9 +31,9 @@
     "popper.js": "^1.15.0",
     "react-animate-height": "2.0.9",
     "react-focus-lock": "^2.1.0",
-    "react-spring": "8.0.23",
+    "react-spring": "^8.0.27",
     "styled-system": "5.0.5",
-    "toasted-notes": "2.1.6",
+    "toasted-notes": "3.0.0",
     "use-dark-mode": "2.3.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,6 +1059,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
+  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -2467,93 +2474,6 @@
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.1.4.tgz#0dc4ecedf523004337214187db70a46183bd945b"
   integrity sha512-QHbzXjflSlCvDd6vJwdwx16mSB+vUCCQMiU/wK/CgVNPibtpEiIbisyxkpZc55DyDFNUIqP91rSUsNae+ogGDQ==
-
-"@react-spring/addons@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/addons/-/addons-9.0.0-beta.33.tgz#0948301c271758f7a52aa39a1d96d4db65c6dd9b"
-  integrity sha512-/QJ5vcq54oljT1n4dSx9maYGaIKzz5WRuKGa12fhLD2JsYo9syTc9S3VH4qmAM4pkbggUQdiaA/AJWack4NF7A==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/animated" "^9.0.0-beta.33"
-    "@react-spring/core" "^9.0.0-beta.33"
-    use-memo-one "^1.1.0"
-
-"@react-spring/animated@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.0.0-beta.33.tgz#5481278056e771466137f4d48c2efbf3277faad3"
-  integrity sha512-0ecIXTLjvUuplQgUOr3fhXzHuVcCuVi4gLAEG74m/OcXZ8JZ0DuQCwdIT2TNJYaWX1pOG0OstT3bJ8KN+Ji/BQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/shared" "^9.0.0-beta.33"
-    tiny-invariant "^1.0.4"
-
-"@react-spring/core@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.0.0-beta.33.tgz#3b894fb9fbc3d0dde5e4cdfc8eb52935e8cea9bf"
-  integrity sha512-fIUGsAsCmZSBtucfE3zf2XTBjdTYbzdcblZyeo1/pUGW7ehjB85x2oNj7o6JQ603+elsTJ9k7POiYI5/wn1N3A==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/animated" "^9.0.0-beta.33"
-    "@react-spring/shared" "^9.0.0-beta.33"
-    use-memo-one "^1.1.0"
-
-"@react-spring/konva@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.0.0-beta.33.tgz#2a116aee5a32ab4cde1b5eef1c10b533183f6518"
-  integrity sha512-9tfrbd/j3ZZHu8Vjpx86vAkLZ3lQLv9VEgvDIQSpzUzQOUojeQPdbB/xVKSoqR2hWR0XMV2IurD2e6rolZv7fQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/animated" "^9.0.0-beta.33"
-    "@react-spring/core" "^9.0.0-beta.33"
-    "@react-spring/shared" "^9.0.0-beta.33"
-
-"@react-spring/native@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.0.0-beta.33.tgz#0e27f34acbb395e2f355c9f91fc8010fbd1c4967"
-  integrity sha512-x2Wlcr0JSxc2O/6QsOut4aR3VOVYP8QOLBNXA+5tgQGK5yfkTaDoXTZC8vD/uX3dBsY41FUr2x9a+LOqvTfziQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/animated" "^9.0.0-beta.33"
-    "@react-spring/core" "^9.0.0-beta.33"
-    "@react-spring/shared" "^9.0.0-beta.33"
-
-"@react-spring/shared@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.0.0-beta.33.tgz#8630cf68f79a7b12f075345bdf23a47dff6ed877"
-  integrity sha512-oGalrGtIg7ZMn9VW5PzLFMDAa8vH5V0XIeC4WFk7JB4hBfhxx6yzPwjMxSJfRrt/Q+WuS2cPoR5qN0RpH+fJOA==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    tiny-invariant "^1.0.4"
-
-"@react-spring/three@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.0.0-beta.33.tgz#556f8ef92397c3b9bec0f92c13acc9c7d7c6995d"
-  integrity sha512-ouTN6w1VMjN2V04JGSG7eliesBgOqPmplrETeUSc3gAl3unv9LzqRDK/NGan0GwvsCx98BUycKYD26wWAAu1lA==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/animated" "^9.0.0-beta.33"
-    "@react-spring/core" "^9.0.0-beta.33"
-    "@react-spring/shared" "^9.0.0-beta.33"
-
-"@react-spring/web@^9.0.0-beta.34":
-  version "9.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.0.0-beta.34.tgz#d71fef11416a6be8b07d22faea16c8597e9487f3"
-  integrity sha512-K5kF2e0BgUE6ehY81NF9C8eYiopFx9YrWQvxRXVUbXUYOgLjZ5JsKFlAbM52PAl3AgP5c1pMP9ir6yzn144nig==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/animated" "^9.0.0-beta.33"
-    "@react-spring/core" "^9.0.0-beta.33"
-    "@react-spring/shared" "^9.0.0-beta.33"
-
-"@react-spring/zdog@^9.0.0-beta.33":
-  version "9.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.0.0-beta.33.tgz#0f49d72bd56c9d9c797ac0390b141d6f9c7eafbe"
-  integrity sha512-cGxNJxZxbKpaagpelTxdOLOxJkdUEjmiXzrePu0dAgO58WTGcya9XWcI0ntKZo1/8T6E2qR29j0J59MDeHkAZQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/animated" "^9.0.0-beta.33"
-    "@react-spring/core" "^9.0.0-beta.33"
-    "@react-spring/shared" "^9.0.0-beta.33"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -11820,27 +11740,13 @@ react-sizeme@^2.6.7:
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
 
-react-spring@8.0.23:
-  version "8.0.23"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.23.tgz#2a0ddaeb0816ea9e21898d04d3b8da7d1a3daa14"
-  integrity sha512-2mp7+0DnoBQ67h2zY0rFztdMqSm8gdvSWHgfwKz4TbLQ+N4n2IauB6DCMc046K8uvUNwDCUdlKgshUrCj14QUA==
+react-spring@^8.0.27:
+  version "8.0.27"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
+  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
   dependencies:
     "@babel/runtime" "^7.3.1"
     prop-types "^15.5.8"
-
-react-spring@^9.0.0-beta.20:
-  version "9.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.0.0-beta.34.tgz#909fdccec45b15f317cabe0d4746e636b60e39ed"
-  integrity sha512-Ey+Zg/jS2b/uaT6MlvMLnnNZ+N16Gc6r/CAwduC1+jy9UnB/fYnMMflZPemkGVEpZ+T9ef5FvWknw4ytnGl4zw==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@react-spring/addons" "^9.0.0-beta.33"
-    "@react-spring/core" "^9.0.0-beta.33"
-    "@react-spring/konva" "^9.0.0-beta.33"
-    "@react-spring/native" "^9.0.0-beta.33"
-    "@react-spring/three" "^9.0.0-beta.33"
-    "@react-spring/web" "^9.0.0-beta.34"
-    "@react-spring/zdog" "^9.0.0-beta.33"
 
 react-syntax-highlighter@^8.0.1:
   version "8.1.0"
@@ -13640,11 +13546,6 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
-tiny-invariant@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
-  integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
-
 tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
@@ -13708,15 +13609,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toasted-notes@2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/toasted-notes/-/toasted-notes-2.1.6.tgz#8e828dbbe2f5c52b7cf98d01fb3052ad167e26b5"
-  integrity sha512-e4UWJ/zwFKL0/fxB0B2HzNz+G9VOMc8dqKWLNjU5gG86kr1dQ8dWArD9vUJhK4er3mbaB7ocyHEE+pLHIokwVw==
+toasted-notes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toasted-notes/-/toasted-notes-3.0.0.tgz#ad72e9e601d658b301117d84c5ab431bfb75e1fa"
+  integrity sha512-gjL18/1aNP+bgipt1YbCBFeinFYExubltm8HIAJIYmlzDquC+YpajYOfhVysUCnBGwkX0w1V1AF5whpHGqohkQ==
   dependencies:
     "@reach/alert" "^0.1.2"
     "@types/react" "^16.8.10"
     "@types/react-dom" "^16.8.3"
-    react-spring "^9.0.0-beta.20"
 
 toggle-selection@^1.0.6:
   version "1.0.6"
@@ -14209,11 +14109,6 @@ use-dark-mode@2.3.1:
   dependencies:
     "@use-it/event-listener" "^0.1.2"
     use-persisted-state "^0.3.0"
-
-use-memo-one@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
-  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use-persisted-state@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
I was trying out the yarn v2 release candidate, and ran across issues using chakra-ui with a project of mine.

They are all dependency/peerDependency issues. Before my updates, I was getting the following warnings running yarn:

```
❯ yarn
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @react-spring/core@npm:9.0.0-canary.809.3.a66b280 doesn't provide react@^16.8.0 requested by use-memo-one@npm:1.1.1
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react@>=16.8 requested by @react-spring/addons@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide konva@>=2.6 requested by @react-spring/konva@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react@>=16.8 requested by @react-spring/konva@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react-konva@>=16.8 requested by @react-spring/konva@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react@>=16.8 requested by @react-spring/native@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react-native@>=0.58 requested by @react-spring/native@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react@>=16.8 requested by @react-spring/three@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react-three-fiber@>=2.0 requested by @react-spring/three@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide three@>=0.104 requested by @react-spring/three@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react@>=16.8 requested by @react-spring/web@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react-dom@>=16.8 requested by @react-spring/web@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react@>=16.8 requested by @react-spring/zdog@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react-dom@>=16.8 requested by @react-spring/zdog@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide react-zdog@>=1.0 requested by @react-spring/zdog@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ react-spring@npm:9.0.0-canary.809.3.a66b280 doesn't provide zdog@>=1.0 requested by @react-spring/zdog@npm:9.0.0-canary.809.3.a66b280
➤ YN0002: │ @reach/alert@npm:0.1.5 [6511f] doesn't provide prop-types@^15.6.2 requested by @reach/component-component@npm:0.1.3
```

And the following breakages when running webpack build (edited for brevity, many similar errors removed, full log available on request):
```
ERROR in /path/to/my/project/.yarn/cache/@react-spring-animated-npm-9.0.0-canary.809.3.a66b280-d1ff118115.zip/node_modules/@react-spring/animated/index.js
Module not found: Error: A package is trying to access another package without the second one being listed as a dependency of the first one

Required package: react (via "react")
Required by: @react-spring/animated@npm:9.0.0-canary.809.3.a66b280 (via /path/to/my/project/.yarn/cache/@react-spring-animated-npm-9.0.0-canary.809.3.a66b280-d1ff118115.zip/node_modules/@react-spring/animated/index.js)

 @ /path/to/my/project/.yarn/cache/@react-spring-animated-npm-9.0.0-canary.809.3.a66b280-d1ff118115.zip/node_modules/@react-spring/animated/index.js 6:0-50 518:45-55 519:22-28 545:9-14
 @ /path/to/my/project/.yarn/virtual/@react-spring-web-virtual-a428cfb2f8/0/cache/@react-spring-web-npm-9.0.0-canary.809.3.a66b280-77c9cd96ed.zip/node_modules/@react-spring/web/index.js
 @ /path/to/my/project/.yarn/cache/react-spring-npm-9.0.0-canary.809.3.a66b280-79383e0207.zip/node_modules/react-spring/web.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/Message.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/ToastManager.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/Toast.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/index.js
 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/Toast/index.js
 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/index.js
 @ ./src/main.js

ERROR in /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/CSSReset/index.js
Module not found: Error: A package is trying to access another package without the second one being listed as a dependency of the first one

Required package: @babel/runtime (via "@babel/runtime/helpers/taggedTemplateLiteralLoose")
Required by: @chakra-ui/core@virtual:130c84d57260c8520bce27d015c801af805a16f78bada4ba941fcd9c66a981b825c20990855ddd8937c212390e7c2b7a46bd46b54ac36704a66a2f225c2b7ecc#npm:0.3.2 (via /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/CSSReset/index.js)

 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/CSSReset/index.js 1:0-92 4:13-40
 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/index.js
 @ ./src/main.js


ERROR in /path/to/my/project/.yarn/virtual/@reach-component-component-virtual-1b212e295a/0/cache/@reach-component-component-npm-0.1.3-94c20ffc6f.zip/node_modules/@reach/component-component/es/index.js
Module not found: Error: A package is trying to access a peer dependency that should be provided by its direct ancestor but isn't

Required package: prop-types (via "prop-types")
Required by: @reach/component-component@virtual:ab71b639f6610e4dc9442d7d3ed938120a8fba4af3488976f3a0f33fa2cc526a3a6f2f25c2ca32df041eb9f3cdf7ccc909527bbee1f5387e4872268da091e058#npm:0.1.3 (via /path/to/my/project/.yarn/virtual/@reach-component-component-virtual-1b212e295a/0/cache/@reach-component-component-npm-0.1.3-94c20ffc6f.zip/node_modules/@reach/component-component/es/index.js)

 @ /path/to/my/project/.yarn/virtual/@reach-component-component-virtual-1b212e295a/0/cache/@reach-component-component-npm-0.1.3-94c20ffc6f.zip/node_modules/@reach/component-component/es/index.js 10:0-59 132:16-22 133:19-23 134:8-14 135:11-15 136:12-16 137:13-17 138:15-19 139:27-31 140:16-20 141:10-14 142:12-21 142:23-27 142:29-33
 @ /path/to/my/project/.yarn/virtual/@reach-alert-virtual-ab71b639f6/0/cache/@reach-alert-npm-0.1.5-9ba9a0e66d.zip/node_modules/@reach/alert/es/index.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/Message.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/ToastManager.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/Toast.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/index.js
 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/Toast/index.js
 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/index.js
 @ ./src/main.js


ERROR in /path/to/my/project/.yarn/virtual/use-memo-one-virtual-1ffc48c826/0/cache/use-memo-one-npm-1.1.1-41d1dc2ef9.zip/node_modules/use-memo-one/dist/use-memo-one.esm.js
Module not found: Error: A package is trying to access a peer dependency that should be provided by its direct ancestor but isn't

Required package: react (via "react")
Required by: use-memo-one@virtual:10b1f2df4f6943e601f19c7c4aebc6a0fd5a80a4dfa5d837722ffec27325d7aab9aa9b534665664d80ec402ec29c4bedd854760dd6300abba3efb39daa9d4b09#npm:1.1.1 (via /path/to/my/project/.yarn/virtual/use-memo-one-virtual-1ffc48c826/0/cache/use-memo-one-npm-1.1.1-41d1dc2ef9.zip/node_modules/use-memo-one/dist/use-memo-one.esm.js)

 @ /path/to/my/project/.yarn/virtual/use-memo-one-virtual-1ffc48c826/0/cache/use-memo-one-npm-1.1.1-41d1dc2ef9.zip/node_modules/use-memo-one/dist/use-memo-one.esm.js 1:0-52 18:16-24 24:18-24 30:2-11
 @ /path/to/my/project/.yarn/unplugged/@react-spring-core-npm-9.0.0-canary.809.3.a66b280-10b1f2df4f/node_modules/@react-spring/core/index.js
 @ /path/to/my/project/.yarn/virtual/@react-spring-web-virtual-a428cfb2f8/0/cache/@react-spring-web-npm-9.0.0-canary.809.3.a66b280-77c9cd96ed.zip/node_modules/@react-spring/web/index.js
 @ /path/to/my/project/.yarn/cache/react-spring-npm-9.0.0-canary.809.3.a66b280-79383e0207.zip/node_modules/react-spring/web.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/Message.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/ToastManager.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/Toast.js
 @ /path/to/my/project/.yarn/virtual/toasted-notes-virtual-6511f0e024/0/cache/toasted-notes-npm-2.1.6-d78ea7a248.zip/node_modules/toasted-notes/lib/index.js
 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/Toast/index.js
 @ /path/to/my/project/.yarn/virtual/@chakra-ui-core-virtual-36cb862b0f/0/cache/@chakra-ui-core-npm-0.3.2-5c3a781b78.zip/node_modules/@chakra-ui/core/dist/es/index.js
 @ ./src/main.js
```


The changes in this PR resolve most of the issues above, by adding some missing deps and updating toasted-notes to version 3.0.0.

The remaining issue has to do with @reach/alert, which is brought in by toasted-notes:

```
@reach/alert@npm:0.1.5 [37363] doesn't provide prop-types@^15.6.2 requested by @reach/component-component@npm:0.1.3
```

Yarn pnp is strict about peerDeps being provided, and so this breaks the build. Since I don't use chakra-ui's Toast notifications, I was able to work around the issue using the webpack null-loader:
```
    module: {
        rules: [{
            // Test for a polyfill (or any file) and it won't be included in your
            // bundle
            test: /chakra-ui\/dist\/es\/Toast\/index.js/,
            use: 'null-loader',
          },
       ...
    } 

```


There will have to be a fix in the @reach/alert project to resolve the actual issue.