### PR TITLE
build: Skeleton component improvements

### DIFF
--- a/packages/chakra-ui/src/Skeleton/examples.js
+++ b/packages/chakra-ui/src/Skeleton/examples.js
@@ -37,8 +37,43 @@ stories.add("isLoaded after 1 second", () => {
   );
 });
 
+stories.add("no fade in", () => {
+  const [isLoaded, setLoaded] = React.useState(false);
+  React.useEffect(() => {
+    setTimeout(() => setLoaded(true), 1000);
+  }, []);
+
+  return (
+    <Skeleton fadeInDuration={0} width="100px" isLoaded={isLoaded}>
+      <span>Chakra ui is cool</span>
+    </Skeleton>
+  );
+});
+
 stories.add("with borderRadius", () => {
   return <Skeleton size="100px" borderRadius="100px" />;
+});
+
+stories.add("isLoaded loop", () => {
+  const [isLoaded, setLoaded] = React.useState(false);
+  React.useEffect(() => {
+    const intervalId = setInterval(() => setLoaded(x => !x), 1000);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <Box position="relative">
+      <Box height="100px" border="solid 1px black">
+        Content
+      </Box>
+      <Skeleton width="100px" isLoaded={isLoaded}>
+        <span>Chakra ui is cool</span>
+      </Skeleton>
+      <Box height="100px" border="solid 1px black">
+        Content
+      </Box>
+    </Box>
+  );
 });
 
 stories.add("with custom speed", () => {

--- a/packages/chakra-ui/src/Skeleton/examples.js
+++ b/packages/chakra-ui/src/Skeleton/examples.js
@@ -3,6 +3,7 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 import Box from "../Box";
 import Skeleton from ".";
+import { Text, ColorModeProvider, CSSReset, Stack } from "../";
 
 const stories = storiesOf("Skeleton", module);
 stories.addDecorator(withKnobs);
@@ -78,4 +79,18 @@ stories.add("isLoaded loop", () => {
 
 stories.add("with custom speed", () => {
   return <Skeleton size="100px" speed={2.4} borderRadius="100px" />;
+});
+
+stories.add("with dark mode", () => {
+  return (
+    <ColorModeProvider value="dark">
+      <CSSReset />
+      <Stack>
+        <Text>Some text</Text>
+        <Skeleton size="100px" />
+        <Skeleton size="100px" />
+        <Skeleton size="100px" />
+      </Stack>
+    </ColorModeProvider>
+  );
 });

--- a/packages/chakra-ui/src/Skeleton/index.d.ts
+++ b/packages/chakra-ui/src/Skeleton/index.d.ts
@@ -18,6 +18,10 @@ export interface ISkeleton {
    * The animation speed in seconds
    */
   speed?: number;
+  /**
+   * The fadeIn duration in seconds
+   */
+  fadeInDuration?: number;
 }
 
 export type SkeletonProps = ISkeleton & BoxProps;

--- a/packages/chakra-ui/src/Skeleton/index.js
+++ b/packages/chakra-ui/src/Skeleton/index.js
@@ -20,7 +20,7 @@ to {
 const getStyle = ({ colorStart, colorEnd, speed }) => css`
   border-color: ${colorStart} !important;
   box-shadow: none !important;
-
+  opacity: 0.7;
   // do not !important this for Firefox support
   background: ${colorStart};
 
@@ -56,13 +56,13 @@ const Skeleton = props => {
   const { colors } = useTheme();
   const { colorMode } = useColorMode();
   const defaultStart = { light: colors.gray[100], dark: colors.gray[800] };
-  const defaultEnd = { light: colors.gray[400], dark: colors.gray[500] };
+  const defaultEnd = { light: colors.gray[400], dark: colors.gray[600] };
   const {
     colorStart = defaultStart[colorMode],
     colorEnd = defaultEnd[colorMode],
     isLoaded = false,
-    fadeInDuration = 0.2,
-    speed = 1,
+    fadeInDuration = 0.3,
+    speed = 0.8,
     ...rest
   } = props;
   if (isLoaded) {

--- a/packages/chakra-ui/src/Skeleton/index.js
+++ b/packages/chakra-ui/src/Skeleton/index.js
@@ -56,7 +56,7 @@ const Skeleton = props => {
     ...rest
   } = props;
   if (isLoaded) {
-    return <Fragment children={props.children} />;
+    return <Box {...rest} />;
   }
 
   return (

--- a/packages/chakra-ui/src/Skeleton/index.js
+++ b/packages/chakra-ui/src/Skeleton/index.js
@@ -43,6 +43,15 @@ const getStyle = ({ colorStart, colorEnd, speed }) => css`
   }
 `;
 
+const fadeIn = keyframes`
+from { opacity: 0; }
+to   { opacity: 1; }
+`;
+
+const fadeInCss = duration => css`
+  animation: ${fadeIn} ${duration}s;
+`;
+
 const Skeleton = props => {
   const { colors } = useTheme();
   const { colorMode } = useColorMode();
@@ -52,11 +61,12 @@ const Skeleton = props => {
     colorStart = defaultStart[colorMode],
     colorEnd = defaultEnd[colorMode],
     isLoaded = false,
+    fadeInDuration = 0.2,
     speed = 1,
     ...rest
   } = props;
   if (isLoaded) {
-    return <Box {...rest} />;
+    return <Box css={fadeInCss(fadeInDuration)} {...rest} />;
   }
 
   return (

--- a/packages/chakra-ui/src/Skeleton/index.js
+++ b/packages/chakra-ui/src/Skeleton/index.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Fragment } from "react";
+import { Fragment, useMemo } from "react";
 import { useTheme } from "../ThemeProvider";
 import { useColorMode } from "../ColorModeProvider";
 import { css, jsx, keyframes } from "@emotion/core";
@@ -61,21 +61,21 @@ const Skeleton = props => {
     colorStart = defaultStart[colorMode],
     colorEnd = defaultEnd[colorMode],
     isLoaded = false,
-    fadeInDuration = 0.3,
+    fadeInDuration = 0.4,
     speed = 0.8,
     ...rest
   } = props;
-  if (isLoaded) {
-    return <Box css={fadeInCss(fadeInDuration)} {...rest} />;
-  }
-
-  return (
-    <Box
-      css={getStyle({ colorStart, colorEnd, speed })}
-      borderRadius="2px"
-      {...rest}
-    />
+  const fadeInStyle = useMemo(() => fadeInCss(fadeInDuration), [
+    fadeInDuration,
+  ]);
+  const skeletonStyle = useMemo(
+    () => getStyle({ colorStart, colorEnd, speed }),
+    [colorStart, colorEnd, speed],
   );
+  if (isLoaded) {
+    return <Box css={fadeInStyle} {...rest} />;
+  }
+  return <Box css={skeletonStyle} borderRadius="2px" {...rest} />;
 };
 
 export default Skeleton;


### PR DESCRIPTION
This pull request adds:
- skeleton renders Box instead of Fragment if `isLoaded` is true
- fadeIn animation of children after `isLoaded` is true
- styles are cached with  `useMemo`

Working on my project using the `Skeleton` component I notices that using `Fragment` when the prop `isLoaded` is true removes all the other styling properties applied to `Skeleton`, like margins and spacing and i cannot use `Stack` component

I also added a customizable fadeIn animation that makes everything nicer

This is a small change but improves the usage a lot.