### PR TITLE
docs: add theme keys

### DIFF
--- a/docs/pages/components/accordion.mdx
+++ b/docs/pages/components/accordion.mdx
@@ -265,3 +265,12 @@ etc.
 
 AccordionPanel renders a `div` and composes `Collapse` to provide the height
 animation.
+
+## Theme Keys
+
+| Component         | Theme Key          |
+| ----------------- | ------------------ |
+| `Accordion`       | `Accordion.Root`   |
+| `AccordionItem`   | `Accordion.Item`   |
+| `AccordionButton` | `Accordion.Button` |
+| `AccordionPanel`  | `Accordion.Panel`  |

--- a/docs/pages/components/alert.mdx
+++ b/docs/pages/components/alert.mdx
@@ -141,3 +141,11 @@ AlertTitle composes the `Box` component.
 ### AlertDescription Props
 
 AlertDescription composes the `Box` component.
+
+## Theme Keys
+
+| Component    | Theme Key     |
+| ------------ | ------------- |
+| `Alert`      | `Alert.Root`  |
+| `AlertTitle` | `Alert.Title` |
+| `AlertIcon`  | `Alert.Icon`  |

--- a/docs/pages/components/alertdialog.mdx
+++ b/docs/pages/components/alertdialog.mdx
@@ -165,3 +165,11 @@ exception is that it requires a `leastDestructiveRef` which is similar to the
 | Name                           | Type        | Default | Description                                                   |
 | ------------------------------ | ----------- | ------- | ------------------------------------------------------------- |
 | leastDestructiveRef (required) | `React.Ref` |         | The least destructive action to get focus when dialog is open |
+
+| Component            | Theme Key       |
+| -------------------- | --------------- |
+| `AlertDialogContent` | `Modal.Content` |
+| `AlertDialogOverlay` | `Modal.Overlay` |
+| `AlertDialogHeader`  | `Modal.Header`  |
+| `AlertDialogBody`    | `Modal.Body`    |
+| `AlertDialogFooter`  | `Modal.Footer`  |

--- a/docs/pages/components/avatar.mdx
+++ b/docs/pages/components/avatar.mdx
@@ -131,3 +131,11 @@ The Avatar component composes `Box` component so you can pass props for `Box`.
 | name       | `string`                                   |         | The name of the user in the avatar                                                |
 | src        | `string`                                   |         | The image url of the `Avatar`                                                     |
 | children   | `React.ReactNode`                          |         | The badge at the bottom right corner of the Avatar.                               |
+
+## Theme Keys
+
+| Component                    | Theme Key            |
+| ---------------------------- | -------------------- |
+| `Avatar`                     | `Avatar.Root`        |
+| `AvatarBadge`                | `Avatar.Badge`       |
+| `AvatarGroup` (excess label) | `Avatar.ExcessLabel` |

--- a/docs/pages/components/badge.mdx
+++ b/docs/pages/components/badge.mdx
@@ -92,3 +92,9 @@ The Badge component composes `Box` component so you can pass props for `Box`.
 | ------------- | ---------------------------- | -------- | ---------------------------------------------------------------------- |
 | `variant`     | `solid`, `subtle`, `outline` | `subtle` | The style variant of the badge                                         |
 | `colorScheme` | `string`                     | `gray`   | The color scheme to use for the badge. Must be a key in `theme.colors` |
+
+## Theme Key
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Badge`   | `Badge`   |

--- a/docs/pages/components/breadcrumb.mdx
+++ b/docs/pages/components/breadcrumb.mdx
@@ -183,3 +183,9 @@ props.
 
 The BreadcrumbSeparator composes the [Box](/box) component so you can all Box
 props.
+
+## Theme Keys
+
+| Component        | Theme Key |
+| ---------------- | --------- |
+| `BreadcrumbLink` | `Link`    |

--- a/docs/pages/components/button.mdx
+++ b/docs/pages/components/button.mdx
@@ -201,3 +201,9 @@ are props related to the Button component.
 | `isLoading`   | `boolean`                                         |         | If `true`, the button will show a spinner.                                                                |
 | `loadingText` | `string`                                          |         | The label to show in the button when `isLoading` is true. If no text is passed, it only shows the spinner |
 | `size`        | `sm`, `md`, `lg`                                  | `md`    | The size of the button.                                                                                   |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Button`  | `Button`  |

