### PR TITLE
fix: Broken default theme link

### DIFF
--- a/docs/pages/theming/theme.mdx
+++ b/docs/pages/theming/theme.mdx
@@ -45,7 +45,7 @@ export default {
 ```
 
 Chakra provide a sensible
-[default theme](https://github.com/chakra-ui/chakra-ui/blob/master/packages/chakra-ui/src/theme)
+[default theme](https://github.com/chakra-ui/chakra-ui/tree/master/packages/theme)
 inspired by Tailwind CSS, but you can customize it to fit your design.
 
 ### Black & White


### PR DESCRIPTION
Link to default theme in docs is broken. If I'm not wrong the updated link on the pull request should be correct.