### PR TITLE
docs(contributing): add changesets overview to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ your contribution.
 - [Making a Pull Request?](#making-a-pull-request)
   - [Commit Convention](#commit-convention)
   - [Steps to PR](#steps-to-pr)
+  - [Changesets](#changesets)
   - [Tests](#tests)
 - [Want to write a blog post or tutorial](#want-to-write-a-blog-post-or-tutorial)
 - [Want to help improve the docs?](#want-to-help-improve-the-docs)
@@ -59,6 +60,8 @@ use consumed independently.
 - [Testing Library](https://testing-library.com/) for testing components and
   hooks
 - [Gatsby](https://www.gatsbyjs.org/) for a blazing fast documentation website.
+- [Changesets](https://github.com/atlassian/changesets) A way to manage
+  versioning and changelogs
 
 ### Commands
 
@@ -184,6 +187,31 @@ https://www.conventionalcommits.org/ or check out the
   - `type` can be either `docs`, `fix`, `feat`, `build`, or any other
     conventional commit type
   - `scope` is just a short id that describes the scope of work.
+
+### Changesets
+
+The Chakra project uses [`changesets`](https://github.com/atlassian/changesets)
+to manage versioning and changelogs.
+
+A new changeset can be created using `yarn changeset`. This will begin a guided
+process that will ask you to select which packages you're changing, which type
+of version bump each package should receive (major, minor, or patch, defaulting
+to patch for all packages if no option is selected), and the change that you've
+made.
+
+Changesets are stored in `.changesets/` and don't do anything until we release a
+new version. At this time, the changesets are processed to determine which
+packages to bump, and the change messages are appended to the corresponding
+`CHANGELOG.md` files for each package.
+
+If you don't feel comfortable generating a changeset for changes you've made to
+the project, don't worry about it! We have a GitHub bot that will automatically
+reply to your PR letting us know that you haven't created a changeset, and a
+maintainer can add a changeset for you.
+
+See the
+[Detailed Explanation](https://github.com/atlassian/changesets/blob/master/docs/detailed-explanation.md)
+document for more information.
 
 ### Tests
 


### PR DESCRIPTION
Closes #1228 

This PR adds basic notes about `changesets` to `CONTRIBUTING.md`.