### PR TITLE
docs: Update guide on aligning TabsList

### DIFF
--- a/website/docs/components/tabs.mdx
+++ b/website/docs/components/tabs.mdx
@@ -134,12 +134,11 @@ You can change the size of the tab by passing `size` prop. We support 3 sizes
 
 ### Changing the tabs alignment
 
-You can change the alignment of the `TabList` by passing `align` prop. We
-support 3 sizes `start`, `center`, `end`.
+You can change the alignment of the `TabList` by ajusting its `justifyContent` prop.
 
 ```jsx
-<Tabs align="end" variant="enclosed">
-  <TabList>
+<Tabs variant="enclosed">
+  <TabList justifyContent="flex-end">
     <Tab>One</Tab>
     <Tab>Two</Tab>
   </TabList>


### PR DESCRIPTION
In the docs the align prop is not working anymore in the parent Tabs Component.
I think it has been removed in favor of using justifyContent on the TabsList Component
This PR changes the docs to reflect those changes.