### PR TITLE
fix(stack): ensure that invalid elements are filtered correctly

### DIFF
--- a/packages/chakra-ui/src/Stack/index.js
+++ b/packages/chakra-ui/src/Stack/index.js
@@ -37,11 +37,12 @@ const Stack = ({
     _direction = "column";
   }
 
+  const validChildren = children.filter(isValidElement);
+
   return (
     <Flex align={align} justify={justify} direction={_direction} {...rest}>
-      {Children.map(children, (child, index) => {
-        if (!isValidElement(child)) return;
-        let isLastChild = children.length === index + 1;
+      {Children.map(validChildren, (child, index) => {
+        let isLastChild = validChildren.length === index + 1;
         let spacingProps = _isInline
           ? { [_isReversed ? "ml" : "mr"]: isLastChild ? null : spacing }
           : { [_isReversed ? "mt" : "mb"]: isLastChild ? null : spacing };


### PR DESCRIPTION
In this example, a bottom margin is added to the 2nd Headline.

```tsx
    <Stack>
      <Heading>Headline 1</Heading>
      <Heading>Headline 2</Heading>

      {false && <Heading>Headline 3</Heading>}
    </Stack>
```

While the expected behavior is, that 2nd Headline has no margin. The PR will fix this issue.