### PR TITLE
chore(system): remove shouldForwardProp isValid check

### DIFF
--- a/packages/system/src/should-forward-prop.ts
+++ b/packages/system/src/should-forward-prop.ts
@@ -1,6 +1,5 @@
 import { propNames } from "@chakra-ui/styled-system"
 import { memoizeOne } from "@chakra-ui/utils"
-import isValid from "@emotion/is-prop-valid"
 
 const allPropNames = [
   ...propNames,
@@ -13,7 +12,7 @@ const allPropNames = [
 
 function createShouldForwardProp(props: any) {
   const regex = new RegExp(`^(${props.join("|")})$`)
-  return memoizeOne((prop: string) => isValid(prop) && !regex.test(prop))
+  return memoizeOne((prop: string) => !regex.test(prop))
 }
 
 export const shouldForwardProp = createShouldForwardProp(allPropNames)

--- a/packages/system/tests/should-forward-prop.test.ts
+++ b/packages/system/tests/should-forward-prop.test.ts
@@ -1,0 +1,42 @@
+import { propNames } from "@chakra-ui/styled-system"
+import { shouldForwardProp } from "../src/should-forward-prop"
+
+describe("does not forward styled-system props", () => {
+  test.each(propNames)("%s", (propName) => {
+    expect(shouldForwardProp(propName)).toBe(false)
+  })
+})
+
+describe("does not forward reserved internal props", () => {
+  const internalPropNames = [
+    "htmlWidth",
+    "htmlHeight",
+    "htmlSize",
+    "__css",
+    "sx",
+  ]
+
+  test.each(internalPropNames)("%s", (propName) => {
+    expect(shouldForwardProp(propName)).toBe(false)
+  })
+})
+
+test('forwards "children" prop', () => {
+  expect(shouldForwardProp("children")).toBe(true)
+})
+
+describe("forwards other random props", () => {
+  const randomPropNames = [
+    "0hello",
+    "1goodbye",
+    "upside-down",
+    "inside-out",
+    "liberty",
+    "equality",
+    "fraternity",
+  ]
+
+  test.each(randomPropNames)("%s", (propName) => {
+    expect(shouldForwardProp(propName)).toBe(true)
+  })
+})


### PR DESCRIPTION
Resolves #1347

The `isValid` check was added recently, but I don't think that logic works quite the way we were expecting it to. The only way I could set the correct "should forward" status and get the tests to pass was by removing `isValid`.