### PR TITLE
fix(select): pass placeholder prop to SelectField

### DIFF
--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -106,7 +106,13 @@ export type SelectProps = Omit<Props, "ref"> &
 
 export const Select = forwardRef(
   (props: SelectProps, ref: React.Ref<HTMLSelectElement>) => {
-    const { rootProps, icon = SelectIcon, iconSize = 5, ...rest } = props
+    const {
+      rootProps,
+      placeholder,
+      icon = SelectIcon,
+      iconSize = 5,
+      ...rest
+    } = props
 
     const color = useColorModeValue("inherit", "whiteAlpha.800")
     const opacity = props.isReadOnly || props.isDisabled ? 0.5 : undefined
@@ -122,6 +128,7 @@ export const Select = forwardRef(
           paddingRight="2rem"
           ref={ref}
           color={color}
+          placeholder={placeholder}
           {...(select as Dict)}
         />
         <SelectIconWrapper opacity={opacity} color={select.color || color}>


### PR DESCRIPTION
This PR fixes an issue where `placeholder` was being incorrectly passed to the root `chakra.div` by destructuring it from `props` and passing it to `SelectField`.