### PR TITLE
Fix iOS Safari input style

### DIFF
--- a/packages/chakra-ui/src/Input/styles.js
+++ b/packages/chakra-ui/src/Input/styles.js
@@ -160,6 +160,7 @@ const baseProps = {
   position: "relative",
   transition: "all 0.2s",
   outline: "none",
+  appearance: "none",
 };
 
 export const inputSizes = {


### PR DESCRIPTION
iOS Safari adds a shadow unless you specify `appearance: none`.

See https://stackoverflow.com/questions/23211656/remove-ios-input-shadow