### PR TITLE
Fix incorrect title in number input docs

### DIFF
--- a/packages/chakra-ui-docs/pages/numberinput.mdx
+++ b/packages/chakra-ui-docs/pages/numberinput.mdx
@@ -54,7 +54,7 @@ styling of each part.
 </NumberInput>
 ```
 
-### Setting a minimum and minimum value
+### Setting a minimum and maximum value
 
 Simply pass the `min` prop or `max` prop to set an upper and lower limit for the
 input. By default, the input will restrict the value to stay within the


### PR DESCRIPTION
This fixes the title for the documentation regarding setting the `min` and `max` props of the `NumberInput` component.