### PR TITLE
docs: fix nav link ordering

### DIFF
--- a/docs/src/components/docs/side-nav.js
+++ b/docs/src/components/docs/side-nav.js
@@ -4,8 +4,7 @@ import { graphql, useStaticQuery } from "gatsby"
 import { Box, Heading, Badge } from "@chakra-ui/core"
 import { ComponentLink, TopNavLink } from "./nav-link"
 
-const sortByOrder = sortBy(["frontmatter.order"])
-const sortByTitle = sortBy(["frontmatter.title"])
+const sortNodes = sortBy(["frontmatter.order", "frontmatter.title"])
 
 const useLinksQuery = () => {
   return useStaticQuery(
@@ -28,6 +27,7 @@ const useLinksQuery = () => {
           nodes {
             frontmatter {
               title
+              order
             }
             fields {
               slug
@@ -40,6 +40,7 @@ const useLinksQuery = () => {
           nodes {
             frontmatter {
               title
+              order
             }
             fields {
               slug
@@ -50,6 +51,7 @@ const useLinksQuery = () => {
           nodes {
             frontmatter {
               title
+              order
             }
             fields {
               slug
@@ -63,7 +65,7 @@ const useLinksQuery = () => {
 
 const MainLinks = () => {
   const { main } = useLinksQuery()
-  const nodes = sortByOrder(main.nodes)
+  const nodes = sortNodes(main.nodes)
 
   return nodes.map(({ frontmatter, fields }) => (
     <TopNavLink key={frontmatter.title} href={fields.slug}>
@@ -74,7 +76,7 @@ const MainLinks = () => {
 
 const ComponentLinks = () => {
   const { components } = useLinksQuery()
-  const nodes = sortByTitle(components.nodes)
+  const nodes = sortNodes(components.nodes)
 
   return nodes.map(({ frontmatter: { title }, fields: { slug } }) => (
     <ComponentLink key={title} href={slug}>
@@ -85,7 +87,7 @@ const ComponentLinks = () => {
 
 const UtilitiesLinks = () => {
   const { utilities } = useLinksQuery()
-  const nodes = sortByTitle(utilities.nodes)
+  const nodes = sortNodes(utilities.nodes)
 
   return nodes.map(({ frontmatter, fields }) => (
     <ComponentLink key={frontmatter.title} href={fields.slug}>
@@ -96,7 +98,7 @@ const UtilitiesLinks = () => {
 
 const ThemingLinks = () => {
   const { theming } = useLinksQuery()
-  const nodes = sortByOrder(theming.nodes)
+  const nodes = sortNodes(theming.nodes)
 
   return nodes.map(({ frontmatter, fields }) => (
     <ComponentLink key={frontmatter.title} href={fields.slug}>

--- a/docs/src/components/docs/side-nav.js
+++ b/docs/src/components/docs/side-nav.js
@@ -1,16 +1,17 @@
 import * as React from "react"
-import { sortBy, upperFirst, camelCase } from "lodash/fp"
+import { sortBy, upperFirst, camelCase, groupBy } from "lodash/fp"
 import { graphql, useStaticQuery } from "gatsby"
 import { Box, Heading, Badge } from "@chakra-ui/core"
 import { ComponentLink, TopNavLink } from "./nav-link"
 
 const sortNodes = sortBy(["frontmatter.order", "frontmatter.title"])
+const groupNodesByCollection = groupBy("fields.collection")
 
-const useLinksQuery = () => {
-  return useStaticQuery(
+const useSortedCollectionLinks = (collection) => {
+  const { allMdx } = useStaticQuery(
     graphql`
       query LinksQuery {
-        main: allMdx(filter: { fields: { collection: { eq: "main" } } }) {
+        allMdx {
           nodes {
             frontmatter {
               title
@@ -18,54 +19,20 @@ const useLinksQuery = () => {
             }
             fields {
               slug
-            }
-          }
-        }
-        components: allMdx(
-          filter: { fields: { collection: { eq: "components" } } }
-        ) {
-          nodes {
-            frontmatter {
-              title
-              order
-            }
-            fields {
-              slug
-            }
-          }
-        }
-        utilities: allMdx(
-          filter: { fields: { collection: { eq: "utilities" } } }
-        ) {
-          nodes {
-            frontmatter {
-              title
-              order
-            }
-            fields {
-              slug
-            }
-          }
-        }
-        theming: allMdx(filter: { fields: { collection: { eq: "theming" } } }) {
-          nodes {
-            frontmatter {
-              title
-              order
-            }
-            fields {
-              slug
+              collection
             }
           }
         }
       }
     `,
   )
+  const sorted = sortNodes(allMdx.nodes)
+  const grouped = groupNodesByCollection(sorted)
+  return grouped[collection]
 }
 
 const MainLinks = () => {
-  const { main } = useLinksQuery()
-  const nodes = sortNodes(main.nodes)
+  const nodes = useSortedCollectionLinks("main")
 
   return nodes.map(({ frontmatter, fields }) => (
     <TopNavLink key={frontmatter.title} href={fields.slug}>
@@ -75,8 +42,7 @@ const MainLinks = () => {
 }
 
 const ComponentLinks = () => {
-  const { components } = useLinksQuery()
-  const nodes = sortNodes(components.nodes)
+  const nodes = useSortedCollectionLinks("components")
 
   return nodes.map(({ frontmatter: { title }, fields: { slug } }) => (
     <ComponentLink key={title} href={slug}>
@@ -86,8 +52,7 @@ const ComponentLinks = () => {
 }
 
 const UtilitiesLinks = () => {
-  const { utilities } = useLinksQuery()
-  const nodes = sortNodes(utilities.nodes)
+  const nodes = useSortedCollectionLinks("utilities")
 
   return nodes.map(({ frontmatter, fields }) => (
     <ComponentLink key={frontmatter.title} href={fields.slug}>
@@ -97,8 +62,7 @@ const UtilitiesLinks = () => {
 }
 
 const ThemingLinks = () => {
-  const { theming } = useLinksQuery()
-  const nodes = sortNodes(theming.nodes)
+  const nodes = useSortedCollectionLinks("theming")
 
   return nodes.map(({ frontmatter, fields }) => (
     <ComponentLink key={frontmatter.title} href={fields.slug}>


### PR DESCRIPTION
This PR cleans fixes nav link ordering by sorting all links first by `frontmatter.order` and then by `frontmatter.title`. It also cleans up the link query.