### PR TITLE
fix: Throw error when theme is empty object

### DIFF
--- a/packages/chakra-ui/src/ThemeProvider/index.js
+++ b/packages/chakra-ui/src/ThemeProvider/index.js
@@ -14,7 +14,7 @@ ThemeProvider.defaultProps = {
 
 const useTheme = () => {
   const theme = useContext(ThemeContext);
-  if (theme === undefined || Object.keys(theme).length === 0 ) {
+  if (Object.keys(theme).length === 0 ) {
     throw new Error("useTheme must be used within a ThemeProvider");
   }
   return theme;

--- a/packages/chakra-ui/src/ThemeProvider/index.js
+++ b/packages/chakra-ui/src/ThemeProvider/index.js
@@ -14,7 +14,7 @@ ThemeProvider.defaultProps = {
 
 const useTheme = () => {
   const theme = useContext(ThemeContext);
-  if (theme === undefined) {
+  if (theme === undefined || Object.keys(theme).length === 0 ) {
     throw new Error("useTheme must be used within a ThemeProvider");
   }
   return theme;


### PR DESCRIPTION
I got error `TypeError: Cannot use 'in' operator to search...` like those issues.
https://github.com/chakra-ui/chakra-ui/issues/632
https://github.com/chakra-ui/chakra-ui/issues/627

This error happen when forget `<ThemeProvider>`.
`ThemeProvider` throw error when `theme` is `undefined`.
But sadly, `@emotion/core`'s `ThemeContext` returns empty object by default and this check is not passed
https://github.com/emotion-js/emotion/blob/master/packages/core/src/context.js#L17

This pull request append empty object checking.