### PR TITLE
[WIP] Stack - add 'key' prop to wrapped children when 'shouldWrapChildren' is set to true

### DIFF
--- a/packages/chakra-ui/src/Stack/index.js
+++ b/packages/chakra-ui/src/Stack/index.js
@@ -49,7 +49,11 @@ const Stack = ({
 
         if (shouldWrapChildren) {
           return (
-            <Box d="inline-block" {...spacingProps}>
+            <Box
+              d="inline-block"
+              {...spacingProps}
+              key={`stack-box-wrapper-${index}`}
+            >
               {child}
             </Box>
           );


### PR DESCRIPTION
Hello.

I'm opening this PR because whenever I'm using Stack with 'shouldWrapChildren' prop set to true I keep getting following console warning:

```
react.development.js:167 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `Stack`. See https://fb.me/react-warning-keys for more information.
    in Box (created by Stack)
    in Stack (created by GenerateForm)
    in form (created by GenerateForm)
    in div (created by Context.Consumer)
    in Box (created by Flex)
    in Flex (created by GenerateForm)
    in GenerateForm
    in Route
    in Switch
    in div (created by Context.Consumer)
    in Box (created by Flex)
    in Flex
    in Router (created by HashRouter)
    in HashRouter
    in Unknown
    in ThemeProvider (created by ThemeProvider)
    in ThemeProvider
    in div
```

However, I was not able to test my solution because I was not able to install my forked repo using yarn or npm. 

I'm opening this PR as kind of issue with provided solution and I hope somebody can help me test it or provide better solution :D Thanks!