### PR TITLE
test(icon): remove presentation role from rendered icon snapshots

### DIFF
--- a/packages/icon/tests/__snapshots__/icon.test.tsx.snap
+++ b/packages/icon/tests/__snapshots__/icon.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`Icon renders a third-party icon correctly 1`] = `
     fill="currentColor"
     focusable="false"
     height="1em"
-    role="presentation"
     stroke="currentColor"
     stroke-width="0"
     viewBox="0 0 24 24"
@@ -49,7 +48,6 @@ exports[`Icon renders correctly 1`] = `
 <svg
     class="chakra-icon emotion-0"
     focusable="false"
-    role="presentation"
     viewBox="0 0 24 24"
   >
     <g


### PR DESCRIPTION
This PR allows current icon tests to pass by removing `role="presentation"` from the rendered icon snapshots.

This attribute appears to have been removed in `develop`, possibly related to #1197. It seems like this is part of an ongoing conversation, but in the meantime this PR updates the tests to match the current code state.

<details>
  <summary><strong>Before</strong></summary>

```bash
$ yarn icon test

yarn run v1.22.4
$ yarn workspace @chakra-ui/icon test
$ jest --env=jsdom --passWithNoTests
 FAIL  tests/icon.test.tsx
  ✕ Icon renders correctly (101 ms)
  ✕ Icon renders a third-party icon correctly (70 ms)

  ● Icon renders correctly

    expect(received).toMatchSnapshot()

    Snapshot name: `Icon renders correctly 1`

    - Snapshot  - 1
    + Received  + 0

    @@ -12,11 +12,10 @@
      }

      <svg
          class="chakra-icon emotion-0"
          focusable="false"
    -     role="presentation"
          viewBox="0 0 24 24"
        >
          <g
            stroke="currentColor"
            stroke-width="1.5"

       6 | test("Icon renders correctly", () => {
       7 |   const { asFragment } = render(<Icon />)
    >  8 |   expect(asFragment()).toMatchSnapshot()
         |                        ^
       9 | })
      10 |
      11 | test("Icon renders a third-party icon correctly", () => {

      at Object.<anonymous> (tests/icon.test.tsx:8:24)

  ● Icon renders a third-party icon correctly

    expect(received).toMatchSnapshot()

    Snapshot name: `Icon renders a third-party icon correctly 1`

    - Snapshot  - 1
    + Received  + 0

    @@ -13,11 +13,10 @@
      <svg
          class="chakra-icon emotion-0"
          fill="currentColor"
          focusable="false"
          height="1em"
    -     role="presentation"
          stroke="currentColor"
          stroke-width="0"
          viewBox="0 0 24 24"
          width="1em"
          xmlns="http://www.w3.org/2000/svg"

      11 | test("Icon renders a third-party icon correctly", () => {
      12 |   const { asFragment } = render(<Icon as={Md3DRotation} />)
    > 13 |   expect(asFragment()).toMatchSnapshot()
         |                        ^
      14 | })
      15 |

      at Object.<anonymous> (tests/icon.test.tsx:13:24)

 › 2 snapshots failed.
Snapshot Summary
 › 2 snapshots failed from 1 test suite. Inspect your code changes or run `yarn test -u` to update them.

Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 total
Snapshots:   2 failed, 2 total
Time:        5.098 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
```
</details>

<details open>
  <summary><strong>After</strong></summary>

```bash
$ yarn icon test

yarn run v1.22.4
$ yarn workspace @chakra-ui/icon test
$ jest --env=jsdom --passWithNoTests
 PASS  tests/icon.test.tsx
  ✓ Icon renders correctly (85 ms)
  ✓ Icon renders a third-party icon correctly (66 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        2.376 s, estimated 4 s
Ran all test suites.
✨  Done in 4.29s.
```
</details>

**Related issues:**
- #1197