### PR TITLE
fix(number-input): allow left and right arrow keys for movement

### DIFF
--- a/packages/chakra-ui/src/useNumberInput/index.js
+++ b/packages/chakra-ui/src/useNumberInput/index.js
@@ -2,7 +2,7 @@ import { canUseDOM } from "exenv";
 import { useRef, useState, useEffect, useCallback } from "react";
 import {
   calculatePrecision,
-  preventNonNumberKey,
+  preventNonNumberNonArrowKey,
   roundToPrecision,
 } from "./utils";
 
@@ -151,7 +151,7 @@ function useNumberInput({
   };
 
   const handleKeyDown = event => {
-    preventNonNumberKey(event);
+    preventNonNumberNonArrowKey(event);
     if (!isInteractive) return;
 
     if (event.key === "ArrowUp") {

--- a/packages/chakra-ui/src/useNumberInput/utils.js
+++ b/packages/chakra-ui/src/useNumberInput/utils.js
@@ -11,8 +11,12 @@ export function isNumberKey(event) {
   return true;
 }
 
-export function preventNonNumberKey(event) {
-  if (!isNumberKey(event)) {
+export function isArrowKey(event) {
+  return ["ArrowLeft", "ArrowRight"].includes(event.key);
+}
+
+export function preventNonNumberNonArrowKey(event) {
+  if (!isNumberKey(event) && !isArrowKey(event)) {
     event.preventDefault();
   }
 }


### PR DESCRIPTION
fixes #711 

This PR enables left and right arrow keys to function as movement keys inside the input. Currently the user can only click in order to change their position in the input, which is non-standard input behavior.