### PR TITLE
chore(docs): fix lineHeight object keys

### DIFF
--- a/packages/chakra-ui-docs/pages/theme.mdx
+++ b/packages/chakra-ui-docs/pages/theme.mdx
@@ -149,7 +149,7 @@ export default {
   },
   lineHeights: {
     normal: "normal",
-    base: "1",
+    none: "1",
     shorter: "1.25",
     short: "1.375",
     base: "1.5",


### PR DESCRIPTION
`lineHeight` object should display the `none` key for the `1` value to reflect the typography theme object.