### PR TITLE
chore(site): move from github api v4 to v3 for team page

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,7 +1,3 @@
-require("dotenv").config({
-  path: `.env.${process.env.NODE_ENV}`,
-})
-
 const siteMetadata = {
   title: "Chakra UI",
   description:
@@ -57,17 +53,6 @@ module.exports = {
       options: {
         name: `pages`,
         path: `${__dirname}/pages`,
-      },
-    },
-    {
-      resolve: `gatsby-source-graphql`,
-      options: {
-        typeName: "GitHub",
-        fieldName: "github",
-        url: "https://api.github.com/graphql",
-        headers: {
-          Authorization: `Bearer ${process.env.GITHUB_API_TOKEN}`,
-        },
       },
     },
     "gatsby-transformer-sharp",

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -5,10 +5,9 @@ const {
   sortPostNodes,
   getRelativePagePath,
   getNodeContributors,
+  getOrgMembers,
   readAllContributorsRc,
 } = require("./utils")
-
-console.log(process.env.GITHUB_API_TOKEN)
 
 exports.onCreateNode = async ({ node, actions, getNode }) => {
   const { createNodeField } = actions
@@ -185,6 +184,22 @@ exports.sourceNodes = async ({
       },
     }
     const node = { ...contributor, ...nodeMeta }
+    createNode(node)
+  })
+
+  const team = await getOrgMembers()
+  team.forEach((member) => {
+    const id = createNodeId(`team__${member.login}`)
+    const nodeContent = JSON.stringify(member)
+    const nodeMeta = {
+      id,
+      internal: {
+        type: "TeamMember",
+        content: nodeContent,
+        contentDigest: createContentDigest(member),
+      },
+    }
+    const node = { ...member, ...nodeMeta }
     createNode(node)
   })
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
     "@chakra-ui/core": "1.0.0",
     "@mdx-js/mdx": "1.6.1",
     "@mdx-js/react": "1.6.1",
-    "@octokit/rest": "^17.0.0",
+    "@octokit/rest": "^18.0.0",
     "@reach/router": "^1.3.3",
     "docsearch.js": "^2.6.3",
     "formik": "^2.1.4",
@@ -26,7 +26,6 @@
     "gatsby-plugin-sharp": "^2.2.9",
     "gatsby-remark-autolink-headers": "^2.3.3",
     "gatsby-source-filesystem": "^2.1.8",
-    "gatsby-source-graphql": "^2.5.3",
     "gatsby-transformer-sharp": "^2.2.5",
     "lodash": "^4.17.15",
     "prism-react-renderer": "^1.1.0",
@@ -46,7 +45,6 @@
   },
   "devDependencies": {
     "eslint": "7.1.0",
-    "prettier": "2.0.5",
-    "dotenv": "8.2.0"
+    "prettier": "2.0.5"
   }
 }

--- a/docs/src/pages/team.js
+++ b/docs/src/pages/team.js
@@ -70,24 +70,14 @@ function Contributor({ contributor }) {
   )
 }
 
