### PR TITLE
docs: correct unclear heading

### DIFF
--- a/packages/chakra-ui-docs/pages/modal.mdx
+++ b/packages/chakra-ui-docs/pages/modal.mdx
@@ -209,7 +209,7 @@ function InitialFocus() {
 }
 ```
 
-### Close Modal on Overlay Click
+### Prevent Modal from closing on Overlay click
 
 By default, the modal closes when you click it's overlay. You can set
 `closeOnOverlayClick` to `false` if you want the modal to stay visible.


### PR DESCRIPTION
Change `Close Modal on Overlay Click` to `Prevent Modal from closing on Overlay click`