### PR TITLE
chore(site): adjust metadata

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,5 +1,5 @@
 const siteMetadata = {
-  title: "Chakra UI | Design System built with React",
+  title: "Chakra UI",
   description:
     "Simple, Modular and Accessible UI Components for your React Applications.",
   author: "Chakra UI",

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,7 +1,7 @@
 const siteMetadata = {
   title: "Chakra UI | Design System built with React",
   description:
-    "Simple, Modular and Accessible UI Components for your React Applications. Built with Styled System",
+    "Simple, Modular and Accessible UI Components for your React Applications.",
   author: "Chakra UI",
   siteUrl: "https://chakra-ui.com",
   repository: "https://github.com/chakra-ui/chakra-ui",


### PR DESCRIPTION
This PR makes two changes:

1. Removed "Design System built with React" from `title` because it made tab titles so long they were essentially useless. You can now see most page-specific titles on a normal sized tab now.
2. Removes "Built with Styled System" from `description`.