### PR TITLE
docs: add github edit link to docs pages

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -4,6 +4,7 @@ const siteMetadata = {
     "Simple, Modular and Accessible UI Components for your React Applications. Built with Styled System",
   author: "Chakra UI",
   siteUrl: "https://chakra-ui.com",
+  repository: "https://github.com/chakra-ui/chakra-ui",
 }
 
 module.exports = {

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -1,6 +1,9 @@
 const path = require("path")
 const { createFilePath } = require("gatsby-source-filesystem")
-const { sortPostNodes } = require("./utils")
+const {
+  sortPostNodes,
+  getRelativeDocsPath: getRelativeDocPath,
+} = require("./utils")
 
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
@@ -46,6 +49,7 @@ exports.createPages = async ({ graphql, actions }) => {
       {
         allMdx {
           nodes {
+            fileAbsolutePath
             frontmatter {
               title
               order
@@ -69,6 +73,7 @@ exports.createPages = async ({ graphql, actions }) => {
     const next =
       index === sortedNodes.length - 1 ? null : sortedNodes[index + 1]
     const slug = node.fields.slug
+    const relativePath = getRelativeDocPath(node.fileAbsolutePath)
     createPage({
       // we use the generated slug for the path
       path: slug,
@@ -89,6 +94,9 @@ exports.createPages = async ({ graphql, actions }) => {
         // previous and next pages
         previous,
         next,
+
+        // relative path to file ('/docs/pages/getting-started.mdx')
+        relativePath,
       },
     })
   })

--- a/docs/src/components/github-edit-link.js
+++ b/docs/src/components/github-edit-link.js
@@ -1,0 +1,39 @@
+import * as React from "react"
+import { chakra, Box, Stack, Link } from "@chakra-ui/core"
+import { DiGithubBadge } from "react-icons/di"
+import { graphql, useStaticQuery } from "gatsby"
+
+export const GithubLink = ({ path }) => {
+  const {
+    site: {
+      siteMetadata: { repository },
+    },
+  } = useStaticQuery(graphql`
+    query REPOSITORY_QUERY {
+      site {
+        siteMetadata {
+          repository
+        }
+      }
+    }
+  `)
+
+  if (!repository || !path) {
+    return null
+  }
+
+  const href = `${repository}/blob/master${path}`
+  return (
+    <Stack
+      as={Link}
+      direction="row"
+      spacing={1}
+      href={href}
+      isExternal
+      alignItems="center"
+    >
+      <Box as={DiGithubBadge} boxSize="32px" />
+      <chakra.span>Edit this page on GitHub</chakra.span>
+    </Stack>
+  )
+}

--- a/docs/src/templates/docs.js
+++ b/docs/src/templates/docs.js
@@ -6,6 +6,7 @@ import { MDXRenderer } from "gatsby-plugin-mdx"
 import SEO from "../components/seo"
 import { TableOfContents } from "../components/toc"
 import { Pagination } from "../components/pagination"
+import { GithubLink } from "../components/github-edit-link"
 
 // memoized to prevent from re-rendering on in-page anchor link navigation
 const Body = React.memo(
@@ -35,7 +36,7 @@ const Body = React.memo(
 
 const Docs = ({ data, pageContext }) => {
   const location = useLocation()
-  const { previous, next, slug } = pageContext
+  const { previous, next, slug, relativePath } = pageContext
   const { body, frontmatter, tableOfContents } = data.mdx
   const { title, description } = frontmatter
 
@@ -50,6 +51,11 @@ const Docs = ({ data, pageContext }) => {
         slug={slug}
         tableOfContents={tableOfContents}
       />
+      {relativePath && (
+        <Flex as="footer" mt={12} alignItems="center" justifyContent="center">
+          <GithubLink path={relativePath} />
+        </Flex>
+      )}
     </>
   )
 }

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -21,11 +21,18 @@ const orderByOrderThenTitle = _.orderBy(
   ["asc", "asc"],
 )
 
-module.exports.sortPostNodes = nodes => {
+module.exports.sortPostNodes = (nodes) => {
   const collections = groupByCollection(nodes)
   const sortedCollectionNodes = _.values(collections).map(orderByOrderThenTitle)
   const flattened = _.flatten(_.values(sortedCollectionNodes))
   const allSorted = flattened.sort(compareCollections)
 
   return allSorted
+}
+
+const DOCS_REGEX = /\/docs\/pages\/.*/
+module.exports.getRelativeDocsPath = (fileAbsolutePath) => {
+  if (!fileAbsolutePath) return
+  const match = fileAbsolutePath.match(DOCS_REGEX)
+  return match ? match[0] : null
 }


### PR DESCRIPTION
This PR adds an "Edit this page on GitHub" link to the bottom of each docs page.

![image](https://user-images.githubusercontent.com/1954752/83257008-80ae9680-a181-11ea-9d1b-edec09047b07.png)

The link is generated using the relative path to the file. 

Links don't currently work because they point to `master` (example: https://github.com/chakra-ui/chakra-ui/blob/master/docs/pages/components/menu.mdx), but once `dev-ts` is merged in, they will work correctly. You can test them by replacing `/master` with `/dev-ts` in the link.