### PR TITLE
chore: add kripod to '.all-contributorsrc'

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -58,6 +58,18 @@
       ]
     },
     {
+      "login": "kripod",
+      "name": "Kristóf Poduszló",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/14854048?v=4",
+      "profile": "https://github.com/kripod",
+      "contributions": [
+        "code",
+        "ideas",
+        "bug",
+        "doc"
+      ]
+    },
+    {
       "login": "wKovacs64",
       "name": "Justin Hall",
       "avatar_url": "https://avatars1.githubusercontent.com/u/1288694?v=4",


### PR DESCRIPTION
As suggested by @segunadebayo, I've added myself as a contributor, respecting the chronological order of contributions.