### PR TITLE
docs(switch): wrap usage code with FormControl

### DIFF
--- a/website/docs/form/switch.mdx
+++ b/website/docs/form/switch.mdx
@@ -31,10 +31,10 @@ import { Switch } from "@chakra-ui/core"
 ## Usage
 
 ```jsx
-<Flex justify="center" align="center">
+<FormControl as={Flex} justifyContent="center" alignItems="center">
   <FormLabel htmlFor="email-alerts">Enable email alerts?</FormLabel>
   <Switch id="email-alerts" />
-</Flex>
+</FormControl>
 ```
 
 ## Sizes


### PR DESCRIPTION
This PR fixes a docs build failure due to `FormLabel` requiring a surrounding `StylesProvider`.