### PR TITLE
feat: add support for native required attribute in FormControl

### DIFF
--- a/packages/form-control/src/use-form-control.ts
+++ b/packages/form-control/src/use-form-control.ts
@@ -41,6 +41,7 @@ export function useFormControl<T extends HTMLElement>(
     ...props,
     id: props.id ?? field?.id,
     disabled: props.disabled || props.isDisabled || field?.isDisabled,
+    required: props.required || props.isRequired || field?.isRequired,
     readOnly: props.readOnly || props.isReadOnly || field?.isReadOnly,
     "aria-invalid": ariaAttr(props.isInvalid || field?.isInvalid),
     "aria-required": ariaAttr(props.isRequired || field?.isRequired),


### PR DESCRIPTION
This branch adds support for the native `required` attribute when `isRequired` is passed to an `Input` or `FormControl` component. If the omission of the native `required` attribute was intentional, please disregard this 🙏 

Addresses #1375 