### PR TITLE
fix: Gatsby plugin path to theme file

### DIFF
--- a/packages/gatsby-plugin-chakra-ui/gatsby-browser.js
+++ b/packages/gatsby-plugin-chakra-ui/gatsby-browser.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { ThemeProvider, ColorModeProvider, CSSReset } from "@chakra-ui/core";
-import theme from "./theme";
+import theme from "./src/theme";
 
 export const wrapRootElement = (
   { element },

--- a/packages/gatsby-plugin-chakra-ui/theme.js
+++ b/packages/gatsby-plugin-chakra-ui/theme.js
@@ -1,7 +1,0 @@
-exports.__esModule = true;
-exports["default"] = void 0;
-
-var _core = require("@chakra-ui/core");
-
-var _default = _core.theme;
-exports["default"] = _default;


### PR DESCRIPTION
This branch fixes an error made in #362 where although I moved the `gatsby-*.js` files to the root of the package, I forgot to update the path to `src/theme.js`, and kept the old `theme.js` file hanging out in the root of the package directory.

This change makes the plugin's directory structure _truly_ match the structure of [the temporary package](https://github.com/trevorblades/gatsby-plugin-chakra-ui) that I had used to test the previous change.