### PR TITLE
fix(radio-group): call querySelector from rootNode directly

### DIFF
--- a/packages/radio/src/RadioGroup.hook.tsx
+++ b/packages/radio/src/RadioGroup.hook.tsx
@@ -38,10 +38,11 @@ export function useRadioGroup(props: RadioGroupHookProps = {}) {
     const rootNode = rootRef.current
     if (!rootNode) return
 
-    const { querySelector } = rootNode
     let query = `input:not(:disabled):checked`
 
-    const firstEnabledAndCheckedInput = querySelector(query) as HTMLElement
+    const firstEnabledAndCheckedInput = rootNode.querySelector(
+      query,
+    ) as HTMLElement
 
     if (firstEnabledAndCheckedInput) {
       firstEnabledAndCheckedInput.focus()
@@ -50,7 +51,7 @@ export function useRadioGroup(props: RadioGroupHookProps = {}) {
 
     query = `input:not(:disabled)`
 
-    const firstEnabledInput = querySelector(query) as HTMLElement
+    const firstEnabledInput = rootNode.querySelector(query) as HTMLElement
     firstEnabledInput?.focus()
   }, [])
 


### PR DESCRIPTION
Calling `querySelector` by itself causes a `TypeError: Illegal Invocation` error because it uses `this` and must be bound to `rootNode`. Calling `rootNode.querySelector` fixes this binding issue.