### PR TITLE
fix(pseudobox): responsive props

### DIFF
--- a/packages/chakra-ui/src/Box/config.js
+++ b/packages/chakra-ui/src/Box/config.js
@@ -170,7 +170,7 @@ const transformAlias = (prop, propValue) => {
 export const transformAliasProps = props => {
   let result = {};
   for (let prop in props) {
-    if (typeof props[prop] === "object") {
+    if (typeof props[prop] === "object" && !Array.isArray(props[prop])) {
       result = { ...result, [prop]: transformAliasProps(props[prop]) };
     } else {
       result = { ...result, ...transformAlias(prop, props[prop]) };


### PR DESCRIPTION
While using `PseudoBox`, the following code had no stylistic effect:

```jsx
<PseudoBox
  _odd={{
    flexDirection: ["column", "row"],
    // `flexDirection: "column"` would work fine, though
  }}
>
  ...
</PseudoBox>
```

It turns out that `{ transformAliasProps } from "chakra-ui/src/Box/config"` transforms responsive arrays into objects by mistake, which could not be [interpreted by `css from "@styled-system/css"`](https://github.com/chakra-ui/chakra-ui/blob/37a19d8da7a628152fd1b4e44a33a96fb7beb527/packages/chakra-ui/src/PseudoBox/index.js#L74). This PR solves the issue by leaving arrays passed to `transformAliasProps` intact.