### PR TITLE
chore: use theme provide radius for outline button

### DIFF
--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -73,12 +73,12 @@ function ghost(props: Props) {
 }
 
 function outline(props: Props) {
-  const { colorScheme: c } = props
+  const { colorScheme: c, theme } = props
   const borderColor = mode(`gray.200`, `whiteAlpha.300`)(props)
 
   return {
     container: {
-      border: "1px solid",
+      border: theme.borders['1px'],
       borderColor: c === "gray" ? borderColor : "currentColor",
       ...ghost(props).container,
     },


### PR DESCRIPTION
We can use defined borders for the outline button.