### PR TITLE
fix(select): add padding on select with arrow icon

### DIFF
--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -11,7 +11,6 @@ const baseStyle: BaseStyle<typeof register> = {
   field: {
     ...input.baseStyle.field,
     appearance: "none",
-    paddingRight: "2rem",
     paddingBottom: "1px",
     lineHeight: "normal",
   },
@@ -22,9 +21,38 @@ const baseStyle: BaseStyle<typeof register> = {
   },
 }
 
-const sizes = input.sizes
 const variants = input.variants
 const defaultProps = input.defaultProps
+
+const sizes = {
+  sm: {
+    field: {
+      ...input.sizes.sm.field,
+      paddingRight: "2rem",
+    },
+    addon: {
+      ...input.sizes.sm.addon,
+    },
+  },
+  md: {
+    field: {
+      ...input.sizes.md.field,
+      paddingRight: "2rem",
+    },
+    addon: {
+      ...input.sizes.md.addon,
+    },
+  },
+  lg: {
+    field: {
+      ...input.sizes.lg.field,
+      paddingRight: "2rem",
+    },
+    addon: {
+      ...input.sizes.lg.addon,
+    },
+  },
+}
 
 const select = {
   register,


### PR DESCRIPTION
fixes: #1146

I encountered the same problem as issue #1146 and I found we don't overwrite padding from the input component.

### Screenshot
<img width="201" alt="螢幕快照 2020-07-17 下午2 37 46" src="https://user-images.githubusercontent.com/10325111/87756241-21910800-c83b-11ea-8938-83e166345dcd.png">

Sorry for not familiar TypeScript...😣