### PR TITLE
Fix `lineHeights.none` in the theme docs

### DIFF
--- a/website/docs/theming/theme.mdx
+++ b/website/docs/theming/theme.mdx
@@ -154,7 +154,7 @@ export default {
   },
   lineHeights: {
     normal: "normal",
-    base: "1",
+    none: "1",
     shorter: "1.25",
     short: "1.375",
     base: "1.5",


### PR DESCRIPTION
This branch updates a typo in the docs. The key `base` was accidentally used twice in place of the `none` key in the `lineHeights` part of the theme docs.