### PR TITLE
docs: Import CSSReset to match reference on GS page

### DIFF
--- a/packages/chakra-ui-docs/pages/getting-started.mdx
+++ b/packages/chakra-ui-docs/pages/getting-started.mdx
@@ -93,7 +93,8 @@ inspired by
 > application to ensure all components work correctly.
 
 ```jsx live=false
-// import customTheme from "./theme"
+import { ThemeProvider, CSSReset } from '@chakra-ui/core'
+import customTheme from "./theme"
 
 function App({ children }) {
   return (


### PR DESCRIPTION
This is the first time the `CSSReset` component was mentioned in the docs. It is not always intuitive to beginners that they should import it.

I also removed the comment from `customTheme` import since it's actually being used in the code snippet