### PR TITLE
docs: fix form pagination ordering

### DIFF
--- a/website/utils.js
+++ b/website/utils.js
@@ -5,7 +5,14 @@ const { Octokit } = require("@octokit/rest")
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
 
-const collections = ["main", "theming", "layout", "components", "utilities"]
+const collections = [
+  "main",
+  "theming",
+  "layout",
+  "form",
+  "components",
+  "utilities",
+]
 const compareCollections = (
   { fields: { collection: a } },
   { fields: { collection: b } },


### PR DESCRIPTION
This adds `form` to the collection sorting/ordering util, so that docs pagination works correctly again.