### PR TITLE
fix: Updated the selector for the focus-visible polyfill

### DIFF
--- a/packages/css-reset/src/css-reset.tsx
+++ b/packages/css-reset/src/css-reset.tsx
@@ -300,7 +300,7 @@ export const CSSReset = () => (
         height: auto;
       }
 
-      .js-focus-visible :focus:not([data-focus-visible-added]) {
+      [data-js-focus-visible] :focus:not([data-focus-visible-added]) {
         outline: none;
         box-shadow: none;
       }


### PR DESCRIPTION
Changed the selector for the focus-visible polyfill to use an attribute instead of a class.
Per this update to the polyfill documentation: https://github.com/WICG/focus-visible/commit/fda80f8401807c1cbb702fb1a15b9635828bfc6d