### PR TITLE
feat: <ModalContent /> can now have minGap specified for mobile screens

### DIFF
--- a/packages/chakra-ui-docs/components/MDXComponents.js
+++ b/packages/chakra-ui-docs/components/MDXComponents.js
@@ -18,7 +18,9 @@ import CarbonAd from "./CarbonAd";
 const Pre = props => <Box my="2em" rounded="sm" {...props} />;
 
 const Table = props => (
-  <Box as="table" textAlign="left" mt="32px" width="full" {...props} />
+  <Box overflowX="auto">
+    <Box as="table" textAlign="left" mt="1em" width="full" {...props} />
+  </Box>
 );
 
 const THead = props => {

--- a/packages/chakra-ui-docs/pages/modal.mdx
+++ b/packages/chakra-ui-docs/pages/modal.mdx
@@ -417,6 +417,53 @@ function SizeExample() {
 }
 ```
 
+### Minimum gap around the Modal
+
+By default, when a modal is displayed in a mobile device, there is no gap on the
+sides. If you prefer there to be a gap, you can pass the `minGap` prop to
+specify a desired thickness.
+
+```jsx
+function MinimumGap() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [gap, setGap] = React.useState();
+
+  const handleGapClick = minGap => {
+    setGap(minGap);
+    onOpen();
+  };
+
+  const gapSizes = [
+    { label: "No Gap (default)", minGap: undefined },
+    { label: "10px Gap", minGap: "10px" },
+  ];
+
+  return (
+    <>
+      {gapSizes.map(({ label, minGap }) => (
+        <Button onClick={() => handleGapClick(minGap)} key={label} m={4}>
+          {label}
+        </Button>
+      ))}
+
+      <Modal onClose={onClose} isOpen={isOpen}>
+        <ModalOverlay />
+        <ModalContent minGap={gap}>
+          <ModalHeader>View from a Mobile Screen</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Lorem count={10} />
+          </ModalBody>
+          <ModalFooter>
+            <Button>Close</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+```
+
 ### Preserving the scrollbar gap
 
 By default, scrolling is blocked when the modal opens. This can lead to

--- a/packages/chakra-ui/src/Modal/index.js
+++ b/packages/chakra-ui/src/Modal/index.js
@@ -76,6 +76,7 @@ const Modal = ({
   scrollBehavior = "outside",
   isCentered,
   addAriaLabels = true,
+  minGap = 0,
   preserveScrollBarGap,
   formatIds = id => ({
     content: `modal-${id}`,
@@ -223,7 +224,10 @@ ModalOverlay.displayName = "ModalOverlay";
 ////////////////////////////////////////////////////////////////////////
 
 const ModalContent = React.forwardRef(
-  ({ onClick, children, zIndex = "modal", noStyles, ...props }, ref) => {
+  (
+    { onClick, children, zIndex = "modal", minGap, noStyles, ...props },
+    ref,
+  ) => {
     const {
       contentRef,
       onClose,
@@ -291,6 +295,13 @@ const ModalContent = React.forwardRef(
         overflowY: "auto",
         overflowX: "hidden",
       };
+
+      if (minGap) {
+        wrapperStyle = {
+          ...wrapperStyle,
+          padding: minGap,
+        };
+      }
 
       contentStyle = {
         ...contentStyle,


### PR DESCRIPTION
## Summary
Currently in ChakraUI, when a modal is displayed in a mobile device, there is no gap on the sides. If you prefer there to be a gap (see screenshots below), you can now pass the minGap prop to specify a desired thickness.

- Adds `minGap` prop to `<ModalContent />` with example in docs
- Fixes Table overflow problem in docs when viewing from mobile screens

Thoughts on the name `minGap`?

## Screenshots
![image](https://user-images.githubusercontent.com/300092/81893162-f825d880-957a-11ea-89b2-3056bbc51c1d.png)
![image](https://user-images.githubusercontent.com/300092/81893191-0c69d580-957b-11ea-942d-1e8a4a8a30ea.png)
![image](https://user-images.githubusercontent.com/300092/81893210-168bd400-957b-11ea-8629-845cc940f2c7.png)

