### PR TITLE
fix(site): update pagination node order

### DIFF
--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -27,8 +27,6 @@ exports.onCreateNode = async ({ node, actions, getNode }) => {
       trailingSlash: false,
     }).toLowerCase()
 
-    console.log(sourceInstanceName)
-
     const slug = `/${sourceInstanceName}${relativeFilePath}`
 
     // create `slug` field (`node.fields.slug`)

--- a/website/utils.js
+++ b/website/utils.js
@@ -5,19 +5,17 @@ const { Octokit } = require("@octokit/rest")
 
 const octokit = new Octokit()
 
+const collections = ["main", "theming", "layout", "components", "utilities"]
 const compareCollections = (
   { fields: { collection: a } },
   { fields: { collection: b } },
 ) => {
-  // comparison when one or both are "main"
-  if (a === "main" && b === "main") return 0
-  if (a === "main" && b !== "main") return -1
-  if (a !== "main" && b === "main") return 1
+  const aIndex = collections.indexOf(a)
+  const bIndex = collections.indexOf(b)
 
-  // comparisons when neither are "main"
-  if (a < b) return -1
-  if (a > b) return 1
-  return 0
+  if (aIndex === bIndex) return 0
+  if (aIndex > bIndex) return 1
+  if (aIndex < bIndex) return -1
 }
 
 const groupByCollection = _.groupBy("fields.collection")

--- a/website/utils.spec.js
+++ b/website/utils.spec.js
@@ -11,12 +11,16 @@ test("sortPostNodes", () => {
     { frontmatter: { title: "C" }, fields: { collection: "components" } },
     { frontmatter: { title: "B", order: 2 }, fields: { collection: "main" } },
     { frontmatter: { title: "A" }, fields: { collection: "utilities" } },
+    { frontmatter: { title: "A" }, fields: { collection: "theming" } },
+    { frontmatter: { title: "A" }, fields: { collection: "layout" } },
     { frontmatter: { title: "A", order: 1 }, fields: { collection: "main" } },
   ]
 
   const expected = [
     { frontmatter: { title: "A", order: 1 }, fields: { collection: "main" } },
     { frontmatter: { title: "B", order: 2 }, fields: { collection: "main" } },
+    { frontmatter: { title: "A" }, fields: { collection: "theming" } },
+    { frontmatter: { title: "A" }, fields: { collection: "layout" } },
     {
       frontmatter: { title: "A", order: 1 },
       fields: { collection: "components" },


### PR DESCRIPTION
This PR updates docs nodes to be finally ordered by their collection, so that previous/next links lead to the correct pages.