### PR TITLE
docs(guides): fix guide contributors functionality

### DIFF
--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -40,13 +40,7 @@ exports.onCreateNode = async ({ node, actions, getNode }) => {
     })
 
     if (collection === "guides") {
-      const contributors = getNodeContributors(node)
-      console.log("contributors", contributors)
-      // createNodeField({
-      //   name: 'creator',
-      //   node,
-      //   value: contributors[0]
-      // })
+      const contributors = await getNodeContributors(node)
       createNodeField({
         name: "contributors",
         node,
@@ -69,6 +63,7 @@ exports.createSchemaCustomization = (props) => {
     type Contributor {
       name: String!
       image: String!
+      url: String!
     }
   `,
     // we use buildObjectType here so we can default `contributors` to `[]`
@@ -77,7 +72,7 @@ exports.createSchemaCustomization = (props) => {
       fields: {
         contributors: {
           type: "[Contributor!]!",
-          async resolve(source) {
+          resolve(source) {
             return source.contributors || []
           },
         },

--- a/docs/pages/guides/with-framer.mdx
+++ b/docs/pages/guides/with-framer.mdx
@@ -3,10 +3,6 @@ title: Chakra UI + Framer Motion
 description: Adding Animation to Chakra UI Components with Framer Motion
 ---
 
-## Adding Animation to Chakra UI Components with Framer Motion
-
-by [Segun Adebayo](https://github.com/segunadebayo)
-
 If you'd like to add some interesting motion interaction or animation to your
 Chakra UI websites or apps, here's a quick tip:
 

--- a/docs/pages/guides/with-rhf.mdx
+++ b/docs/pages/guides/with-rhf.mdx
@@ -3,8 +3,6 @@ title: Chakra UI + React Hook Form
 description: Building Forms with Chakra UI and React Hook Form
 ---
 
-## Building Forms with Chakra UI and React Hook Form
-
 This example shows how to build a simple form with Chakra UI's form components
 and the [React Hook Form](https://react-hook-form.com) form library.
 

--- a/docs/src/pages/guides.js
+++ b/docs/src/pages/guides.js
@@ -13,7 +13,16 @@ import {
 } from "@chakra-ui/core"
 
 function GuidePreview(props) {
-  const { title, children, createdAt, birthTime, url, ...rest } = props
+  const {
+    title,
+    children,
+    createdAt,
+    birthTime,
+    url,
+    contributors,
+    ...rest
+  } = props
+  const creator = contributors[0]
   return (
     <chakra.a as={GatsbyLink} to={url}>
       <Flex
@@ -38,8 +47,8 @@ function GuidePreview(props) {
         </Box>
         <Flex justify="space-between" mt="6" color="gray.500" width="100%">
           <Stack align="center" direction="row" flex="1">
-            <Avatar size="sm" />
-            <Text fontSize="sm">Segun Adebayo</Text>
+            <Avatar size="sm" name={creator.name} src={creator.image} />
+            <Text fontSize="sm">{creator.name}</Text>
           </Stack>
           <Text fontSize="sm">
             <span>Created at: </span>

--- a/docs/src/templates/guides.js
+++ b/docs/src/templates/guides.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from "@chakra-ui/core"
+import { Box, Flex, Heading, Text, Link } from "@chakra-ui/core"
 import { useLocation } from "@reach/router"
 import { graphql } from "gatsby"
 import { MDXRenderer } from "gatsby-plugin-mdx"
@@ -24,9 +24,27 @@ function LastEdited(props) {
 }
 
 const Body = (props) => {
-  const { contributors, relativePath, body, modifiedTime } = props
+  const {
+    title,
+    description,
+    contributors,
+    relativePath,
+    body,
+    modifiedTime,
+  } = props
+  const creator = contributors[0]
   return (
     <Box mx="auto" maxW="48rem" mt="1em">
+      <Heading as="h1">{title}</Heading>
+      <Text>{description}</Text>
+      {creator && (
+        <Text>
+          by{" "}
+          <Link href={creator.url} isExternal>
+            {creator.name}
+          </Link>
+        </Text>
+      )}
       <MDXRenderer>{body}</MDXRenderer>
       {relativePath && (
         <LastEdited
@@ -52,6 +70,8 @@ const Guides = ({ data, pageContext }) => {
       <Body
         pathname={location.pathname}
         body={body}
+        title={title}
+        description={description}
         previous={previous}
         next={next}
         slug={slug}
@@ -73,6 +93,7 @@ export const query = graphql`
         contributors {
           name
           image
+          url
         }
       }
       frontmatter {

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -2,7 +2,7 @@ const _ = require("lodash/fp")
 const { Octokit } = require("@octokit/rest")
 
 const octokit = new Octokit({
-  auth: "b452f7c3d86fcffa6bd1fd82dd4614ec757437ea",
+  auth: process.env.GITHUB_API_TOKEN,
 })
 
 const compareCollections = (
@@ -42,8 +42,37 @@ const getRelativePagePath = (fileAbsolutePath) => {
   return match ? match[0] : null
 }
 
+const orderByCommitAuthorDate = _.orderBy(["commit.author.date"], ["asc"])
+const getCommitAuthorDetails = _.pick([
+  "commit.author.name",
+  "author.avatar_url",
+  "author.html_url",
+])
+
 const getNodeContributors = async (node) => {
-  return []
+  const relativePath = getRelativePagePath(node.fileAbsolutePath)
+  const { data: commits } = await octokit.repos.listCommits({
+    owner: "chakra-ui",
+    repo: "chakra-ui",
+    sha: "master",
+    path: relativePath,
+  })
+  const orderedCommits = orderByCommitAuthorDate(commits)
+  const contributors = orderedCommits
+    .map(getCommitAuthorDetails)
+    .map(
+      ({
+        commit: {
+          author: { name },
+        },
+        author: { avatar_url: image, html_url: url },
+      }) => ({
+        name,
+        image,
+        url,
+      }),
+    )
+  return contributors
 }
 
 module.exports = { sortPostNodes, getRelativePagePath, getNodeContributors }


### PR DESCRIPTION
This PR uses `@octokit/rest.js` to fetch the contributors for guides. It also moves rendering for guide title/description/link to `templates/guides.js`.