--- a/docs/pages/components/checkbox.mdx
+++ b/docs/pages/components/checkbox.mdx
@@ -188,3 +188,10 @@ CheckboxGroup composes `Box` so you can pass all `Box` props.
 | spacing      | `StyledSystem.MarginProps`                 | `8px`   | The space between each checkbox                                                                                     |
 | size         | `sm`, `md`, `lg`                           | `md`    | The size of the checkbox, it's forwarded to all children checkbox.                                                  |
 | isInline     | `boolean`                                  |         | If `true`, the checkboxes will aligned horizontally.                                                                |
+
+## Theme Keys
+
+| Component            | Theme Key          |
+| -------------------- | ------------------ |
+| `Checkbox` (control) | `Checkbox.Control` |
+| `Checkbox` (label)   | `Checkbox.Label`   |

--- a/docs/pages/components/closebutton.mdx
+++ b/docs/pages/components/closebutton.mdx
@@ -49,3 +49,9 @@ The CloseButton composes `PseudoBox` component.
 | `isDisabled` | `boolean`        |         | If `true`, the button will be disabled   |
 | `color`      | `string`         |         | The color of the close icon              |
 | `size`       | `sm`, `md`, `lg` | `md`    | The size of the close button             |
+
+## Theme Keys
+
+| Component     | Theme Key     |
+| ------------- | ------------- |
+| `CloseButton` | `CloseButton` |

--- a/docs/pages/components/code.mdx
+++ b/docs/pages/components/code.mdx
@@ -43,3 +43,9 @@ prop.
 | ------------- | ----------------- | ------- | ------------------------------------- |
 | `colorScheme` | `string`          |         | The color scheme to use for the code. |
 | `children`    | `React.ReactNode` |         | The content of the code               |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Code`    | `Code`    |

--- a/docs/pages/components/editable.mdx
+++ b/docs/pages/components/editable.mdx
@@ -118,3 +118,11 @@ props. Here are the custom props:
 ### EditablePreview Props
 
 `EditablePreview` composes `PseudoBox` so you can pass all `PseudoBox` props.
+
+## Theme Keys
+
+| Component         | Theme Key          |
+| ----------------- | ------------------ |
+| `Editable`        | `Editable.Root`    |
+| `EditablePreview` | `Editable.Preview` |
+| `EditableInput`   | `Editable.Input`   |

--- a/docs/pages/components/formcontrol.mdx
+++ b/docs/pages/components/formcontrol.mdx
@@ -137,3 +137,13 @@ function FormikExample() {
 | `isRequired` | `boolean` |         | If `true`, this prop is passed to its children. |
 | `isDisabled` | `boolean` |         | If `true`, this prop is passed to its children. |
 | `isReadOnly` | `boolean` |         | If `true`, this prop is passed to its children. |
+
+## Theme Keys
+
+| Component           | Theme Key                |
+| ------------------- | ------------------------ |
+| `FormControl`       | `Form.Root`              |
+| `FormLabel`         | `Form.Label`             |
+| `FormHelperText`    | `Form.HelperText`        |
+| `FormErrorMessage`  | `Form.ErrorText`         |
+| `RequiredIndicator` | `Form.RequiredIndicator` |

--- a/docs/pages/components/heading.mdx
+++ b/docs/pages/components/heading.mdx
@@ -96,3 +96,9 @@ The Heading composes the [Box](/box) component, so you can pass all `Box` props.
 | Name   | Type                                 | Default | Description              |
 | ------ | ------------------------------------ | ------- | ------------------------ |
 | `size` | `2xl`, `xl` , `lg`, `md`, `sm`, `xs` | `xl`    | The size of the heading. |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Heading` | `Heading` |

