### PR TITLE
chore(lint-staged): clean up and fix lintstagedrc

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,9 +1,5 @@
 {
-  "**/*.{ts,tsx,js,jsx}": [
-      "prettier --write && git add ."
-    ],
-    "**/*.{md,yml,json,babelrc,eslintrc,prettierrc}": [
-      "prettier --write && git add ."
-    ]
- 
+  "**/*.{ts,tsx,js,jsx,md,yml,json,babelrc,eslintrc,prettierrc}": [
+    "prettier --write"
+  ]
 }


### PR DESCRIPTION
This PR merges the `.lintstagedrc` entries together, and removes the use of `git add`. `lint-staged` will automatically use `git add` on any files.

I opened this because I've been having occasional pre-commit issues, and I think this should fix them.