### PR TITLE
fix: document of Input and Select about sizes

### DIFF
--- a/packages/chakra-ui-docs/pages/input.mdx
+++ b/packages/chakra-ui-docs/pages/input.mdx
@@ -27,8 +27,8 @@ Here's a basic usage of the Input component.
 
 ### Changing the size of the Input
 
-There are three sizes of an Input : large (40px), default (32px) and small
-(24px).
+There are three sizes of an Input : large (48px), default (40px) and small
+(32px).
 
 ```jsx
 <Stack spacing={3}>

--- a/packages/chakra-ui-docs/pages/select.mdx
+++ b/packages/chakra-ui-docs/pages/select.mdx
@@ -31,7 +31,7 @@ Here's a basic usage of the Select component.
 
 ### Changing the size of the Select
 
-There are three sizes of select : large (40px), default (32px) and small (24px).
+There are three sizes of select : large (48px), default (40px) and small (32px).
 
 ```jsx
 <Stack spacing={3}>


### PR DESCRIPTION
According to the code [here](https://github.com/chakra-ui/chakra-ui/blob/master/packages/chakra-ui/src/Input/styles.js#L170-L182), the actual heights of `size` of `Input` and `Select`, are different from those in document. 

This PR fixes the document to reflect the actual height.
