### PR TITLE
chore(site): add team page

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -55,6 +55,17 @@ module.exports = {
         path: `${__dirname}/pages`,
       },
     },
+    {
+      resolve: `gatsby-source-graphql`,
+      options: {
+        typeName: "GitHub",
+        fieldName: "github",
+        url: "https://api.github.com/graphql",
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_API_TOKEN}`,
+        },
+      },
+    },
     "gatsby-transformer-sharp",
     "gatsby-plugin-sharp",
     {

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -5,6 +5,7 @@ const {
   sortPostNodes,
   getRelativePagePath,
   getNodeContributors,
+  readAllContributorsRc,
 } = require("./utils")
 
 exports.onCreateNode = async ({ node, actions, getNode }) => {
@@ -158,5 +159,30 @@ exports.createPages = async ({ graphql, actions }) => {
         relativePath,
       },
     })
+  })
+}
+
+exports.sourceNodes = async ({
+  createNodeId,
+  createContentDigest,
+  actions,
+}) => {
+  const { createNode } = actions
+
+  const contributors = await readAllContributorsRc()
+  contributors.forEach(({ login, avatar_url }) => {
+    const id = createNodeId(`contributors__${login}`)
+    const contributor = { login, avatarUrl: avatar_url }
+    const nodeContent = JSON.stringify(contributor)
+    const nodeMeta = {
+      id,
+      internal: {
+        type: "ChakraContributor",
+        content: nodeContent,
+        contentDigest: createContentDigest(contributor),
+      },
+    }
+    const node = { ...contributor, ...nodeMeta }
+    createNode(node)
   })
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
     "gatsby-plugin-sharp": "^2.2.9",
     "gatsby-remark-autolink-headers": "^2.3.3",
     "gatsby-source-filesystem": "^2.1.8",
+    "gatsby-source-graphql": "^2.5.3",
     "gatsby-transformer-sharp": "^2.2.5",
     "lodash": "^4.17.15",
     "prism-react-renderer": "^1.1.0",

--- a/docs/src/components/header.js
+++ b/docs/src/components/header.js
@@ -62,6 +62,7 @@ const HeaderContent = () => {
         <HStack as="nav" spacing="8" ml="32px">
           <NavLink to="/getting-started">Docs</NavLink>
           <NavLink to="/guides">Guides</NavLink>
+          <NavLink to="/team">Team</NavLink>
         </HStack>
       </Flex>
 

--- a/docs/src/pages/team.js
+++ b/docs/src/pages/team.js
@@ -13,6 +13,7 @@ import {
   Tooltip,
 } from "@chakra-ui/core"
 import { IoLogoTwitter, IoLogoGithub, IoIosGlobe } from "react-icons/io"
+import SEO from "../components/seo"
 
 const SocialLink = ({ icon, href }) => (
   <Link display="inline-block" href={href} isExternal>
@@ -83,44 +84,51 @@ function Team({ data }) {
   const sortedMemberNodes = memberNodes.sort(sortMembers)
 
   return (
-    <Box py="56px">
-      <Box py="80px">
+    <>
+      <SEO
+        title="Chakra UI Team &amp; Contributors"
+        description="List of team members and contributors that make the Chakra UI project possible"
+        slug="/team"
+      />
+      <Box py="56px">
+        <Box py="80px">
+          <Container maxWidth="lg">
+            <Heading as="h1" size="2xl" mb="3">
+              Chakra UI Team &amp; Contributors
+            </Heading>
+            <Text maxW="60ch">
+              The people listed on this page have contributed time, effort, and
+              thought to Chakra UI. Without them, this project would not be
+              possible.
+            </Text>
+          </Container>
+        </Box>
         <Container maxWidth="lg">
-          <Heading as="h1" size="2xl" mb="3">
-            Chakra UI Team &amp; Contributors
-          </Heading>
-          <Text maxW="60ch">
-            The people listed on this page have contributed time, effort, and
-            thought to Chakra UI. Without them, this project would not be
-            possible.
-          </Text>
+          <Stack spacing={12}>
+            <Stack spacing={8}>
+              <Heading as="h2">Core Team</Heading>
+              <SimpleGrid columns={[1, 1, 2]} spacing={6}>
+                {sortedMemberNodes.map((member) => (
+                  <Member key={member.login} member={member} />
+                ))}
+              </SimpleGrid>
+            </Stack>
+
+            <Stack spacing={8}>
+              <Heading as="h2">Project Contributors</Heading>
+              <Flex wrap="wrap">
+                {contributorsWithoutTeam.map((contributor) => (
+                  <Contributor
+                    key={contributor.login}
+                    contributor={contributor}
+                  />
+                ))}
+              </Flex>
+            </Stack>
+          </Stack>
         </Container>
       </Box>
-      <Container maxWidth="lg">
-        <Stack spacing={12}>
-          <Stack spacing={8}>
-            <Heading as="h2">Core Team</Heading>
-            <SimpleGrid columns={[1, 1, 2]} spacing={6}>
-              {sortedMemberNodes.map((member) => (
-                <Member key={member.login} member={member} />
-              ))}
-            </SimpleGrid>
-          </Stack>
-
-          <Stack spacing={8}>
-            <Heading as="h2">Project Contributors</Heading>
-            <Flex wrap="wrap">
-              {contributorsWithoutTeam.map((contributor) => (
-                <Contributor
-                  key={contributor.login}
-                  contributor={contributor}
-                />
-              ))}
-            </Flex>
-          </Stack>
-        </Stack>
-      </Container>
-    </Box>
+    </>
   )
 }
 

--- a/docs/src/pages/team.js
+++ b/docs/src/pages/team.js
@@ -1,0 +1,104 @@
+import * as React from "react"
+import { graphql } from "gatsby"
+import {
+  Box,
+  Container,
+  Heading,
+  Text,
+  Stack,
+  Avatar,
+  SimpleGrid,
+  Link,
+} from "@chakra-ui/core"
+import { IoLogoTwitter, IoLogoGithub, IoIosGlobe } from "react-icons/io"
+
+const SocialLink = ({ icon, href }) => (
+  <Link display="inline-block" href={href} isExternal>
+    <Box as={icon} fontSize="xl" color="gray.700" />
+  </Link>
+)
+
+function Member({ member }) {
+  const { avatarUrl, bio, name, twitterUsername, url, websiteUrl } = member
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={6}>
+        <Avatar size="lg" src={avatarUrl} />
+        <Stack spacing={3}>
+          <Text fontWeight="bold" fontSize="2xl">
+            {name}
+          </Text>
+
+          <Stack direction="row" spacing={2} justify="center">
+            <SocialLink href={url} icon={IoLogoGithub} />
+            {twitterUsername && (
+              <SocialLink
+                href={`https://twitter.com/${twitterUsername}`}
+                icon={IoLogoTwitter}
+              />
+            )}
+            {websiteUrl && <SocialLink href={websiteUrl} icon={IoIosGlobe} />}
+          </Stack>
+          <Text>{bio}</Text>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}
+
+const sortMembers = (a, b) => {
+  // segun comes first!
+  if (a.login === "segunadebayo") return -1
+  if (b.login === "segunadebayo") return 1
+
+  // everything else is alphabetical by login
+  return a.login.localeCompare(b.login, "en")
+}
+
+function Team({ data }) {
+  const { nodes } = data.github.organization.membersWithRole
+  const sorted = nodes.sort(sortMembers)
+
+  return (
+    <Box pt="56px">
+      <Box py="80px">
+        <Container maxWidth="lg">
+          <Heading as="h1" size="2xl" mb="3">
+            Chakra UI Team
+          </Heading>
+          <Text>These are the members of the Chakra UI core team.</Text>
+        </Container>
+      </Box>
+      <Container maxWidth="lg">
+        <SimpleGrid columns={[1, 1, 2]} spacing={6}>
+          {sorted.map((member) => (
+            <Member key={member.login} member={member} />
+          ))}
+        </SimpleGrid>
+      </Container>
+    </Box>
+  )
+}
+
+export default Team
+
+export const query = graphql`
+  query TeamQuery {
+    github {
+      organization(login: "chakra-ui") {
+        membersWithRole(first: 50) {
+          nodes {
+            avatarUrl
+            bio
+            login
+            name
+            twitterUsername
+            url
+            websiteUrl
+          }
+        }
+      }
+    }
+  }
+`

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -1,3 +1,5 @@
+const fs = require("fs").promises
+const path = require("path")
 const _ = require("lodash/fp")
 const { Octokit } = require("@octokit/rest")
 
