### PR TITLE
fix: fixed margin bug for Stack column-reverse and row-reverse

### DIFF
--- a/packages/layout/src/stack.tsx
+++ b/packages/layout/src/stack.tsx
@@ -106,11 +106,11 @@ export const Stack = React.forwardRef(function Stack(
     },
     "column-reverse": {
       marginBottom: spacing,
-      marginLeft: 0,
+      marginRight: 0,
     },
     "row-reverse": {
       marginRight: spacing,
-      marginTop: 0,
+      marginBottom: 0,
     },
   }
 


### PR DESCRIPTION
Found and issue with the margin while testing out the responsive direction prop. Sorry about that.