### PR TITLE
chore(stale): adjust settings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,9 +19,11 @@ exemptLabels:
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  Hi!
+
+  This issue hasn't seen any activity recently. We close inactive issues after 20 days to manage the volume of issues we receive.
+
+  If we missed this issue or you want to keep it open, please reply here. That will reset the timer and allow more time for this issue to be addressed before it is closed.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
 unmarkComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 15
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 5
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "good first issue 👍"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,6 +4,7 @@ daysUntilStale: 15
 daysUntilClose: 5
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - "not stale"
   - "good first issue 👍"
   - "good for beginners 😃"
   - "help wanted 🆘"


### PR DESCRIPTION
I've been doing a lot of work the last few days to groom our issues backlog so that we can become better organized. While doing so, I've been thinking a lot about how to make that process easier. One of the ways I think we can improve that is to better utilize `probot/stale`.

This PR makes a few changes to the `stale` config:

- Reduces the number of days until an issue is closed to 20. We're currently waiting 74 days until an issue is closed as stale and that's quite a bit longer than it should be imo. I think 20 is plenty, especially since I plan to continuously groom and tag issues to help manage them and prevent issues that matter from being marked stale.
- Updates the `stale` mark comment to be more friendly and provide more explanation for what's happening.
- Adds `not stale` to `exemptLabels`. Eventually I'd like to make that one of two labels that prevents stale closures, but I'll document that as a proposal and we can migrate over more slowly if we decide to go that direction.