### PR TITLE
chore(vercel): add /discord invite redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "version": 2,
   "alias": "next.chakra-ui.com",
-  "scope": "chakra-ui"
+  "scope": "chakra-ui",
+  "redirects": [
+    {
+      "source": "/discord",
+      "destination": "https://discord.com/invite/BEZ8VDy"
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds a Vercel redirect from `/discord` to https://discord.com/invite/BEZ8VDy which is a permanent invite to the Chakra Discord. This means can can invite people easily by linking them to https://chakra-ui.com/discord.