### PR TITLE
fix(number-input): cannot use numeric keypad

### DIFF
--- a/packages/chakra-ui/src/useNumberInput/utils.js
+++ b/packages/chakra-ui/src/useNumberInput/utils.js
@@ -3,7 +3,8 @@ import prettyNum, { PRECISION_SETTING } from "pretty-num";
 export function isNumberKey(event) {
   const charCode = event.which ? event.which : event.keyCode;
   if (event.key === ".") return true;
-  if (charCode > 31 && (charCode < 48 || charCode > 57)) return false;
+  if (charCode > 31 && (charCode < 48 || charCode > 57) &&
+    (charCode < 96 || charCode > 105) && charCode !== 110) return false;
   return true;
 }
 


### PR DESCRIPTION
I added char codes range for numeric keypads 96-105 and extra code 110 for decimal point character.