### PR TITLE
docs: add minimum typescript version notes

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -112,6 +112,17 @@ function App() {
 
 That's it, you're good to go!
 
+## TypeScript
+
+Please note that when adding Chakra UI to a TypeScript project, a minimum
+TypeScript version of `3.8.0` is required.
+
+If you're adding Chakra UI to a `create-react-app` project, this means you'll
+need to manually upgrade `typescript` from `~3.7.2` to `~3.8.0`. See
+[the guide for our official `create-react-app`](../guides/cra-templates)
+templates if you'd like to generate a Chakra-enabled `create-react-app` project
+from scratch.
+
 ## Contributing
 
 Please see our [contribution guidelines](/contributing) to learn how you can

--- a/website/docs/migration.mdx
+++ b/website/docs/migration.mdx
@@ -85,6 +85,17 @@ Chakra moved all icons to a separate package `@chakra-ui/icons`. We recommend
 using `react-icons` in your projects considering it has a robust set of icons.
 However, you can still install this package.
 
+#### Usage with TypeScript
+
+Please note that when adding Chakra UI to a TypeScript project, a minimum
+TypeScript version of `3.8.0` is required.
+
+If you're adding Chakra UI to a `create-react-app` project, this means you'll
+need to manually upgrade `typescript` from `~3.7.2` to `~3.8.0`. See
+[the guide for our official `create-react-app`](../guides/cra-templates)
+templates if you'd like to generate a Chakra-enabled `create-react-app` project
+from scratch.
+
 ### 2. Adding the default theme
 
 Chakra no longer comes with the default theme pre-installed, so you'll need to


### PR DESCRIPTION
Resolves #913

This PR adds a note about the minimum TypeScript version requirement for TypeScript projects to `getting-started.mdx` and `migration.mdx`.