### PR TITLE
[docs] fix toast component `title` prop type

### DIFF
--- a/packages/chakra-ui-docs/pages/toast.mdx
+++ b/packages/chakra-ui-docs/pages/toast.mdx
@@ -163,7 +163,7 @@ function PositionExample() {
 
 | Name          | Type                                                                    | Default  | Description                                                          |
 | ------------- | ----------------------------------------------------------------------- | -------- | -------------------------------------------------------------------- |
-| `title`       | `boolean`                                                               |          | The title of the toast.                                              |
+| `title`       | `string`                                                                |          | The title of the toast.                                              |
 | `isClosable`  | `boolean`                                                               | `false`  | If `true` adds a close button to the toast.                          |
 | `onClose`     | `function`                                                              |          | Callback function to close the toast.                                |
 | `description` | `string`                                                                |          | The description of the toast.                                        |


### PR DESCRIPTION
Fixes a simple bug in the documentation for the props of the toast component.

Addresses issue: https://github.com/chakra-ui/chakra-ui/issues/288.