### PR TITLE
fix: use state for menuRef so its available

### DIFF
--- a/packages/chakra-ui/src/Menu/index.js
+++ b/packages/chakra-ui/src/Menu/index.js
@@ -32,6 +32,7 @@ const Menu = ({
   closeOnSelect = true,
   defaultActiveIndex,
   placement,
+  usePortal,
 }) => {
   const { colorMode } = useColorMode();
 
@@ -45,20 +46,20 @@ const Menu = ({
   const buttonId = `menubutton-${useId()}`;
 
   const focusableItems = useRef(null);
-  const menuRef = useRef(null);
   const buttonRef = useRef(null);
+  const [menuRef, setMenuRef] = useState(null);
 
   useEffect(() => {
-    if (_isOpen && menuRef && menuRef.current) {
-      let focusables = getFocusables(menuRef.current).filter(node =>
+    if (_isOpen && menuRef) {
+      let focusables = getFocusables(menuRef).filter(node =>
         ["menuitem", "menuitemradio", "menuitemcheckbox"].includes(
           node.getAttribute("role"),
         ),
       );
-      focusableItems.current = menuRef.current ? focusables : [];
+      focusableItems.current = menuRef ? focusables : [];
       initTabIndex();
     }
-  }, [_isOpen]);
+  }, [_isOpen, menuRef]);
 
   const updateTabIndex = index => {
     if (focusableItems.current.length > 0) {
@@ -87,7 +88,7 @@ const Menu = ({
   const wasPreviouslyOpen = usePrevious(_isOpen);
 
   useEffect(() => {
-    if (activeIndex !== -1) {
+    if (activeIndex !== -1 && focusableItems.current) {
       focusableItems.current[activeIndex] &&
         focusableItems.current[activeIndex].focus();
       updateTabIndex(activeIndex);
@@ -96,7 +97,7 @@ const Menu = ({
       buttonRef.current && buttonRef.current.focus();
     }
     if (activeIndex === -1 && _isOpen) {
-      menuRef.current && menuRef.current.focus();
+      menuRef && menuRef.focus();
     }
   }, [activeIndex, _isOpen, buttonRef, menuRef, wasPreviouslyOpen]);
 
@@ -146,6 +147,8 @@ const Menu = ({
     closeMenu,
     buttonRef,
     menuRef,
+    setMenuRef,
+    usePortal,
     focusableItems,
     placement,
     menuId,
@@ -251,10 +254,12 @@ const MenuList = ({ onKeyDown, onBlur, ...props }) => {
     focusableItems,
     buttonRef,
     menuId,
+    setMenuRef,
     buttonId,
     menuRef,
     closeOnBlur,
     placement,
+    usePortal,
   } = useMenuContext();
 
   const handleKeyDown = event => {
@@ -299,9 +304,9 @@ const MenuList = ({ onKeyDown, onBlur, ...props }) => {
     if (
       closeOnBlur &&
       isOpen &&
-      menuRef.current &&
+      menuRef &&
       buttonRef.current &&
-      !menuRef.current.contains(event.relatedTarget) &&
+      !menuRef.contains(event.relatedTarget) &&
       !buttonRef.current.contains(event.relatedTarget)
     ) {
       closeMenu();
@@ -314,7 +319,7 @@ const MenuList = ({ onKeyDown, onBlur, ...props }) => {
 
   return (
     <Popper
-      usePortal={false}
+      usePortal={usePortal}
       isOpen={isOpen}
       anchorEl={buttonRef.current}
       placement={placement}
@@ -324,7 +329,7 @@ const MenuList = ({ onKeyDown, onBlur, ...props }) => {
       minW="3xs"
       rounded="md"
       role="menu"
-      ref={menuRef}
+      ref={setMenuRef}
       id={menuId}
       py={2}
       aria-labelledby={buttonId}


### PR DESCRIPTION
## Summary
* Menu expects `menuRef` to be defined at this point https://github.com/chakra-ui/chakra-ui/blob/master/packages/chakra-ui/src/Menu/index.js#L52. This ref is attached to a `PseudoBox` inside of a `Portal` component. `Portal` returns `null` on initial render since it initializes `mountNode` as `null`, so it attaches no ref until it's `useEnhancedEffect` and `setMountNode` are called, but this are called after the ancestors `useEffect`, so any ancestors relying on that ref being attached would fail.
* This is actually a known pitfall of refs (https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780). Viable solutions are to use a callback ref as described https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node or to use state. I think using state makes the most sense for this case.

## Issue
* https://github.com/chakra-ui/chakra-ui/issues/406