### PR TITLE
chore(storybook): expand stories path

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,7 @@ const path = require("path")
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
 
 module.exports = {
-  stories: ["../packages/Alert/src/*.stories.tsx"],
+  stories: ["../packages/**/*.stories.tsx"],
   webpackFinal: async config => {
     config.module.rules.push({
       test: /\.(ts|tsx)$/,


### PR DESCRIPTION
The existing storybook configuration was pathed to
`packages/Alert/src/*.stories.tsx` specifically. This change expands the
path to any stories in `packages/` (`packages/**/*.stories.tsx`), so
that all stories appear in storybook.