### PR TITLE
fix: make component typings discoverable

### DIFF
--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -4,6 +4,7 @@
   "description": "Responsive and accessible React UI components built with React and Emotion",
   "main": "dist/index.js",
   "module": "dist/es/index.js",
+  "typings": "dist/index",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Adding a "typings" field to the `@chakra-ui/core` package.json makes the component typings automatically discoverable by IDEs.