### PR TITLE
fix: alignment of live code box

### DIFF
--- a/packages/chakra-ui-docs/components/CodeBlock.js
+++ b/packages/chakra-ui-docs/components/CodeBlock.js
@@ -20,6 +20,7 @@ export const liveEditorStyle = {
   overflowX: "auto",
   fontFamily: "Menlo,monospace",
   borderRadius: 10,
+  paddingTop: 10,
 };
 
 // const highlightStyle = {


### PR DESCRIPTION
It is hard to read the demo code because of the first line of code is overlapped.

Eg https://chakra-ui.com/grid
<img width="922" alt="Screen Shot 2020-02-28 at 7 20 26 AM" src="https://user-images.githubusercontent.com/3622010/75498857-eceef200-59fa-11ea-8933-7afb5cc05d65.png">


After this update:

<img width="918" alt="Screen Shot 2020-02-28 at 7 20 15 AM" src="https://user-images.githubusercontent.com/3622010/75498870-f37d6980-59fa-11ea-9797-1e4be69caa11.png">

