### PR TITLE
chore(github): re-add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help make Chakra UI better
+title: "[Component] A concise description of bug"
+labels: ""
+assignees: ""
+---
+
+**Describe the bug** A clear and concise description of what the bug is.
+
+<!-- If applicable, add screenshots/videos to help explain the problem. -->
+
+**Expected Behavior** A clear and concise description of what you expected to
+happen.
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**To Reproduce**
+
+- Use this template:
+- List the steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Suggested solution(s)**
+
+<!-- How could we solve this bug? What changes would need to be made? -->
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Additional context** Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for a feature or a new component for Chakra UI
+title: Request to add [Component] component
+labels: ""
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.** A clear and
+concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like** A clear and concise description of what you
+want to happen.
+
+**Describe alternatives you've considered** A clear and concise description of
+any alternative solutions or features you've considered.
+
+**Additional context** Add any other context or screenshots about the feature
+request here.


### PR DESCRIPTION
We lost our issue templates in the move (possibly intentional?). This PR re-adds them.