### PR TITLE
fix: button storybook in docs header

### DIFF
--- a/packages/chakra-ui-docs/components/DocsHeader.js
+++ b/packages/chakra-ui-docs/components/DocsHeader.js
@@ -15,6 +15,7 @@ import { DiGithubBadge } from "react-icons/di";
 import Logo from "./Logo";
 import MobileNav from "./MobileNav";
 import SponsorButton from "./SponsorButton";
+import { StorybookIcon } from "./Storybook-icon";
 
 const styles = css`
   .algolia-autocomplete {
@@ -86,6 +87,24 @@ const ThemeSwitch = props => (
   />
 );
 
+export const StorybookLink = props => (
+  <PseudoBox
+    as="a"
+    href="https://chakra-ui.netlify.com"
+    rel="noopener noreferrer"
+    target="_blank"
+    size="32px"
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    borderRadius="md"
+    isExternal
+    {...props}
+  >
+    <Box as={StorybookIcon} size="6" color="current" />
+  </PseudoBox>
+);
+
 const DocsHeader = props => {
   const { colorMode, toggleColorMode } = useColorMode();
   const bg = { light: "white", dark: "gray.800" };
@@ -104,6 +123,7 @@ const DocsHeader = props => {
         >
           <SponsorButton />
           <GithubLink />
+          <StorybookLink ml="3" />
           <ThemeSwitch
             aria-label={`Switch to ${
               colorMode === "light" ? "dark" : "light"

--- a/packages/chakra-ui-docs/components/Header.js
+++ b/packages/chakra-ui-docs/components/Header.js
@@ -12,7 +12,11 @@ import Logo from "./Logo";
 import GitHubButton from "./GitHubButton";
 import { Container } from "../pages";
 import { StorybookIcon } from "./Storybook-icon";
-import { Header as HeaderContainer, GithubLink } from "./DocsHeader";
+import {
+  Header as HeaderContainer,
+  GithubLink,
+  StorybookLink,
+} from "./DocsHeader";
 import SponsorButton from "./SponsorButton";
 
 const Header = props => {
@@ -33,21 +37,17 @@ const Header = props => {
               <GitHubButton />
             </Box>
           </Box>
-          <Flex align="center" color="gray.500">
+          <Flex
+            flex={{ sm: "1", md: "none" }}
+            ml={5}
+            align="center"
+            color="gray.500"
+            justify="flex-end"
+          >
             <SponsorButton mr="4" />
             <Stack align="center" isInline spacing="3">
               <GithubLink />
-              <Link
-                size="32px"
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                borderRadius="md"
-                isExternal
-                href="https://chakra-ui.netlify.com"
-              >
-                <Box as={StorybookIcon} size="6" color="current" />
-              </Link>
+              <StorybookLink />
             </Stack>
             <IconButton
               aria-label={`Switch to ${


### PR DESCRIPTION
Previously in docs page there is no button to storybook page, but in homepage has it. This PR add button storybook in docs pages.

_Before_
![image](https://user-images.githubusercontent.com/4416419/83327938-eb5af180-a2a9-11ea-9b90-d23bde69e383.png)

_After_
![image](https://user-images.githubusercontent.com/4416419/83327875-6bcd2280-a2a9-11ea-9fd8-90b493c40520.png)
