### PR TITLE
fix(select): remove duplicate Select arrow in ie11

### DIFF
--- a/packages/css-reset/src/CSSReset.tsx
+++ b/packages/css-reset/src/CSSReset.tsx
@@ -308,6 +308,10 @@ export const CSSReset = () => (
         outline: none;
         box-shadow: none;
       }
+
+      select::-ms-expand {
+        display: none;
+      }
     `}
   />
 )


### PR DESCRIPTION
fixes #733 

This PR adds an ie-specific rule to `CSSReset` to prevent duplicate dropdown arrows showing on `Select`.