### PR TITLE
chore: refactor component props style computation as an interpolation

### DIFF
--- a/packages/system/src/create-styled.tsx
+++ b/packages/system/src/create-styled.tsx
@@ -1,4 +1,4 @@
-import { css, CSSObject } from "@chakra-ui/css"
+import { CSSObject } from "@chakra-ui/css"
 import {
   As,
   Dict,
@@ -9,7 +9,6 @@ import {
 } from "@chakra-ui/utils"
 import hoist from "hoist-non-react-statics"
 import * as React from "react"
-import { getComponentStyles } from "./component"
 import { useChakra } from "./hooks"
 import jsx from "./jsx"
 import {
@@ -31,37 +30,6 @@ function createStyled<T extends As, P extends Dict>(
         let computedStyles: CSSObject = {}
 
         const propsWithTheme = { theme, colorMode, ...props }
-
-        /**
-         * Users can pass a base style to the component options.
-         *
-         * @example
-         * const Button = chakra("button", {
-         *  baseStyle: {
-         *    margin: 4,
-         *    color: "red.300"
-         *  }
-         * })
-         */
-        if (options?.baseStyle) {
-          const baseStyleObject = runIfFn(options.baseStyle, propsWithTheme)
-          const baseStyle = css(baseStyleObject as Dict)(theme)
-          computedStyles = { ...computedStyles, ...baseStyle } as CSSObject
-        }
-
-        /**
-         * Users can pass a theme key to reference styles in the theme
-         * Styles will be read from `theme.components.<themeKey>`
-         *
-         * @example
-         * const Button = chakra("button", {
-         *  themeKey: "Button"
-         * })
-         */
-        if (options) {
-          const styles = getComponentStyles(propsWithTheme, options)
-          computedStyles = { ...computedStyles, ...styles } as CSSObject
-        }
 
         // Resolve each interpolation and add result to final style
         interpolations.forEach((interpolation) => {

--- a/packages/system/src/system.tsx
+++ b/packages/system/src/system.tsx
@@ -3,6 +3,7 @@ import createStyled from "./create-styled"
 import { As, ChakraComponent, Options } from "./system.types"
 import {
   applyProp,
+  componentProps,
   domElements,
   DOMElements,
   pseudoProps,
@@ -12,6 +13,7 @@ import {
 
 function styled<T extends As, P = {}>(component: T, options?: Options<T, P>) {
   return createStyled<T, P>(component, options)(
+    componentProps(options),
     systemProps,
     pseudoProps,
     applyProp(component),


### PR DESCRIPTION
Move the style calculation for component props to utils to be calculated as an interpolation.