### PR TITLE
fix: By default, proportional spacing are factors of 4

### DIFF
--- a/packages/chakra-ui-docs/pages/style-props.mdx
+++ b/packages/chakra-ui-docs/pages/style-props.mdx
@@ -24,7 +24,7 @@ import { Box } from "@chakra-ui/core";
 // You can also use custom values
 <Box maxW="960px" mx="auto" />;
 
-// sets margin `8px` on all viewports and `16px` from the first breakpoint and up
+// sets margin `8px` on all viewports and `12px` from the first breakpoint and up
 <Box m={[2, 3]} />;
 ```
 


### PR DESCRIPTION
If I understand correctly, I _think_ this was just a typo