### PR TITLE
chore(stale): re-add configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,16 +4,24 @@ daysUntilStale: 60
 daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - regression
-  - pinned
-  - security
+  - "good first issue 👍"
+  - "good for beginners 😃"
+  - "help wanted 🆘"
+  - "Priority: High 🚨"
+  - "Showcase 💖"
+  - "Topic: Reviews ⭐️💖"
+  - "Status: Assigned ➡"
+  - "Status: Work in Progress 🛠"
+  - "Type: Bug 🐛"
+  - "Type: Documentation 📚"
+  - "Type: Feature 🚀"
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs.Thank you for
-  your contributions.
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
 unmarkComment: false


### PR DESCRIPTION
Explains why so many things are suddenly marked as `stale`.