### PR TITLE
feat: add onCloseComplete prop for toast component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,7 @@ const path = require("path")
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
 
 module.exports = {
-  stories: ["../packages/menu/**/*.stories.tsx"],
+  stories: ["../packages/toast/**/*.stories.tsx"],
   webpackFinal: async config => {
     config.module.rules.push({
       test: /\.(ts|tsx)$/,

--- a/packages/toast/migration.md
+++ b/packages/toast/migration.md
@@ -9,4 +9,4 @@ of things
   `toast.closeAll` methods
 - Add support to programmatically update a toast using `toast.update` method.
 - Add Support for `onCloseComplete` prop, a callback function to run side
-  effects after the toast has closed.
+  effects after the toast component has closed.

--- a/packages/toast/migration.md
+++ b/packages/toast/migration.md
@@ -8,3 +8,5 @@ of things
 - Add support to programmatically close one to all toasts using `toast.close` or
   `toast.closeAll` methods
 - Add support to programmatically update a toast using `toast.update` method.
+- Add Support for `onCloseComplete` prop, a callback function to run side
+  effects after the toast has closed.

--- a/packages/toast/src/Toast.hook.tsx
+++ b/packages/toast/src/Toast.hook.tsx
@@ -58,6 +58,10 @@ export interface UseToastOptions {
    * By default, we generate a unique `id` for each toast
    */
   id?: ToastId
+  /**
+   * Callback function to run side effects after the toast has closed.
+   */
+  onCloseComplete?: () => void
 }
 
 export type IToast = UseToastOptions

--- a/packages/toast/src/Toast.manager.tsx
+++ b/packages/toast/src/Toast.manager.tsx
@@ -24,7 +24,10 @@ interface Props {
 type State = { [K in ToastPosition]: ToastOptions[] }
 
 type CreateToastOptions = Partial<
-  Pick<ToastOptions, "status" | "duration" | "position" | "id">
+  Pick<
+    ToastOptions,
+    "status" | "duration" | "position" | "id" | "onCloseComplete"
+  >
 >
 
 /**
@@ -137,6 +140,7 @@ export class ToastManager extends React.Component<Props, State> {
       message,
       position,
       duration: options.duration,
+      onCloseComplete: options.onCloseComplete,
       onRequestRemove: () => this.removeToast(String(id), position),
       status: options.status,
     }

--- a/packages/toast/src/Toast.stories.tsx
+++ b/packages/toast/src/Toast.stories.tsx
@@ -29,6 +29,9 @@ export function ToastExample() {
             status: "error",
             duration: null,
             isClosable: true,
+            onCloseComplete: () => {
+              console.log("hello")
+            },
           })
         }}
       >

--- a/packages/toast/src/Toast.tsx
+++ b/packages/toast/src/Toast.tsx
@@ -16,6 +16,7 @@ export function Toast(props: ToastProps) {
   const {
     id,
     message,
+    onCloseComplete,
     onRequestRemove,
     requestClose = false,
     position = "bottom",
@@ -42,6 +43,7 @@ export function Toast(props: ToastProps) {
     if (!show) {
       onRequestRemove()
     }
+    onCloseComplete?.()
   }
 
   const close = () => {

--- a/packages/toast/src/Toast.types.ts
+++ b/packages/toast/src/Toast.types.ts
@@ -54,6 +54,10 @@ export interface ToastOptions {
    * The position of the toast
    */
   position: ToastPosition
+  /**
+   * Callback function to run side effects after the toast has closed.
+   */
+  onCloseComplete?(): void
 }
 
 export type ToastState = { [K in ToastPosition]: ToastOptions[] }


### PR DESCRIPTION
This PR includes updates made to the toast component package in preparation for release. The following activities were carried out:

- Add Support for `onCloseComplete` prop, a callback function to run side
  effects after the toast component has closed.