### PR TITLE
fix: bottom nav works with dark mode

### DIFF
--- a/website/src/components/bottom-nav.js
+++ b/website/src/components/bottom-nav.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { NavLink } from "./header"
-import { Stack, Box, Text, Icon } from "@chakra-ui/core"
+import { Stack, Box, Text, Icon, useColorModeValue } from "@chakra-ui/core"
 import { FiUsers, FiBookOpen, FiFileText } from "react-icons/fi"
 
 export function BottomNavItem(props) {
@@ -23,6 +23,7 @@ export function BottomNavItem(props) {
 }
 
 const BottomNav = () => {
+  const bg = useColorModeValue("white", "gray.800")
   return (
     <Stack
       bottom="0"
@@ -34,7 +35,7 @@ const BottomNav = () => {
       position="fixed"
       paddingY="0.8rem"
       borderTopWidth="1px"
-      background="white"
+      background={bg}
       display={["flex", "flex", "none", "none"]}
     >
       <BottomNavItem


### PR DESCRIPTION
This resolves #945. It was an issue in mobile and desktop.

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/181441/85483286-83d74f80-b592-11ea-9b81-a144f457caef.png">

<img width="374" alt="image" src="https://user-images.githubusercontent.com/181441/85483299-88036d00-b592-11ea-9e1d-470314b8e7a7.png">
