### PR TITLE
docs: removed references to isInline. remaining are in before examples

### DIFF
--- a/website/docs/components/code.mdx
+++ b/website/docs/components/code.mdx
@@ -41,7 +41,7 @@ You can change the color scheme of the component by passing the `colorScheme`
 prop.
 
 ```jsx
-<Stack isInline>
+<Stack direction="row">
   <Code children="console.log(welcome)" />
   <Code colorScheme="red" children="var chakra = 'awesome!'" />
   <Code colorScheme="yellow" children="npm install chakra" />

--- a/website/docs/components/tag.mdx
+++ b/website/docs/components/tag.mdx
@@ -39,7 +39,7 @@ import { Tag, TagIcon, TagLabel, TagCloseButton } from "@chakra-ui/core"
 ```
 
 ```jsx
-<Stack spacing={4} isInline>
+<Stack spacing={4} direction="row">
   {["sm", "md", "lg"].map((size) => (
     <Tag size={size} key={size} colorScheme="gray">
       Gray
@@ -51,7 +51,7 @@ import { Tag, TagIcon, TagLabel, TagCloseButton } from "@chakra-ui/core"
 ## With left icon
 
 ```jsx
-<Stack spacing={4} isInline>
+<Stack spacing={4} direction="row">
   {["sm", "md", "lg"].map((size) => (
     <Tag size={size} key={size} colorScheme="cyan">
       <TagIcon icon="add" size="12px" />
@@ -64,7 +64,7 @@ import { Tag, TagIcon, TagLabel, TagCloseButton } from "@chakra-ui/core"
 ## With right icon
 
 ```jsx
-<Stack spacing={4} isInline>
+<Stack spacing={4} direction="row">
   <Tag colorScheme="cyan">
     <TagLabel>Green</TagLabel>
     <TagIcon icon="check" size="12px" />
@@ -81,7 +81,7 @@ import { Tag, TagIcon, TagLabel, TagCloseButton } from "@chakra-ui/core"
 ## With close button
 
 ```jsx
-<Stack spacing={4} isInline>
+<Stack spacing={4} direction="row">
   {["sm", "md", "lg"].map((size) => (
     <Tag
       size={size}

--- a/website/docs/form/checkbox.mdx
+++ b/website/docs/form/checkbox.mdx
@@ -141,19 +141,6 @@ its children.
 </CheckboxGroup>
 ```
 
-You can also make checkbox group appear horizontally by passing the `isInline`
-prop.
-
-```jsx
-<CheckboxGroup colorScheme="teal" defaultValue={["itachi", "kisame"]}>
-  <HStack spacing={8}>
-    <Checkbox value="itachi">Itachi</Checkbox>
-    <Checkbox value="madara">Madara</Checkbox>
-    <Checkbox value="kisame">Kisame</Checkbox>
-  </HStack>
-</CheckboxGroup>
-```
-
 ## Props
 
 ### Checkbox Props
@@ -193,4 +180,3 @@ CheckboxGroup composes `Box` so you can pass all `Box` props.
 | children     | `React.ReactNode`                          |         | The content of the checkbox group. Must be the `Checkbox` component                                                 |
 | spacing      | `StyledSystem.MarginProps`                 | `8px`   | The space between each checkbox                                                                                     |
 | size         | `sm`, `md`, `lg`                           | `md`    | The size of the checkbox, it's forwarded to all children checkbox.                                                  |
-| isInline     | `boolean`                                  |         | If `true`, the checkboxes will aligned horizontally.                                                                |

--- a/website/docs/form/numberinput.mdx
+++ b/website/docs/form/numberinput.mdx
@@ -186,7 +186,7 @@ Like the `Input` component, you can pass the `size` prop to change the size of
 the input.
 
 ```jsx
-<Stack shouldWrapChildren isInline>
+<Stack shouldWrapChildren direction="row">
   <NumberInput size="sm" defaultValue={15} min={10}>
     <NumberInputField />
     <NumberInputStepper>

--- a/website/docs/form/switch.mdx
+++ b/website/docs/form/switch.mdx
@@ -42,7 +42,7 @@ import { Switch } from "@chakra-ui/core"
 Pass the `size` prop to change the size of the switch.
 
 ```jsx
-<Stack align="center" isInline>
+<Stack align="center" direction="row">
   <Switch size="sm" />
   <Switch size="md" />
   <Switch size="lg" />
@@ -55,7 +55,7 @@ You can change the checked background color of the switch by passing the `color`
 prop.
 
 ```jsx
-<Stack isInline>
+<Stack direction="row">
   <Switch color="red" />
   <Switch color="teal" size="lg" />
 </Stack>

--- a/website/docs/layout/stack.mdx
+++ b/website/docs/layout/stack.mdx
@@ -60,7 +60,7 @@ render(<StackEx />)
 
 ### Stack items horizontally
 
-Pass the `isInline` prop or `direction` and set it to `horizontal`.
+Pass the `direction` prop and set it to `column`.
 
 Optionally, you can use `align` and `justify` to adjust the alignment and
 distribution of the items.
@@ -104,7 +104,6 @@ render(<StackEx />)
 
 | Name                 | Type                          | Default | Description                                                                                                              |
 | -------------------- | ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `isInline`           | `boolean`                     |         | If `true` the items will be stacked horizontally.                                                                        |
 | `direction`          | `FlexProps["flexDirection"]`  |         | The direction to stack the items.                                                                                        |
 | `children`           | `React.ReactNode`             |         | The content of the stack.                                                                                                |
 | `spacing`            | `StyledSystem.MarginProps`    |         | The space between each stack item                                                                                        |


### PR DESCRIPTION
Removed references to isInline prop. Replaced with `direction="row"`

Only remaining instances are in 'before' code examples and migration guide calling out the removal of the prop.

This resolved #999 