### PR TITLE
feat(numberinput): store value as `number | null`

### DIFF
--- a/packages/NumberInput/package.json
+++ b/packages/NumberInput/package.json
@@ -47,7 +47,9 @@
     "tslib": "1.10.0",
     "typescript": "3.7.4"
   },
-  "dependencies": {},
+  "dependencies": {
+    "react-typed-inputs": "^1.0.1"
+  },
   "peerDependencies": {
     "@emotion/core": "10.x",
     "@emotion/styled": "10.x",

--- a/packages/NumberInput/src/NumberInput.hook.tsx
+++ b/packages/NumberInput/src/NumberInput.hook.tsx
@@ -106,8 +106,8 @@ export function useNumberInput(options: NumberInputOptions = {}) {
     counter.update(nextValue);
   };
 
-  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    counter.update(event.target.value);
+  const onValueChange = (value: number | null) => {
+    counter.update(value);
   };
 
   const onKeyDown = (event: React.KeyboardEvent) => {
@@ -152,23 +152,13 @@ export function useNumberInput(options: NumberInputOptions = {}) {
     return ratio;
   };
 
-  const validateAndClamp = () => {
-    if (counter.value > max) counter.update(max);
-    if (counter.value < min) counter.update(min);
-  };
-
   const ariaValueText =
     typeof props.getAriaValueText === "function"
       ? props.getAriaValueText(counter.value)
       : undefined;
 
   const onFocus = () => setIsFocused(true);
-  const onBlur = () => {
-    setIsFocused(false);
-    if (props.clampValueOnBlur) {
-      validateAndClamp();
-    }
-  };
+  const onBlur = () => setIsFocused(false);
 
   return {
     value: counter.value,
@@ -203,7 +193,7 @@ export function useNumberInput(options: NumberInputOptions = {}) {
       }),
     },
     input: {
-      onChange,
+      onValueChange,
       onKeyDown,
       ref: inputRef,
       value: counter.value,
@@ -217,6 +207,7 @@ export function useNumberInput(options: NumberInputOptions = {}) {
       "aria-valuetext": ariaValueText,
       readOnly: props.isReadOnly,
       disabled: props.isDisabled,
+      clampValueOnBlur: props.clampValueOnBlur,
       autoComplete: "off",
       autoCorrect: "off",
       onFocus,

--- a/packages/NumberInput/src/NumberInput.tsx
+++ b/packages/NumberInput/src/NumberInput.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { NumberInput as TypedNumberInput } from "react-typed-inputs";
 import { useNumberInput, NumberInputOptions } from "./NumberInput.hook";
 import { chakra, forwardRef, PropsOf } from "@chakra-ui/system";
 import { createContext, composeEventHandlers } from "@chakra-ui/utils";
@@ -125,10 +126,11 @@ const NumberInputField = forwardRef(
         ref: _ref,
         onBlur: _onBlur,
         onFocus: _onFocus,
-        onChange: _onChange,
+        onValueChange: _onValueChange,
         onKeyDown: _onKeyDown,
         disabled: isDisabled,
         readOnly: isReadOnly,
+        clampValueOnBlur: clampOnBlur,
         ...otherInputProps
       },
     } = useNumberInputCtx();
@@ -137,13 +139,15 @@ const NumberInputField = forwardRef(
     const handleBlur = composeEventHandlers(onBlur, _onBlur);
     const handleFocus = composeEventHandlers(onFocus, _onFocus);
     const handleKeyDown = composeEventHandlers(onKeyDown, _onKeyDown);
-    const handleChange = composeEventHandlers(onChange, _onChange);
+    const handleChange = composeEventHandlers(onChange, _onValueChange);
 
     return (
       <Input
+        as={TypedNumberInput}
         ref={inputRef}
         isReadOnly={isReadOnly}
         isDisabled={isDisabled}
+        clampOnBlur={clampOnBlur}
         onBlur={handleBlur}
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}

--- a/packages/NumberInput/src/NumberInput.tsx
+++ b/packages/NumberInput/src/NumberInput.tsx
@@ -145,6 +145,7 @@ const NumberInputField = forwardRef(
       <Input
         as={TypedNumberInput}
         ref={inputRef}
+        type="text"
         isReadOnly={isReadOnly}
         isDisabled={isDisabled}
         clampOnBlur={clampOnBlur}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12039,6 +12039,11 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
+react-typed-inputs@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-typed-inputs/-/react-typed-inputs-1.0.1.tgz#f3c7722a177e7e431e1481b63cb3d67be484a899"
+  integrity sha512-6qJyRh4UIz0PVnp/5r4xopmF/O0C8qJe847RRR9VqK0HIol5xOCThKISkWzSuW2nu6B4UrnXIPFJw4BdXA6Qiw==
+
 react-uid@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.2.0.tgz#0f77e1e0594fbf29fc4fe528cc9aa415c5bf9159"


### PR DESCRIPTION
BREAKING CHANGE: NumberInput now uses null to denote an empty value. In-between states (e.g. "3.")
are no longer interpreted as a value change, thankfully to [react-typed-inputs](https://github.com/kripod/react-typed-inputs).