### PR TITLE
fix/transition: Change children type

### DIFF
--- a/packages/chakra-ui/src/Transition/index.d.ts
+++ b/packages/chakra-ui/src/Transition/index.d.ts
@@ -9,7 +9,7 @@ interface ISlideIn {
   children: (styles: Object) => React.ReactNode;
 }
 
-type SlideInProps = ISlideIn & TransitionProps<boolean>;
+type SlideInProps = TransitionProps<boolean> & ISlideIn;
 export const SlideIn: React.FC<SlideInProps>;
 
 interface IScale {
@@ -19,7 +19,7 @@ interface IScale {
   children: (styles: Object) => React.ReactNode;
 }
 
-type ScaleProps = IScale & TransitionProps<boolean>;
+type ScaleProps = TransitionProps<boolean> & IScale;
 export const Scale: React.FC<ScaleProps>;
 
 interface ISlide {


### PR DESCRIPTION
This commit makes sure the `children` prop is set to whatever we specify in `IScale` and `ISlideIn`, instead of React Spring's TransitionProps's implementation.

Fixes #1473 