### PR TITLE
docs(recipes): add recipes page to docs with initial example

### DIFF
--- a/packages/chakra-ui-docs/components/SideNav.js
+++ b/packages/chakra-ui-docs/components/SideNav.js
@@ -10,6 +10,7 @@ const topNavLinks = [
   "Color Mode",
   "Responsive Styles",
   "Theme",
+  "Recipes",
 ];
 
 const utilsNavLinks = ["useClipboard", "useDisclosure", "useTheme"];

--- a/packages/chakra-ui-docs/pages/recipes.mdx
+++ b/packages/chakra-ui-docs/pages/recipes.mdx
@@ -1,0 +1,8 @@
+# Recipes
+
+## Building Forms with Chakra UI and React Hook Form
+
+This example shows how to build a simple form with Chakra UI's form components
+and the [React Hook Form](https://react-hook-form.com) form library.
+
+[Explore on Code Sandbox](https://codesandbox.io/s/chakra-ui-react-hook-form-v382z)


### PR DESCRIPTION
Adds a recipes page to the docs with an initial example of using Chakra UI with React Hook Form. Resolves #165 