### PR TITLE
fix(docs): updated gatsby-plugin-manifest options from starter values

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -36,13 +36,13 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: "gatsby-default-mdx-basic",
-        short_name: "starter",
+        name: "Chakra UI",
+        short_name: "Chakra UI",
         start_url: "/",
-        background_color: "#663399",
-        theme_color: "#663399",
+        background_color: "#000000",
+        theme_color: "#319795",
         display: "minimal-ui",
-        icon: "src/images/gatsby-icon.png", // This path is relative to the root of the site.
+        icon: "../logo/logomark-colored@2x.png", // This path is relative to the root of the site.
       },
     },
     {


### PR DESCRIPTION
I updated the `gatsby-plugin-manifest` options from the values that were included in the Gatsby starter.

Here is more information about [Web app manifests](https://developer.mozilla.org/en-US/docs/Web/Manifest) and the [gatsby-plugin-manifest](https://www.gatsbyjs.org/packages/gatsby-plugin-manifest/).