### PR TITLE
fix: erroneous event handler in Image component

### DIFF
--- a/packages/chakra-ui/src/Image/index.js
+++ b/packages/chakra-ui/src/Image/index.js
@@ -21,7 +21,7 @@ export const useHasImageLoaded = ({ src, onLoad, onError }) => {
       }
     };
 
-    image.onError = event => {
+    image.onerror = event => {
       if (isMounted.current) {
         setHasLoaded(false);
         onError && onError(event);


### PR DESCRIPTION
Image component had incorrectly typed `onError` event in camelcase, leading to the native DOM element having a property on it that it didn't recognize. Renaming it to `onerror` did the trick.