### PR TITLE
fix(styled-system): Fix error in SystemStyleObject type

### DIFF
--- a/packages/styled-system/src/css.types.ts
+++ b/packages/styled-system/src/css.types.ts
@@ -121,12 +121,11 @@ type PseudoStyles = {
     : SystemCSSProperties
 }
 
-export type SystemStyleObject =
-  | SystemCSSProperties
-  | CSSPseudoStyles
-  | CSSSelectorStyles
-  | ApplyPropStyles
-  | PseudoStyles
+export type SystemStyleObject = SystemCSSProperties &
+  CSSPseudoStyles &
+  CSSSelectorStyles &
+  ApplyPropStyles &
+  PseudoStyles
 
 export type StyleObjectOrFn =
   | SystemStyleObject


### PR DESCRIPTION
I believe this type was meant to be an intersection type rather than a union. Close this if I'm wrong.