### PR TITLE
feat(utils): replace null values in mapResponsive with previous value

### DIFF
--- a/packages/utils/src/responsive.ts
+++ b/packages/utils/src/responsive.ts
@@ -4,7 +4,7 @@ import { objectKeys } from "./object"
 
 export function mapResponsive(prop: any, mapper: (val: any) => any) {
   if (isArray(prop)) {
-    return prop.map(mapper)
+    return removeNullValues(prop).map(mapper)
   }
 
   if (isObject(prop)) {
@@ -19,4 +19,15 @@ export function mapResponsive(prop: any, mapper: (val: any) => any) {
   }
 
   return null
+}
+
+// ["1px", null, "2px"] becomes ["1px", "1px", "2px"]
+function removeNullValues(prop: any[]): any[] {
+  return prop.reduce((acc: string[], x: string) => {
+    if (x == null) {
+      let last = acc.length !== 0 ? acc[acc.length - 1] : x
+      return [...acc.slice(0, -1), last, last]
+    }
+    return [...acc, x]
+  }, [])
 }

--- a/packages/utils/src/tests/responsive.test.ts
+++ b/packages/utils/src/tests/responsive.test.ts
@@ -14,3 +14,16 @@ test("should run mapper on array or object and return mapped data", () => {
     md: "grid-template-columns(3, 1fr )",
   })
 })
+
+test("null values in array are replaced with previous value", () => {
+  expect(mapResponsive([2, null, 3], mapper)).toStrictEqual([
+    "grid-template-columns(2, 1fr )",
+    "grid-template-columns(2, 1fr )",
+    "grid-template-columns(3, 1fr )",
+  ])
+  expect(mapResponsive([2, null, null], mapper)).toStrictEqual([
+    "grid-template-columns(2, 1fr )",
+    "grid-template-columns(2, 1fr )",
+    "grid-template-columns(2, 1fr )",
+  ])
+})


### PR DESCRIPTION
This let you omit values ti use the previous one, like `styled-system` does

```tsx
<Stack direction={['column', null, 'row']} />
```