### PR TITLE
fix: fix overlapping navbar

### DIFF
--- a/website/src/components/header.js
+++ b/website/src/components/header.js
@@ -122,7 +122,7 @@ const Header = (props) => {
     <chakra.header
       pos="fixed"
       top="0"
-      zIndex="1"
+      zIndex="99"
       bg={bg}
       left="0"
       right="0"


### PR DESCRIPTION
Fix overlapping navbar on the menu page.

Closes #1452 