### PR TITLE
docs(avatar): add wrap to stack containers

### DIFF
--- a/website/docs/components/avatar.mdx
+++ b/website/docs/components/avatar.mdx
@@ -38,7 +38,7 @@ import { Avatar, AvatarBadge } from "@chakra-ui/core"
 ## Usage
 
 ```jsx
-<Stack direction="row">
+<Wrap>
   <Avatar name="Dan Abrahmov" src="https://bit.ly/dan-abramov" />
   <Avatar name="Kola Tioluwani" src="https://bit.ly/tioluwani-kolawole" />
   <Avatar name="Kent Dodds" src="https://bit.ly/kent-c-dodds" />
@@ -46,7 +46,7 @@ import { Avatar, AvatarBadge } from "@chakra-ui/core"
   <Avatar name="Prosper Otemuyiwa" src="https://bit.ly/prosper-baba" />
   <Avatar name="Christian Nwamba" src="https://bit.ly/code-beast" />
   <Avatar name="Segun Adebayo" src="https://bit.ly/sage-adebayo" />
-</Stack>
+</Wrap>
 ```
 
 ### Avatar Sizes
@@ -54,7 +54,7 @@ import { Avatar, AvatarBadge } from "@chakra-ui/core"
 The `Avatar` component comes in 7 sizes.
 
 ```jsx
-<Stack direction="row">
+<Wrap>
   <Avatar size="2xs" name="Dan Abrahmov" src="https://bit.ly/dan-abramov" />
   <Avatar
     size="xs"
@@ -70,7 +70,7 @@ The `Avatar` component comes in 7 sizes.
   />
   <Avatar size="xl" name="Christian Nwamba" src="https://bit.ly/code-beast" />
   <Avatar size="2xl" name="Segun Adebayo" src="https://bit.ly/sage-adebayo" />
-</Stack>
+</Wrap>
 ```
 
 ### Avatar Fallbacks


### PR DESCRIPTION
Closes #660 

This PR adds `wrap` to both `Stack` containers. 

![image](https://user-images.githubusercontent.com/1954752/87214444-983d7b00-c2fa-11ea-890d-32806f68dea5.png)
