### PR TITLE
fix(button): unset hover and active styles when Button is disabled

### DIFF
--- a/packages/chakra-ui/src/Button/index.js
+++ b/packages/chakra-ui/src/Button/index.js
@@ -46,13 +46,14 @@ const Button = forwardRef(
     },
     ref,
   ) => {
+    const _isDisabled = isDisabled || isLoading;
     const buttonStyleProps = useButtonStyle({
       color: variantColor,
       variant,
       size,
       colorMode,
+      disabled: _isDisabled,
     });
-    const _isDisabled = isDisabled || isLoading;
 
     return (
       <PseudoBox

--- a/packages/chakra-ui/src/Button/styles.js
+++ b/packages/chakra-ui/src/Button/styles.js
@@ -150,6 +150,8 @@ const disabledProps = {
     cursor: "not-allowed",
     boxShadow: "none",
   },
+  _hover: undefined,
+  _active: undefined,
 };
 
 ////////////////////////////////////////////////////////////
@@ -252,8 +254,8 @@ const useButtonStyle = props => {
     ...baseProps,
     ...sizeProps(_props),
     ...focusProps,
-    ...disabledProps,
     ...variantProps(_props),
+    ...disabledProps,
   };
 };
 

--- a/packages/chakra-ui/src/Button/styles.js
+++ b/packages/chakra-ui/src/Button/styles.js
@@ -144,15 +144,18 @@ const linkVariantProps = ({ color, colorMode }) => {
 
 ////////////////////////////////////////////////////////////
 
-const disabledProps = {
-  _disabled: {
-    opacity: "40%",
-    cursor: "not-allowed",
-    boxShadow: "none",
-  },
-  _hover: undefined,
-  _active: undefined,
-};
+const disabledProps = ({ disabled }) =>
+  disabled
+    ? {
+        _disabled: {
+          opacity: "40%",
+          cursor: "not-allowed",
+          boxShadow: "none",
+        },
+        _hover: undefined,
+        _active: undefined,
+      }
+    : {};
 
 ////////////////////////////////////////////////////////////
 
@@ -255,7 +258,7 @@ const useButtonStyle = props => {
     ...sizeProps(_props),
     ...focusProps,
     ...variantProps(_props),
-    ...disabledProps,
+    ...disabledProps(_props),
   };
 };
 


### PR DESCRIPTION
Currently disabled button still gives feedback (e.g. change in background color) when hovered as shown below,

![image](https://user-images.githubusercontent.com/410792/68456529-f92b2580-0238-11ea-94df-b677a172412c.png)

This change unsets the hover and active styles for disabled button so that there will no be additional feedback given for user when user hovers on the button