### PR TITLE
fix: use same image crossOrigin in preloading and img tag

### DIFF
--- a/packages/chakra-ui/src/Image/index.js
+++ b/packages/chakra-ui/src/Image/index.js
@@ -4,7 +4,7 @@ import { useEffect, useState, forwardRef, useRef } from "react";
 import Box from "../Box";
 
 export function useHasImageLoaded(props) {
-  const { src, onLoad, onError, enabled = true } = props;
+  const { src, onLoad, onError, crossOrigin, enabled = true } = props;
   const isMounted = useRef(true);
   const [hasLoaded, setHasLoaded] = useState(false);
 
@@ -14,6 +14,11 @@ export function useHasImageLoaded(props) {
     }
 
     const image = new window.Image();
+
+    if (crossOrigin) {
+      image.crossOrigin = crossOrigin;
+    }
+
     image.src = src;
 
     image.onload = event => {
@@ -29,7 +34,7 @@ export function useHasImageLoaded(props) {
         onError && onError(event);
       }
     };
-  }, [src, onLoad, onError, enabled]);
+  }, [src, onLoad, onError, crossOrigin, enabled]);
 
   useEffect(() => {
     return () => {
@@ -47,12 +52,21 @@ const NativeImage = forwardRef(
 );
 
 const Image = forwardRef((props, ref) => {
-  const { src, fallbackSrc, onError, onLoad, ignoreFallback, ...rest } = props;
+  const {
+    src,
+    fallbackSrc,
+    onError,
+    onLoad,
+    ignoreFallback,
+    crossOrigin,
+    ...rest
+  } = props;
 
   const hasLoaded = useHasImageLoaded({
     src,
     onLoad,
     onError,
+    crossOrigin,
     enabled: !Boolean(ignoreFallback),
   });
 
@@ -60,7 +74,15 @@ const Image = forwardRef((props, ref) => {
     ? { src, onLoad, onError }
     : { src: hasLoaded ? src : fallbackSrc };
 
-  return <Box as={NativeImage} ref={ref} {...imageProps} {...rest} />;
+  return (
+    <Box
+      as={NativeImage}
+      ref={ref}
+      crossOrigin={crossOrigin}
+      {...imageProps}
+      {...rest}
+    />
+  );
 });
 
 Image.displayName = "Image";


### PR DESCRIPTION
The `<img>` HTML tag already supports the `crossOrigin` property, and Chakra's `<Image>` will already forward the `crossOrigin` prop to the tag, hooray!

But, when we _preload_ the image, we do so without `crossOrigin` set, which means that the preloaded image can't actually be reused for the final `<img>` tag 😓

This means that the browser sends a second request, and preloading is not only unhelpful, but more expensive on bandwidth, and approximately doubles the image load time!

In this change, we update the `<Image>` component to use the `crossOrigin` prop in its image preload request, if present. Now, when an `<Image>` is provided a `crossOrigin` prop, we'll make only one request, with the `crossOrigin` behavior that the caller requested.