### PR TITLE
docs: Update formcontrol.mdx for formik example

### DIFF
--- a/packages/chakra-ui-docs/pages/formcontrol.mdx
+++ b/packages/chakra-ui-docs/pages/formcontrol.mdx
@@ -100,19 +100,18 @@ function FormikExample() {
           actions.setSubmitting(false);
         }, 1000);
       }}
-      render={props => (
+    >
+      {props => (
         <form onSubmit={props.handleSubmit}>
-          <Field
-            name="name"
-            validate={validateName}
-            render={({ field, form }) => (
+          <Field name="name" validate={validateName}>
+            {({ field, form }) => (
               <FormControl isInvalid={form.errors.name && form.touched.name}>
                 <FormLabel htmlFor="name">First name</FormLabel>
                 <Input {...field} id="name" placeholder="name" />
                 <FormErrorMessage>{form.errors.name}</FormErrorMessage>
               </FormControl>
             )}
-          />
+          </Field>
           <Button
             mt={4}
             variantColor="teal"
@@ -123,7 +122,7 @@ function FormikExample() {
           </Button>
         </form>
       )}
-    />
+    </Formik>
   );
 }
 ```


### PR DESCRIPTION
This PR updates the formik example for formcontrol to use a child-callback function instead of using a render prop. 
https://jaredpalmer.com/formik/docs/migrating-v2#deprecation-warnings