### PR TITLE
chore: update internal peer deps to ^1.0.0-next.4

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -62,7 +62,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -54,7 +54,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -56,7 +56,7 @@
     "@chakra-ui/utils": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -53,7 +53,7 @@
     "@chakra-ui/utils": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/utils": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -61,7 +61,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -53,7 +53,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -56,7 +56,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -58,7 +58,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/editable/package.json
+++ b/packages/editable/package.json
@@ -57,7 +57,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -58,7 +58,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -52,7 +52,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -39,7 +39,7 @@
     "lint:types": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "devDependencies": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -60,7 +60,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/media-query/package.json
+++ b/packages/media-query/package.json
@@ -54,7 +54,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -60,7 +60,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -66,7 +66,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/number-input/package.json
+++ b/packages/number-input/package.json
@@ -61,7 +61,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/pin-input/package.json
+++ b/packages/pin-input/package.json
@@ -56,7 +56,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -57,7 +57,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -53,7 +53,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/skip-nav/package.json
+++ b/packages/skip-nav/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/utils": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -63,7 +63,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -52,7 +52,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/stat/package.json
+++ b/packages/stat/package.json
@@ -56,7 +56,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -65,7 +65,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -54,7 +54,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -55,7 +55,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/theme-tools/package.json
+++ b/packages/theme-tools/package.json
@@ -50,7 +50,7 @@
     "tinycolor2": "1.4.1"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8"
+    "@chakra-ui/system": "^1.0.0-next.4"
   },
   "devDependencies": {
     "@chakra-ui/system": "^1.0.0-next.4"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -48,7 +48,7 @@
     "@chakra-ui/theme-tools": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8"
+    "@chakra-ui/system": "^1.0.0-next.4"
   },
   "devDependencies": {
     "@chakra-ui/system": "^1.0.0-next.4"

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -59,7 +59,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x",
     "react-dom": "16.x"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -58,7 +58,7 @@
     "@chakra-ui/system": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -59,7 +59,7 @@
     "@chakra-ui/utils": "^1.0.0-next.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">0.8",
+    "@chakra-ui/system": "^1.0.0-next.4",
     "react": "16.x"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"

--- a/tooling/gatsby-plugin-chakra-ui/package.json
+++ b/tooling/gatsby-plugin-chakra-ui/package.json
@@ -18,8 +18,8 @@
     "test": "jest --passWithNoTests"
   },
   "peerDependencies": {
-    "@chakra-ui/core": ">0.8",
-    "@chakra-ui/theme": ">0.8",
+    "@chakra-ui/core": "^1.0.0-next.4",
+    "@chakra-ui/theme": "^1.0.0-next.4",
     "gatsby": "^2.21.33"
   },
   "gitHead": "ce6fe489afaddba502a2611f1fb1dcedb991325b"


### PR DESCRIPTION
Fixes #1076 

This PR updates internal peer dependencies from `>0.8` to `^1.0.0-next.4`.