### PR TITLE
fix(modal): multiple modal overlay styles

### DIFF
--- a/packages/chakra-ui-docs/pages/theme.mdx
+++ b/packages/chakra-ui-docs/pages/theme.mdx
@@ -290,12 +290,11 @@ export default {
     dropdown: 1000,
     sticky: 1100,
     banner: 1200,
-    overlay: 1300,
-    modal: 1400,
-    popover: 1500,
-    skipLink: 1600,
-    toast: 1700,
-    tooltip: 1800,
+    modal: 1300,
+    popover: 1400,
+    skipLink: 1500,
+    toast: 1600,
+    tooltip: 1700,
   },
 };
 ```

--- a/packages/chakra-ui/src/Modal/index.js
+++ b/packages/chakra-ui/src/Modal/index.js
@@ -208,7 +208,7 @@ const ModalOverlay = React.forwardRef((props, ref) => {
       w="100vw"
       h="100vh"
       ref={ref}
-      zIndex="overlay"
+      zIndex="modal"
       onClick={wrapEvent(props.onClick, event => {
         event.stopPropagation();
       })}

--- a/packages/chakra-ui/src/theme/theme.js
+++ b/packages/chakra-ui/src/theme/theme.js
@@ -32,12 +32,11 @@ const zIndices = {
   dropdown: 1000,
   sticky: 1100,
   banner: 1200,
-  overlay: 1300,
-  modal: 1400,
-  popover: 1500,
-  skipLink: 1600,
-  toast: 1700,
-  tooltip: 1800,
+  modal: 1300,
+  popover: 1400,
+  skipLink: 1500,
+  toast: 1600,
+  tooltip: 1700,
 };
 
 const radii = {


### PR DESCRIPTION
Using the same z-index for the modal content and modal overlay to fix the styles of overlapping modals. I remove the z-index for the `overlay` and used the `modal` z-index for the overlay. This might warrent a minor version bump since we're removing a property of the `zIndices` theme object.

### Before
![2020-01-02 14 19 54](https://user-images.githubusercontent.com/16786990/71687094-006b3d00-2d6b-11ea-9ee2-02badaa0dbe5.gif)

### After
![2020-01-02 14 17 22](https://user-images.githubusercontent.com/16786990/71687116-0c56ff00-2d6b-11ea-9c3e-672b03f844b2.gif)

Related issue: #322 