### PR TITLE
fix(popover): fix popover flickering when trigger is "hover"

### DIFF
--- a/packages/chakra-ui/src/Popover/index.js
+++ b/packages/chakra-ui/src/Popover/index.js
@@ -59,6 +59,8 @@ const PopoverTrigger = ({ children }) => {
     };
   }
 
+  const openTimeout = useRef(null);
+
   if (trigger === "hover") {
     eventHandlers = {
       onFocus: wrapEvent(child.props.onFocus, onOpen),
@@ -70,10 +72,14 @@ const PopoverTrigger = ({ children }) => {
       onBlur: wrapEvent(child.props.onBlur, onClose),
       onMouseEnter: wrapEvent(child.props.onMouseEnter, () => {
         isHoveringRef.current = true;
-        setTimeout(onOpen, 300);
+        openTimeout.current = setTimeout(onOpen, 300);
       }),
       onMouseLeave: wrapEvent(child.props.onMouseLeave, () => {
         isHoveringRef.current = false;
+        if (openTimeout.current) {
+          clearTimeout(openTimeout.current);
+          openTimeout.current = null;
+        }
         setTimeout(() => {
           if (isHoveringRef.current === false) {
             onClose();


### PR DESCRIPTION
Cancels the popover open timeout if a leave event happens before it is completed.
This prevents the flickering that occurs when you move the mouse quickly past an element with a "hover" popover.