### PR TITLE
chore(site): add optional octokit auth via .env

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -1,3 +1,5 @@
+require("dotenv").config({ path: `.env.${process.env.NODE_ENV}` })
+
 const siteMetadata = {
   title: "Chakra UI",
   description:

--- a/website/utils.js
+++ b/website/utils.js
@@ -3,7 +3,7 @@ const path = require("path")
 const _ = require("lodash/fp")
 const { Octokit } = require("@octokit/rest")
 
-const octokit = new Octokit()
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
 
 const compareCollections = (
   { fields: { collection: a } },


### PR DESCRIPTION
This PR adds optional auth support via `.env.development` and the `GITHUB_TOKEN` variable. The v3 API is rate limited for anonymous users to 60 requests/hour, which works for minor development work but anything involved multiple restarts will need a token.

I'll follow up with a note explaining how to use this functionality.