@@ -75,4 +77,16 @@ const getNodeContributors = async (node) => {
   return contributors
 }
 
-module.exports = { sortPostNodes, getRelativePagePath, getNodeContributors }
+const readAllContributorsRc = async () => {
+  const rcPath = path.resolve("..", ".all-contributorsrc")
+  const contributorsRcData = await fs.readFile(rcPath, "utf-8")
+  const { contributors } = JSON.parse(contributorsRcData)
+  return contributors
+}
+
+module.exports = {
+  sortPostNodes,
+  getRelativePagePath,
+  getNodeContributors,
+  readAllContributorsRc,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11408,6 +11408,7 @@ gatsby-source-filesystem@^2.1.8:
 gatsby-source-graphql@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/gatsby-source-graphql/-/gatsby-source-graphql-2.5.3.tgz#353f2949502bf73875caf06653a68265923b9fa7"
+  integrity sha512-6WiEdyCpjFKFUzWvY26jrQUF3sBg5F0cpVLndJtSMtwvv6GYeiqllhMC2f8ygGYZvUVBCq1NHN/5Z/wGd0d0ww==
   dependencies:
     "@babel/runtime" "^7.10.2"
     apollo-link "1.2.14"


### PR DESCRIPTION
This PR adds a team page to the site, fetching the team's data using `gatsby-source-graphql` and the GitHub API.

![image](https://user-images.githubusercontent.com/1954752/83950641-518bcb00-a7fa-11ea-80c0-f8efb50fb8bc.png)

In order for this to work, we need to make sure we have a `GITHUB_API_TOKEN` in env with `repo` and `read:org` permissions available in the build step.