### PR TITLE
docs(input): pointer to making <Input> accessible

### DIFF
--- a/packages/chakra-ui-docs/pages/input.mdx
+++ b/packages/chakra-ui-docs/pages/input.mdx
@@ -8,6 +8,8 @@ import SEO from "../components/SEO";
 # Input
 
 Input component is a component that is used to get user input in a text field.
+It is usually used together with a [FormControl](/formcontrol) to provide an
+accessible label, validation messages, etc.
 
 ## Import
 
@@ -129,7 +131,6 @@ function Example() {
 
   return (
     <>
-      <Text mb="8px">Value: {value}</Text>
       <Input
         value={value}
         onChange={handleChange}


### PR DESCRIPTION
This includes a pointer in the docs that <Input>s can be wrapped
in <FormControl>s and combined with a <FormLabel>s.

It also removes the <Text> element from one example - it is not
relevant to the example, and fulfils the role of a <FormLabel>,
hence nudging developers to inaccessible code.