### PR TITLE
[CheckboxGroup] Fix controlling with `value` prop

### DIFF
--- a/packages/chakra-ui/src/CheckboxGroup/index.js
+++ b/packages/chakra-ui/src/CheckboxGroup/index.js
@@ -31,9 +31,9 @@ const CheckboxGroup = ({
     const { checked, value } = event.target;
     let newValues;
     if (checked) {
-      newValues = [...values, value];
+      newValues = [..._values, value];
     } else {
-      newValues = values.filter(val => val !== value);
+      newValues = _values.filter(val => val !== value);
     }
 
     !isControlled && setValues(newValues);


### PR DESCRIPTION
The `onChange` event should append to the array of controlled values.