### PR TITLE
docs: remove unnecessary memoization

### DIFF
--- a/docs/src/components/layout.js
+++ b/docs/src/components/layout.js
@@ -15,34 +15,28 @@ const HomeLayout = ({ children }) => (
   </Box>
 )
 
-// memoized to prevent in-page anchor link navigation from re-rendering the
-// entire layout
-const SidebarLayout = React.memo(
-  ({ children }) => {
-    return (
-      <MDXProvider components={MDXComponents}>
-        <Header />
-        <Box>
-          <SideNav
-            display={["none", null, "block"]}
-            maxWidth="18rem"
-            width="full"
-          />
-          <Box pl={[0, null, "18rem"]} py={2} mb={20}>
-            <Box as="main" minH="90vh" pt={8} px={5} mt="4rem">
-              {children}
-            </Box>
-            <Footer />
+const SidebarLayout = ({ children }) => {
+  return (
+    <MDXProvider components={MDXComponents}>
+      <Header />
+      <Box>
+        <SideNav
+          display={["none", null, "block"]}
+          maxWidth="18rem"
+          width="full"
+        />
+        <Box pl={[0, null, "18rem"]} py={2} mb={20}>
+          <Box as="main" minH="90vh" pt={8} px={5} mt="4rem">
+            {children}
           </Box>
+          <Footer />
         </Box>
-      </MDXProvider>
-    )
-  },
-  (prev, next) => prev.pathname === next.pathname,
-)
+      </Box>
+    </MDXProvider>
+  )
+}
 
 const Layout = ({ children, pageContext }) => {
-  const location = useLocation()
   const Container =
     pageContext && pageContext.layout === "docs" ? SidebarLayout : HomeLayout
 
@@ -50,7 +44,7 @@ const Layout = ({ children, pageContext }) => {
     <>
       <SkipNavLink zIndex={20}>Skip to Content</SkipNavLink>
       <SkipNavContent as="main">
-        <Container pathname={location.pathname}>{children}</Container>
+        <Container>{children}</Container>
       </SkipNavContent>
     </>
   )

--- a/docs/src/templates/docs.js
+++ b/docs/src/templates/docs.js
@@ -1,17 +1,19 @@
+import React from "react"
 import { Box, Flex } from "@chakra-ui/core"
-import { useLocation } from "@reach/router"
 import { graphql } from "gatsby"
 import { MDXRenderer } from "gatsby-plugin-mdx"
-import React from "react"
 import { GithubLink } from "../components/github-edit-link"
 import { Pagination } from "../components/pagination"
 import SEO from "../components/seo"
 
-// memoized to prevent from re-rendering on in-page anchor link navigation
-const Body = React.memo(
-  (props) => {
-    const { relativePath, body, previous, next, modifiedTime } = props
-    return (
+const Docs = ({ data, pageContext }) => {
+  const { previous, next, slug, relativePath, modifiedTime } = pageContext
+  const { body, frontmatter } = data.mdx
+  const { title, description } = frontmatter
+
+  return (
+    <>
+      <SEO title={title} description={description} slug={slug} />
       <Box mx="auto" maxW="46rem" mt="1em">
         <MDXRenderer>{body}</MDXRenderer>
         <Pagination previous={previous} next={next} />
@@ -29,30 +31,6 @@ const Body = React.memo(
           </Flex>
         )}
       </Box>
-    )
-  },
-  (prev, next) => prev.pathname === next.pathname,
-)
-
-const Docs = ({ data, pageContext }) => {
-  const location = useLocation()
-  const { previous, next, slug, relativePath, modifiedTime } = pageContext
-  const { body, frontmatter, tableOfContents } = data.mdx
-  const { title, description } = frontmatter
-
-  return (
-    <>
-      <SEO title={title} description={description} slug={slug} />
-      <Body
-        pathname={location.pathname}
-        body={body}
-        previous={previous}
-        next={next}
-        slug={slug}
-        tableOfContents={tableOfContents}
-        relativePath={relativePath}
-        modifiedTime={modifiedTime}
-      />
     </>
   )
 }


### PR DESCRIPTION
I'm not sure what changed from the time this was added to now, but it appears we no longer need to memoize any of these components. Things are loading fine locally and the sidebar nav no longer scrolls to the top when changing to a new page. Memoization was also breaking hot reload, so that's working again as well.