### PR TITLE
fix: remove emotion core direct dependency

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -25,7 +25,7 @@ one by one. All you need to do is install the `@chakra-ui/core` package:
 ```sh
 $ yarn add @chakra-ui/core
 # or
-$ npm install --save @chakra-ui/core
+$ npm install --save @chakra-ui/core @emotion/core
 ```
 
 # Getting set up

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -54,13 +54,16 @@
     "@chakra-ui/css-reset": "^1.0.0-next.3",
     "@chakra-ui/parser": "^1.0.0-next.3",
     "@chakra-ui/utils": "^1.0.0-next.3",
-    "@emotion/core": "10.0.28",
     "@emotion/is-prop-valid": "0.8.8",
     "@types/hoist-non-react-statics": "3.3.1",
     "hoist-non-react-statics": "3.3.2"
   },
+  "devDependencies": {
+    "@emotion/core": "10.0.28"
+  },
   "peerDependencies": {
-    "react": "16.x"
+    "react": "16.x",
+    "@emotion/core": "10.0.28"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"
 }

--- a/website/docs/components/visually-hidden.mdx
+++ b/website/docs/components/visually-hidden.mdx
@@ -24,7 +24,7 @@ from the visual client, but keep it readable for screen readers.
 ## Installation
 
 ```bash
-npm install @chakra-ui/core
+npm install @chakra-ui/core @emotion/core
 ```
 
 ## Usage

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -12,11 +12,11 @@ order: 1
 1. Install Chakra UI
 
 ```bash
-npm i @chakra-ui/core
+npm i @chakra-ui/core @emotion/core
 
 # or
 
-yarn add @chakra-ui/core
+yarn add @chakra-ui/core @emotion/core
 ```
 
 <carbon-ad></carbon-ad>


### PR DESCRIPTION
If we include the `@emotion/core` package as a dependency the theme context will be duplicated, making impossible to share the `chakra-ui` theme with other components that rely on `useTheme` exported from emotion

The same happens in the inverse direction, chakra cannot use theme from other packages

Making emotion a peer dependency forces the user to only use only an instance of emotion theme context