### PR TITLE
Fix header link to GitHub repository

### DIFF
--- a/packages/chakra-ui-docs/components/DocsHeader.js
+++ b/packages/chakra-ui-docs/components/DocsHeader.js
@@ -60,7 +60,7 @@ export const Header = props => (
 export const GithubLink = props => (
   <PseudoBox
     as="a"
-    href="https://github.com/chakra-ui/chakra-ui/tree/master/packages/chakra-ui"
+    href="https://github.com/chakra-ui/chakra-ui"
     rel="noopener noreferrer"
     target="_blank"
     aria-label="Go to Chakra UI's Github Repo"


### PR DESCRIPTION
**This link should point to the repo, not the package.** By linking to the package, the current link makes Chakra UI look like a much smaller project than it really is!

One of my biggest concerns when adopting any new framework is project health. I want to see evidence of an active community, many contributors. I'd never heard of Chakra (I'm new to React!) so I did the usual; visit the homepage (very compelling!), quickly skim the starter doc, then click through to the GitHub repo.

Imagine my surprise when Chakra only had two listed contributors! Immediate red flag. "I don't care how many stars it has, I can't adopt a framework that won't take community contributions!" I closed the window and moved on; decisions happen quickly.

While documenting my decision against Chakra, I went back to the home page, then clicked the GitHub link _on the home page._ Immediate double-take. 102 contributors?! What happened!

I've never been so glad to be wrong, and I'm taking another proper look at Chakra now; and hopefully you'll fix the link so others won't make the same error! Thanks. 👍