### PR TITLE
docs: use git for accurate file history dates

### DIFF
--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -7,6 +7,7 @@ const {
   getNodeContributors,
   getOrgMembers,
   readAllContributorsRc,
+  getRelativePathHistoryDates,
 } = require("./utils")
 
 exports.onCreateNode = async ({ node, actions, getNode }) => {
@@ -42,6 +43,26 @@ exports.onCreateNode = async ({ node, actions, getNode }) => {
       name: "source",
       node,
       value: sourceInstanceName,
+    })
+
+    const relativePath = getRelativePagePath(
+      node.fileAbsolutePath,
+      sourceInstanceName,
+    )
+    const { createdAt, updatedAt } = await getRelativePathHistoryDates(
+      relativePath,
+    )
+
+    createNodeField({
+      name: "createdAt",
+      node,
+      value: createdAt,
+    })
+
+    createNodeField({
+      name: "updatedAt",
+      node,
+      value: updatedAt,
     })
 
     if (sourceInstanceName === "docs") {
@@ -107,57 +128,55 @@ const createDocsPages = async (nodes, { actions }) => {
   const docsTemplate = path.resolve("./src/templates/docs.js")
   const sortedNodes = sortPostNodes(nodes)
 
-  sortedNodes.forEach((node, index) => {
-    const {
-      fileAbsolutePath,
-      fields: { slug },
-      parent: { createdAt, updatedAt },
-    } = node
-    const previous = index === 0 ? null : sortedNodes[index - 1]
-    const next =
-      index === sortedNodes.length - 1 ? null : sortedNodes[index + 1]
-    const relativePath = getRelativePagePath(fileAbsolutePath, "docs")
+  return Promise.all(
+    sortedNodes.map(async (node, index) => {
+      const {
+        fileAbsolutePath,
+        fields: { slug },
+      } = node
+      const previous = index === 0 ? null : sortedNodes[index - 1]
+      const next =
+        index === sortedNodes.length - 1 ? null : sortedNodes[index + 1]
+      const relativePath = getRelativePagePath(fileAbsolutePath, "docs")
 
-    createPage({
-      path: slug,
-      component: docsTemplate,
-      context: {
-        slug,
-        layout: "docs",
-        previous,
-        next,
-        createdAt,
-        updatedAt,
-        relativePath,
-      },
-    })
-  })
+      createPage({
+        path: slug,
+        component: docsTemplate,
+        context: {
+          slug,
+          layout: "docs",
+          previous,
+          next,
+          relativePath,
+        },
+      })
+    }),
+  )
 }
 
 const createGuidesPages = async (nodes, { actions }) => {
   const { createPage } = actions
   const guidesTemplate = path.resolve("./src/templates/guides.js")
 
-  nodes.forEach((node) => {
-    const {
-      fileAbsolutePath,
-      fields: { slug },
-      parent: { createdAt, updatedAt },
-    } = node
-    const relativePath = getRelativePagePath(fileAbsolutePath, "guides")
+  return Promise.all(
+    nodes.map(async (node) => {
+      const {
+        fileAbsolutePath,
+        fields: { slug },
+      } = node
+      const relativePath = getRelativePagePath(fileAbsolutePath, "guides")
 
-    createPage({
-      path: slug,
-      component: guidesTemplate,
-      context: {
-        slug,
-        layout: "guides",
-        createdAt,
-        updatedAt,
-        relativePath,
-      },
-    })
-  })
+      createPage({
+        path: slug,
+        component: guidesTemplate,
+        context: {
+          slug,
+          layout: "guides",
+          relativePath,
+        },
+      })
+    }),
+  )
 }
 
 exports.createPages = async ({ graphql, actions }) => {
@@ -173,12 +192,6 @@ exports.createPages = async ({ graphql, actions }) => {
           collection
           slug
           source
-        }
-        parent {
-          ... on File {
-            createdAt: birthTime(formatString: "MMMM DD, YYYY")
-            updatedat: modifiedTime(formatString: "MMMM DD, YYYY")
-          }
         }
       }
 
@@ -199,8 +212,10 @@ exports.createPages = async ({ graphql, actions }) => {
 
   const { docs, guides } = result.data
 
-  await createDocsPages(docs.nodes, { actions })
-  await createGuidesPages(guides.nodes, { actions })
+  await Promise.all([
+    createDocsPages(docs.nodes, { actions }),
+    createGuidesPages(guides.nodes, { actions }),
+  ])
 }
 
 exports.sourceNodes = async ({

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "@mdx-js/react": "1.6.6",
     "@octokit/rest": "^18.0.0",
     "@reach/router": "^1.3.3",
+    "date-fns": "^2.15.0",
     "docsearch.js": "^2.6.3",
     "formik": "^2.1.4",
     "gatsby": "2.24.3",
@@ -32,7 +33,8 @@
     "prop-types": "^15.7.2",
     "react-helmet": "^6.1.0",
     "react-icons": "3.10.0",
-    "react-live": "2.2.2"
+    "react-live": "2.2.2",
+    "simple-git": "^2.13.0"
   },
   "scripts": {
     "build": "gatsby build",

--- a/website/src/components/github-edit-link.js
+++ b/website/src/components/github-edit-link.js
@@ -9,7 +9,7 @@ export function GithubLink({ path }) {
 
   if (!repository || !path) return null
 
-  const href = `${repository}/blob/master${path}`
+  const href = `${repository}/blob/master/${path}`
 
   return (
     <Link href={href} isExternal>

--- a/website/src/pages/guides.js
+++ b/website/src/pages/guides.js
@@ -75,6 +75,7 @@ function Guides() {
       allMdx(filter: { fields: { source: { eq: "guides" } } }) {
         nodes {
           fields {
+            createdAt
             slug
             contributors {
               name
@@ -90,7 +91,6 @@ function Guides() {
           parent {
             ... on File {
               birthTime
-              createdAt: birthTime(formatString: "MMMM DD, YYYY")
             }
           }
         }
@@ -118,9 +118,9 @@ function Guides() {
           <Stack spacing="4rem">
             {allMdx.nodes.map(
               ({
-                fields: { contributors, slug },
+                fields: { createdAt, contributors, slug },
                 frontmatter: { title, tags },
-                parent: { createdAt, birthTime },
+                parent: { birthTime },
                 excerpt,
               }) => (
                 <GuidePreview

--- a/website/src/templates/docs.js
+++ b/website/src/templates/docs.js
@@ -39,9 +39,10 @@ const Body = (props) => {
 
 const Docs = ({ data, pageContext }) => {
   const location = useLocation()
-  const { previous, next, slug, relativePath, updatedAt } = pageContext
-  const { body, frontmatter, tableOfContents } = data.mdx
+  const { previous, next, slug, relativePath } = pageContext
+  const { body, frontmatter, fields, tableOfContents } = data.mdx
   const { title, description } = frontmatter
+  const { updatedAt } = fields
 
   return (
     <>
@@ -65,6 +66,9 @@ export const query = graphql`
   query docBySlug($slug: String!) {
     mdx(fields: { slug: { eq: $slug } }) {
       body
+      fields {
+        updatedAt
+      }
       frontmatter {
         title
         description

--- a/website/src/templates/guides.js
+++ b/website/src/templates/guides.js
@@ -60,10 +60,10 @@ const Body = (props) => {
 
 const Guides = ({ data, pageContext }) => {
   const location = useLocation()
-  const { slug, relativePath, updatedAt } = pageContext
+  const { slug, relativePath } = pageContext
   const { body, frontmatter, fields, tableOfContents } = data.mdx
   const { title, description } = frontmatter
-  const { contributors } = fields
+  const { contributors, updatedAt } = fields
 
   return (
     <>
@@ -89,6 +89,7 @@ export const query = graphql`
     mdx(fields: { slug: { eq: $slug } }) {
       body
       fields {
+        updatedAt
         contributors {
           name
           image

--- a/website/utils.js
+++ b/website/utils.js
@@ -24,7 +24,7 @@ const orderByOrderThenTitle = _.orderBy(
   ["asc", "asc"],
 )
 
-const sortPostNodes = (nodes) => {
+const sortPostNodes = nodes => {
   const collections = groupByCollection(nodes)
   const sortedCollectionNodes = _.values(collections).map(orderByOrderThenTitle)
   const flattened = _.flatten(_.values(sortedCollectionNodes))
@@ -36,7 +36,7 @@ const sortPostNodes = (nodes) => {
 const getRelativePagePath = (fileAbsolutePath, source) => {
   if (!fileAbsolutePath) return
 
-  const regex = new RegExp(`/docs/${source}/.*`)
+  const regex = new RegExp(`/website/${source}/.*`)
   const match = fileAbsolutePath.match(regex)
   return match ? match[0] : null
 }
@@ -48,7 +48,7 @@ const getCommitAuthorDetails = _.pick([
   "author.html_url",
 ])
 
-const getNodeContributors = async (node) => {
+const getNodeContributors = async node => {
   const relativePath = getRelativePagePath(node.fileAbsolutePath)
   const { data: commits } = await octokit.repos.listCommits({
     owner: "chakra-ui",

--- a/website/utils.js
+++ b/website/utils.js
@@ -36,7 +36,7 @@ const sortPostNodes = nodes => {
 const getRelativePagePath = (fileAbsolutePath, source) => {
   if (!fileAbsolutePath) return
 
-  const regex = new RegExp(`/website/${source}/.*`)
+  const regex = new RegExp(`website/${source}/.*`)
   const match = fileAbsolutePath.match(regex)
   return match ? match[0] : null
 }

--- a/website/utils.js
+++ b/website/utils.js
@@ -1,8 +1,11 @@
 const fs = require("fs").promises
 const path = require("path")
 const _ = require("lodash/fp")
+const { format, parseISO } = require("date-fns/fp")
+const simpleGit = require("simple-git")
 const { Octokit } = require("@octokit/rest")
 
+const git = simpleGit({ baseDir: path.join(process.cwd(), "..") })
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
 
 const collections = ["main", "theming", "layout", "form", "components", "hooks"]
@@ -24,7 +27,7 @@ const orderByOrderThenTitle = _.orderBy(
   ["asc", "asc"],
 )
 
-const sortPostNodes = nodes => {
+const sortPostNodes = (nodes) => {
   const collections = groupByCollection(nodes)
   const sortedCollectionNodes = _.values(collections).map(orderByOrderThenTitle)
   const flattened = _.flatten(_.values(sortedCollectionNodes))
@@ -48,7 +51,7 @@ const getCommitAuthorDetails = _.pick([
   "author.html_url",
 ])
 
-const getNodeContributors = async node => {
+const getNodeContributors = async (node) => {
   const relativePath = getRelativePagePath(node.fileAbsolutePath)
   const { data: commits } = await octokit.repos.listCommits({
     owner: "chakra-ui",
@@ -102,6 +105,35 @@ const getOrgMembers = async () => {
   return await Promise.all(sorted.map(getMemberData))
 }
 
+/**
+ * Get all commits made to a specific path.
+ */
+const getPathCommits = async (path) => {
+  // --follow allows git to follow a file's history across renames/moves
+  // -- makes sure log knows that path is for a file
+  const { all: commits } = await git.log(["--follow", "--", path])
+  return commits
+}
+
+/** Convert a date string to the "MMMM DD, YYYY" format.  */
+const formatDateString = _.compose(format("MMMM dd, yyyy"), parseISO)
+
+/**
+ * Get the creation and last updated dates for a file. Uses `git` commit
+ * history.
+ */
+const getRelativePathHistoryDates = async (path) => {
+  const commits = await getPathCommits(path)
+
+  const firstCommit = _.last(commits)
+  const latestCommit = _.first(commits)
+
+  return {
+    createdAt: formatDateString(firstCommit.date),
+    updatedAt: formatDateString(latestCommit.date),
+  }
+}
+
 const readAllContributorsRc = async () => {
   const rcPath = path.resolve("..", ".all-contributorsrc")
   const contributorsRcData = await fs.readFile(rcPath, "utf-8")
@@ -115,4 +147,5 @@ module.exports = {
   getNodeContributors,
   getOrgMembers,
   readAllContributorsRc,
+  getRelativePathHistoryDates,
 }

--- a/website/utils.spec.js
+++ b/website/utils.spec.js
@@ -2,7 +2,7 @@ const { sortPostNodes } = require("./utils")
 
 test("sortPostNodes", () => {
   const nodes = [
-    { frontmatter: { title: "B" }, fields: { collection: "utilities" } },
+    { frontmatter: { title: "B" }, fields: { collection: "hooks" } },
     {
       frontmatter: { title: "A", order: 1 },
       fields: { collection: "components" },
@@ -10,7 +10,7 @@ test("sortPostNodes", () => {
     { frontmatter: { title: "B" }, fields: { collection: "components" } },
     { frontmatter: { title: "C" }, fields: { collection: "components" } },
     { frontmatter: { title: "B", order: 2 }, fields: { collection: "main" } },
-    { frontmatter: { title: "A" }, fields: { collection: "utilities" } },
+    { frontmatter: { title: "A" }, fields: { collection: "hooks" } },
     { frontmatter: { title: "A" }, fields: { collection: "theming" } },
     { frontmatter: { title: "A" }, fields: { collection: "layout" } },
     { frontmatter: { title: "A", order: 1 }, fields: { collection: "main" } },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2691,6 +2691,18 @@
     core-js "^3.4.1"
     regenerator-runtime "^0.13.3"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -9300,6 +9312,11 @@ date-fns@^2.0.1, date-fns@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
   integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
+
+date-fns@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz#424de6b3778e4e69d3ff27046ec136af58ae5d5f"
+  integrity sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -22470,6 +22487,15 @@ simple-get@^4.0.0:
     decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+simple-git@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.13.0.tgz#eb28b40190f3294ac389389b4df540904a7696e6"
+  integrity sha512-iqLN/MwnUfLUWWNuPPEbwSExdamcyXRtqAIp8V9ew6x0cibjKnHRPaBF4V04qG1TJfsG/4Sp+ZX9b0zYh3wh6Q==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.1.1"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
Closes #1204 

This PR uses `git` to look up the dates of the first and latest commits of `.mdx` files and uses the dates from those commits as the `createdAt` and `updatedAt` fields on `Mdx` nodes. Those fields are then available in GQL queries.

- uses [`simple-git`](https://github.com/steveukx/git-js) to access `git log` for commit lookup
- creates `createdAt`/`updatedAt` fields in `onCreateNode`
- reads `createdAt`/`updatedAt` fields using GQL queries in docs+guides pages/templates
- modifies `getRelativePagePath` to return the path without the `/` prefix