### PR TITLE
build: generate declaration maps for better developer experience

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -43,7 +43,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -40,7 +40,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -40,7 +40,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -43,7 +43,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/clickable/package.json
+++ b/packages/clickable/package.json
@@ -37,7 +37,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -37,7 +37,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -41,7 +41,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/color-mode/package.json
+++ b/packages/color-mode/package.json
@@ -43,7 +43,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -36,7 +36,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -41,7 +41,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/css-reset/package.json
+++ b/packages/css-reset/package.json
@@ -36,7 +36,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -32,7 +32,7 @@
     "start": "nodemon --exec yarn build -e ts,tsx --ignore dist/ --ignore src/tests/ --ignore \"*.stories.tsx\"",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "build": "concurrently yarn:build:*",
     "test": "jest --env=jsdom --passWithNoTests",
     "test:cov": "yarn test --coverage",

--- a/packages/descendant/package.json
+++ b/packages/descendant/package.json
@@ -40,7 +40,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -42,7 +42,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/editable/package.json
+++ b/packages/editable/package.json
@@ -41,7 +41,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/focus-lock/package.json
+++ b/packages/focus-lock/package.json
@@ -37,7 +37,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -41,7 +41,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -35,7 +35,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -37,7 +37,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -30,7 +30,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -44,7 +44,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/live-region/package.json
+++ b/packages/live-region/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/media-query/package.json
+++ b/packages/media-query/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -40,7 +40,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -45,7 +45,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/number-input/package.json
+++ b/packages/number-input/package.json
@@ -44,7 +44,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -42,7 +42,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/pin-input/package.json
+++ b/packages/pin-input/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -42,7 +42,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/preset-base/package.json
+++ b/packages/preset-base/package.json
@@ -36,7 +36,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/preset-stripe/package.json
+++ b/packages/preset-stripe/package.json
@@ -36,7 +36,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -36,7 +36,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -36,7 +36,7 @@
     "start": "nodemon --exec yarn build --watch src",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "build": "concurrently yarn:build:*",
     "test": "jest --env=jsdom --passWithNoTests",
     "test:cov": "yarn test --coverage",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -47,7 +47,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -36,7 +36,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/stat/package.json
+++ b/packages/stat/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -41,7 +41,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -47,7 +47,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -36,7 +36,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -39,7 +39,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/transition/package.json
+++ b/packages/transition/package.json
@@ -38,7 +38,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,7 +23,7 @@
     "start": "nodemon --exec yarn build -e ts,tsx --ignore dist/ --ignore src/tests/ --ignore \"*.stories.tsx\"",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "build": "concurrently yarn:build:*",
     "test": "jest --env=jsdom --passWithNoTests",
     "test:cov": "yarn test --coverage",

--- a/packages/variant/package.json
+++ b/packages/variant/package.json
@@ -32,7 +32,7 @@
     "start": "nodemon --exec yarn build -e ts,tsx --ignore dist/ --ignore src/tests/ --ignore \"*.stories.tsx\"",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "build": "concurrently yarn:build:*",
     "test": "jest --env=jsdom --passWithNoTests",
     "test:cov": "yarn test --coverage",

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -44,7 +44,7 @@
     "version": "yarn build",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"

--- a/scripts/template/package.json
+++ b/scripts/template/package.json
@@ -32,7 +32,7 @@
     "start": "nodemon --exec yarn build --watch src",
     "build:esm": "tsc --module esnext --outDir dist/esm --declaration false",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --declaration false",
-    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --declarationDir dist/types",
     "build": "concurrently yarn:build:*",
     "test": "jest --env=jsdom --passWithNoTests",
     "test:cov": "yarn test --coverage",


### PR DESCRIPTION
With the declaration maps in place, you can now look at the actual implementation when you click on a component imported from Chakra