### PR TITLE
feat: add displayName to anonymous components

### DIFF
--- a/packages/chakra-ui/src/Accordion/index.js
+++ b/packages/chakra-ui/src/Accordion/index.js
@@ -134,6 +134,8 @@ const AccordionItem = forwardRef(
   },
 );
 
+AccordionItem.displayName = "AccordionItem";
+
 /////////////////////////////////////////////////////////////
 
 const AccordionHeader = forwardRef(({ onClick, ...props }, ref) => {
@@ -175,6 +177,8 @@ const AccordionHeader = forwardRef(({ onClick, ...props }, ref) => {
   );
 });
 
+AccordionHeader.displayName = "AccordionHeader";
+
 /////////////////////////////////////////////////////////////
 
 const AccordionPanel = forwardRef((props, ref) => {
@@ -195,6 +199,8 @@ const AccordionPanel = forwardRef((props, ref) => {
     />
   );
 });
+
+AccordionPanel.displayName = "AccordionPanel";
 
 /////////////////////////////////////////////////////////////
 

--- a/packages/chakra-ui/src/AlertDialog/index.js
+++ b/packages/chakra-ui/src/AlertDialog/index.js
@@ -29,6 +29,8 @@ const AlertDialogContent = forwardRef((props, ref) => (
   <ModalContent ref={ref} role="alertdialog" {...props} />
 ));
 
+AlertDialogContent.displayName = "AlertDialogContent";
+
 export {
   AlertDialog,
   AlertDialogContent,

--- a/packages/chakra-ui/src/Badge/index.js
+++ b/packages/chakra-ui/src/Badge/index.js
@@ -26,4 +26,6 @@ const Badge = forwardRef(
   },
 );
 
+Badge.displayName = "Badge";
+
 export default Badge;

--- a/packages/chakra-ui/src/Box/index.js
+++ b/packages/chakra-ui/src/Box/index.js
@@ -73,4 +73,6 @@ const Box = styled("div", {
   },
 })(truncate, systemProps);
 
+Box.displayName = "Box";
+
 export default Box;

--- a/packages/chakra-ui/src/Breadcrumb/index.js
+++ b/packages/chakra-ui/src/Breadcrumb/index.js
@@ -10,6 +10,8 @@ const BreadcrumbSeparator = forwardRef(({ spacing, ...props }, ref) => {
   );
 });
 
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
+
 const Span = forwardRef((props, ref) => <Box ref={ref} as="span" {...props} />);
 
 const BreadcrumbLink = forwardRef(({ isCurrentPage, ...props }, ref) => {
@@ -19,6 +21,8 @@ const BreadcrumbLink = forwardRef(({ isCurrentPage, ...props }, ref) => {
     <Comp ref={ref} aria-current={isCurrentPage ? "page" : null} {...props} />
   );
 });
+
+BreadcrumbLink.displayName = "BreadcrumbLink";
 
 const BreadcrumbItem = ({
   isCurrentPage,

--- a/packages/chakra-ui/src/Button/index.js
+++ b/packages/chakra-ui/src/Button/index.js
@@ -94,4 +94,6 @@ const Button = forwardRef(
   },
 );
 
+Button.displayName = "Button";
+
 export default Button;

--- a/packages/chakra-ui/src/Checkbox/index.js
+++ b/packages/chakra-ui/src/Checkbox/index.js
@@ -87,4 +87,6 @@ const Checkbox = forwardRef(
   },
 );
 
+Checkbox.displayName = "Checkbox";
+
 export default Checkbox;

--- a/packages/chakra-ui/src/CircularProgress/index.js
+++ b/packages/chakra-ui/src/CircularProgress/index.js
@@ -9,12 +9,12 @@ const circularProgressCircle = keyframes`
     stroke-dasharray: 1, 400;
     stroke-dashoffset: 0;
   }
-  
+
   50% {
     stroke-dasharray: 400, 400;
     stroke-dashoffset: -100;
   }
-  
+
   100% {
     stroke-dasharray: 400, 400;
     stroke-dashoffset: -300;
@@ -178,5 +178,7 @@ const CircularProgress = forwardRef((props, ref) => {
     </Box>
   );
 });
+
+CircularProgress.displayName = "CircularProgress";
 
 export default CircularProgress;

--- a/packages/chakra-ui/src/Collapse/index.js
+++ b/packages/chakra-ui/src/Collapse/index.js
@@ -42,4 +42,6 @@ const Collapse = forwardRef(
   },
 );
 
+Collapse.displayName = "Collapse";
+
 export default Collapse;

--- a/packages/chakra-ui/src/ControlBox/index.js
+++ b/packages/chakra-ui/src/ControlBox/index.js
@@ -43,6 +43,8 @@ const ControlBox = styled(Box)(
   },
 );
 
+ControlBox.displayName = "ControlBox";
+
 ControlBox.defaultProps = {
   display: "inline-flex",
   alignItems: "center",

--- a/packages/chakra-ui/src/Drawer/index.js
+++ b/packages/chakra-ui/src/Drawer/index.js
@@ -79,14 +79,20 @@ const DrawerContent = forwardRef((props, ref) => {
   );
 });
 
+DrawerContent.displayName = "DrawerContent";
+
 const DrawerOverlay = forwardRef((props, ref) => {
   const { styles } = useDrawerContext();
   return <ModalOverlay ref={ref} opacity={styles.opacity} {...props} />;
 });
 
+DrawerOverlay.displayName = "DrawerOverlay";
+
 const DrawerCloseButton = forwardRef(({ onClick, ...rest }, ref) => (
   <ModalCloseButton ref={ref} position="fixed" zIndex="1" {...rest} />
 ));
+
+DrawerCloseButton.displayName = "DrawerCloseButton";
 
 export {
   Drawer,

--- a/packages/chakra-ui/src/Editable/index.js
+++ b/packages/chakra-ui/src/Editable/index.js
@@ -130,6 +130,8 @@ const Editable = forwardRef(
   },
 );
 
+Editable.displayName = "Editable";
+
 const sharedProps = {
   fontSize: "inherit",
   fontWeight: "inherit",

--- a/packages/chakra-ui/src/Flex/index.js
+++ b/packages/chakra-ui/src/Flex/index.js
@@ -13,4 +13,6 @@ const Flex = forwardRef(({ align, justify, wrap, direction, ...rest }, ref) => (
   />
 ));
 
+Flex.displayName = "Flex";
+
 export default Flex;

--- a/packages/chakra-ui/src/FormControl/index.js
+++ b/packages/chakra-ui/src/FormControl/index.js
@@ -47,4 +47,6 @@ const FormControl = forwardRef(
   },
 );
 
+FormControl.displayName = "FormControl";
+
 export default FormControl;

--- a/packages/chakra-ui/src/FormErrorMessage/index.js
+++ b/packages/chakra-ui/src/FormErrorMessage/index.js
@@ -36,4 +36,6 @@ const FormErrorMessage = forwardRef(({ children, icon, ...props }, ref) => {
   );
 });
 
+FormErrorMessage.displayName = "FormErrorMessage";
+
 export default FormErrorMessage;

--- a/packages/chakra-ui/src/FormHelperText/index.js
+++ b/packages/chakra-ui/src/FormHelperText/index.js
@@ -23,4 +23,6 @@ export const FormHelperText = forwardRef((props, ref) => {
   );
 });
 
+FormHelperText.displayName = "FormHelperText";
+
 export default FormHelperText;

--- a/packages/chakra-ui/src/FormLabel/index.js
+++ b/packages/chakra-ui/src/FormLabel/index.js
@@ -42,4 +42,6 @@ export const FormLabel = forwardRef(({ children, ...props }, ref) => {
   );
 });
 
+FormLabel.displayName = "FormLabel";
+
 export default FormLabel;

--- a/packages/chakra-ui/src/Grid/index.js
+++ b/packages/chakra-ui/src/Grid/index.js
@@ -40,4 +40,6 @@ const Grid = forwardRef(
   ),
 );
 
+Grid.displayName = "Grid";
+
 export default Grid;

--- a/packages/chakra-ui/src/Heading/index.js
+++ b/packages/chakra-ui/src/Heading/index.js
@@ -24,4 +24,6 @@ const Heading = forwardRef(({ size = "xl", ...props }, ref) => (
   />
 ));
 
+Heading.displayName = "Heading";
+
 export default Heading;

--- a/packages/chakra-ui/src/Icon/index.js
+++ b/packages/chakra-ui/src/Icon/index.js
@@ -56,4 +56,6 @@ const Icon = forwardRef(
   },
 );
 
+Icon.displayName = "Icon";
+
 export default Icon;

--- a/packages/chakra-ui/src/IconButton/index.js
+++ b/packages/chakra-ui/src/IconButton/index.js
@@ -33,6 +33,8 @@ const IconButton = forwardRef(
   },
 );
 
+IconButton.displayName = "IconButton";
+
 IconButton.defaultProps = Button.defaultProps;
 
 export default IconButton;

--- a/packages/chakra-ui/src/Image/index.js
+++ b/packages/chakra-ui/src/Image/index.js
@@ -43,4 +43,6 @@ const Image = forwardRef(
   },
 );
 
+Image.displayName = "Image";
+
 export default Image;

--- a/packages/chakra-ui/src/Input/index.js
+++ b/packages/chakra-ui/src/Input/index.js
@@ -44,6 +44,8 @@ const Input = forwardRef((props, ref) => {
   );
 });
 
+Input.displayName = "Input";
+
 Input.defaultProps = {
   size: "md",
   as: "input",

--- a/packages/chakra-ui/src/InputElement/index.js
+++ b/packages/chakra-ui/src/InputElement/index.js
@@ -41,13 +41,19 @@ const InputElement = forwardRef(
   },
 );
 
+InputElement.displayName = "InputElement";
+
 const InputLeftElement = forwardRef((props, ref) => (
   <InputElement ref={ref} placement="left" {...props} />
 ));
 
+InputLeftElement.displayName = "InputLeftElement";
+
 const InputRightElement = forwardRef((props, ref) => (
   <InputElement ref={ref} placement="right" {...props} />
 ));
+
+InputRightElement.displayName = "InputRightElement";
 
 export { InputLeftElement, InputRightElement };
 export default InputElement;

--- a/packages/chakra-ui/src/Link/index.js
+++ b/packages/chakra-ui/src/Link/index.js
@@ -38,4 +38,6 @@ const Link = forwardRef(({ isDisabled, isExternal, onClick, ...rest }, ref) => {
   );
 });
 
+Link.displayName = "Link";
+
 export default Link;

--- a/packages/chakra-ui/src/List/index.js
+++ b/packages/chakra-ui/src/List/index.js
@@ -31,9 +31,13 @@ const List = forwardRef(
   ),
 );
 
+List.displayName = "List";
+
 export const ListItem = forwardRef(({ spacing, ...props }, ref) => (
   <PseudoBox ref={ref} as="li" mb={spacing} {...props} />
 ));
+
+ListItem.diplayName = "ListItem";
 
 export const ListIcon = ({ icon, ...props }) => {
   if (typeof icon === "string") {

--- a/packages/chakra-ui/src/Menu/MenuOption.js
+++ b/packages/chakra-ui/src/Menu/MenuOption.js
@@ -125,6 +125,8 @@ export const MenuItemOption = forwardRef(
   },
 );
 
+MenuItemOption.displayName = "MenuItemOption";
+
 export const MenuOptionGroup = ({
   children,
   type = "radio",

--- a/packages/chakra-ui/src/Menu/index.js
+++ b/packages/chakra-ui/src/Menu/index.js
@@ -181,6 +181,8 @@ const PseudoButton = forwardRef((props, ref) => (
   <PseudoBox ref={ref} as="button" {...props} />
 ));
 
+PseudoButton.displayName = "PseudoButton";
+
 const MenuButton = forwardRef(
   ({ onClick, onKeyDown, as: Comp = PseudoButton, ...rest }, ref) => {
     const {
@@ -232,6 +234,9 @@ const MenuButton = forwardRef(
     );
   },
 );
+
+MenuButton.displayName = "MenuButton";
+
 //////////////////////////////////////////////////////////////////////////////////////////
 
 const MenuList = ({ onKeyDown, onBlur, ...props }) => {
@@ -418,11 +423,15 @@ const MenuItem = forwardRef(
   },
 );
 
+MenuItem.displayName = "MenuItem";
+
 //////////////////////////////////////////////////////////////////////////////////////////
 
 const MenuDivider = forwardRef((props, ref) => (
   <Divider ref={ref} orientation="horizontal" {...props} />
 ));
+
+MenuDivider.displayName = "MenuDivider";
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
@@ -436,6 +445,8 @@ const MenuGroup = forwardRef(({ children, title, ...rest }, ref) => (
     {children}
   </Box>
 ));
+
+MenuGroup.displayName = "MenuGroup";
 
 //////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/chakra-ui/src/Modal/index.js
+++ b/packages/chakra-ui/src/Modal/index.js
@@ -210,6 +210,8 @@ const ModalOverlay = React.forwardRef((props, ref) => {
   );
 });
 
+ModalOverlay.displayName = "ModalOverlay";
+
 ////////////////////////////////////////////////////////////////////////
 
 const ModalContent = React.forwardRef(
@@ -346,6 +348,8 @@ const ModalContent = React.forwardRef(
   },
 );
 
+ModalContent.displayName = "ModalContent";
+
 ////////////////////////////////////////////////////////////////////////
 
 const ModalHeader = forwardRef((props, ref) => {
@@ -365,6 +369,8 @@ const ModalHeader = forwardRef((props, ref) => {
   );
 });
 
+ModalHeader.displayName = "ModalHeader";
+
 ////////////////////////////////////////////////////////////////////////
 
 const ModalFooter = forwardRef((props, ref) => (
@@ -378,6 +384,8 @@ const ModalFooter = forwardRef((props, ref) => (
     {...props}
   />
 ));
+
+ModalFooter.displayName = "ModalFooter";
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -394,6 +402,8 @@ const ModalBody = forwardRef((props, ref) => {
   );
 });
 
+ModalBody.displayName = "ModalBody";
+
 ////////////////////////////////////////////////////////////////////////
 
 const ModalCloseButton = forwardRef((props, ref) => {
@@ -409,6 +419,8 @@ const ModalCloseButton = forwardRef((props, ref) => {
     />
   );
 });
+
+ModalCloseButton.displayName = "ModalCloseButton";
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/packages/chakra-ui/src/NumberInput/index.js
+++ b/packages/chakra-ui/src/NumberInput/index.js
@@ -84,6 +84,8 @@ const NumberInput = forwardRef(
   },
 );
 
+NumberInput.displayName = "NumberInput";
+
 const NumberInputField = forwardRef(
   ({ onBlur, onFocus, onKeyDown, onChange, ...props }, ref) => {
     const {
@@ -122,6 +124,8 @@ const NumberInputField = forwardRef(
     );
   },
 );
+
+NumberInputField.displayName = "NumberInputField";
 
 const NumberInputStepper = forwardRef((props, ref) => {
   return (
@@ -164,6 +168,8 @@ const StepperButton = forwardRef((props, ref) => {
   );
 });
 
+NumberInputStepper.displayName = "NumberInputStepper";
+
 const NumberIncrementStepper = forwardRef((props, ref) => {
   const { incrementStepper, size } = useNumberInputContext();
   const iconSize = size === "sm" ? "11px" : "15px";
@@ -180,6 +186,8 @@ const NumberIncrementStepper = forwardRef((props, ref) => {
   );
 });
 
+NumberIncrementStepper.displayName = "NumberIncrementStepper";
+
 const NumberDecrementStepper = forwardRef((props, ref) => {
   const { decrementStepper, size } = useNumberInputContext();
   const iconSize = size === "sm" ? "11px" : "15px";
@@ -195,6 +203,8 @@ const NumberDecrementStepper = forwardRef((props, ref) => {
     </StepperButton>
   );
 });
+
+NumberDecrementStepper.displayName = "NumberDecrementStepper";
 
 export {
   NumberInput,

--- a/packages/chakra-ui/src/Portal/index.js
+++ b/packages/chakra-ui/src/Portal/index.js
@@ -53,4 +53,6 @@ const Portal = forwardRef(
   },
 );
 
+Portal.displayName = "Portal";
+
 export default Portal;

--- a/packages/chakra-ui/src/PseudoBox/index.js
+++ b/packages/chakra-ui/src/PseudoBox/index.js
@@ -85,4 +85,6 @@ const PseudoBox = styled(Box)(
   },
 );
 
+PseudoBox.displayName = "PseudoBox";
+
 export default PseudoBox;

--- a/packages/chakra-ui/src/Radio/index.js
+++ b/packages/chakra-ui/src/Radio/index.js
@@ -84,4 +84,6 @@ const Radio = forwardRef(
   },
 );
 
+Radio.displayName = "Radio";
+
 export default Radio;

--- a/packages/chakra-ui/src/RadioButtonGroup/index.js
+++ b/packages/chakra-ui/src/RadioButtonGroup/index.js
@@ -106,4 +106,6 @@ const RadioButtonGroup = ({
   );
 };
 
+RadioButtonGroup.displayName = "RadioButtonGroup";
+
 export default RadioButtonGroup;

--- a/packages/chakra-ui/src/RadioGroup/index.js
+++ b/packages/chakra-ui/src/RadioGroup/index.js
@@ -99,4 +99,6 @@ const RadioGroup = forwardRef(
   },
 );
 
+RadioGroup.displayName = "RadioGroup";
+
 export default RadioGroup;

--- a/packages/chakra-ui/src/Select/index.js
+++ b/packages/chakra-ui/src/Select/index.js
@@ -98,4 +98,6 @@ const Select = forwardRef(
   },
 );
 
+Select.displayName = "Select";
+
 export default Select;

--- a/packages/chakra-ui/src/SimpleGrid/index.js
+++ b/packages/chakra-ui/src/SimpleGrid/index.js
@@ -21,4 +21,6 @@ const SimpleGrid = forwardRef(
   },
 );
 
+SimpleGrid.displayName = "SimpleGrid";
+
 export default SimpleGrid;

--- a/packages/chakra-ui/src/Slider/index.js
+++ b/packages/chakra-ui/src/Slider/index.js
@@ -99,6 +99,8 @@ export const SliderThumb = forwardRef((props, ref) => {
   );
 });
 
+SliderThumb.displayName = "SliderThumb";
+
 ////////////////////////////////////////////////////////////////
 
 export const SliderTrack = props => {
@@ -341,5 +343,7 @@ const Slider = forwardRef(
     );
   },
 );
+
+Slider.displayName = "Slider";
 
 export default Slider;

--- a/packages/chakra-ui/src/Spinner/index.js
+++ b/packages/chakra-ui/src/Spinner/index.js
@@ -57,4 +57,6 @@ const Spinner = forwardRef(
   },
 );
 
+Spinner.displayName = "Spinner";
+
 export default Spinner;

--- a/packages/chakra-ui/src/Stat/index.js
+++ b/packages/chakra-ui/src/Stat/index.js
@@ -8,9 +8,13 @@ const StatLabel = forwardRef((props, ref) => (
   <Text ref={ref} fontWeight="medium" fontSize="sm" {...props} />
 ));
 
+StatLabel.displayName = "StatLabel";
+
 const StatHelpText = forwardRef((props, ref) => (
   <Text ref={ref} fontSize="sm" opacity="0.8" mb={2} {...props} />
 ));
+
+StatHelpText.displayName = "StatHelpText";
 
 const StatNumber = props => (
   <Text
@@ -46,9 +50,13 @@ const StatArrow = forwardRef(
   ),
 );
 
+StatArrow.displayName = "StatArrow";
+
 const Stat = forwardRef((props, ref) => (
   <Box ref={ref} flex="1" pr={4} position="relative" {...props} />
 ));
+
+Stat.displayName = "Stat";
 
 const StatGroup = forwardRef((props, ref) => (
   <Flex
@@ -59,5 +67,7 @@ const StatGroup = forwardRef((props, ref) => (
     {...props}
   />
 ));
+
+StatGroup.displayName = "StatGroup";
 
 export { StatLabel, StatNumber, Stat, StatHelpText, StatArrow, StatGroup };

--- a/packages/chakra-ui/src/Switch/index.js
+++ b/packages/chakra-ui/src/Switch/index.js
@@ -104,6 +104,8 @@ const Switch = forwardRef(
   },
 );
 
+Switch.displayName = "Switch";
+
 Switch.defaultProps = {
   color: "blue",
   size: "md",

--- a/packages/chakra-ui/src/Tabs/index.js
+++ b/packages/chakra-ui/src/Tabs/index.js
@@ -40,6 +40,8 @@ const Tab = forwardRef((props, ref) => {
   );
 });
 
+Tab.displayName = "Tab";
+
 ////////////////////////////////////////////////////////////////////////
 
 const TabList = forwardRef((props, ref) => {
@@ -144,6 +146,8 @@ const TabList = forwardRef((props, ref) => {
   );
 });
 
+TabList.displayName = "TabList";
+
 ////////////////////////////////////////////////////////////////////////
 
 const TabPanel = forwardRef(
@@ -169,6 +173,8 @@ const TabPanel = forwardRef(
     );
   },
 );
+
+TabPanel.displayName = "TabPanel";
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -197,6 +203,8 @@ const TabPanels = forwardRef(({ children, ...rest }, ref) => {
     </Box>
   );
 });
+
+TabPanels.displayName = "TabPanels";
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -305,6 +313,8 @@ const Tabs = forwardRef(
     );
   },
 );
+
+Tabs.displayName = "Tabs";
 
 export default Tabs;
 export { TabList, Tab, TabPanel, TabPanels };

--- a/packages/chakra-ui/src/Text/index.js
+++ b/packages/chakra-ui/src/Text/index.js
@@ -5,4 +5,6 @@ const Text = React.forwardRef((props, ref) => {
   return <Box ref={ref} as="p" fontFamily="body" {...props} />;
 });
 
+Text.displayName = "Text";
+
 export default Text;

--- a/packages/chakra-ui/src/Textarea/index.js
+++ b/packages/chakra-ui/src/Textarea/index.js
@@ -16,6 +16,8 @@ const Textarea = forwardRef((props, ref) => {
   );
 });
 
+Textarea.displayName = "Textarea";
+
 export default Textarea;
 
 export const ExpandingTextarea = forwardRef(
@@ -52,3 +54,5 @@ export const ExpandingTextarea = forwardRef(
     );
   },
 );
+
+ExpandingTextarea.displayName = "ExpandingTextarea";

--- a/packages/chakra-ui/src/VisuallyHidden/index.js
+++ b/packages/chakra-ui/src/VisuallyHidden/index.js
@@ -13,4 +13,6 @@ const VisuallyHidden = styled(Box)`
   position: absolute;
 `;
 
+VisuallyHidden.displayName = "VisuallyHidden";
+
 export default VisuallyHidden;


### PR DESCRIPTION
In the [React Dev Tools](https://github.com/facebook/react/tree/master/packages/react-devtools) component names are displayed based on either the class' name, the function's name or a `displayName` property on the component. When a component is not created as a class or a named function the component has no display name. To show Chakra UI's component names correctly in the developer tools this commit introduces display names to all components that are created using `forwardRef` or `styled`.

One last problem remains: The some of the `AlertOverlay*` components are simply reexports from the `Modal` component. When using these components the name will be wrong in the developer tools. This could be solved by wrapping with a function that simply forwards props and gets the name right, but it might not be that much of a big deal so I have not made this change.

closes #211 