### PR TITLE
fix: updated Stack to allow 'row-reverse' and 'column-reverse' for di…

### DIFF
--- a/packages/layout/src/stack.tsx
+++ b/packages/layout/src/stack.tsx
@@ -15,7 +15,9 @@ import {
 import * as React from "react"
 import { FlexOptions } from "./flex"
 
-export type StackDirection = ResponsiveValue<"row" | "column">
+export type StackDirection = ResponsiveValue<
+  "row" | "column" | "row-reverse" | "column-reverse"
+>
 
 interface StackOptions extends Pick<FlexOptions, "align" | "justify" | "wrap"> {
   /**
@@ -93,13 +95,28 @@ export const Stack = React.forwardRef(function Stack(
    * @see https://medium.com/@emmenko/patching-lobotomized-owl-selector-for-emotion-ssr-5a582a3c424c
    */
   const selector = "& > *:not(style) ~ *:not(style)"
+  const directionStyles = {
+    column: {
+      marginTop: spacing,
+      marginLeft: 0,
+    },
+    row: {
+      marginLeft: spacing,
+      marginTop: 0,
+    },
+    "column-reverse": {
+      marginBottom: spacing,
+      marginLeft: 0,
+    },
+    "row-reverse": {
+      marginRight: spacing,
+      marginTop: 0,
+    },
+  }
 
   const styles = {
     flexDirection: direction,
-    [selector]: mapResponsive(direction, (value) => ({
-      [value === "column" ? "marginTop" : "marginLeft"]: spacing,
-      [value === "column" ? "marginLeft" : "marginTop"]: 0,
-    })),
+    [selector]: mapResponsive(direction, (value) => directionStyles[value]),
   }
 
   const validChildren = getValidChildren(children)

--- a/website/docs/layout/stack.mdx
+++ b/website/docs/layout/stack.mdx
@@ -177,13 +177,13 @@ render(<StackEx />)
 
 ### Props
 
-| Name                 | Type                          | Description                                                                                                              |
-| -------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `direction`          | `Responsive(row or column)`   | The direction to stack the elements                                                                                      |
-| `divider`            | `ReactElement`                | The divider element to use between elements                                                                              |
-| `children`           | `ReactNode`                   | The elements to be stackes                                                                                               |
-| `spacing`            | `MarginProps`                 | The space between each stack item. Defaults to `0.5rem`                                                                  |
-| `align`              | `FlexProps["alignItems"]`     | The alignment of the stack item. Similar to `align-items`                                                                |
-| `justify`            | `FlexProps["justifyContent"]` | The distribution of the stack item. Similar to `justify-content`                                                         |
-| `shouldWrapChildren` | `boolean`                     | If `true`, the children will be wrapped in a `Box` with `display: inline-block`, and the Box will take the spacing props |
+| Name                 | Type                                                     | Description                                                                                                              |
+| -------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `direction`          | `Responsive(row, column, row-reverse, column-reverse)`   | The direction to stack the elements                                                                                      |
+| `divider`            | `ReactElement`                                           | The divider element to use between elements                                                                              |
+| `children`           | `ReactNode`                                              | The elements to be stackes                                                                                               |
+| `spacing`            | `MarginProps`                                            | The space between each stack item. Defaults to `0.5rem`                                                                  |
+| `align`              | `FlexProps["alignItems"]`                                | The alignment of the stack item. Similar to `align-items`                                                                |
+| `justify`            | `FlexProps["justifyContent"]`                            | The distribution of the stack item. Similar to `justify-content`                                                         |
+| `shouldWrapChildren` | `boolean`                                                | If `true`, the children will be wrapped in a `Box` with `display: inline-block`, and the Box will take the spacing props |
 


### PR DESCRIPTION
Fixes #1021 

Added `row-reverse` and `column-reverse` to the Stack component's direction prop.

<img width="1464" alt="image" src="https://user-images.githubusercontent.com/181441/86365083-0a50f880-bc47-11ea-82a6-abe8dcd827e4.png">

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/181441/86365095-0d4be900-bc47-11ea-8abf-82fb781dae90.png">
