### PR TITLE
fix(modal): add missing z-index to overlay and content

### DIFF
--- a/packages/modal/src/use-modal.ts
+++ b/packages/modal/src/use-modal.ts
@@ -161,6 +161,7 @@ export function useModal(props: UseModalProps) {
       id: dialogId,
       role: props.role || "dialog",
       tabIndex: -1,
+      zIndex: "modal",
       "aria-modal": true,
       "aria-labelledby": headerMounted ? headerId : undefined,
       "aria-describedby": bodyMounted ? bodyId : undefined,
@@ -170,6 +171,7 @@ export function useModal(props: UseModalProps) {
     }),
     getOverlayProps: (props: Dict = {}) => ({
       ...props,
+      zIndex: "overlay",
       ref: mergeRefs(props.ref, overlayRef),
       onClick: callAllHandlers(props.onClick, onOverlayClick),
       onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),


### PR DESCRIPTION
AFAIK there isn't any `z-index` applied to `Modal` elements in v1 so I used the v0 way of adding them.

Note that I put `zIndex` declaration after user's props (`...props`) so that `z-index` will always output values from styled system. 👍 / 👎 ? :)