### PR TITLE
fix: getMediaQuery sort was returning NaN, which behaved differently …

### DIFF
--- a/packages/parser/src/utils/get-media-query.ts
+++ b/packages/parser/src/utils/get-media-query.ts
@@ -21,12 +21,7 @@ export function getMediaQuery(breakpoints?: Dict, mapper = toMediaQuery) {
 
   const asArray = objectKeys(_breakpoints)
     .map((key) => _breakpoints[key])
-    .sort((a, b) => {
-      const regex = /^\d+/
-      const aMatch = a.match(regex)
-      const bMatch = b.match(regex)
-      return aMatch[0] - bMatch[0]
-    })
+    .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
     .map(mapper)
 
   const asObject = objectKeys(_breakpoints).reduce((result, point) => {

--- a/packages/parser/src/utils/get-media-query.ts
+++ b/packages/parser/src/utils/get-media-query.ts
@@ -21,7 +21,12 @@ export function getMediaQuery(breakpoints?: Dict, mapper = toMediaQuery) {
 
   const asArray = objectKeys(_breakpoints)
     .map((key) => _breakpoints[key])
-    .sort((a, b) => a - b)
+    .sort((a, b) => {
+      const regex = /^\d+/
+      const aMatch = a.match(regex)
+      const bMatch = b.match(regex)
+      return aMatch[0] - bMatch[0]
+    })
     .map(mapper)
 
   const asObject = objectKeys(_breakpoints).reduce((result, point) => {


### PR DESCRIPTION
Fixes #1137 

Ok so this was a fun one. The compare function in `sort` was returning `NaN`. That is because `'30em' - '48em'` results in `NaN`.

In Chrome nothing happened to the order of the array after `sort` was executed, but in Firefox the array was reversed.