### PR TITLE
fix: Adding Icon to theme export

### DIFF
--- a/packages/theme/src/components/index.ts
+++ b/packages/theme/src/components/index.ts
@@ -9,6 +9,7 @@ import Code from "./code"
 import Divider from "./divider"
 import Modal from "./modal"
 import Heading from "./heading"
+import Icon from "./icon"
 import Input from "./input"
 import InputAddon from "./input-addon"
 import Link from "./link"
@@ -36,6 +37,7 @@ export default {
   Accordion,
   Button,
   Heading,
+  Icon,
   Alert,
   Badge,
   Avatar,


### PR DESCRIPTION
I'm not sure if this was intentional, but there's no mention of Icon in the theme, despite being a theme file to customize icons. If it's not exported with the theme, I'm not sure how this file was ever doing anything. :)