### PR TITLE
fix bad path in accordion/package.json

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
   "license": "MIT",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index/js",
+  "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
this broke my parcel bundling

```
> parcel build frontend/src/index.html

🚨 Build failed.
@parcel/core: Failed to resolve '@chakra-ui/accordion' from './node_modules/@chakra-ui/core/dist/esm/index.js'
/home/capaj/work-repos/4house/4house-be-admin/node_modules/@chakra-ui/core/dist/esm/index.js:34:15
  33 | export * from "@chakra-ui/tooltip";
> 34 | export * from "@chakra-ui/accordion";
>    |               ^^^^^^^^^^^^^^^^^^^^^^
  35 | export * from "@chakra-ui/alert";
  36 | export * from "@chakra-ui/button";
@parcel/resolver-default: Could not load './dist/esm/index/js' from module '@chakra-ui/accordion' found in package.json#module
/home/capaj/work-repos/4house/4house-be-admin/node_modules/@chakra-ui/accordion/package.json:69:13
  68 |   "main": "dist/cjs/index.js",
> 69 |   "module": "dist/esm/index/js",
>    |             ^^^^^^^^^^^^^^^^^^^ './dist/esm/index/js' does not exist, did you mean './dist/esm/index.js'?'
  70 |   "name": "@chakra-ui/accordion",
  71 |   "peerDependencies": {
```