### PR TITLE
[WIP] fix: Allow Portal to initialize with provided container

### DIFF
--- a/packages/chakra-ui/src/Portal/index.js
+++ b/packages/chakra-ui/src/Portal/index.js
@@ -16,7 +16,7 @@ function getContainer(container) {
 
 const Portal = forwardRef(
   ({ children, container, isDisabled = false, onRendered }, ref) => {
-    const [mountNode, setMountNode] = useState(null);
+    const [mountNode, setMountNode] = useState(getContainer(container));
     const handleRef = useForkRef(children.ref, ref);
 
     useEnhancedEffect(() => {


### PR DESCRIPTION
## Summary
* Menu expects `menuRef` to be defined at this point https://github.com/chakra-ui/chakra-ui/blob/master/packages/chakra-ui/src/Menu/index.js#L52. This ref is attached to a `PseudoBox` inside of a `Portal` component. `Portal` returns `null` on initial render since it initializes `mountNode` as `null`, so it attaches no ref until it's `useEnhancedEffect` and `setMountNode` are called, but this are called after the ancestors `useEffect`, so any ancestors relying on that ref being attached would fail.
 I considered changing the `useEnhancedEffect` to `useEffect` but the `setMountNode` re-render was still getting run after the ancestors `useEffect`. By initializing `mountNode` to the provided `container` we can ensure that there is an attached ref by providing a valid DOM node for `container` on the initial render.
*  Since `finDOMNode` will return `null` if the container is not defined this won't cause any extra renders for component who's `container` is dynamic (`Modal`).

## Issue
* https://github.com/chakra-ui/chakra-ui/issues/406