--- a/docs/pages/components/icon.mdx
+++ b/docs/pages/components/icon.mdx
@@ -155,3 +155,9 @@ Icon component composes `Box` so you can pass all `Box` props.
 | `color`     | `string`              | `currentColor` | The color of the icon.                                                              |
 | `focusable` | `boolean`             | `false`        | Denotes that the icon is not an interative element, and only used for presentation. |
 | `role`      | `presentation`, `img` | `presentation` | The html role of the icon.                                                          |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Icon`    | `Icon`    |

--- a/docs/pages/components/input.mdx
+++ b/docs/pages/components/input.mdx
@@ -188,3 +188,14 @@ The Input component composes [PseudoBox](/pseudobox) so you can pass all
 | `variant`          | `outline`, `unstyled`, `flushed`, `filled` | `outline` | The variant of the input style to use.                                                                                                |
 | `focusBorderColor` | `string`                                   |           | The border color when the input is focused.                                                                                           |
 | `errorBorderColor` | `string`                                   |           | The border color when `isInvalid` is set to `true`.                                                                                   |
+
+## Theme Keys
+
+| Component           | Theme Key    |
+| ------------------- | ------------ |
+| `Input`             | `Input`      |
+| `InputAddon`        | `InputAddon` |
+| `InputLeftAddon`    | `InputAddon` |
+| `InputRightAddon`   | `InputAddon` |
+| `InputLeftElement`  | `Input`      |
+| `InputRightElement` | `Input`      |

--- a/docs/pages/components/keyboardkey.mdx
+++ b/docs/pages/components/keyboardkey.mdx
@@ -52,3 +52,9 @@ look different on the user’s keyboard, insert or.
   <Kbd>alt</Kbd> or <Kbd>option</Kbd>
 </span>
 ```
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Kbd`     | `Kdb`     |

--- a/docs/pages/components/link.mdx
+++ b/docs/pages/components/link.mdx
@@ -67,3 +67,9 @@ The link component composes the [PseudoBox](/pseudobox) component.
 | `isExternal` | `boolean`  |         | If `true`, the link will open in new tab. |
 | `isDisabled` | `boolean`  |         | If `true`, the link will be disabled.     |
 | `onClick`    | `function` |         | Function called when the link is clicked. |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Link`    | `Link`    |

--- a/docs/pages/components/menu.mdx
+++ b/docs/pages/components/menu.mdx
@@ -288,3 +288,13 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
 | type         | `radio`, `checkbox`       | The initial value of the option item                    |
 | onMouseLeave | `React.MouseEventHandler` | The value of the option item                            |
 | onMouseEnter | `React.MouseEventHandler` | Function called when selection changes                  |
+
+## Theme Keys
+
+| Component           | Theme Key             |
+| ------------------- | --------------------- |
+| `MenuButton`        | `Menu.MenuButton`     |
+| `MenuList`          | `Menu.MenuList`       |
+| `MenuItem`          | `Menu.MenuItem`       |
+| `MenuGroup` (title) | `Menu.MenuGroupTitle` |
+| `MenuDivider`       | `Menu.MenuDivider`    |

--- a/docs/pages/components/modal.mdx
+++ b/docs/pages/components/modal.mdx
@@ -492,3 +492,13 @@ To disable this behavior, set `useInert` to `false`.
 - `ModalOverlay`, `ModalHeader`, `ModalFooter` and `ModalBody` composes `Box`
   component
 - `ModalCloseButton` composes `CloseButton`
+
+## Theme Keys
+
+| Component      | Theme Key       |
+| -------------- | --------------- |
+| `ModalContent` | `Modal.Content` |
+| `ModalOverlay` | `Modal.Overlay` |
+| `ModalHeader`  | `Modal.Header`  |
+| `ModalBody`    | `Modal.Body`    |
+| `ModalFooter`  | `Modal.Footer`  |

--- a/docs/pages/components/numberinput.mdx
+++ b/docs/pages/components/numberinput.mdx
@@ -300,3 +300,13 @@ NumberInputStepper composes `Flex` so you can pass all `Flex` props.
 
 NumberDecrementStepper and NumberIncrementStepper composes the `PseudoBox` props
 so you can pass all `PseudoBox` props.
+
+## Theme Keys
+
+| Component                | Theme Key                  |
+| ------------------------ | -------------------------- |
+| `NumberInput`            | `NumberInput.Root`         |
+| `NumberInputStepper`     | `NumberInput.StepperGroup` |
+| `NumberInputField`       | `Input`                    |
+| `NumberDecrementStepper` | `NumberInput.Stepper`      |
+| `NumberIncrementStepper` | `NumberInput.Stepper`      |

