### PR TITLE
[TypeScript] Incorrect merging of Editable's event handler types

### DIFF
--- a/packages/chakra-ui/src/Editable/index.d.ts
+++ b/packages/chakra-ui/src/Editable/index.d.ts
@@ -61,7 +61,7 @@ interface IEditable {
   children: React.ReactNode;
 }
 
-export type EditableProps = IEditable & Omit<BoxProps, "onChange">;
+export type EditableProps = IEditable & Omit<BoxProps, "onChange" | "onSubmit">;
 
 export const EditablePreview: React.FC<PseudoBoxProps>;
 


### PR DESCRIPTION
It's relevant to #173, `onSubmit` also needs to be omitted .
I don't know whether any other components need to have same fix or not, but for my project i need this fix.