### PR TITLE
docs: mention HStack and VStack in Stack docs

### DIFF
--- a/website/docs/layout/stack.mdx
+++ b/website/docs/layout/stack.mdx
@@ -100,6 +100,45 @@ function StackEx() {
 render(<StackEx />)
 ```
 
+### HStack and VStack
+
+You can also use the `HStack` and `VStack` components to conveniently stack elements in the horizontal or vertical directions respectively.
+
+```jsx manual=true
+function Feature({ title, desc, ...rest }) {
+  return (
+    <Box
+      p={5}
+      shadow="md"
+      borderWidth="1px"
+      flex="1"
+      borderRadius="md"
+      {...rest}
+    >
+      <Heading fontSize="xl">{title}</Heading>
+      <Text mt={4}>{desc}</Text>
+    </Box>
+  )
+}
+
+function StackEx() {
+  return (
+    <HStack spacing={8}>
+      <Feature
+        title="Plan Money"
+        desc="The future can be even brighter but a goal without a plan is just a wish"
+      />
+      <Feature
+        title="Save Money"
+        desc="You deserve good things. With a whooping 10-15% interest rate per annum, grow your savings."
+      />
+    </HStack>
+  )
+}
+
+render(<StackEx />)
+```
+
 ### Props
 
 | Name                 | Type                          | Default | Description                                                                                                              |


### PR DESCRIPTION
`HStack` and `VStack` are used in the doc's code examples, but only mentioned in the migration doc. This PR references them in the Stack docs.