### PR TITLE
docs(tag): fix and update examples for tag component

### DIFF
--- a/website/docs/components/icon.mdx
+++ b/website/docs/components/icon.mdx
@@ -61,7 +61,7 @@ Here's the list of default icons that comes with Chakra UI with their respective
 ## Using an Icon library
 
 Using icons from a popular icon library like
-[react-icons](https://react-icons.github.io//) just renders the `svg`,
+[react-icons](https://react-icons.github.io) just renders the `svg`,
 
 ```jsx live=false
 import { MdSettings } from "react-icons/md"
@@ -154,8 +154,8 @@ export const UpDownIcon = createIcon({
 Before generating custom icons do the following:
 
 - Export the icon's `svg` from Figma, Sketch, etc.
-- Use a tool like [SvgOmg](https://jakearchibald.github.io/svgomg/) to reduce
-  the size and minify the markup.
+- Use a tool like [SvgOmg](https://jakearchibald.github.io/svgomg) to reduce the
+  size and minify the markup.
 - Use `createIcon` to create an icon as shown above.
 
 Start using the icons right away. There is no need to update theme files.

--- a/website/docs/components/icon.mdx
+++ b/website/docs/components/icon.mdx
@@ -61,7 +61,8 @@ Here's the list of default icons that comes with Chakra UI with their respective
 ## Using an Icon library
 
 Using icons from a popular icon library like
-[react-icons](https://react-icons.github.io) just renders the `svg`,
+[react-icons](https://react-icons.github.io/react-icons/) just renders the
+`svg`,
 
 ```jsx live=false
 import { MdSettings } from "react-icons/md"
@@ -154,8 +155,8 @@ export const UpDownIcon = createIcon({
 Before generating custom icons do the following:
 
 - Export the icon's `svg` from Figma, Sketch, etc.
-- Use a tool like [SvgOmg](https://jakearchibald.github.io/svgomg) to reduce the
-  size and minify the markup.
+- Use a tool like [SvgOmg](https://jakearchibald.github.io/svgomg/) to reduce
+  the size and minify the markup.
 - Use `createIcon` to create an icon as shown above.
 
 Start using the icons right away. There is no need to update theme files.

--- a/website/docs/components/icon.mdx
+++ b/website/docs/components/icon.mdx
@@ -61,7 +61,7 @@ Here's the list of default icons that comes with Chakra UI with their respective
 ## Using an Icon library
 
 Using icons from a popular icon library like
-[react-icons](https://react-icons.netlify.com/) just renders the `svg`,
+[react-icons](https://react-icons.github.io//) just renders the `svg`,
 
 ```jsx live=false
 import { MdSettings } from "react-icons/md"

--- a/website/docs/components/icon.mdx
+++ b/website/docs/components/icon.mdx
@@ -61,7 +61,7 @@ Here's the list of default icons that comes with Chakra UI with their respective
 ## Using an Icon library
 
 Using icons from a popular icon library like
-[react-icons](https://react-icons.netlify.com/) just renders the `svg,
+[react-icons](https://react-icons.netlify.com/) just renders the `svg`,
 
 ```jsx live=false
 import { MdSettings } from "react-icons/md"

--- a/website/docs/components/tag.mdx
+++ b/website/docs/components/tag.mdx
@@ -9,7 +9,7 @@ import ComponentLinks from "../../src/components/component-links"
 
 # Tag
 
-Tag component is used for items that needs to be labeled, categorized, or
+Tag component is used for items that need to be labeled, categorized, or
 organized using keywords that describe them.
 
 <ComponentLinks

--- a/website/docs/components/tag.mdx
+++ b/website/docs/components/tag.mdx
@@ -9,7 +9,7 @@ import ComponentLinks from "../../src/components/component-links"
 
 # Tag
 
-Tag component is used for items that need to be labeled, categorized, or
+Tag component is used for items that needs to be labeled, categorized, or
 organized using keywords that describe them.
 
 <ComponentLinks
@@ -31,7 +31,13 @@ Chakra UI exports 5 Tag related components:
 - **TagCloseButton**: The close button for the tag.
 
 ```js
-import { Tag, TagLabel, TagLeftIcon, TagRightIcon, TagCloseButton } from "@chakra-ui/core"
+import {
+  Tag,
+  TagLabel,
+  TagLeftIcon,
+  TagRightIcon,
+  TagCloseButton,
+} from "@chakra-ui/core"
 ```
 
 ## Usage
@@ -41,62 +47,58 @@ import { Tag, TagLabel, TagLeftIcon, TagRightIcon, TagCloseButton } from "@chakr
 ```
 
 ```jsx
-<Stack spacing={4} direction="row">
+<HStack spacing={4}>
   {["sm", "md", "lg"].map((size) => (
-    <Tag size={size} key={size} colorScheme="gray">
-      Gray
+    <Tag size={size} key={size} variant="solid" colorScheme="teal">
+      Teal
     </Tag>
   ))}
-</Stack>
+</HStack>
 ```
 
 ## With left icon
 
 ```jsx
-<Stack spacing={4} direction="row">
+<HStack spacing={4}>
   {["sm", "md", "lg"].map((size) => (
-    <Tag size={size} key={size} colorScheme="cyan">
+    <Tag size={size} key={size} variant="subtle" colorScheme="cyan">
       <TagLeftIcon boxSize="12px" as={AddIcon} />
-      <TagLabel>Green</TagLabel>
+      <TagLabel>Cyan</TagLabel>
     </Tag>
   ))}
-</Stack>
+</HStack>
 ```
 
 ## With right icon
 
 ```jsx
-<Stack spacing={4} direction="row">
-  <Tag colorScheme="cyan">
-    <TagLabel>Green</TagLabel>
-    <TagRightIcon boxSize="12px" as={CheckIcon} />
-  </Tag>
-
-  {/* You can also use custom svg icons */}
-  <Tag colorScheme="teal">
-    <TagLabel>Green</TagLabel>
-    <TagRightIcon as={MdSettings} />
-  </Tag>
-</Stack>
+<HStack spacing={4}>
+  {["sm", "md", "lg"].map((size) => (
+    <Tag size={size} key={size} variant="outline" colorScheme="blue">
+      <TagLabel>Blue</TagLabel>
+      <TagRightIcon as={MdSettings} />
+    </Tag>
+  ))}
+</HStack>
 ```
 
 ## With close button
 
 ```jsx
-<Stack spacing={4} direction="row">
+<HStack spacing={4}>
   {["sm", "md", "lg"].map((size) => (
     <Tag
       size={size}
       key={size}
       borderRadius="full"
       variant="solid"
-      colorScheme="cyan"
+      colorScheme="green"
     >
       <TagLabel>Green</TagLabel>
       <TagCloseButton />
     </Tag>
   ))}
-</Stack>
+</HStack>
 ```
 
 ## With custom element

--- a/website/docs/form/button.mdx
+++ b/website/docs/form/button.mdx
@@ -102,7 +102,7 @@ and `RightIcon` props respectively.
 ```
 
 You can also use icons from popular libraries like
-[react-icons](https://react-icons.netlify.com) and pass it into the button.
+[react-icons](https://react-icons.github.io/) and pass it into the button.
 
 ```jsx
 // import { MdBuild , MdCall } from "react-icons/md"

--- a/website/docs/form/button.mdx
+++ b/website/docs/form/button.mdx
@@ -102,7 +102,7 @@ and `RightIcon` props respectively.
 ```
 
 You can also use icons from popular libraries like
-[react-icons](https://react-icons.github.io/) and pass it into the button.
+[react-icons](https://react-icons.github.io) and pass it into the button.
 
 ```jsx
 // import { MdBuild , MdCall } from "react-icons/md"

--- a/website/docs/form/button.mdx
+++ b/website/docs/form/button.mdx
@@ -102,7 +102,8 @@ and `RightIcon` props respectively.
 ```
 
 You can also use icons from popular libraries like
-[react-icons](https://react-icons.github.io) and pass it into the button.
+[react-icons](https://react-icons.github.io/react-icons/) and pass it into the
+button.
 
 ```jsx
 // import { MdBuild , MdCall } from "react-icons/md"


### PR DESCRIPTION
All tags stretch to full height since the removal of default `align` prop in `Stack` component,

![image](https://user-images.githubusercontent.com/39694575/86505198-59ca2c80-bddf-11ea-9a37-a0d9ad9e0794.png)

So, today I took some time to update the examples of `Tag` component showing all variants,

![image](https://user-images.githubusercontent.com/39694575/86505213-854d1700-bddf-11ea-9f72-9c665482dfd0.png)
