### PR TITLE
Remove duplicate border-style for img

### DIFF
--- a/packages/css-reset/src/css-reset.tsx
+++ b/packages/css-reset/src/css-reset.tsx
@@ -233,10 +233,6 @@ export const CSSReset = () => (
         border-top-width: 1px;
       }
 
-      img {
-        border-style: solid;
-      }
-
       textarea {
         resize: vertical;
       }


### PR DESCRIPTION
`CSSReset` sets the default `border-style` for images to `solid` but it's already set to `none` above.