### PR TITLE
feat(theme): apply fonts to Heading and Text

### DIFF
--- a/packages/chakra-ui/src/Heading/index.js
+++ b/packages/chakra-ui/src/Heading/index.js
@@ -19,6 +19,7 @@ const Heading = forwardRef(({ size = "xl", ...props }, ref) => (
     fontSize={sizes[size]}
     lineHeight="shorter"
     fontWeight="bold"
+    fontFamily="heading"
     {...props}
   />
 ));

--- a/packages/chakra-ui/src/Text/index.js
+++ b/packages/chakra-ui/src/Text/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import Box from "../Box";
 
 const Text = React.forwardRef((props, ref) => {
-  return <Box ref={ref} as="p" {...props} />;
+  return <Box ref={ref} as="p" fontFamily="body" {...props} />;
 });
 
 export default Text;


### PR DESCRIPTION
This commit follows up on #217. It adds the `fontFamily`attribute to Heading and Text components. This way the font families specified in the theme are applied to the headings and texts automatically. 💅 The `<Code>` element already automatically choses the `mono` font from the theme.

This change is introduced to make the `fonts` property in the theme object behave more consistently with the other properties in the theme.

Currently it is still unclear how to apply the font specified in the `body` property of the fonts object to all elements automatically but this change can be a good start. But components like `<Button>` are still untouched and should probably also have the font inherited from the theme but right now I don't know if there is a good way to do that. It might be to modify the base components like `<Box>`.

Or one might not want to change the font family of these elements at all but then the behaviour is even more incosistent with the other elements 😕 