### PR TITLE
docs: fixing a few spelling and grammar mistakes

### DIFF
--- a/website/docs/color-mode.mdx
+++ b/website/docs/color-mode.mdx
@@ -75,7 +75,7 @@ function StyleColorMode() {
 ## Forcing a specific mode
 
 In some occasions, you might want Chakra components to look the same in both
-light and dark modes. To achieve this, wrap the component in `LightMode` or
+light and dark modes. To achieve this, wrap the component in a `LightMode` or
 `DarkMode` component. Doing this will override the global `colorMode`.
 
 > Click the **"Toggle Mode"** button to see it in action.
@@ -108,7 +108,8 @@ function Example() {
 
 ## Change color mode behavior
 
-Starting from v1.0, you can now set default color mode or use default OS color mode.
+Starting from v1.0, you can now set default color mode or use default OS color
+mode.
 
 ### Setting initial mode
 

--- a/website/docs/contributing.mdx
+++ b/website/docs/contributing.mdx
@@ -11,7 +11,7 @@ order: 9
 Thanks for being interested in contributing! We're so glad you want to help!
 
 We want contributing to Chakra UI to be enjoyable and educational for anyone and
-everyone. All contributions are welcome, including issues, new docs, as well as
+everyone. All contributions are welcome, including: issues, new docs, as well as
 updates and tweaks, blog posts, workshops, and more.
 
 When contributing to this repository, please first discuss the change you wish
@@ -47,7 +47,7 @@ git checkout -b my-feature-branch
 
 ## Docs contribution
 
-Chakra UI uses gatsby for its documentation website. Thank you in advance and
+Chakra UI uses Gatsby for its documentation website. Thank you in advance and
 cheers for contributing to our documentation! We created a simple command to run
 it.
 

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -38,7 +38,7 @@ yarn add @chakra-ui/core
    <br />
 
 3. **Add the providers**: For Chakra to work correctly, you need to setup some
-   global providers and add broswer css-reset. At the root of your application ,
+   global providers and add browser css reset. At the root of your application,
    here's what you need do:
 
 ```jsx live=false

--- a/website/docs/migration.mdx
+++ b/website/docs/migration.mdx
@@ -38,8 +38,8 @@ worry if your styles aren't exactly the same—this is to be expected.
 
 ### 1. Update your dependencies
 
-Chakra no longer requires `@emotion/styled`, `@emotion/core` and
-`@emotion/theming`. If you're not using these libraries in your code, you can
+Chakra no longer requires `@emotion/core`, `@emotion/styled` and
+`emotion-theming`. If you're not using these libraries in your code, you can
 safely remove them and update Chakra UI to v1.
 
 > We use only `@emotion/core` internally.
@@ -47,9 +47,9 @@ safely remove them and update Chakra UI to v1.
 ```diff
 "dependencies": {
   "@chakra-ui/core": "1.0.0-beta",
--  "@emotion/styled": "10.X",
--  "@emotion/theming": "10.x",
--  "@emotion/core": "10.x"
+-  "@emotion/core": "10.x",
+-  "@emotion/styled": "10.x",
+-  "emotion-theming": "10.x"
 }
 ```
 

--- a/website/docs/principles.mdx
+++ b/website/docs/principles.mdx
@@ -9,7 +9,7 @@ Chakra UI is established on principles that keep its components fairly
 consistent. Understanding these concepts will help you better contribute to
 Chakra UI.
 
-Our goal is to design simple, composable components that cater to real life UI
+Our goal is to design simple, composable components that cater to real-life UI
 design problems. In order to do that, we developed a set of principles that help
 us always be on that path.
 

--- a/website/docs/theming/advanced.mdx
+++ b/website/docs/theming/advanced.mdx
@@ -30,7 +30,7 @@ interface Options {
 
 ## Using color mode
 
-Here's an example of how to create a simple badge that changes it's background
+Here's an example of how to create a simple badge that changes its background
 based on color mode.
 
 > Switch to dark mode and see how how the badge background changes

--- a/website/docs/theming/overview.mdx
+++ b/website/docs/theming/overview.mdx
@@ -28,12 +28,13 @@ component.
 
 The most common style modifiers are:
 
-- **Size.** A component can have different sizes (small, medium, large)
-- **Variant.** A component can different visual styles (outline, solid, ghost)
-- **Color scheme.** For a given variant, a component can have different color
-  schemes. For example, an outline button with a red color scheme.
-- **Color mode.** A component can change its visual styles based on color mode
-  (light or dark).
+- **Size:** A component can have different sizes (e.g. small, medium, large)
+- **Variant:** A component can different visual styles (e.g. outline, solid,
+  ghost)
+- **Color scheme:** For a given variant, a component can have different color
+  schemes (e.g. an outline button with a red color scheme)
+- **Color mode:** A component can change its visual styles based on color mode
+  (e.g. light or dark).
 
 ## Theming API
 

--- a/website/docs/z-index.mdx
+++ b/website/docs/z-index.mdx
@@ -10,8 +10,8 @@ Every UI has stackable layers and it's important to have control over how these
 layers play together. Some examples of stackable layers are tooltips, modals,
 popovers, selects, dropdowns, and menus.
 
-The issues that come up across these layers usage are z-index and visibility
-handling, what layer goes on top.
+The issues that come up across the usage of these these layers are related to
+z-index and visibility handling, in other words, "what layer goes on top?"
 
 ## What's wrong with z-index?
 
@@ -47,7 +47,7 @@ stacking context(s) now only have meaning in this parent.
 An alternative to `z-index` is to use the DOM's natural stacking order to our
 advantage. [React's Portals](https://reactjs.org/docs/portals.html) allow us to
 insert a child into a different location in the document, whilst not affecting
-other behaviours in React, such as event bubbling.
+other behaviours in React such as event bubbling.
 
 Chakra Portal implementation allows for nesting, and defaults to inserting
 children at the end of `document.body`.


### PR DESCRIPTION
Added a variety of changes to typos, grammar mistakes, clarifying confusing sentences, and (in one place) fixing a mistake related to a package name.