### PR TITLE
test: use module public exports

### DIFF
--- a/packages/accordion/src/tests/Accordion.test.tsx
+++ b/packages/accordion/src/tests/Accordion.test.tsx
@@ -1,11 +1,6 @@
 import React from "react"
 import { userEvent, render, fireEvent, wait } from "@chakra-ui/test-utils"
-import {
-  Accordion,
-  AccordionButton,
-  AccordionItem,
-  AccordionPanel,
-} from "../Accordion"
+import { Accordion, AccordionButton, AccordionItem, AccordionPanel } from ".."
 
 jest.mock("@chakra-ui/collapse", () => {
   const Collapse = jest.fn(({ children, isOpen }) => (

--- a/packages/avatar/src/tests/Avatar.test.tsx
+++ b/packages/avatar/src/tests/Avatar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { render } from "@chakra-ui/test-utils"
-import { Avatar, AvatarBadge } from "../Avatar"
+import { Avatar, AvatarBadge } from ".."
 
 test("Avatar renders correctly", () => {
   const { asFragment } = render(<Avatar />)

--- a/packages/breadcrumb/src/tests/Breadcrumb.test.tsx
+++ b/packages/breadcrumb/src/tests/Breadcrumb.test.tsx
@@ -5,7 +5,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbSeparator,
-} from "../Breadcrumb"
+} from ".."
 
 test("Breadcrumb renders correctly", () => {
   const { asFragment } = render(

--- a/packages/close-button/src/tests/CloseButton.test.tsx
+++ b/packages/close-button/src/tests/CloseButton.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { render } from "@chakra-ui/test-utils"
-import { CloseButton } from "../CloseButton"
+import { CloseButton } from ".."
 
 test("CloseButton renders correctly", () => {
   const { asFragment } = render(<CloseButton />)

--- a/packages/collapse/src/tests/Collapse.test.tsx
+++ b/packages/collapse/src/tests/Collapse.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { render } from "@chakra-ui/test-utils"
-import { Collapse } from "../Collapse"
+import { Collapse } from ".."
 
 jest.mock("react-transition-group/Transition", () => {
   const FakeTransition = jest.fn(({ children }) => children())

--- a/packages/counter/src/tests/Counter.test.tsx
+++ b/packages/counter/src/tests/Counter.test.tsx
@@ -1,5 +1,5 @@
 import { invoke, renderHook } from "@chakra-ui/test-utils"
-import { useCounter } from "../Counter.hook"
+import { useCounter } from ".."
 
 test("should increment", () => {
   const { result } = renderHook(() => useCounter({ defaultValue: 0 }))

--- a/packages/dialog/src/tests/Dialog.test.tsx
+++ b/packages/dialog/src/tests/Dialog.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { render, userEvent, fireEvent } from "@chakra-ui/test-utils"
+import { PortalManager } from "@chakra-ui/portal"
 import {
   Dialog,
   DialogBody,
@@ -8,8 +9,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogOverlay,
-} from "../Dialog"
-import { PortalManager } from "@chakra-ui/portal"
+} from ".."
 
 test("Dialog renders correctly", () => {
   const { asFragment } = render(

--- a/packages/drawer/src/tests/Drawer.test.tsx
+++ b/packages/drawer/src/tests/Drawer.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { render } from "@chakra-ui/test-utils"
 import { PortalManager } from "@chakra-ui/portal"
-import { Drawer } from "../Drawer"
+import { Drawer } from ".."
 
 test("Drawer renders correctly", () => {
   const { asFragment } = render(

--- a/packages/editable/src/tests/Editable.test.tsx
+++ b/packages/editable/src/tests/Editable.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { render, userEvent, fireEvent } from "@chakra-ui/test-utils"
-import { Editable, EditableInput, EditablePreview } from "../Editable"
+import { Editable, EditableInput, EditablePreview } from ".."
 
 test("should match snapshot", () => {
   const utils = render(

--- a/packages/form-control/src/tests/FormControl.test.tsx
+++ b/packages/form-control/src/tests/FormControl.test.tsx
@@ -10,7 +10,7 @@ import {
   RequiredIndicator,
   useField,
   ControlProps,
-} from "../FormControl"
+} from ".."
 
 type OmittedTypes = "disabled" | "required" | "readOnly"
 type InputProps = Omit<PropsOf<typeof StyledInput>, OmittedTypes> & ControlProps

--- a/packages/icon/src/tests/Icon.test.tsx
+++ b/packages/icon/src/tests/Icon.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { render } from "@chakra-ui/test-utils"
 import { Md3DRotation } from "react-icons/md"
-import { Icon } from "../Icon"
+import { Icon } from ".."
 
 test("Icon renders correctly", () => {
   const { asFragment } = render(<Icon />)

--- a/packages/live-region/src/tests/LiveRegion.test.tsx
+++ b/packages/live-region/src/tests/LiveRegion.test.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { render, wait } from "@chakra-ui/test-utils"
-import { LiveRegion } from ".."
-import { LiveRegionOptions } from "../live-region"
+import { LiveRegion, LiveRegionOptions } from ".."
 
 test("LiveRegion creates a container and has the proper aria and role attributes", () => {
   render(<div />)

--- a/packages/number-input/src/tests/NumberInput.test.tsx
+++ b/packages/number-input/src/tests/NumberInput.test.tsx
@@ -1,6 +1,5 @@
 import { userEvent, render, renderHook, fireEvent } from "@chakra-ui/test-utils"
 import * as React from "react"
-import { useNumberInput } from "../NumberInput.hook"
 import {
   NumberInput,
   NumberInputField,
@@ -8,7 +7,8 @@ import {
   NumberIncrementStepper,
   NumberInputStepper,
   NumberInputProps,
-} from "../NumberInput"
+  useNumberInput,
+} from ".."
 
 function Component(props: NumberInputProps) {
   return (

--- a/packages/popover/src/tests/Popover.test.tsx
+++ b/packages/popover/src/tests/Popover.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, wait } from "@chakra-ui/test-utils"
 import * as React from "react"
+import { fireEvent, render, wait } from "@chakra-ui/test-utils"
 import { usePopover } from ".."
 
 const Component = () => {

--- a/packages/switch/src/tests/Switch.test.tsx
+++ b/packages/switch/src/tests/Switch.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { userEvent, render } from "@chakra-ui/test-utils"
-import { Switch } from "../Switch"
+import { Switch } from ".."
 
 test("Switch renders correctly", () => {
   const utils = render(<Switch />)


### PR DESCRIPTION
This PR converts existing tests to import directly from the module exports rather than individual files within the module. This ensures that we're testing the public exports of each module, and will allow tests to catch unintentionally-removed public exports.