### PR TITLE
Fix validation logic in Formik example for FormControl

### DIFF
--- a/packages/chakra-ui-docs/pages/formcontrol.mdx
+++ b/packages/chakra-ui-docs/pages/formcontrol.mdx
@@ -85,8 +85,7 @@ function FormikExample() {
     let error;
     if (!value) {
       error = "Name is required";
-    }
-    if (value !== "Naruto") {
+    } else if (value !== "Naruto") {
       error = "Jeez! You're not a fan 😱";
     }
     return error;


### PR DESCRIPTION
This is a very small fix for the Formik example in the FormControl docs. Currently the validation logic will only show the second error message, even if the field is blank.