### PR TITLE
fix(link): prevent navigate when link is disabled

### DIFF
--- a/packages/theme/src/components/link.ts
+++ b/packages/theme/src/components/link.ts
@@ -4,28 +4,30 @@ const register = {
   parts: ["link"],
 } as const
 
-const baseStyle: BaseStyle<typeof register> = {
-  link: {
-    transition: `all 0.15s ease-out`,
-    cursor: "pointer",
-    textDecoration: "none",
-    outline: "none",
-    color: "inherit",
-    _hover: {
-      textDecoration: "underline",
-    },
-    _focus: {
-      boxShadow: "outline",
-    },
-    _disabled: {
-      opacity: 0.4,
-      cursor: "not-allowed",
+const baseStyle: BaseStyle<typeof register> = (props) => {
+  return {
+    link: {
+      transition: `all 0.15s ease-out`,
+      cursor: "pointer",
       textDecoration: "none",
+      outline: "none",
+      color: "inherit",
+      _hover: {
+        textDecoration: "underline",
+      },
+      _focus: {
+        boxShadow: props.isDisabled ? "none" : "outline",
+      },
+      _disabled: {
+        opacity: 0.4,
+        cursor: "not-allowed",
+        textDecoration: "none",
+      },
+      "_disabled:active": {
+        pointerEvents: "none",
+      },
     },
-    "_disabled:active": {
-      pointerEvents: "none",
-    },
-  },
+  }
 }
 
 const link = {

--- a/packages/theme/src/components/link.ts
+++ b/packages/theme/src/components/link.ts
@@ -22,6 +22,9 @@ const baseStyle: BaseStyle<typeof register> = {
       cursor: "not-allowed",
       textDecoration: "none",
     },
+    "_disabled:active": {
+      pointerEvents: "none",
+    },
   },
 }
 


### PR DESCRIPTION
fixes: #1317 

When link is disabled and user try to click (focus), it will not navigate to another page.