### PR TITLE
fix: update toast status documentation

### DIFF
--- a/packages/chakra-ui-docs/pages/toast.mdx
+++ b/packages/chakra-ui-docs/pages/toast.mdx
@@ -167,7 +167,7 @@ function PositionExample() {
 | `isClosable`  | `boolean`                                                               | `false`  | If `true` adds a close button to the toast.                          |
 | `onClose`     | `function`                                                              |          | Callback function to close the toast.                                |
 | `description` | `string`                                                                |          | The description of the toast.                                        |
-| `status`      | `success`, `danger`, `warning`, `info`                                  |          | The status of the toast.                                             |
+| `status`      | `success`, `error`, `warning`, `info`                                  |          | The status of the toast.                                             |
 | `duration`    | `number`                                                                | `5000ms` | Duration before dismiss in milliseconds, or `null` to never dismiss. |
 | `position`    | `top`, `top-left`, `top-right`, `bottom`, `bottom-left`, `bottom-right` | `bottom` | Position the toast will popup out from.                              |
 | `render`      | `(props: {onClose:() => void, id: string}) => React.ReactNode`          |          | The description of the toast.                                        |


### PR DESCRIPTION
I believe this should be 'error' instead of 'danger'