### PR TITLE
feat: allow responsive pseudo props with object notation

### DIFF
--- a/packages/css/src/css.ts
+++ b/packages/css/src/css.ts
@@ -5,7 +5,15 @@ import {
   parser,
   StyleConfig,
 } from "@chakra-ui/parser"
-import { get, isArray, isObject, merge, runIfFn } from "@chakra-ui/utils"
+import {
+  get,
+  isArray,
+  isObject,
+  isResponsiveObjectLike,
+  merge,
+  objectToArrayNotation,
+  runIfFn,
+} from "@chakra-ui/utils"
 import { CSSObject, StyleObjectOrFn } from "./css.types"
 import {
   determineTheme,
@@ -35,8 +43,10 @@ export const css = (styleObject: StyleObjectOrFn) => (props: PropsOrTheme) => {
   }
 
   for (const key in styles) {
-    const valueOrFn = styles[key]
-    const value = runIfFn(valueOrFn, theme)
+    let value = runIfFn(styles[key], theme)
+    if (isResponsiveObjectLike(value)) {
+      value = objectToArrayNotation(value)
+    }
 
     const config = parser.config[key] as StyleConfig | undefined
 

--- a/packages/css/src/css.types.ts
+++ b/packages/css/src/css.types.ts
@@ -1,4 +1,4 @@
-import { Pseudos } from "@chakra-ui/parser"
+import { Pseudos, ResponsiveValue } from "@chakra-ui/parser"
 import { Omit } from "@chakra-ui/utils"
 import {
   BoxShadowProperty,
@@ -11,8 +11,6 @@ import {
 } from "csstype"
 
 type CSS = PropertiesFallback<number | string>
-
-type Responsive<T> = T | Array<T | null>
 
 type CSSProperties = StandardProperties<number | string> &
   SvgProperties<number | string>
@@ -102,8 +100,8 @@ interface AllSystemCSSProperties
 type SystemCSSProperties = {
   [K in keyof AllSystemCSSProperties]:
     | string
-    | Responsive<AllSystemCSSProperties[K]>
-    | ((theme: any) => Responsive<AllSystemCSSProperties[K]>)
+    | ResponsiveValue<AllSystemCSSProperties[K]>
+    | ((theme: any) => ResponsiveValue<AllSystemCSSProperties[K]>)
     | SystemStyleObject
 }
 
@@ -113,8 +111,8 @@ interface ApplyPropStyles {
 
 type PseudoStyles = {
   [K in keyof Pseudos]?: K extends "_before" | "_after"
-    ? SystemStyleObject & { content?: string }
-    : SystemStyleObject
+    ? SystemCSSProperties & { content?: string }
+    : SystemCSSProperties
 }
 
 export type SystemStyleObject =

--- a/packages/css/tests/css.test.ts
+++ b/packages/css/tests/css.test.ts
@@ -436,3 +436,27 @@ test("returns correct media query order 2", () => {
     "paddingBottom",
   ])
 })
+
+test("pseudo selectors are transformed", () => {
+  const result = css({
+    _before: {
+      paddingBottom: 2,
+      paddingLeft: [2, 3, 4],
+      paddingRight: { base: 1, sm: 2 },
+    },
+  })(theme)
+  expect(result).toEqual({
+    "&::before": {
+      "@media screen and (min-width: 40em)": {
+        paddingLeft: 16,
+        paddingRight: 8,
+      },
+      "@media screen and (min-width: 52em)": {
+        paddingLeft: 32,
+      },
+      paddingBottom: 8,
+      paddingLeft: 8,
+      paddingRight: 4,
+    },
+  })
+})

--- a/packages/layout/src/aspect-ratio.tsx
+++ b/packages/layout/src/aspect-ratio.tsx
@@ -1,6 +1,7 @@
-import { cx, __DEV__ } from "@chakra-ui/utils"
+import { cx, __DEV__, mapResponsive } from "@chakra-ui/utils"
 import * as React from "react"
 import { chakra, PropsOf } from "@chakra-ui/system"
+import { ResponsiveValue } from "@chakra-ui/system"
 
 interface AspectRatioOptions {
   /**
@@ -8,7 +9,7 @@ interface AspectRatioOptions {
    *
    * `21/9`, `16/9`, `9/16`, `4/3`, `1.85/1`
    */
-  ratio?: number
+  ratio?: ResponsiveValue<number>
 }
 
 export type AspectRatioProps = PropsOf<typeof chakra.div> & AspectRatioOptions
@@ -39,7 +40,7 @@ export const AspectRatio = React.forwardRef(function AspectRatio(
         height: 0,
         content: `""`,
         display: "block",
-        paddingBottom: `${(1 / ratio) * 100}%`,
+        paddingBottom: mapResponsive(ratio, (r) => `${(1 / r) * 100}%`),
       }}
       css={{
         "& > *": {

--- a/packages/layout/stories/aspect-ratio.stories.tsx
+++ b/packages/layout/stories/aspect-ratio.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { AspectRatio } from "../src"
+import { AspectRatio, Box } from "../src"
 
 export default {
   title: "AspectRatio",
@@ -42,5 +42,25 @@ export const WithMap = () => (
       src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3963.952912260219!2d3.375295414770757!3d6.5276316452784755!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x103b8b2ae68280c1%3A0xdc9e87a367c3d9cb!2sLagos!5e0!3m2!1sen!2sng!4v1567723392506!5m2!1sen!2sng"
       title="demo"
     />
+  </AspectRatio>
+)
+
+/**
+ * Embed a map in AspectRatio, and it's automatically
+ * sized to the desired ratio.
+ */
+export const WithResponsive = () => (
+  <AspectRatio
+    maxWidth="300px"
+    ratio={{ base: 1, sm: 4 / 3, md: 16 / 9, lg: 21 / 9 }}
+  >
+    <Box
+      backgroundColor={{
+        base: "red.500",
+        sm: "red.400",
+        md: "red.300",
+        lg: "red.200",
+      }}
+    ></Box>
   </AspectRatio>
 )

--- a/packages/utils/src/responsive.ts
+++ b/packages/utils/src/responsive.ts
@@ -1,7 +1,9 @@
 import { isArray, isObject } from "./assertion"
 import { Dict } from "./types"
-import { objectKeys, merge } from "./object"
+import { objectKeys } from "./object"
 import { getLastItem } from "./array"
+
+export const breakpoints = Object.freeze(["base", "sm", "md", "lg", "xl"])
 
 export function mapResponsive(prop: any, mapper: (val: any) => any) {
   if (isArray(prop)) {
@@ -28,33 +30,14 @@ export function mapResponsive(prop: any, mapper: (val: any) => any) {
 }
 
 export function objectToArrayNotation(obj: Dict) {
-  const base = [
-    ["base", null],
-    ["sm", null],
-    ["md", null],
-    ["lg", null],
-  ]
-
-  const entries = merge(base, Object.entries(obj))
-  const mergedObj = Object.fromEntries(entries)
-  let array = Object.values(mergedObj)
-
-  let isNullBetweenValues = false
-
-  array.forEach((item, index) => {
-    const next = array[index + 1]
-    if (item === null && next != null) {
-      isNullBetweenValues = true
-    }
-  })
-
-  if (!isNullBetweenValues) {
-    array = array.filter((item) => item !== null)
+  const result = breakpoints.map((br) => obj[br] ?? null)
+  while (getLastItem(result) === null) {
+    result.pop()
   }
+  return result
+}
 
-  while (getLastItem(array) === null) {
-    array.pop()
-  }
-
-  return array
+export function isResponsiveObjectLike(obj: Dict) {
+  const keys = Object.keys(obj)
+  return keys.length > 0 && keys.every((key) => breakpoints.includes(key))
 }

--- a/packages/utils/tests/responsive.test.ts
+++ b/packages/utils/tests/responsive.test.ts
@@ -1,4 +1,8 @@
-import { mapResponsive, objectToArrayNotation } from "../src"
+import {
+  mapResponsive,
+  objectToArrayNotation,
+  isResponsiveObjectLike,
+} from "../src"
 
 const arr = [2, 3]
 const obj = { sm: 2, md: 3 }
@@ -37,4 +41,14 @@ test("should convert object to array notation", () => {
     400,
   ])
   expect(objectToArrayNotation({})).toEqual([])
+})
+
+test("should tell if object is responsive-like", () => {
+  expect(isResponsiveObjectLike({ lg: 400, sm: 100, base: 40 })).toBe(true)
+  expect(isResponsiveObjectLike({ base: 40 })).toBe(true)
+  expect(isResponsiveObjectLike({ sm: 100 })).toBe(true)
+  expect(isResponsiveObjectLike({})).toBe(false)
+  expect(isResponsiveObjectLike({ base: 40, paddingTop: 4 })).toBe(false)
+  expect(isResponsiveObjectLike({ md: 40, paddingTop: 4 })).toBe(false)
+  expect(isResponsiveObjectLike({ paddingTop: 4, paddingLeft: 4 })).toBe(false)
 })


### PR DESCRIPTION
I might have completely missed the point here. Please guide me if this can be fixed in some other way.

This would also fix #876

The isssue was that while this worked:
```
<Box _before={{paddingBottom: [1, 2, 3, 4]}}/>
```
the equivalent object notation didn't
```
<Box _before={{paddingBottom: { base: 1, sm: 2, md: 3, lg: 4 }}}/>
```