### PR TITLE
fix: tabs align prop didnt do anything

### DIFF
--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -52,9 +52,7 @@ export const Tabs = React.forwardRef(function Tabs(
   ref: React.Ref<any>,
 ) {
   const styles = useStyleConfig("Tabs", props)
-  const { children, className, align = "start", ...rest } = omitThemingProps(
-    props,
-  )
+  const { children, className, ...rest } = omitThemingProps(props)
 
   const { htmlProps, ...tabsContext } = useTabs(rest)
   const ctx = React.useMemo(() => tabsContext, [tabsContext])

--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -37,7 +37,7 @@ const baseStyle: BaseStyle<typeof register> = (props) => {
         boxShadow: "outline",
       },
     },
-    tablist: alignments[align],
+    tablist: { justifyContent: alignments[align] },
     tabpanel: {
       padding: 4,
     },


### PR DESCRIPTION
Señor Bruno was asking in Discord if it was possible to right align Tabs. The `align` prop didnt seem to work, and the example in the docs was broken.

This fixes the align issue in the Tabs component.