### PR TITLE
fix(stat): add missing @chakra-ui/visually-hidden dependency

### DIFF
--- a/packages/stat/package.json
+++ b/packages/stat/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "tslib": "1.11.1",
     "@chakra-ui/icon": "0.0.1",
-    "@chakra-ui/utils": "0.0.1"
+    "@chakra-ui/utils": "0.0.1",
+    "@chakra-ui/visually-hidden": "0.0.1"
   },
   "devDependencies": {
     "@chakra-ui/system": "0.0.1"


### PR DESCRIPTION
`@chakra-ui/visually-hidden` was missing from `dependencies` in the `stat` package, causing build failure. This PR resolves that.