### PR TITLE
docs: removed isFullWidth props for checkbox and radio components

### DIFF
--- a/website/docs/form/checkbox.mdx
+++ b/website/docs/form/checkbox.mdx
@@ -167,7 +167,6 @@ prop.
 | defaultIsChecked | `boolean`            |         | If `true`, the checkbox will be initially checked.                                                                       |
 | isChecked        | `boolean`            |         | If `true`, the checkbox will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled) |
 | isIndeterminate  | `boolean`            |         | If `true`, the checkbox will be indeterminate. This only affects the icon shown inside checkbox                          |
-| isFullWidth      | `boolean`            |         | If `true`, the checkbox should take up the full width of the parent.                                                     |
 | size             | `sm`, `md`, `lg`     | `md`    | The size (width and height) of the checkbox                                                                              |
 | isDisabled       | `boolean`            |         | If `true`, the checkbox will be disabled                                                                                 |
 | isInvalid        | `boolean`            |         | If `true`, the checkbox is marked as invalid. Changes style of unchecked state.                                          |

--- a/website/docs/form/radio.mdx
+++ b/website/docs/form/radio.mdx
@@ -199,7 +199,6 @@ render(<Example />)
 | colorScheme      | `string`             |         | The color of the radio when it's checked. This should be one of the color keys in the theme (e.g."green", "red")      |
 | defaultIsChecked | `boolean`            |         | If `true`, the radio will be initially checked                                                                        |
 | isChecked        | `boolean`            |         | If `true`, the radio will be checked. You'll need to pass `onChange` to update it's value (since it's now controlled) |
-| isFullWidth      | `boolean`            |         | If `true`, the radio should take up the full width of the parent                                                      |
 | size             | `sm`, `md`, `lg`     | `md`    | The size (width and height) of the radio                                                                              |
 | isDisabled       | `boolean`            |         | If `true`, the radio will be disabled                                                                                 |
 | isInvalid        | `boolean`            |         | If `true`, the radio is marked as invalid. Changes style of unchecked state                                           |


### PR DESCRIPTION
Removed `isFullWidth` props from Checkbox and Radio component docs.

Fixes #1002 