### PR TITLE
feat(toast): remove manager z-index

### DIFF
--- a/packages/toast/src/toast-manager.tsx
+++ b/packages/toast/src/toast-manager.tsx
@@ -188,7 +188,6 @@ export class ToastManager extends React.Component<Props, State> {
   getStyle = (position: ToastPosition) => {
     const style: React.CSSProperties = {
       position: "fixed",
-      zIndex: 5500,
       pointerEvents: "none",
     }
 


### PR DESCRIPTION
When testing, I found that this wasn't required - the docs, as an example, work fine with no `z-index` value.