### PR TITLE
docs(breadcrumb): removes obviously from documentation

### DIFF
--- a/packages/breadcrumb/README.md
+++ b/packages/breadcrumb/README.md
@@ -20,7 +20,7 @@ Chakra UI exports 3 breadcrumb related components:
 - `Breadcrumb`: The parent container for breadcrumbs.
 - `BreadcrumbItem`: Individual breadcrumb element containing a link and a
   divider.
-- `BreadcrumbLink`: The breadcrumb link, obviously.
+- `BreadcrumbLink`: The breadcrumb link.
 
 ```js
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from "@chakra-ui/core"


### PR DESCRIPTION
Ran into the term obviously when viewing the Popover docs today. That was removed earlier but found another instance. Suggest removing the term to make the documentation a little friendlier.