### PR TITLE
feat: impl closeAll in useToast

### DIFF
--- a/packages/chakra-ui-docs/pages/toast.mdx
+++ b/packages/chakra-ui-docs/pages/toast.mdx
@@ -11,6 +11,15 @@ Toasts can be configured to appear at either the top or the bottom of an
 application window, and it is possible to have more than one toast onscreen at a
 time.
 
+## Return value
+
+The `useToast` hook returns an object with the following fields:
+
+| Name       | Type       | Default | Description                              |
+| ---------- | ---------- | ------- | ---------------------------------------- |
+| `toast`    | `function` |         | Function that displays the toast         |
+| `closeAll` | `function` |         | Function to programatically remove toast |
+
 ## Import
 
 ```js
@@ -21,7 +30,7 @@ import { useToast } from "@chakra-ui/core";
 
 ```jsx
 function ToastExample() {
-  const toast = useToast();
+  const { toast } = useToast();
   return (
     <Button
       onClick={() =>
@@ -46,7 +55,7 @@ Display a custom component instead of the default Toast UI.
 
 ```jsx
 function Example() {
-  const toast = useToast();
+  const { toast } = useToast();
   return (
     <Button
       onClick={() =>
@@ -70,7 +79,7 @@ function Example() {
 
 ```jsx
 function Example() {
-  const toast = useToast();
+  const { toast } = useToast();
   return (
     <Button
       onClick={() =>
@@ -93,7 +102,7 @@ function Example() {
 
 ```jsx
 function Example() {
-  const toast = useToast();
+  const { toast } = useToast();
   return (
     <Button
       onClick={() =>
@@ -116,7 +125,7 @@ function Example() {
 
 ```jsx
 function ErrorToast() {
-  const toast = useToast();
+  const { toast } = useToast();
   return (
     <Button
       onClick={() =>
@@ -141,7 +150,7 @@ Using the `position` prop you can adjust where your toast will be popup from.
 
 ```jsx
 function PositionExample() {
-  const toast = useToast();
+  const { toast } = useToast();
   return (
     <Button
       onClick={() =>
@@ -161,7 +170,37 @@ function PositionExample() {
 }
 ```
 
-## Props
+## Programatically remove toasts
+
+Use the `closeAll` function provided by the `useToast` hook to programatically
+remove toasts.
+
+```jsx
+function RemoveToastExample() {
+  const { toast, closeAll } = useToast();
+  return (
+    <>
+    <Button
+      onClick={() =>
+        toast({
+          position: "bottom-left",
+          title: "Account created.",
+          description: "We've created your account for you.",
+          status: "success",
+          duration: 9000,
+          isClosable: true,
+        })
+      }
+    >
+      Show Toast
+    </Button>
+    <Button onClick={() => closeAll()} />Remove Toasts</Button>
+    </>
+  );
+}
+```
+
+## `toast` Props
 
 | Name          | Type                                                                    | Default  | Description                                                          |
 | ------------- | ----------------------------------------------------------------------- | -------- | -------------------------------------------------------------------- |

--- a/packages/chakra-ui/src/Toast/examples.js
+++ b/packages/chakra-ui/src/Toast/examples.js
@@ -15,7 +15,7 @@ stories.addDecorator(story => {
 
 stories.add("Default", () => {
   const Toaster = () => {
-    const toast = useToast();
+    const { toast } = useToast();
     return (
       <Button
         onClick={() =>
@@ -38,7 +38,7 @@ stories.add("Default", () => {
 
 stories.add("Custom Component", () => {
   const Toaster = () => {
-    const toast = useToast();
+    const { toast } = useToast();
     return (
       <Button
         onClick={() =>
@@ -54,6 +54,36 @@ stories.add("Custom Component", () => {
       >
         Show Toast
       </Button>
+    );
+  };
+
+  return <Toaster />;
+});
+
+stories.add("Programatically remove toasts", () => {
+  const Toaster = () => {
+    const { toast, closeAll } = useToast();
+
+    return (
+      <>
+        <Button
+          onClick={() =>
+            toast({
+              position: "bottom-left",
+              render: () => (
+                <Box m={3} color="white" p={3} bg="blue.500">
+                  Hello World
+                </Box>
+              ),
+            })
+          }
+        >
+          Show Toast
+        </Button>
+        <Button ml={3} variantColor="red" onClick={() => closeAll()}>
+          Remove Toast
+        </Button>
+      </>
     );
   };
 

--- a/packages/chakra-ui/src/Toast/index.d.ts
+++ b/packages/chakra-ui/src/Toast/index.d.ts
@@ -35,6 +35,9 @@ interface RenderOption {
   render?: (props: { onClose: () => void; id: string }) => React.ReactNode;
 }
 export type useToastOptions = IToast & RenderOption;
-declare const useToast: () => (props: useToastOptions) => void;
+declare const useToast: () => {
+  toast: (props: useToastOptions) => void;
+  closeAll: () => void;
+};
 
 export default useToast;

--- a/packages/chakra-ui/src/Toast/index.js
+++ b/packages/chakra-ui/src/Toast/index.js
@@ -100,7 +100,10 @@ function useToast() {
     [theme],
   );
 
-  return notify;
+  return {
+    toast: notify,
+    closeAll: toaster.closeAll,
+  };
 }
 
 export default useToast;


### PR DESCRIPTION
Added a `closeAll` function to be returned by `useToast` along with the original toast function.

Breaking change since `useToast` now returns an object instead instead of a function

This enables programatic closing of toast notifications, which might be ideal when switching routes and not wanting to keep toast notifications hanging around

![Kapture 2020-04-27 at 10 38 41](https://user-images.githubusercontent.com/15570714/80326345-67a98180-8873-11ea-9b45-405ff9002a9e.gif)

https://github.com/chakra-ui/chakra-ui/issues/645