### PR TITLE
chore: remove spectrum badge from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
   <img alt="Bundle Size" src="https://badgen.net/bundlephobia/minzip/@chakra-ui/core"/>
   <img alt="MIT License" src="https://img.shields.io/github/license/chakra-ui/chakra-ui"/>
   <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@chakra-ui/core.svg?style=flat"/>
-  <a href="https://spectrum.chat/chakra-ui"><img alt="Spectrum" src="https://img.shields.io/badge/community-spectrum-7A2DFB.svg?style=flat-square" /></a>
-  <img alt="Spectrum" src="https://badgen.net/github/stars/chakra-ui/chakra-ui" />
+  <img alt="Github Stars" src="https://badgen.net/github/stars/chakra-ui/chakra-ui" />
   <a href="https://lernajs.io/"><img alt="Lerna" src="https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg" /></a>
 </p>
 <br />


### PR DESCRIPTION
Spectrum is no longer the tool used for discussions so this commit removes the badge from the Readme to avoid confusion among users.