### PR TITLE
docs: update installation instructions and add link to next docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ that make it super easy to create websites and apps.
 
 ## Looking for the documentation? 📝
 
-Head over here => https://chakra-ui.com
+For older versions, head over here => https://chakra-ui.com
+
+Latest version (pre-release) => https://next.chakra-ui.com
 
 ## Features 🚀
 

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -12,11 +12,11 @@ order: 1
 1. Install Chakra UI
 
 ```bash
-npm i @chakra-ui/core
+npm i @chakra-ui/core@next
 
 # or
 
-yarn add @chakra-ui/core
+yarn add @chakra-ui/core@next
 ```
 
 <carbon-ad></carbon-ad>


### PR DESCRIPTION
This PR adds link to v1 docs in README.md 
Additionally, it updates installation instructions to use `@chakra-ui/core@next`