### PR TITLE
[Image] useHasImageLoaded tries to load image even if no src is provided

### DIFF
--- a/packages/chakra-ui/src/Image/index.js
+++ b/packages/chakra-ui/src/Image/index.js
@@ -8,6 +8,9 @@ export const useHasImageLoaded = ({ src, onLoad, onError }) => {
   const [hasLoaded, setHasLoaded] = useState(false);
 
   useEffect(() => {
+    if (!src) {
+      return;
+    }
     const image = new window.Image();
     image.src = src;
 


### PR DESCRIPTION
The `Avatar` component makes use of `useHasImageLoaded` which tries to load the image even if src is undefined.
