### PR TITLE
fix: use next docs link in cra templates

### DIFF
--- a/tooling/cra-template-typescript/template/src/App.tsx
+++ b/tooling/cra-template-typescript/template/src/App.tsx
@@ -32,7 +32,7 @@ export const App = () => (
           </Text>
           <Link
             color="teal.500"
-            href="https://chakra-ui.com"
+            href="https://next.chakra-ui.com"
             fontSize="2xl"
             target="_blank"
             rel="noopener noreferrer"

--- a/tooling/cra-template/template/src/App.js
+++ b/tooling/cra-template/template/src/App.js
@@ -33,7 +33,7 @@ function App() {
             </Text>
             <Link
               color="teal.500"
-              href="https://chakra-ui.com"
+              href="https://next.chakra-ui.com"
               fontSize="2xl"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
This PR fixes the docs linked in the cra templates to use https://next.chakra-ui.com/