### PR TITLE
fix(media-query): create media queries using breakpoint name keys only

### DIFF
--- a/packages/media-query/package.json
+++ b/packages/media-query/package.json
@@ -50,7 +50,9 @@
     "calculate-measurement": "0.1.0"
   },
   "devDependencies": {
-    "@chakra-ui/system": "1.0.0-rc.0"
+    "@chakra-ui/system": "1.0.0-rc.0",
+    "@chakra-ui/test-utils": "1.0.0-rc.0",
+    "jest-matchmedia-mock": "^1.0.1"
   },
   "peerDependencies": {
     "@chakra-ui/system": "1.0.0-rc.0",

--- a/packages/media-query/src/create-media-query.ts
+++ b/packages/media-query/src/create-media-query.ts
@@ -1,4 +1,4 @@
-import { objectKeys, Dict, isNumber } from "@chakra-ui/utils"
+import { Dict, isNumber, breakpoints as bps } from "@chakra-ui/utils"
 import calculateMeasurement from "calculate-measurement"
 
 /**
@@ -6,7 +6,12 @@ import calculateMeasurement from "calculate-measurement"
  * using a combination of `min-width` and `max-width`.
  */
 function createMediaQueries(breakpoints: Dict) {
-  const sorted = getSortedKeys(breakpoints)
+  // get the non-number breakpoint keys from the provided breakpoints
+  const keys = Object.keys(breakpoints)
+
+  // use only the keys matching the official breakpoints names, and sort them in
+  // largest to smallest order
+  const sorted = bps.filter((bp) => keys.includes(bp)).reverse()
 
   // create a min-max media query string
   return sorted.map((breakpoint, index) => {
@@ -54,13 +59,6 @@ function subtract(value: any) {
  */
 function toMediaString(value: any) {
   return isNumber(value) ? `${value}px` : value
-}
-
-/**
- * Sort the breakpoints in descending order
- */
-function getSortedKeys(bps: Dict) {
-  return objectKeys(bps).sort((a, b) => parseInt(bps[b]) - parseInt(bps[a]))
 }
 
 export default createMediaQueries

--- a/packages/media-query/tests/create-media-query.test.ts
+++ b/packages/media-query/tests/create-media-query.test.ts
@@ -1,0 +1,31 @@
+import { breakpoints } from "./test-data"
+import createMediaQueries from "../src/create-media-query"
+
+test("creates media queries for each named breakpoint", () => {
+  expect(createMediaQueries(breakpoints)).toEqual([
+    {
+      breakpoint: "xl",
+      maxWidth: undefined,
+      minWidth: "400px",
+      query: "(min-width: 400px)",
+    },
+    {
+      breakpoint: "lg",
+      maxWidth: "400px",
+      minWidth: "300px",
+      query: "(min-width: 300px) and (max-width: 399.99px)",
+    },
+    {
+      breakpoint: "md",
+      maxWidth: "300px",
+      minWidth: "200px",
+      query: "(min-width: 200px) and (max-width: 299.99px)",
+    },
+    {
+      breakpoint: "sm",
+      maxWidth: "200px",
+      minWidth: "100px",
+      query: "(min-width: 100px) and (max-width: 199.99px)",
+    },
+  ])
+})

--- a/packages/media-query/tests/test-data.ts
+++ b/packages/media-query/tests/test-data.ts
@@ -1,0 +1,15 @@
+export const breakpoints: any = ["100px", "200px", "300px", "400px"]
+breakpoints.sm = breakpoints[0]
+breakpoints.md = breakpoints[1]
+breakpoints.lg = breakpoints[2]
+breakpoints.xl = breakpoints[3]
+
+export const theme = { breakpoints }
+
+export const queries = {
+  base: "(min-width: 0px) and (max-width: 99.99px)",
+  sm: "(min-width: 100px) and (max-width: 199.99px)",
+  md: "(min-width: 200px) and (max-width: 299.99px)",
+  lg: "(min-width: 300px) and (max-width: 399.99px)",
+  xl: "(min-width: 400px)",
+}

--- a/packages/media-query/tests/use-breakpoint-value.test.tsx
+++ b/packages/media-query/tests/use-breakpoint-value.test.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { ThemeProvider } from "@chakra-ui/system"
+import { render, screen } from "@chakra-ui/test-utils"
+import MatchMediaMock from "jest-matchmedia-mock"
+import { theme, queries } from "./test-data"
+import { useBreakpointValue } from "../src"
+
+let matchMedia: any
+
+beforeAll(() => {
+  matchMedia = new MatchMediaMock()
+})
+
+afterEach(() => {
+  matchMedia.clear()
+})
+
+describe("with object", () => {
+  const values = { base: "base", sm: "sm", md: "md", lg: "lg", xl: "xl" }
+
+  test("uses base value if smaller than sm", () => {
+    renderWithQuery(values, queries.base)
+    expect(screen.getByText("base")).toBeInTheDocument()
+  })
+
+  test("sm", () => {
+    renderWithQuery(values, queries.sm)
+    expect(screen.getByText("sm")).toBeInTheDocument()
+  })
+
+  test("md", () => {
+    renderWithQuery(values, queries.md)
+    expect(screen.getByText("md")).toBeInTheDocument()
+  })
+
+  test("lg", () => {
+    renderWithQuery(values, queries.lg)
+    expect(screen.getByText("lg")).toBeInTheDocument()
+  })
+
+  test("xl", () => {
+    renderWithQuery(values, queries.xl)
+    expect(screen.getByText("xl")).toBeInTheDocument()
+  })
+
+  test("base value is used if no breakpoint matches", () => {
+    const values = { base: "base", md: "md" }
+    renderWithQuery(values, queries.sm)
+    expect(screen.getByText("base")).toBeInTheDocument()
+  })
+})
+
+describe("with array", () => {
+  const values = ["base", "sm", "md", "lg", "xl"]
+
+  test("uses base value if smaller than sm", () => {
+    renderWithQuery(values, queries.base)
+    expect(screen.getByText("base")).toBeInTheDocument()
+  })
+
+  test("sm", () => {
+    renderWithQuery(values, queries.sm)
+    expect(screen.getByText("sm")).toBeInTheDocument()
+  })
+
+  test("md", () => {
+    renderWithQuery(values, queries.md)
+    expect(screen.getByText("md")).toBeInTheDocument()
+  })
+
+  test("lg", () => {
+    renderWithQuery(values, queries.lg)
+    expect(screen.getByText("lg")).toBeInTheDocument()
+  })
+
+  test("xl", () => {
+    renderWithQuery(values, queries.xl)
+    expect(screen.getByText("xl")).toBeInTheDocument()
+  })
+
+  test("uses base value if no breakpoint matches", () => {
+    renderWithQuery(["base"], queries.sm)
+    expect(screen.getByText("base")).toBeInTheDocument()
+  })
+})
+
+function renderWithQuery(values: any, query: string) {
+  matchMedia.useMediaQuery(query)
+  return render(
+    <ThemeProvider theme={theme}>
+      <TestComponent values={values} />
+    </ThemeProvider>,
+  )
+}
+
+const TestComponent = ({ values }: { values: any }) => {
+  const value = useBreakpointValue(values)
+  return <>{value}</>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15470,6 +15470,11 @@ jest-matcher-utils@^26.0.1, jest-matcher-utils@^26.1.0:
     jest-get-type "^26.0.0"
     pretty-format "^26.1.0"
 
+jest-matchmedia-mock@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jest-matchmedia-mock/-/jest-matchmedia-mock-1.0.1.tgz#da1c75be82a3b3e46e6c8ae195aa54e4a6032eb4"
+  integrity sha512-IXk2AnldfsCRmhB4pFY0Eb9mk2NxFqOgOwA4DxKOJ22T5bn/j3DzM5s3cdKxuEowmpuXK1gPXAIlVGIC+kb/fA==
+
 jest-message-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
@@ -25631,6 +25636,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+window-resizeto@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/window-resizeto/-/window-resizeto-0.0.2.tgz#94db61ea93e0bfc4292fd82c3e98b24776637bc5"
+  integrity sha512-681jdLyc6p+Whk7lFxWISm+V49ymURtBN+Oz5j5c6UnYoBpqc2Q8e3pjZ5VtedC01TjJqr2Xt9XdJMid4KxZmQ==
 
 windows-release@^3.1.0:
   version "3.3.1"


### PR DESCRIPTION
Fixes #1444 

This PR resolves an issue where `createMediaQueries` was returning a broken breakpoints array, causing `useBreakpointValue` objects to only match when using array numbers as keys rather than the breakpoint names.

Also added tests for both `createMediaQueries` and `useBreakpointValue` to help us avoid this situation in the future.

Thanks to @nassimbenkirane for investigating and sharing what he found!