### PR TITLE
fix: only map over Stack children when necessary

### DIFF
--- a/packages/layout/src/stack.tsx
+++ b/packages/layout/src/stack.tsx
@@ -154,27 +154,29 @@ export const Stack = React.forwardRef(function Stack(
 
   const hasDivider = !!divider
 
-  const clones = validChildren.map((child, index) => {
-    const isLast = index + 1 === validChildren.length
-    const _child = shouldWrapChildren ? <StackItem>{child}</StackItem> : child
+  const clones = !shouldWrapChildren && !divider
+    ? validChildren
+    : validChildren.map((child, index) => {
+        const isLast = index + 1 === validChildren.length
+        const _child = shouldWrapChildren ? <StackItem>{child}</StackItem> : child
 
-    if (!hasDivider) {
-      return <React.Fragment key={index}>{_child}</React.Fragment>
-    }
+        if (!hasDivider) {
+          return <React.Fragment key={index}>{_child}</React.Fragment>
+        }
 
-    const cloneDivider = isLast
-      ? null
-      : React.cloneElement(divider as any, {
-          css: css({ "&": dividerStyles }),
-        })
+        const cloneDivider = isLast
+          ? null
+          : React.cloneElement(divider as any, {
+              css: css({ "&": dividerStyles }),
+            })
 
-    return (
-      <React.Fragment key={index}>
-        {_child}
-        {cloneDivider}
-      </React.Fragment>
-    )
-  })
+        return (
+          <React.Fragment key={index}>
+            {_child}
+            {cloneDivider}
+          </React.Fragment>
+        )
+      })
 
   const sx = (theme: Dict) => {
     if (hasDivider) return undefined


### PR DESCRIPTION
This branch makes an update to the `Stack` component to avoid cloning and assigning new `key`s to its children when it isn't necessary. This addresses an issue brought up in #1377.