-const sortMembers = (a, b) => {
-  // segun comes first!
-  if (a.login === "segunadebayo") return -1
-  if (b.login === "segunadebayo") return 1
-
-  // everything else is alphabetical by login
-  return a.login.localeCompare(b.login, "en")
-}
-
 function Team({ data }) {
-  const { github, contributors } = data
-  const { nodes: memberNodes } = github.organization.membersWithRole
+  const { members, contributors } = data
+  const { nodes: memberNodes } = members
   const { nodes: contributorNodes } = contributors
   const memberLogins = memberNodes.map(({ login }) => login)
   const contributorsWithoutTeam = contributorNodes.filter(
     ({ login }) => !memberLogins.includes(login),
   )
-  const sortedMemberNodes = memberNodes.sort(sortMembers)
 
   return (
     <>
@@ -113,7 +103,7 @@ function Team({ data }) {
           <Stack spacing={8}>
             <Heading size="md">Core Team</Heading>
             <SimpleGrid columns={[1, 1, 2]} spacing="40px">
-              {sortedMemberNodes.map((member) => (
+              {memberNodes.map((member) => (
                 <Member key={member.login} member={member} />
               ))}
             </SimpleGrid>
@@ -139,20 +129,17 @@ function Team({ data }) {
 export default Team
 
 export const query = graphql`
-  query TeamQuery {
-    github {
-      organization(login: "chakra-ui") {
-        membersWithRole(first: 50) {
-          nodes {
-            avatarUrl
-            bio
-            login
-            name
-            twitterUsername
-            url
-            websiteUrl
-          }
-        }
+  query TeamAndContributorsQuery {
+    members: allTeamMember {
+      nodes {
+        avatarUrl
+        bio
+        githubUrl
+        id
+        name
+        login
+        twitterUsername
+        websiteUrl
       }
     }
     contributors: allChakraContributor {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,15 +3535,15 @@
   dependencies:
     "@octokit/types" "^4.0.1"
 
-"@octokit/core@^2.4.3":
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-2.5.3.tgz#dd754e6f5ad9b15631e9b276ae4f00ac2ea2cf9b"
-  integrity sha512-23AHK9xBW0v79Ck8h5U+5iA4MW7aosqv+Yr6uZXolVGNzzHwryNH5wM386/6+etiKUTwLFZTqyMU9oQpIBZcFA==
+"@octokit/core@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.0.0.tgz#4b7bf2a9e744a49abcbb3aca7b4dfc219513e4f9"
+  integrity sha512-FGUUqZbIwl5UPvuUTWq8ly2B12gJGWjYh1DviBzZLXp5LzHUgyzL+NDGsXeE4vszXoGsD/JfpZS+kjkLiD2T9w==
   dependencies:
     "@octokit/auth-token" "^2.4.0"
     "@octokit/graphql" "^4.3.1"
     "@octokit/request" "^5.4.0"
-    "@octokit/types" "^4.0.1"
+    "@octokit/types" "^5.0.0"
     before-after-hook "^2.1.0"
     universal-user-agent "^5.0.0"
 
@@ -3597,12 +3597,12 @@
     "@octokit/types" "^2.0.1"
     deprecation "^2.3.1"
 
-"@octokit/plugin-rest-endpoint-methods@3.15.0":
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.15.0.tgz#2f01bf16a1fd2fb8ec8915aebc4d4b5b348ea8d6"
-  integrity sha512-cx4JScYv3rA7pR9gCd8SBdf8LtkIYsN6Jtl0O0pG1IrKaj/HVz1b27zFaS5gn/MI8UwdDtUuHiN3NMtkrIWoqA==
+"@octokit/plugin-rest-endpoint-methods@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.0.0.tgz#b02a2006dda8e908c3f8ab381dd5475ef5a810a8"
+  integrity sha512-emS6gysz4E9BNi9IrCl7Pm4kR+Az3MmVB0/DoDCmF4U48NbYG3weKyDlgkrz6Jbl4Mu4nDx8YWZwC4HjoTdcCA==
   dependencies:
-    "@octokit/types" "^4.1.6"
+    "@octokit/types" "^5.0.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^1.0.2":
@@ -3659,15 +3659,15 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@octokit/rest@^17.0.0":
-  version "17.10.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-17.10.0.tgz#40d94e8abb98741aa99d0dac39a974cd257f7865"
-  integrity sha512-TT0rsmi/IhYDy37+roEjawvpUfXxXVLWjWfcoOByJ8eQka1N21ka7BqVCi+rWco4x7sSffXcw2QfGmmNSUb7Tw==
+"@octokit/rest@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.0.0.tgz#7f401d9ce13530ad743dfd519ae62ce49bcc0358"
+  integrity sha512-4G/a42lry9NFGuuECnua1R1eoKkdBYJap97jYbWDNYBOUboWcM75GJ1VIcfvwDV/pW0lMPs7CEmhHoVrSV5shg==
   dependencies:
-    "@octokit/core" "^2.4.3"
+    "@octokit/core" "^3.0.0"
     "@octokit/plugin-paginate-rest" "^2.2.0"
     "@octokit/plugin-request-log" "^1.0.0"
-    "@octokit/plugin-rest-endpoint-methods" "3.15.0"
+    "@octokit/plugin-rest-endpoint-methods" "4.0.0"
 
 "@octokit/types@^2.0.0", "@octokit/types@^2.0.1":
   version "2.16.2"
@@ -3676,10 +3676,17 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/types@^4.0.1", "@octokit/types@^4.1.6":
+"@octokit/types@^4.0.1":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-4.1.9.tgz#a3e1ff1a15637ab830fbab0268c2d7ca824bc969"
   integrity sha512-hinM/BA2c1vebN2HSR3JtVdYtrSbmvn/doUBZXXuQuh/9o60hYwitQQAGTpJu+k6pjtjURskDHQxUFvqLvYCeA==
+  dependencies:
+    "@types/node" ">= 8"
+
+"@octokit/types@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.0.1.tgz#5459e9a5e9df8565dcc62c17a34491904d71971e"
+  integrity sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==
   dependencies:
     "@types/node" ">= 8"
 


### PR DESCRIPTION
This PR removes `gatsby-source-graphql` and all the stuff related to Github API v4 and replaces it with Octokit usage. We're making this change because v4 doesn't allow anonymous api access and we don't want to require that users manage a local token just to do dev work on the site.