### PR TITLE
"exenv" import breaks in Node v13, Snowpack

### DIFF
--- a/packages/chakra-ui/src/Modal/index.js
+++ b/packages/chakra-ui/src/Modal/index.js
@@ -15,10 +15,11 @@ import CloseButton from "../CloseButton";
 import { hideOthers } from "aria-hidden";
 import { useId } from "@reach/auto-id";
 import { useColorMode } from "../ColorModeProvider";
-import { canUseDOM } from "exenv";
+import exenv from "exenv";
 
 ////////////////////////////////////////////////////////////////////////
 
+const { canUseDOM } = exenv;
 const ModalContext = createContext({});
 const useModalContext = () => useContext(ModalContext);
 


### PR DESCRIPTION
Hey all, just a small update to catch an issue that a user encountered when trying to use this package with Snowpack: https://www.pika.dev/npm/snowpack/discuss/76

Node has finalized their ESM support plan in v13, and it includes support for ESM->CJS  imports but only via the default export. As a result, this import breaks under that resolution scheme since `exenv` only has a default export and no named imports. Both Snowpack and Rollup follow Node's ESM import conventions, which causes this package to break without this small fix.

See the end of this section for relevant docs: https://nodejs.org/api/esm.html#esm_import_statements

```
import packageMain from 'commonjs-package'; // Works
import { method } from 'commonjs-package'; // Errors
```