### PR TITLE
fix: UnorderedList was not rendering bullets

### DIFF
--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -79,7 +79,7 @@ export const UnorderedList = forwardRef<ListProps>(function UnorderedList(
   ref,
 ) {
   return (
-    <List as="ul" ref={ref} styleType="decimal" marginLeft="1em" {...props} />
+    <List ref={ref} as="ul" styleType="bullet" marginLeft="1em" {...props} />
   )
 })
 


### PR DESCRIPTION
I noticed that UnorderedList was rendering numbers, like an OrderedList. This appears to be corrected with this single change.