### PR TITLE
docs: fix start command

### DIFF
--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -48,12 +48,12 @@ git checkout -b my-feature-branch
 
 ## Docs contribution
 
-Chakra UI uses NextJS for its documentation website. Thank you in advance and
+Chakra UI uses gatsby for its documentation website. Thank you in advance and
 cheers for contributing to our documentation! We created a simple command to run
 it.
 
 ```sh
-npm run docs
+npm run docs:start
 ```
 
 You can now access the documentation site locally. Changes to the docs will hot

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release:ci": "lerna publish -y --loglevel verbose",
     "release:failed": "lerna publish from-package -y --loglevel verbose",
     "docs": "yarn workspace @chakra-ui/docs",
-    "docs:now": "cd docs && now",
+    "docs:start": "yarn docs start",
     "core": "yarn workspace @chakra-ui/core",
     "icon": "yarn workspace @chakra-ui/icon",
     "hooks": "yarn workspace @chakra-ui/hooks",


### PR DESCRIPTION
Replaces `docs:now` with `docs:start` and updates `contributing.mdx`.