### PR TITLE
fix: remove unnecessary event types on image

### DIFF
--- a/packages/chakra-ui/src/Image/index.d.ts
+++ b/packages/chakra-ui/src/Image/index.d.ts
@@ -16,14 +16,6 @@ interface IImage {
    */
   alt?: string;
   /**
-   * A callback for when the image `src` has been loaded
-   */
-  onLoad?: () => void;
-  /**
-   * A callback for when there was an error loading the image `src`
-   */
-  onError?: () => void;
-  /**
    * The native HTML `width` attribute to the passed to the `img`
    */
   htmlWidth?: string | number;


### PR DESCRIPTION
This PR is resolving the missing `onLoad` and `onError` callback types for #777. As @wweaver mentioned on the bug:
> If I just remove the onLoad definition in the IImage interface the type error goes away as the underlying BoxProps, really the React DomAttributes, already supports what is needed.

Unable to add tests for the types. 

Tested by creating a symlink to @chakra-ui/core in a sandbox project of mine and ensuring the default image callback types are available. 