### PR TITLE
docs(guides): add file contributors functionality

### DIFF
--- a/docs/src/pages/guides.js
+++ b/docs/src/pages/guides.js
@@ -12,7 +12,7 @@ import {
 } from "@chakra-ui/core"
 
 function GuidePreview(props) {
-  const { title, children, createdAt, birthTime, contributor, ...rest } = props
+  const { title, children, createdAt, birthTime, contributors, ...rest } = props
   return (
     <Flex
       transition="all 0.3s"
@@ -39,7 +39,7 @@ function GuidePreview(props) {
       </Box>
       <Flex justify="space-between" mt="6" color="gray.500" width="100%">
         <Stack direction="row" flex="1">
-          <Avatar size="xs" src={contributor.image} name={contributor.name} />
+          <Avatar size="xs" />
           <Text fontSize="sm">dsfdfsdd</Text>
         </Stack>
         <Text fontSize="sm">
@@ -56,6 +56,12 @@ function Guides() {
     query AllGuides {
       allMdx(filter: { fields: { collection: { eq: "guides" } } }) {
         nodes {
+          fields {
+            contributors {
+              name
+              image
+            }
+          }
           frontmatter {
             title
             description
@@ -85,6 +91,7 @@ function Guides() {
         <SimpleGrid columns={[1, 1, 2]} spacing="24px">
           {allMdx.nodes.map(
             ({
+              fields: { contributors },
               frontmatter: { title, description },
               parent: { createdAt, birthTime },
             }) => (
@@ -93,7 +100,7 @@ function Guides() {
                 title={title}
                 birthTime={birthTime}
                 createdAt={createdAt}
-                contributor={{}}
+                contributors={contributors}
               >
                 {description}
               </GuidePreview>

--- a/docs/src/templates/guides.js
+++ b/docs/src/templates/guides.js
@@ -25,7 +25,7 @@ function LastEdited(props) {
 
 // memoized to prevent from re-rendering on in-page anchor link navigation
 const Body = (props) => {
-  const { relativePath, body, modifiedTime } = props
+  const { contributors, relativePath, body, modifiedTime } = props
   return (
     <Box mx="auto" maxW="48rem" mt="1em">
       <MDXRenderer>{body}</MDXRenderer>
@@ -43,8 +43,9 @@ const Body = (props) => {
 const Guides = ({ data, pageContext }) => {
   const location = useLocation()
   const { previous, next, slug, relativePath, modifiedTime } = pageContext
-  const { body, frontmatter, tableOfContents } = data.mdx
+  const { body, frontmatter, fields, tableOfContents } = data.mdx
   const { title, description } = frontmatter
+  const { contributors } = fields
 
   return (
     <>
@@ -56,6 +57,7 @@ const Guides = ({ data, pageContext }) => {
         next={next}
         slug={slug}
         tableOfContents={tableOfContents}
+        contributors={contributors}
         relativePath={relativePath}
         modifiedTime={modifiedTime}
       />
@@ -68,6 +70,12 @@ export const query = graphql`
   query guideBySlug($slug: String!) {
     mdx(fields: { slug: { eq: $slug } }) {
       body
+      fields {
+        contributors {
+          name
+          image
+        }
+      }
       frontmatter {
         title
         description

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -1,4 +1,6 @@
 const _ = require("lodash/fp")
+const getFileContributors = require("file-contributors").default
+require("isomorphic-fetch")
 
 const compareCollections = (
   { fields: { collection: a } },
@@ -21,7 +23,7 @@ const orderByOrderThenTitle = _.orderBy(
   ["asc", "asc"],
 )
 
-module.exports.sortPostNodes = (nodes) => {
+const sortPostNodes = (nodes) => {
   const collections = groupByCollection(nodes)
   const sortedCollectionNodes = _.values(collections).map(orderByOrderThenTitle)
   const flattened = _.flatten(_.values(sortedCollectionNodes))
@@ -31,8 +33,23 @@ module.exports.sortPostNodes = (nodes) => {
 }
 
 const DOCS_REGEX = /\/docs\/pages\/.*/
-module.exports.getRelativeDocsPath = (fileAbsolutePath) => {
+const getRelativePagePath = (fileAbsolutePath) => {
   if (!fileAbsolutePath) return
   const match = fileAbsolutePath.match(DOCS_REGEX)
   return match ? match[0] : null
 }
+
+const getNodeContributors = async (node) => {
+  const relativePath = getRelativePagePath(node.fileAbsolutePath)
+  const fileContributors = await getFileContributors(
+    "chakra-ui",
+    "chakra-ui",
+    relativePath,
+  )
+  const contributors = fileContributors.map(
+    ({ login: name, avatar_url: image }) => ({ name, image }),
+  )
+  return contributors
+}
+
+module.exports = { sortPostNodes, getRelativePagePath, getNodeContributors }


### PR DESCRIPTION
This PR adds `fields.contributors` to `Mdx`. This is a field intended for use with `guides` pages, so we can list users that contributed to each guide.