### PR TITLE
[Icon] Add missing `focusable` prop to types

### DIFF
--- a/packages/chakra-ui/src/Icon/index.d.ts
+++ b/packages/chakra-ui/src/Icon/index.d.ts
@@ -20,6 +20,10 @@ interface IIcon {
    * The role of the icon. `presentation` or `img`
    */
   role?: "presentation" | "img";
+  /**
+   * Denotes whether the icon is an interactive element or only used for presentation.
+   */
+  focusable?: boolean;
 }
 
 export type IconProps = IIcon & Omit<BoxProps, "size">;


### PR DESCRIPTION
I discovered that the `focusable` prop is not set in the types file and made this small change to fix the issue. Please let me know if there's anything else to be done here. Thanks for the awesome library!