### PR TITLE
fix(Toast): wrap notify in useCallback

### DIFF
--- a/packages/chakra-ui/src/Toast/index.js
+++ b/packages/chakra-ui/src/Toast/index.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import toaster from "toasted-notes";
+import { useCallback } from "react";
 import { Alert, AlertIcon, AlertTitle, AlertDescription } from "../Alert";
 import ThemeProvider, { useTheme } from "../ThemeProvider";
 import Box from "../Box";
@@ -50,49 +51,54 @@ const Toast = ({
 function useToast() {
   const theme = useTheme();
 
-  function notify({
-    position = "bottom",
-    duration = 5000,
-    render,
-    title,
-    description,
-    status,
-    variant = "solid",
-    isClosable,
-  }) {
-    const options = {
-      position,
-      duration,
-    };
+  const notify = useCallback(
+    ({
+      position = "bottom",
+      duration = 5000,
+      render,
+      title,
+      description,
+      status,
+      variant = "solid",
+      isClosable,
+    }) => {
+      const options = {
+        position,
+        duration,
+      };
 
-    if (render) {
-      return toaster.notify(
+      if (render) {
+        return toaster.notify(
+          ({ onClose, id }) => (
+            <ThemeProvider theme={theme}>
+              {render({ onClose, id })}
+            </ThemeProvider>
+          ),
+          options,
+        );
+      }
+
+      toaster.notify(
         ({ onClose, id }) => (
-          <ThemeProvider theme={theme}>{render({ onClose, id })}</ThemeProvider>
+          <ThemeProvider theme={theme}>
+            <Toast
+              {...{
+                onClose,
+                id,
+                title,
+                description,
+                status,
+                variant,
+                isClosable,
+              }}
+            />
+          </ThemeProvider>
         ),
         options,
       );
-    }
-
-    toaster.notify(
-      ({ onClose, id }) => (
-        <ThemeProvider theme={theme}>
-          <Toast
-            {...{
-              onClose,
-              id,
-              title,
-              description,
-              status,
-              variant,
-              isClosable,
-            }}
-          />
-        </ThemeProvider>
-      ),
-      options,
-    );
-  }
+    },
+    [theme],
+  );
 
   return notify;
 }


### PR DESCRIPTION
When using the toast method from `useToast` in a `useEffect` hook I noticed that whenever the component re-renders a new toast method gets returned which means that another toast component gets added. This PR wraps the `notify` function inside the `useToast` hook in `useCallback` to make sure that the function is the same between renders.

Example code to replicate issue:

```js
import React, { useState, useEffect } from "react";
import { useToast, Button } from "@chakra-ui/core";

function TestComponent() {
  const toast = useToast();
  const [count, setCount] = useState(0);

  useEffect(() => {
    toast({
      position: "bottom",
      title: "Hello world",
      duration: null,
    });
  }, [toast]);

  return (
    <Button onClick={() => setCount(count => count + 1)}>{count}</Button>
  );
}
```