--- a/docs/pages/components/popover.mdx
+++ b/docs/pages/components/popover.mdx
@@ -481,3 +481,13 @@ function TwitterEx() {
 - `PopoverArrow`, `PopoverHeader`, `PopoverFooter` and `PopoverBody` composes
   `Box`.
 - `PopoverCloseButton` composes `PseudoBox` component.
+
+## Theme Keys
+
+| Component        | Theme Key         |
+| ---------------- | ----------------- |
+| `PopoverContent` | `Popover.Content` |
+| `PopoverHeader`  | `Popover.Header`  |
+| `PopoverBody`    | `Popover.Body`    |
+| `PopoverFooter`  | `Popover.Footer`  |
+| `PopoverArray`   | `Popover.Arrow`   |

--- a/docs/pages/components/progress.mdx
+++ b/docs/pages/components/progress.mdx
@@ -73,3 +73,11 @@ animations.
 - Progress has a `role` set to `progressbar` to denote that it's a progress.
 - Progress has `aria-valuenow` set to the percentage completion value passed to
   the component, to ensure the progress percent is visible to screen readers.
+
+## Theme Keys
+
+| Component              | Theme Key            |
+| ---------------------- | -------------------- |
+| `Progress` (indicator) | `Progress.Indicator` |
+| `Progress` (track)     | `Progress.Track`     |
+| `ProgressLabel`        | `Progress.Label`     |

--- a/docs/pages/components/radio.mdx
+++ b/docs/pages/components/radio.mdx
@@ -182,3 +182,10 @@ render(<Example />)
 | onFocus          | `function`           |         | Function called when the radio receive focus                                                                          |
 | aria-label       | `string`             |         | An accessible label for the radio in event there's no visible label or `children` was passed                          |
 | aria-labelledby  | `string`             |         | Id that points to the label for the radio in event no `children` was passed                                           |
+
+## Theme Keys
+
+| Component         | Theme Key       |
+| ----------------- | --------------- |
+| `Radio` (control) | `Radio.Control` |
+| `Radio` (label)   | `Radio.Label`   |

--- a/docs/pages/components/slider.mdx
+++ b/docs/pages/components/slider.mdx
@@ -112,3 +112,12 @@ props to change it's style.
 
 SliderTrack composes [Box](/box) so you can pass all Box props to change it's
 style.
+
+## Theme Keys
+
+| Component           | Theme Key            |
+| ------------------- | -------------------- |
+| `Slider`            | `Slider.Root`        |
+| `SliderThumb`       | `Slider.Thumb`       |
+| `SliderTrack`       | `Slider.Track`       |
+| `SliderFilledTrack` | `Slider.FilledTrack` |

--- a/docs/pages/components/spinner.mdx
+++ b/docs/pages/components/spinner.mdx
@@ -55,3 +55,9 @@ change or a result.
 | label      | `string`                 | `Loading...`  | An accessible label for the spinner (Useful for screen readers) |
 | color      | `string`                 |               | The color of the spinner.                                       |
 | emptyColor | `string`                 | `transparent` | The color of the empty areas in the spinner.                    |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Spinner` | `Spinner` |

--- a/docs/pages/components/stat.mdx
+++ b/docs/pages/components/stat.mdx
@@ -60,3 +60,11 @@ import {
 - StatLabel, StatHelpText, StatNumber composes [Text](/text) component
 - StatArrow composes [Icon](/icon) component
 - Stat, StatGroup composes [Box](/box) component
+
+## Theme Keys
+
+| Component      | Theme Key       |
+| -------------- | --------------- |
+| `StatLabel`    | `Stat.Label`    |
+| `StatHelpText` | `Stat.HelpText` |
+| `StatNumber`   | `Stat.Number`   |

--- a/docs/pages/components/switch.mdx
+++ b/docs/pages/components/switch.mdx
@@ -66,3 +66,10 @@ prop.
 | `defaultIsChecked` | `boolean`           |         | If `true`, the checkbox will be initially checked.   |
 | `isDisabled`       | `boolean`           |         | If `true`, set the disabled to the invalid state.    |
 | `isInvalid`        | `boolean`           |         | If `true`, set the switch to the invalid state.      |
+
+## Theme Keys
+
+| Component        | Theme Key      |
+| ---------------- | -------------- |
+| `Switch` (track) | `Switch.Track` |
+| `Switch` (thumb) | `Switch.Thumb` |

--- a/docs/pages/components/tabs.mdx
+++ b/docs/pages/components/tabs.mdx
@@ -401,3 +401,11 @@ function Example() {
 |           | `aria-orientation` | Set to vertical or horizontal based on the value of the `orientation` prop. |
 |           | `role="tablist"`   | Indicates that it's a tablist                                               |
 |           | `aria-labelledby`  | Set to the `id` of the `Tab` that labels the `TabPanel`.                    |
+
+## Theme Keys
+
+| Component  | Theme Key       |
+| ---------- | --------------- |
+| `Tab`      | `Tabs.Tab`      |
+| `TabList`  | `Tabs.TabList`  |
+| `TabPanel` | `Tabs.TabPanel` |

--- a/docs/pages/components/tag.mdx
+++ b/docs/pages/components/tag.mdx
@@ -109,3 +109,9 @@ import { Tag, TagIcon, TagLabel, TagCloseButton } from "@chakra-ui/core"
 | `variant`     | `solid`, `subtle`, `outline` | `solid` | The variant style of the tag component. |
 | `size`        | `sm`, `md`, `lg`             | `md`    | The size of the tag component.          |
 | `colorScheme` | `string`                     |         | The color scheme of the tag variant.    |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Tag`     | `Tag`     |

--- a/docs/pages/components/text.mdx
+++ b/docs/pages/components/text.mdx
@@ -94,3 +94,9 @@ Element** to see the element that gets rendered in html.
 ## Props
 
 Text composes the [Box](/box) component, so you can pass all `Box` style props.
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Text`    | `Text`    |

--- a/docs/pages/components/textarea.mdx
+++ b/docs/pages/components/textarea.mdx
@@ -91,3 +91,9 @@ The Textarea composes the [Input](/input) component
 | Name   | Type     | Default    | Description                                                         |
 | ------ | -------- | ---------- | ------------------------------------------------------------------- |
 | resize | `string` | `vertical` | Textarea resize behavior, can be `vertical`, `horizontal` or `none` |
+
+## Theme Keys
+
+| Component  | Theme Key  |
+| ---------- | ---------- |
+| `Textarea` | `Textarea` |

--- a/docs/pages/components/tooltip.mdx
+++ b/docs/pages/components/tooltip.mdx
@@ -101,3 +101,9 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 | `shouldWrapChildren` | `boolean`            |          | If `true`, the tooltip will wrap the children in a `span` with `tabIndex=0`           |
 | `onOpen`             | `function`           |          | Function called when the tooltip shows.                                               |
 | `onClose`            | `function`           |          | Function called when the tooltip hides.                                               |
+
+## Theme Keys
+
+| Component | Theme Key |
+| --------- | --------- |
+| `Tooltip` | `Tooltip` |

--- a/docs/pages/theming/simple.mdx
+++ b/docs/pages/theming/simple.mdx
@@ -224,6 +224,11 @@ components:
 | `Alert`                             | `Alert.Root`               |
 | `AlertTitle`                        | `Alert.Title`              |
 | `AlertIcon`                         | `Alert.Icon`               |
+| `AlertDialogContent`                | `Modal.Content`            |
+| `AlertDialogOverlay`                | `Modal.Overlay`            |
+| `AlertDialogHeader`                 | `Modal.Header`             |
+| `AlertDialogBody`                   | `Modal.Body`               |
+| `AlertDialogFooter`                 | `Modal.Footer`             |
 | `Avatar`                            | `Avatar.Root`              |
 | `AvatarBadge`                       | `Avatar.Badge`             |
 | `AvatarGroup` (excess label)        | `Avatar.ExcessLabel`       |

--- a/docs/pages/theming/simple.mdx
+++ b/docs/pages/theming/simple.mdx
@@ -211,3 +211,91 @@ future.
 
 > All Chakra's component follows this API and we've made call component styles
 > available to you in the `chakra/` folder of your project.
+
+The following table lists the `themeKey` values for all built-in Chakra
+components:
+
+| Component                           | Theme Key                  |
+| ----------------------------------- | -------------------------- |
+| `Accordion`                         | `Accordion.Root`           |
+| `AccordionItem`                     | `Accordion.Item`           |
+| `AccordionButton`                   | `Accordion.Button`         |
+| `AccordionPanel`                    | `Accordion.Panel`          |
+| `Alert`                             | `Alert.Root`               |
+| `AlertTitle`                        | `Alert.Title`              |
+| `AlertIcon`                         | `Alert.Icon`               |
+| `Avatar`                            | `Avatar.Root`              |
+| `AvatarBadge`                       | `Avatar.Badge`             |
+| `AvatarGroup` (excess label)        | `Avatar.ExcessLabel`       |
+| `Badge`                             | `Badge`                    |
+| `BreadcrumbLink`                    | `Link`                     |
+| `Button`                            | `Button`                   |
+| `Checkbox` (control)                | `Checkbox.Control`         |
+| `Checkbox` (label)                  | `Checkbox.Label`           |
+| `CloseButton`                       | `CloseButton`              |
+| `Code`                              | `Code`                     |
+| `Divider`                           | `Divider`                  |
+| `Editable`                          | `Editable.Root`            |
+| `EditablePreview`                   | `Editable.Preview`         |
+| `EditableInput`                     | `Editable.Input`           |
+| `FormControl`                       | `Form.Root`                |
+| `FormLabel`                         | `Form.Label`               |
+| `RequiredIndicator` (`FormControl`) | `Form.RequiredIndicator`   |
+| `FormHelperText`                    | `Form.HelperText`          |
+| `FormErrorMessage`                  | `Form.ErrorText`           |
+| `Heading`                           | `Heading`                  |
+| `Icon`                              | `Icon`                     |
+| `Input`                             | `Input`                    |
+| `InputAddon`                        | `InputAddon`               |
+| `InputLeftAddon`                    | `InputAddon`               |
+| `InputRightAddon`                   | `InputAddon`               |
+| `InputLeftElement`                  | `Input`                    |
+| `InputRightElement`                 | `Input`                    |
+| `Kbd`                               | `Kdb`                      |
+| `Link`                              | `Link`                     |
+| `MenuButton`                        | `Menu.MenuButton`          |
+| `MenuList`                          | `Menu.MenuList`            |
+| `MenuItem`                          | `Menu.MenuItem`            |
+| `MenuGroup` (title)                 | `Menu.MenuGroupTitle`      |
+| `MenuDivider`                       | `Menu.MenuDivider`         |
+| `ModalContent`                      | `Modal.Content`            |
+| `ModalOverlay`                      | `Modal.Overlay`            |
+| `ModalHeader`                       | `Modal.Header`             |
+| `ModalBody`                         | `Modal.Body`               |
+| `ModalFooter`                       | `Modal.Footer`             |
+| `NumberInput`                       | `NumberInput.Root`         |
+| `NumberInputStepper`                | `NumberInput.StepperGroup` |
+| `NumberInputField`                  | `Input`                    |
+| `NumberDecrementStepper`            | `NumberInput.Stepper`      |
+| `NumberIncrementStepper`            | `NumberInput.Stepper`      |
+| `PinInputField`                     | `PinInput`                 |
+| `PopoverContent`                    | `Popover.Content`          |
+| `PopoverHeader`                     | `Popover.Header`           |
+| `PopoverBody`                       | `Popover.Body`             |
+| `PopoverFooter`                     | `Popover.Footer`           |
+| `PopoverArray`                      | `Popover.Arrow`            |
+| `Progress` (indicator)              | `Progress.Indicator`       |
+| `Progress` (track)                  | `Progress.Track`           |
+| `ProgressLabel`                     | `Progress.Label`           |
+| `Radio` (control)                   | `Radio.Control`            |
+| `Radio` (label)                     | `Radio.Label`              |
+| `Select`                            | `Select`                   |
+| `SelectField`                       | `Select`                   |
+| `Skeleton`                          | `Skeleton`                 |
+| `Slider`                            | `Slider.Root`              |
+| `SliderThumb`                       | `Slider.Thumb`             |
+| `SliderTrack`                       | `Slider.Track`             |
+| `SliderFilledTrack`                 | `Slider.FilledTrack`       |
+| `Spinner`                           | `Spinner`                  |
+| `StatLabel`                         | `Stat.Label`               |
+| `StatHelpText`                      | `Stat.HelpText`            |
+| `StatNumber`                        | `Stat.Number`              |
+| `Switch` (track)                    | `Switch.Track`             |
+| `Switch` (thumb)                    | `Switch.Thumb`             |
+| `Tab`                               | `Tabs.Tab`                 |
+| `TabList`                           | `Tabs.TabList`             |
+| `TabPanel`                          | `Tabs.TabPanel`            |
+| `Tag`                               | `Tag`                      |
+| `Text`                              | `Text`                     |
+| `Textarea`                          | `Textarea`                 |
+| `Tooltip`                           | `Tooltip`                  |


### PR DESCRIPTION
This PR adds the full list of `themeKey` components/values to `theming/simple.mdx`, and adds the theme keys for each component to the bottom of their docs pages.