### PR TITLE
fix: button ignores `type` prop when `as` prop is used

### DIFF
--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -92,6 +92,7 @@ export const Button = forwardRef<ButtonProps>(function Button(props, ref) {
     colorScheme = group?.colorScheme,
     size = group?.size,
     className,
+    as,
     ...rest
   } = props
 
@@ -117,7 +118,8 @@ export const Button = forwardRef<ButtonProps>(function Button(props, ref) {
     <StyledButton
       disabled={isDisabled || isLoading}
       ref={ref}
-      type={type}
+      as={as}
+      type={as ? undefined : type}
       width={isFullWidth ? "100%" : undefined}
       data-active={dataAttr(isActive)}
       data-loading={dataAttr(isLoading)}


### PR DESCRIPTION
The `type` prop has a default of `button` which is passed down even if the `as` prop is used. Not sure if there are any edge cases I need to account for, like is there ever a time we would expect `as` and `type` to both be used at the same time?

Fixes #770  