### PR TITLE
Typings: Support custom icons

### DIFF
--- a/packages/chakra-ui/src/Icon/index.d.ts
+++ b/packages/chakra-ui/src/Icon/index.d.ts
@@ -11,7 +11,7 @@ interface IIcon {
   /**
    * The name of the icon.
    */
-  name?: Icons;
+  name?: Icons | string;
   /**
    * The color of the icon.
    */


### PR DESCRIPTION
Hi, first, thank you for the project!


Related: https://github.com/chakra-ui/chakra-ui/issues/204

This means using custom icons will cause an error:

https://chakra-ui.com/icon#adding-custom-icons

For me:

```
ERROR in /hsk/_ux/js/Layout.tsx(109,30):
TS2322: Type '"faHome"' is not assignable to type 'Icons'.
```

This this case, make the check on `icons` more lenient, allow any string in `name` of `<Icon>`