### PR TITLE
Refactor/use react fc

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "license": "MIT",
   "scripts": {
-    "lint:types": "lerna exec --parallel tsc --noEmit",
+    "lint:types": "lerna exec --parallel \"tsc --noEmit\"",
     "contrib:add": "all-contributors add",
     "contrib:gen": "all-contributors generate",
     "prestart": "yarn && yarn bootstrap",

--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -48,10 +48,7 @@ export type AccordionProps = UseAccordionProps &
  * It wraps all accordion items in a `div` for better grouping.
  * @see Docs https://chakra-ui.com/components/accordion
  */
-export const Accordion = forwardRef<AccordionProps>(function Accordion(
-  props,
-  ref,
-) {
+export const Accordion: React.FC<AccordionProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Accordion", props)
   const _props = omitThemingProps(props)
 
@@ -105,8 +102,8 @@ export type AccordionItemProps = Omit<DivProps, "children"> &
  *
  * It also provides context for the accordion button and panel.
  */
-export const AccordionItem = forwardRef<AccordionItemProps>(
-  function AccordionItem(props, ref) {
+export const AccordionItem: React.FC<AccordionItemProps> = forwardRef(
+  (props, ref) => {
     const { children, className } = props
     const { htmlProps, ...context } = useAccordionItem(props)
 
@@ -152,8 +149,8 @@ export type AccordionButtonProps = PropsOf<typeof chakra.button>
  * Note 🚨: Each accordion button must be wrapped in an heading tag,
  * that is appropriate for the information architecture of the page.
  */
-export const AccordionButton = forwardRef<AccordionButtonProps>(
-  function AccordionButton(props, ref) {
+export const AccordionButton: React.FC<AccordionButtonProps> = forwardRef(
+  (props, ref) => {
     const { getButtonProps } = useAccordionItemContext()
     const buttonProps = getButtonProps(props, ref)
 
@@ -189,8 +186,8 @@ export type AccordionPanelProps = DivProps
  *
  * It uses the `Collapse` component to animate it's height.
  */
-export const AccordionPanel = forwardRef<AccordionPanelProps>(
-  function AccordionPanel(props, ref) {
+export const AccordionPanel: React.FC<AccordionPanelProps> = forwardRef(
+  (props, ref) => {
     const { reduceMotion } = useAccordionContext()
     const { getPanelProps, isOpen } = useAccordionItemContext()
 
@@ -229,7 +226,7 @@ if (__DEV__) {
  * AccordionIcon that gives a visual cue of the open/close state of the accordion item.
  * It rotates `180deg` based on the open/close state.
  */
-export function AccordionIcon(props: IconProps) {
+export const AccordionIcon: React.FC<IconProps> = (props) => {
   const { isOpen, isDisabled } = useAccordionItemContext()
   const { reduceMotion } = useAccordionContext()
 

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -48,8 +48,7 @@
     "lint:types": "tsc --noEmit"
   },
   "dependencies": {
-    "@chakra-ui/modal": "1.0.0-rc.0",
-    "@chakra-ui/system": "1.0.0-rc.0"
+    "@chakra-ui/modal": "1.0.0-rc.0"
   },
   "devDependencies": {
     "@chakra-ui/system": "1.0.0-rc.0"

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -48,7 +48,8 @@
     "lint:types": "tsc --noEmit"
   },
   "dependencies": {
-    "@chakra-ui/modal": "1.0.0-rc.0"
+    "@chakra-ui/modal": "1.0.0-rc.0",
+    "@chakra-ui/system": "1.0.0-rc.0"
   },
   "devDependencies": {
     "@chakra-ui/system": "1.0.0-rc.0"

--- a/packages/alert-dialog/src/alert-dialog.tsx
+++ b/packages/alert-dialog/src/alert-dialog.tsx
@@ -3,12 +3,8 @@ import {
   ModalContent,
   ModalContentProps,
   ModalProps,
-  ModalBody,
-  ModalHeader,
-  ModalFooter,
-  ModalCloseButton,
-  ModalOverlay,
 } from "@chakra-ui/modal"
+
 import * as React from "react"
 import { forwardRef } from "@chakra-ui/system"
 
@@ -27,8 +23,10 @@ export const AlertDialogContent: React.FC<ModalContentProps> = forwardRef(
   },
 )
 
-export const AlertDialogBody = ModalBody
-export const AlertDialogHeader = ModalHeader
-export const AlertDialogFooter = ModalFooter
-export const AlertDialogCloseButton = ModalCloseButton
-export const AlertDialogOverlay = ModalOverlay
+export {
+  ModalBody as AlertDialogBody,
+  ModalHeader as AlertDialogHeader,
+  ModalFooter as AlertDialogFooter,
+  ModalCloseButton as AlertDialogCloseButton,
+  ModalOverlay as AlertDialogOverlay,
+} from "@chakra-ui/modal"

--- a/packages/alert-dialog/src/alert-dialog.tsx
+++ b/packages/alert-dialog/src/alert-dialog.tsx
@@ -3,32 +3,29 @@ import {
   ModalContent,
   ModalContentProps,
   ModalProps,
-} from "@chakra-ui/modal"
-import * as React from "react"
-
-export interface AlertDialogProps extends Omit<ModalProps, "initialFocusRef"> {
-  leastDestructiveRef: ModalProps["initialFocusRef"]
-}
-
-export function AlertDialog(props: AlertDialogProps) {
-  const { leastDestructiveRef, ...rest } = props
-  return <Modal {...rest} initialFocusRef={leastDestructiveRef} />
-}
-
-export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
-  props: ModalContentProps,
-  ref: React.Ref<any>,
-) {
-  return <ModalContent ref={ref} role="alertdialog" {...(props as any)} />
-})
-
-import {
   ModalBody,
   ModalHeader,
   ModalFooter,
   ModalCloseButton,
   ModalOverlay,
 } from "@chakra-ui/modal"
+import * as React from "react"
+import { forwardRef } from "@chakra-ui/system"
+
+export interface AlertDialogProps extends Omit<ModalProps, "initialFocusRef"> {
+  leastDestructiveRef: ModalProps["initialFocusRef"]
+}
+
+export const AlertDialog: React.FC<AlertDialogProps> = (props) => {
+  const { leastDestructiveRef, ...rest } = props
+  return <Modal {...rest} initialFocusRef={leastDestructiveRef} />
+}
+
+export const AlertDialogContent: React.FC<ModalContentProps> = forwardRef(
+  (props, ref) => {
+    return <ModalContent ref={ref} role="alertdialog" {...(props as any)} />
+  },
+)
 
 export const AlertDialogBody = ModalBody
 export const AlertDialogHeader = ModalHeader

--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -42,10 +42,7 @@ export type AlertProps = PropsOf<typeof chakra.div> &
  * React component used to communicate the state or status of a
  * page, feature or action
  */
-export const Alert = forwardRef(function Alert(
-  props: AlertProps,
-  ref: Ref<any>,
-) {
+export const Alert: React.FC<AlertProps> = forwardRef((props, ref) => {
   const { status = "info", ...rest } = props
   const { colorScheme } = STATUSES[status]
 
@@ -76,46 +73,44 @@ export const Alert = forwardRef(function Alert(
 
 export type AlertTitleProps = PropsOf<typeof chakra.div>
 
-export const AlertTitle = forwardRef(function AlertTitle(
-  props: AlertTitleProps,
-  ref: Ref<any>,
-) {
-  const styles = useStyles()
-  return (
-    <chakra.div
-      ref={ref}
-      {...props}
-      className={cx("chakra-alert__title", props.className)}
-      __css={styles.title}
-    />
-  )
-})
+export const AlertTitle: React.FC<AlertTitleProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
+    return (
+      <chakra.div
+        ref={ref}
+        {...props}
+        className={cx("chakra-alert__title", props.className)}
+        __css={styles.title}
+      />
+    )
+  },
+)
 
 export type AlertDescriptionProps = PropsOf<typeof chakra.div>
 
-export const AlertDescription = forwardRef(function AlertDescription(
-  props: AlertDescriptionProps,
-  ref: Ref<any>,
-) {
-  const styles = useStyles()
-  const descriptionStyles = {
-    display: "inline-block",
-    ...styles.description,
-  }
+export const AlertDescription: React.FC<AlertDescriptionProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
+    const descriptionStyles = {
+      display: "inline-block",
+      ...styles.description,
+    }
 
-  return (
-    <chakra.div
-      ref={ref}
-      {...props}
-      className={cx("chakra-alert__desc", props.className)}
-      __css={descriptionStyles}
-    />
-  )
-})
+    return (
+      <chakra.div
+        ref={ref}
+        {...props}
+        className={cx("chakra-alert__desc", props.className)}
+        __css={descriptionStyles}
+      />
+    )
+  },
+)
 
 export type AlertIconProps = PropsOf<typeof chakra.span>
 
-export const AlertIcon = (props: AlertIconProps) => {
+export const AlertIcon: React.FC<AlertIconProps> = (props) => {
   const { status } = useAlertContext()
   const { icon: BaseIcon } = STATUSES[status]
   const styles = useStyles()

--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -10,14 +10,16 @@ import {
 import { createContext, cx } from "@chakra-ui/utils"
 import React, { forwardRef, Ref } from "react"
 
-export const STATUSES = {
+const STATUSES = {
   info: { icon: InfoIcon, colorScheme: "blue" },
   warning: { icon: WarningIcon, colorScheme: "orange" },
   success: { icon: CheckIcon, colorScheme: "green" },
   error: { icon: WarningIcon, colorScheme: "red" },
 }
 
-type AlertContext = { status: keyof typeof STATUSES }
+export type AlertStatus = "info" | "warning" | "success" | "error"
+
+type AlertContext = { status: AlertStatus }
 
 const [AlertProvider, useAlertContext] = createContext<AlertContext>({
   name: "AlertContext",
@@ -29,7 +31,7 @@ interface AlertOptions {
   /**
    * The status of the alert
    */
-  status?: keyof typeof STATUSES
+  status?: AlertStatus
 }
 
 export type AlertProps = PropsOf<typeof chakra.div> &

--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -6,9 +6,10 @@ import {
   useStyles,
   ThemingProps,
   useMultiStyleConfig,
+  forwardRef,
 } from "@chakra-ui/system"
 import { createContext, cx } from "@chakra-ui/utils"
-import React, { forwardRef, Ref } from "react"
+import React from "react"
 
 const STATUSES = {
   info: { icon: InfoIcon, colorScheme: "blue" },

--- a/packages/alert/src/icons.tsx
+++ b/packages/alert/src/icons.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Icon, IconProps } from "@chakra-ui/icon"
 
-export const CheckIcon = (props: IconProps) => (
+export const CheckIcon: React.FC<IconProps> = (props) => (
   <Icon viewBox="0 0 24 24" {...props}>
     <path
       fill="currentColor"
@@ -10,7 +10,7 @@ export const CheckIcon = (props: IconProps) => (
   </Icon>
 )
 
-export const InfoIcon = (props: IconProps) => (
+export const InfoIcon: React.FC<IconProps> = (props) => (
   <Icon viewBox="0 0 24 24" {...props}>
     <path
       fill="currentColor"
@@ -19,7 +19,7 @@ export const InfoIcon = (props: IconProps) => (
   </Icon>
 )
 
-export const WarningIcon = (props: IconProps) => (
+export const WarningIcon: React.FC<IconProps> = (props) => (
   <Icon viewBox="0 0 24 24" {...props}>
     <path
       fill="currentColor"

--- a/packages/avatar/src/avatar-group.tsx
+++ b/packages/avatar/src/avatar-group.tsx
@@ -5,9 +5,10 @@ import {
   ThemingProps,
   useMultiStyleConfig,
   omitThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { getValidChildren, __DEV__, cx } from "@chakra-ui/utils"
-import React, { Ref, ReactNode, forwardRef, cloneElement } from "react"
+import React, { ReactNode, cloneElement } from "react"
 import { baseStyle } from "./avatar"
 
 interface AvatarGroupOptions {
@@ -34,82 +35,81 @@ export type AvatarGroupProps = AvatarGroupOptions &
 /**
  * AvatarGroup displays a number of avatars grouped together in a stack.
  */
-export const AvatarGroup = forwardRef(function AvatarGroup(
-  props: AvatarGroupProps,
-  ref: Ref<any>,
-) {
-  const styles = useMultiStyleConfig("Avatar", props)
+export const AvatarGroup: React.FC<AvatarGroupProps> = forwardRef(
+  (props, ref) => {
+    const styles = useMultiStyleConfig("Avatar", props)
 
-  const {
-    children,
-    borderColor,
-    max,
-    spacing = "-0.75rem",
-    ...rest
-  } = omitThemingProps(props)
+    const {
+      children,
+      borderColor,
+      max,
+      spacing = "-0.75rem",
+      ...rest
+    } = omitThemingProps(props)
 
-  const validChildren = getValidChildren(children)
+    const validChildren = getValidChildren(children)
 
-  /**
-   * get the avatars within the max
-   */
-  const childrenWithinMax = max ? validChildren.slice(0, max) : validChildren
+    /**
+     * get the avatars within the max
+     */
+    const childrenWithinMax = max ? validChildren.slice(0, max) : validChildren
 
-  /**
-   * get the remaining avatar count
-   */
-  const excess = max != null && validChildren.length - max
+    /**
+     * get the remaining avatar count
+     */
+    const excess = max != null && validChildren.length - max
 
-  /**
-   * Reversing the children is a great way to avoid using zIndex
-   * to overlap the avatars
-   */
-  const reversedChildren = childrenWithinMax.reverse()
+    /**
+     * Reversing the children is a great way to avoid using zIndex
+     * to overlap the avatars
+     */
+    const reversedChildren = childrenWithinMax.reverse()
 
-  const clones = reversedChildren.map((child, index) => {
-    const isFirstAvatar = index === 0
+    const clones = reversedChildren.map((child, index) => {
+      const isFirstAvatar = index === 0
 
-    return cloneElement(child, {
-      mr: isFirstAvatar ? 0 : spacing,
-      size: props.size,
-      borderColor: child.props.borderColor || borderColor,
-      showBorder: true,
+      return cloneElement(child, {
+        mr: isFirstAvatar ? 0 : spacing,
+        size: props.size,
+        borderColor: child.props.borderColor || borderColor,
+        showBorder: true,
+      })
     })
-  })
 
-  const groupStyles = {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "flex-end",
-    flexDirection: "row-reverse",
-  }
+    const groupStyles = {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "flex-end",
+      flexDirection: "row-reverse",
+    }
 
-  const excessStyles = {
-    borderRadius: "full",
-    ml: spacing,
-    ...baseStyle,
-    ...styles.excessLabel,
-  }
+    const excessStyles = {
+      borderRadius: "full",
+      ml: spacing,
+      ...baseStyle,
+      ...styles.excessLabel,
+    }
 
-  return (
-    <chakra.div
-      ref={ref}
-      role="group"
-      __css={groupStyles}
-      {...rest}
-      className={cx("chakra-avatar__group", props.className)}
-    >
-      {excess && (
-        <chakra.span
-          className="chakra-avatar__excess"
-          __css={excessStyles}
-          children={`+${excess}`}
-        />
-      )}
-      {clones}
-    </chakra.div>
-  )
-})
+    return (
+      <chakra.div
+        ref={ref}
+        role="group"
+        __css={groupStyles}
+        {...rest}
+        className={cx("chakra-avatar__group", props.className)}
+      >
+        {excess && (
+          <chakra.span
+            className="chakra-avatar__excess"
+            __css={excessStyles}
+            children={`+${excess}`}
+          />
+        )}
+        {clones}
+      </chakra.div>
+    )
+  },
+)
 
 if (__DEV__) {
   AvatarGroup.displayName = "AvatarGroup"

--- a/packages/avatar/src/avatar.tsx
+++ b/packages/avatar/src/avatar.tsx
@@ -12,7 +12,7 @@ import {
   forwardRef,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
-import React, { cloneElement, ReactElement, ReactNode, Ref } from "react"
+import React, { cloneElement, ReactElement, ReactNode } from "react"
 
 interface AvatarOptions {
   /**

--- a/packages/avatar/src/avatar.tsx
+++ b/packages/avatar/src/avatar.tsx
@@ -9,15 +9,10 @@ import {
   useMultiStyleConfig,
   useStyles,
   SystemStyleObject,
+  forwardRef,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
-import React, {
-  cloneElement,
-  forwardRef,
-  ReactElement,
-  ReactNode,
-  Ref,
-} from "react"
+import React, { cloneElement, ReactElement, ReactNode, Ref } from "react"
 
 interface AvatarOptions {
   /**
@@ -74,30 +69,29 @@ export type AvatarBadgeProps = PropsOf<typeof chakra.div>
  * AvatarBadge used to show extra badge to the top-right
  * or bottom-right corner of an avatar.
  */
-export const AvatarBadge = forwardRef(function AvatarBadge(
-  props: AvatarBadgeProps,
-  ref: Ref<any>,
-) {
-  const styles = useStyles()
-  const badgeStyles = {
-    position: "absolute",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    right: "0",
-    bottom: "0",
-    ...styles.badge,
-  }
+export const AvatarBadge: React.FC<AvatarBadgeProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
+    const badgeStyles = {
+      position: "absolute",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      right: "0",
+      bottom: "0",
+      ...styles.badge,
+    }
 
-  return (
-    <chakra.div
-      ref={ref}
-      {...props}
-      className={cx("chakra-avatar__badge", props.className)}
-      __css={badgeStyles}
-    />
-  )
-})
+    return (
+      <chakra.div
+        ref={ref}
+        {...props}
+        className={cx("chakra-avatar__badge", props.className)}
+        __css={badgeStyles}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   AvatarBadge.displayName = "AvatarBadge"
@@ -116,7 +110,7 @@ type InitialsProps = PropsOf<typeof chakra.div> &
 /**
  * The avatar name container
  */
-function Initials(props: InitialsProps) {
+const Initials: React.FC<InitialsProps> = (props) => {
   const { name, getInitials, ...rest } = props
   const styles = useStyles()
 
@@ -131,7 +125,7 @@ function Initials(props: InitialsProps) {
  * Fallback avatar react component.
  * This should be a generic svg used to represent an avatar
  */
-function DefaultIcon(props: PropsOf<"svg">) {
+const DefaultIcon: React.FC<PropsOf<"svg">> = (props) => {
   return (
     <svg
       viewBox="0 0 128 128"
@@ -170,10 +164,7 @@ export type AvatarProps = PropsOf<typeof chakra.span> &
  * Avatar component that renders an user avatar with
  * support for fallback avatar and name-only avatars
  */
-export const Avatar = forwardRef(function Avatar(
-  props: AvatarProps,
-  ref: Ref<any>,
-) {
+export const Avatar: React.FC<AvatarProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Avatar", props)
 
   const {

--- a/packages/breadcrumb/src/breadcrumb.tsx
+++ b/packages/breadcrumb/src/breadcrumb.tsx
@@ -10,7 +10,7 @@ import {
   omitThemingProps,
 } from "@chakra-ui/system"
 import { cx, getValidChildren, __DEV__ } from "@chakra-ui/utils"
-import React, { Ref, cloneElement } from "react"
+import React, { cloneElement } from "react"
 
 export type BreadcrumbSeparatorProps = PropsOf<typeof chakra.div> & {
   spacing?: SystemProps["mx"]

--- a/packages/breadcrumb/src/breadcrumb.tsx
+++ b/packages/breadcrumb/src/breadcrumb.tsx
@@ -19,8 +19,8 @@ export type BreadcrumbSeparatorProps = PropsOf<typeof chakra.div> & {
 /**
  * React component that separates each breadcrumb link
  */
-export const BreadcrumbSeparator = React.forwardRef(
-  function BreadcrumbSeparator(props: BreadcrumbSeparatorProps, ref: Ref<any>) {
+export const BreadcrumbSeparator: React.FC<BreadcrumbSeparatorProps> = forwardRef(
+  (props, ref) => {
     const { spacing, ...rest } = props
 
     const styles = useStyles()
@@ -56,8 +56,8 @@ export type BreadcrumbLinkProps = PropsOf<typeof chakra.a> & LinkOptions
  * It renders a `span` when it's the current link. Otherwise,
  * it renders an anchor tag.
  */
-export const BreadcrumbLink = forwardRef<BreadcrumbLinkProps>(
-  function BreadcrumbLink(props, ref) {
+export const BreadcrumbLink: React.FC<BreadcrumbLinkProps> = forwardRef(
+  (props, ref) => {
     const { isCurrentPage, as, className, ...rest } = props
     const styles = useStyles()
 
@@ -93,8 +93,8 @@ export type BreadcrumbItemProps = BreadcrumbItemOptions &
  * It renders a `li` element to denote it belongs to an order list of links.
  * @see Docs https://chakra-ui.com/components/breadcrumbs
  */
-export const BreadcrumbItem = forwardRef<BreadcrumbItemProps>(
-  function BreadcrumbItem(props, ref) {
+export const BreadcrumbItem: React.FC<BreadcrumbItemProps> = forwardRef(
+  (props, ref) => {
     const {
       isCurrentPage,
       separator,
@@ -171,47 +171,46 @@ export type BreadcrumbProps = PropsOf<typeof chakra.nav> &
  *
  * @see Docs https://chakra-ui.com/components/breadcrumbs
  */
-export const Breadcrumb = React.forwardRef(function Breadcrumb(
-  props: BreadcrumbProps,
-  ref: Ref<any>,
-) {
-  const styles = useMultiStyleConfig("Breadcrumb", props)
-  const realProps = omitThemingProps(props)
+export const Breadcrumb: React.FC<BreadcrumbProps> = forwardRef(
+  (props, ref) => {
+    const styles = useMultiStyleConfig("Breadcrumb", props)
+    const realProps = omitThemingProps(props)
 
-  const {
-    children,
-    spacing = "0.5rem",
-    separator = "/",
-    className,
-    ...rest
-  } = realProps
+    const {
+      children,
+      spacing = "0.5rem",
+      separator = "/",
+      className,
+      ...rest
+    } = realProps
 
-  const validChildren = getValidChildren(children)
-  const count = validChildren.length
+    const validChildren = getValidChildren(children)
+    const count = validChildren.length
 
-  const clones = validChildren.map((child, index) =>
-    cloneElement(child, {
-      separator,
-      spacing,
-      isLastChild: count === index + 1,
-    }),
-  )
+    const clones = validChildren.map((child, index) =>
+      cloneElement(child, {
+        separator,
+        spacing,
+        isLastChild: count === index + 1,
+      }),
+    )
 
-  const _className = cx("chakra-breadcrumb", className)
+    const _className = cx("chakra-breadcrumb", className)
 
-  return (
-    <chakra.nav
-      ref={ref}
-      aria-label="breadcrumb"
-      className={_className}
-      {...rest}
-    >
-      <StylesProvider value={styles}>
-        <chakra.ol className="chakra-breadcrumb__list">{clones}</chakra.ol>
-      </StylesProvider>
-    </chakra.nav>
-  )
-})
+    return (
+      <chakra.nav
+        ref={ref}
+        aria-label="breadcrumb"
+        className={_className}
+        {...rest}
+      >
+        <StylesProvider value={styles}>
+          <chakra.ol className="chakra-breadcrumb__list">{clones}</chakra.ol>
+        </StylesProvider>
+      </chakra.nav>
+    )
+  },
+)
 
 if (__DEV__) {
   Breadcrumb.displayName = "Breadcrumb"

--- a/packages/button/src/button-group.tsx
+++ b/packages/button/src/button-group.tsx
@@ -4,6 +4,7 @@ import {
   SystemProps,
   SystemStyleObject,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { createContext, cx, __DEV__ } from "@chakra-ui/utils"
 import React, { useMemo } from "react"
@@ -37,60 +38,57 @@ const [ButtonGroupProvider, useButtonGroup] = createContext<ButtonGroupContext>(
 
 export { useButtonGroup }
 
-export const ButtonGroup = React.forwardRef(function ButtonGroup(
-  props: ButtonGroupProps,
-  ref: React.Ref<any>,
-) {
-  const {
-    size,
-    colorScheme,
-    variant,
-    className,
-    spacing = "0.5rem",
-    isAttached,
-    isDisabled,
-    ...rest
-  } = props
+export const ButtonGroup: React.FC<ButtonGroupProps> = forwardRef(
+  (props, ref) => {
+    const {
+      size,
+      colorScheme,
+      variant,
+      className,
+      spacing = "0.5rem",
+      isAttached,
+      isDisabled,
+      ...rest
+    } = props
 
-  const _className = cx("chakra-button__group", className)
+    const _className = cx("chakra-button__group", className)
 
-  const context = useMemo(() => ({ size, colorScheme, variant, isDisabled }), [
-    size,
-    colorScheme,
-    variant,
-    isDisabled,
-  ])
+    const context = useMemo(
+      () => ({ size, colorScheme, variant, isDisabled }),
+      [size, colorScheme, variant, isDisabled],
+    )
 
-  let groupStyles: SystemStyleObject = {
-    display: "inline-flex",
-  }
-
-  if (isAttached) {
-    groupStyles = {
-      ...groupStyles,
-      "> *:first-of-type:not(:last-of-type)": { borderRightRadius: 0 },
-      "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
-      "> *:not(:first-of-type):last-of-type": { borderLeftRadius: 0 },
+    let groupStyles: SystemStyleObject = {
+      display: "inline-flex",
     }
-  } else {
-    groupStyles = {
-      ...groupStyles,
-      "& > *:not(style) ~ *:not(style)": { marginLeft: spacing },
-    }
-  }
 
-  return (
-    <ButtonGroupProvider value={context}>
-      <chakra.div
-        ref={ref}
-        role="group"
-        __css={groupStyles}
-        className={_className}
-        {...rest}
-      />
-    </ButtonGroupProvider>
-  )
-})
+    if (isAttached) {
+      groupStyles = {
+        ...groupStyles,
+        "> *:first-of-type:not(:last-of-type)": { borderRightRadius: 0 },
+        "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
+        "> *:not(:first-of-type):last-of-type": { borderLeftRadius: 0 },
+      }
+    } else {
+      groupStyles = {
+        ...groupStyles,
+        "& > *:not(style) ~ *:not(style)": { marginLeft: spacing },
+      }
+    }
+
+    return (
+      <ButtonGroupProvider value={context}>
+        <chakra.div
+          ref={ref}
+          role="group"
+          __css={groupStyles}
+          className={_className}
+          {...rest}
+        />
+      </ButtonGroupProvider>
+    )
+  },
+)
 
 if (__DEV__) {
   ButtonGroup.displayName = "ButtonGroup"

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -60,7 +60,7 @@ export type ButtonProps = PropsOf<typeof chakra.button> &
   ButtonOptions &
   ThemingProps
 
-export const Button = forwardRef<ButtonProps>(function Button(props, ref) {
+export const Button: React.FC<ButtonProps> = forwardRef((props, ref) => {
   const group = useButtonGroup()
   const styles = useStyleConfig("Button", { ...group, ...props })
 
@@ -142,7 +142,7 @@ if (__DEV__) {
   Button.displayName = "Button"
 }
 
-function ButtonIcon(props: PropsOf<typeof chakra.span>) {
+const ButtonIcon: React.FC<PropsOf<typeof chakra.span>> = (props) => {
   const { children, className, ...rest } = props
 
   const _children = isValidElement(children)
@@ -166,7 +166,7 @@ type ButtonSpinnerProps = PropsOf<typeof chakra.div> & {
   spacing?: SystemProps["margin"]
 }
 
-function ButtonSpinner(props: ButtonSpinnerProps) {
+const ButtonSpinner: React.FC<ButtonSpinnerProps> = (props) => {
   const {
     label,
     spacing,

--- a/packages/button/src/icon-button.tsx
+++ b/packages/button/src/icon-button.tsx
@@ -13,35 +13,34 @@ export type IconButtonProps = BaseButtonProps & {
   "aria-label": string
 }
 
-export const IconButton = forwardRef<IconButtonProps>(function IconButton(
-  props,
-  ref,
-) {
-  const { icon, children, isRound, "aria-label": ariaLabel, ...rest } = props
+export const IconButton: React.FC<IconButtonProps> = forwardRef(
+  (props, ref) => {
+    const { icon, children, isRound, "aria-label": ariaLabel, ...rest } = props
 
-  /**
-   * Passing the icon as prop or children should work
-   */
-  const element = icon || children
-  const _children = isValidElement(element)
-    ? cloneElement(element as any, {
-        "aria-hidden": true,
-        focusable: false,
-      })
-    : null
+    /**
+     * Passing the icon as prop or children should work
+     */
+    const element = icon || children
+    const _children = isValidElement(element)
+      ? cloneElement(element as any, {
+          "aria-hidden": true,
+          focusable: false,
+        })
+      : null
 
-  return (
-    <Button
-      padding="0"
-      borderRadius={isRound ? "full" : "md"}
-      ref={ref}
-      aria-label={ariaLabel}
-      {...rest}
-    >
-      {_children}
-    </Button>
-  )
-})
+    return (
+      <Button
+        padding="0"
+        borderRadius={isRound ? "full" : "md"}
+        ref={ref}
+        aria-label={ariaLabel}
+        {...rest}
+      >
+        {_children}
+      </Button>
+    )
+  },
+)
 
 if (__DEV__) {
   IconButton.displayName = "IconButton"

--- a/packages/checkbox/src/checkbox-group.tsx
+++ b/packages/checkbox/src/checkbox-group.tsx
@@ -34,7 +34,7 @@ export { useCheckboxGroupContext }
  *
  * @see Docs https://chakra-ui.com/components/checkbox
  */
-export function CheckboxGroup(props: CheckboxGroupProps) {
+export const CheckboxGroup: React.FC<CheckboxGroupProps> = (props) => {
   const { colorScheme, size, variant, children } = props
   const { value, onChange } = useCheckboxGroup(props)
 

--- a/packages/checkbox/src/checkbox.icon.tsx
+++ b/packages/checkbox/src/checkbox.icon.tsx
@@ -12,7 +12,7 @@ export type CheckboxIconProps = IconProps & {
  * @todo allow users pass their own icon svgs
  */
 export const CheckboxIcon: React.FC<CheckboxIconProps> = (props) => {
-  const { isChecked, isIndeterminate, ...rest } = props
+  const { isChecked, isIndeterminate } = props
   return (
     <Icon {...props}>
       {isIndeterminate ? (

--- a/packages/checkbox/src/checkbox.icon.tsx
+++ b/packages/checkbox/src/checkbox.icon.tsx
@@ -11,7 +11,7 @@ export type CheckboxIconProps = IconProps & {
  * state of a checkbox
  * @todo allow users pass their own icon svgs
  */
-export function CheckboxIcon(props: CheckboxIconProps) {
+export const CheckboxIcon: React.FC<CheckboxIconProps> = (props) => {
   const { isChecked, isIndeterminate, ...rest } = props
   return (
     <Icon {...props}>

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -60,10 +60,7 @@ export type CheckboxProps = StyledControlProps &
  *
  * @see Docs https://chakra-ui.com/components/checkbox
  */
-export const Checkbox = forwardRef<CheckboxProps>(function Checkbox(
-  props,
-  ref,
-) {
+export const Checkbox: React.FC<CheckboxProps> = forwardRef((props, ref) => {
   const group = useCheckboxGroupContext()
 
   const merged = { ...group, ...props }

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -3,13 +3,7 @@ import {
   useControllableProp,
   useSafeLayoutEffect,
 } from "@chakra-ui/hooks"
-import {
-  callAllHandlers,
-  dataAttr,
-  mergeRefs,
-  Dict,
-  focus,
-} from "@chakra-ui/utils"
+import { callAllHandlers, dataAttr, mergeRefs, Dict } from "@chakra-ui/utils"
 import { visuallyHiddenStyle } from "@chakra-ui/visually-hidden"
 import React, {
   Ref,

--- a/packages/clickable/stories/use-clickable.stories.tsx
+++ b/packages/clickable/stories/use-clickable.stories.tsx
@@ -1,4 +1,4 @@
-import { chakra, PropsOf } from "@chakra-ui/system"
+import { chakra, PropsOf, forwardRef } from "@chakra-ui/system"
 import { SafeMerge } from "@chakra-ui/utils"
 import * as React from "react"
 import { UseClickableProps, useClickable } from "../src"
@@ -8,12 +8,10 @@ export type ClickableProps = SafeMerge<
   PropsOf<typeof chakra.button>
 >
 
-const Clickable = React.forwardRef(
-  (props: ClickableProps, ref: React.Ref<any>) => {
-    const clickable = useClickable({ ...props, ref })
-    return <chakra.button display="inline-flex" {...clickable} />
-  },
-)
+const Clickable: React.FC<ClickableProps> = forwardRef((props, ref) => {
+  const clickable = useClickable({ ...props, ref })
+  return <chakra.button display="inline-flex" {...clickable} />
+})
 
 export default {
   title: "Tabbable",

--- a/packages/clickable/tests/clickable.test.tsx
+++ b/packages/clickable/tests/clickable.test.tsx
@@ -1,15 +1,13 @@
 import * as React from "react"
 import { render, userEvent, fireEvent } from "@chakra-ui/test-utils"
-import { chakra } from "@chakra-ui/system"
+import { chakra, forwardRef } from "@chakra-ui/system"
 import { ClickableProps } from "../stories/use-clickable.stories"
 import { useClickable } from "../src"
 
-const Clickable = React.forwardRef(
-  (props: ClickableProps, ref: React.Ref<any>) => {
-    const clickable = useClickable({ ...props, ref })
-    return <chakra.button display="inline-flex" {...clickable} />
-  },
-)
+const Clickable: React.FC<ClickableProps> = forwardRef((props, ref) => {
+  const clickable = useClickable({ ...props, ref })
+  return <chakra.button display="inline-flex" {...clickable} />
+})
 
 test("should render correctly", () => {
   const tools = render(<Clickable>clickable</Clickable>)

--- a/packages/close-button/src/close-button.tsx
+++ b/packages/close-button/src/close-button.tsx
@@ -5,11 +5,12 @@ import {
   omitThemingProps,
   useStyleConfig,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
-const CloseIcon = (props: IconProps) => (
+const CloseIcon: React.FC<IconProps> = (props) => (
   <Icon focusable="false" aria-hidden {...props}>
     <path
       fill="currentColor"
@@ -32,37 +33,36 @@ export type CloseButtonProps = PropsOf<typeof chakra.button> &
  * It is used to handle the close functionality in feedback and overlay components
  * like Alerts, Toasts, Drawers and Modals.
  */
-export const CloseButton = React.forwardRef(function CloseButton(
-  props: CloseButtonProps,
-  ref: React.Ref<any>,
-) {
-  const styles = useStyleConfig("CloseButton", props)
-  const { children, isDisabled, ...rest } = omitThemingProps(props)
+export const CloseButton: React.FC<CloseButtonProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyleConfig("CloseButton", props)
+    const { children, isDisabled, ...rest } = omitThemingProps(props)
 
-  const baseStyle = {
-    outline: 0,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    flexShrink: 0,
-  }
+    const baseStyle = {
+      outline: 0,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+    }
 
-  return (
-    <chakra.button
-      type="button"
-      aria-label="Close"
-      ref={ref}
-      disabled={isDisabled}
-      __css={{
-        ...baseStyle,
-        ...styles,
-      }}
-      {...rest}
-    >
-      {children || <CloseIcon width="1em" height="1em" />}
-    </chakra.button>
-  )
-})
+    return (
+      <chakra.button
+        type="button"
+        aria-label="Close"
+        ref={ref}
+        disabled={isDisabled}
+        __css={{
+          ...baseStyle,
+          ...styles,
+        }}
+        {...rest}
+      >
+        {children || <CloseIcon width="1em" height="1em" />}
+      </chakra.button>
+    )
+  },
+)
 
 if (__DEV__) {
   CloseButton.displayName = "CloseButton"

--- a/packages/collapse/src/collapse.tsx
+++ b/packages/collapse/src/collapse.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import AnimateHeight, {
   AnimateHeightProps as AnimateProps,
 } from "react-animate-height"
-import { chakra, jsx, PropsOf } from "@chakra-ui/system"
+import { chakra, jsx, PropsOf, forwardRef } from "@chakra-ui/system"
 import { __DEV__ } from "@chakra-ui/utils"
 
 type AnimateHeightProps = Pick<
@@ -53,10 +53,7 @@ export type CollapseProps = AnimateHeightProps &
   CollapseOptions &
   PropsOf<typeof chakra.div>
 
-export const Collapse = React.forwardRef(function Collapse(
-  props: CollapseProps,
-  ref: React.Ref<any>,
-) {
+export const Collapse: React.FC<CollapseProps> = forwardRef((props, ref) => {
   const {
     isOpen,
     animateOpacity = true,

--- a/packages/color-mode/src/color-mode.tsx
+++ b/packages/color-mode/src/color-mode.tsx
@@ -40,7 +40,7 @@ export interface ColorModeProviderProps {
  * Provides context for the color mode based on config in `theme`
  * Returns the color mode and function to toggle the color mode
  */
-export function ColorModeProvider(props: ColorModeProviderProps) {
+export const ColorModeProvider: React.FC<ColorModeProviderProps> = (props) => {
   const {
     value,
     children,
@@ -80,11 +80,12 @@ if (__DEV__) {
 /**
  * Locks the color mode to `dark`, without any way to change it.
  */
-export const DarkMode: React.FC = (props) => (
+export const DarkMode: React.FC = ({ children }) => (
   <ColorModeContext.Provider
     value={{ colorMode: "dark", toggleColorMode: noop }}
-    {...props}
-  />
+  >
+    {children}
+  </ColorModeContext.Provider>
 )
 
 if (__DEV__) {
@@ -94,11 +95,12 @@ if (__DEV__) {
 /**
  * Locks the color mode to `light` without any way to change it.
  */
-export const LightMode: React.FC = (props) => (
+export const LightMode: React.FC = ({ children }) => (
   <ColorModeContext.Provider
     value={{ colorMode: "light", toggleColorMode: noop }}
-    {...props}
-  />
+  >
+    {children}
+  </ColorModeContext.Provider>
 )
 
 if (__DEV__) {

--- a/packages/control-box/src/index.tsx
+++ b/packages/control-box/src/index.tsx
@@ -20,7 +20,7 @@ export type IControlBox = ControlBoxOptions
 
 export type ControlBoxProps = PropsOf<typeof chakra.div> & ControlBoxOptions
 
-export function ControlBox(props: ControlBoxProps) {
+export const ControlBox: React.FC<ControlBoxProps> = (props) => {
   const {
     type = "checkbox",
     _hover,

--- a/packages/drawer/src/drawer.tsx
+++ b/packages/drawer/src/drawer.tsx
@@ -7,6 +7,10 @@ import {
   ModalContent,
   ModalOverlayProps,
   ModalOverlay,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+  ModalCloseButton,
 } from "@chakra-ui/modal"
 import { forwardRef, useTheme } from "@chakra-ui/system"
 import { __DEV__ } from "@chakra-ui/utils"
@@ -30,7 +34,7 @@ interface DrawerTransitionProps {
   placement: SlideProps["placement"]
 }
 
-function DrawerTransition(props: DrawerTransitionProps) {
+const DrawerTransition: React.FC<DrawerTransitionProps> = (props) => {
   const { in: inProp, children, placement } = props
   return (
     <Slide
@@ -72,7 +76,7 @@ export interface DrawerProps extends ModalProps {
   isFullHeight?: boolean
 }
 
-export function Drawer(props: DrawerProps) {
+export const Drawer: React.FC<DrawerProps> = (props) => {
   const { isOpen, onClose, placement = "right", children, ...rest } = props
 
   const theme = useTheme()
@@ -87,8 +91,8 @@ export function Drawer(props: DrawerProps) {
   )
 }
 
-export const DrawerContent = forwardRef<ModalContentProps>(
-  function DrawerContent(props, ref) {
+export const DrawerContent: React.FC<ModalContentProps> = forwardRef(
+  (props, ref) => {
     const { content: styles } = useTransitionContext()
     return (
       <ModalContent
@@ -104,19 +108,12 @@ export const DrawerContent = forwardRef<ModalContentProps>(
   },
 )
 
-export const DrawerOverlay = forwardRef<ModalOverlayProps>(
-  function DrawerOverlay(props, ref) {
+export const DrawerOverlay: React.FC<ModalOverlayProps> = forwardRef(
+  (props, ref) => {
     const { overlay: styles } = useTransitionContext()
     return <ModalOverlay style={styles} ref={ref} {...props} />
   },
 )
-
-import {
-  ModalBody,
-  ModalHeader,
-  ModalFooter,
-  ModalCloseButton,
-} from "@chakra-ui/modal"
 
 export const DrawerBody = ModalBody
 export const DrawerHeader = ModalHeader

--- a/packages/drawer/src/drawer.tsx
+++ b/packages/drawer/src/drawer.tsx
@@ -7,10 +7,6 @@ import {
   ModalContent,
   ModalOverlayProps,
   ModalOverlay,
-  ModalBody,
-  ModalHeader,
-  ModalFooter,
-  ModalCloseButton,
 } from "@chakra-ui/modal"
 import { forwardRef, useTheme } from "@chakra-ui/system"
 import { __DEV__ } from "@chakra-ui/utils"
@@ -115,7 +111,9 @@ export const DrawerOverlay: React.FC<ModalOverlayProps> = forwardRef(
   },
 )
 
-export const DrawerBody = ModalBody
-export const DrawerHeader = ModalHeader
-export const DrawerFooter = ModalFooter
-export const DrawerCloseButton = ModalCloseButton
+export {
+  ModalBody as DrawerBody,
+  ModalHeader as DrawerHeader,
+  ModalFooter as DrawerFooter,
+  ModalCloseButton as DrawerCloseButton,
+} from "@chakra-ui/modal"

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -188,7 +188,13 @@ export function useEditableState() {
 /**
  * React hook use to create controls for the editable component
  */
-export function useEditableControls() {
+export function useEditableControls(): Pick<
+  EditableContext,
+  | "isEditing"
+  | "getEditButtonProps"
+  | "getCancelButtonProps"
+  | "getSubmitButtonProps"
+> {
   const {
     isEditing,
     getEditButtonProps,

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -53,10 +53,7 @@ export type EditableProps = UseEditableProps &
  * The wrapper that provides context and logic for all editable
  * components. It renders a `div`
  */
-export const Editable = forwardRef<EditableProps>(function Editable(
-  props,
-  ref,
-) {
+export const Editable: React.FC<EditableProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Editable", props)
 
   const realProps = omitThemingProps(props)
@@ -107,8 +104,8 @@ export type EditablePreviewProps = PropsOf<typeof chakra.div>
  *
  * The `span` used to display the final value, in the `preview` mode
  */
-export const EditablePreview = forwardRef<EditablePreviewProps>(
-  function EditablePreview(props, ref) {
+export const EditablePreview: React.FC<EditablePreviewProps> = forwardRef(
+  (props, ref) => {
     const { getPreviewProps } = useEditableContext()
     const styles = useStyles()
 
@@ -141,8 +138,8 @@ export type EditableInputProps = PropsOf<typeof chakra.input>
  *
  * The input used in the `edit` mode
  */
-export const EditableInput = forwardRef<EditableInputProps>(
-  function EditableInput(props, ref) {
+export const EditableInput: React.FC<EditableInputProps> = forwardRef(
+  (props, ref) => {
     const { getInputProps } = useEditableContext()
     const styles = useStyles()
 

--- a/packages/focus-lock/src/index.tsx
+++ b/packages/focus-lock/src/index.tsx
@@ -47,7 +47,7 @@ export interface FocusLockProps {
  *
  * @see Docs https://chakra-ui.com/components/focuslock
  */
-export function FocusLock(props: FocusLockProps) {
+export const FocusLock: React.FC<FocusLockProps> = (props) => {
   const {
     initialFocusRef,
     finalFocusRef,

--- a/packages/form-control/src/form-control.tsx
+++ b/packages/form-control/src/form-control.tsx
@@ -137,33 +137,32 @@ export type FormControlProps = FormControlContext & PropsOf<typeof chakra.div>
  * This is commonly used in form elements such as `input`,
  * `select`, `textarea`, etc.
  */
-export const FormControl = forwardRef<FormControlProps>(function FormControl(
-  props,
-  ref,
-) {
-  const styles = useMultiStyleConfig("Form", props)
-  const rest = omitThemingProps(props)
-  const { htmlProps, ...context } = useProvider(rest)
+export const FormControl: React.FC<FormControlProps> = forwardRef(
+  (props, ref) => {
+    const styles = useMultiStyleConfig("Form", props)
+    const rest = omitThemingProps(props)
+    const { htmlProps, ...context } = useProvider(rest)
 
-  const _className = cx("chakra-form-control", props.className)
+    const _className = cx("chakra-form-control", props.className)
 
-  return (
-    <FormControlProvider value={context}>
-      <StylesProvider value={styles}>
-        <chakra.div
-          role="group"
-          ref={ref}
-          {...htmlProps}
-          className={_className}
-          __css={{
-            width: "100%",
-            position: "relative",
-          }}
-        />
-      </StylesProvider>
-    </FormControlProvider>
-  )
-})
+    return (
+      <FormControlProvider value={context}>
+        <StylesProvider value={styles}>
+          <chakra.div
+            role="group"
+            ref={ref}
+            {...htmlProps}
+            className={_className}
+            __css={{
+              width: "100%",
+              position: "relative",
+            }}
+          />
+        </StylesProvider>
+      </FormControlProvider>
+    )
+  },
+)
 
 if (__DEV__) {
   FormControl.displayName = "FormControl"
@@ -179,10 +178,7 @@ export type FormLabelProps = PropsOf<typeof chakra.label> & ThemingProps
  *
  * ♿️ Accessibility: Every form field should have a form label.
  */
-export const FormLabel = forwardRef<FormLabelProps>(function FormLabel(
-  props,
-  ref,
-) {
+export const FormLabel: React.FC<FormLabelProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("FormLabel", props)
 
   const { className, children, ...otherProps } = omitThemingProps(props)
@@ -217,8 +213,8 @@ export type RequiredIndicatorProps = PropsOf<typeof chakra.span>
  * Used to show a "required" text or an asterisks (*) to indicate that
  * a field is required.
  */
-export const RequiredIndicator = forwardRef<RequiredIndicatorProps>(
-  function RequiredIndicator(props, ref) {
+export const RequiredIndicator: React.FC<RequiredIndicatorProps> = forwardRef(
+  (props, ref) => {
     const field = useFormControlContext()
     const styles = useStyles()
 
@@ -253,34 +249,33 @@ export type HelpTextProps = PropsOf<typeof chakra.div>
  * about the field, such as how it will be used and what
  * types in values should be provided
  */
-export const FormHelperText = forwardRef<HelpTextProps>(function FormHelperText(
-  props,
-  ref,
-) {
-  const field = useFormControlContext()
-  const styles = useStyles()
+export const FormHelperText: React.FC<HelpTextProps> = forwardRef(
+  (props, ref) => {
+    const field = useFormControlContext()
+    const styles = useStyles()
 
-  /**
-   * Notify the field context when the help text is rendered on
-   * screen, so we can apply the correct `aria-describedby` to the field (e.g. input, textarea)
-   */
-  useSafeLayoutEffect(() => {
-    field?.setHasHelpText.on()
-    return () => field?.setHasHelpText.off()
-  }, [])
+    /**
+     * Notify the field context when the help text is rendered on
+     * screen, so we can apply the correct `aria-describedby` to the field (e.g. input, textarea)
+     */
+    useSafeLayoutEffect(() => {
+      field?.setHasHelpText.on()
+      return () => field?.setHasHelpText.off()
+    }, [])
 
-  const _className = cx("chakra-form__helper-text", props.className)
+    const _className = cx("chakra-form__helper-text", props.className)
 
-  return (
-    <chakra.div
-      ref={ref}
-      __css={styles.helperText}
-      {...props}
-      className={_className}
-      id={props.id ?? field?.helpTextId}
-    />
-  )
-})
+    return (
+      <chakra.div
+        ref={ref}
+        __css={styles.helperText}
+        {...props}
+        className={_className}
+        id={props.id ?? field?.helpTextId}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   FormHelperText.displayName = "FormHelperText"
@@ -292,8 +287,8 @@ export type FormErrorMessageProps = PropsOf<typeof chakra.div>
  * Used to provide feedback about an invalid input,
  * and suggest clear instrctions on how to fix it.
  */
-export const FormErrorMessage = forwardRef<FormErrorMessageProps>(
-  function FormErrorMessage(props, ref) {
+export const FormErrorMessage: React.FC<FormErrorMessageProps> = forwardRef(
+  (props, ref) => {
     const styles = useStyles()
     const field = useFormControlContext()
 
@@ -326,10 +321,7 @@ if (__DEV__) {
  * Used as the visual indicator that a field is invalid or
  * a field has incorrect values.
  */
-export const FormErrorIcon = forwardRef<IconProps>(function FormErrorIcon(
-  props,
-  ref,
-) {
+export const FormErrorIcon: React.FC<IconProps> = forwardRef((props, ref) => {
   const styles = useStyles()
   const field = useFormControlContext()
 

--- a/packages/form-control/stories/form-control.stories.tsx
+++ b/packages/form-control/stories/form-control.stories.tsx
@@ -3,6 +3,7 @@ import {
   PropsOf,
   useStyleConfig,
   useMultiStyleConfig,
+  forwardRef,
 } from "@chakra-ui/system"
 import * as React from "react"
 import {
@@ -38,13 +39,11 @@ type InputProps = Omit<PropsOf<"input">, OmittedTypes> &
 // Create an input that consumes useFormControl
 type Props = { focusBorderColor?: string; errorBorderColor?: string }
 
-const Input = React.forwardRef(
-  (props: InputProps, ref: React.Ref<HTMLInputElement>) => {
-    const styles = useMultiStyleConfig("Input", props)
-    const inputProps = useFormControl<HTMLInputElement>(props)
-    return <chakra.input ref={ref} __css={styles.field} {...inputProps} />
-  },
-)
+const Input: React.FC<InputProps> = forwardRef((props, ref) => {
+  const styles = useMultiStyleConfig("Input", props)
+  const inputProps = useFormControl<HTMLInputElement>(props)
+  return <chakra.input ref={ref} __css={styles.field} {...inputProps} />
+})
 
 export const InputExample = () => (
   <FormControl id="first-name" isRequired isInvalid>
@@ -58,15 +57,13 @@ export const InputExample = () => (
 type TextAreaProps = Omit<PropsOf<"textarea">, OmittedTypes> &
   FormControlOptions
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  (props, ref) => {
-    const styles = useStyleConfig("Textarea", props)
-    const inputProps = useFormControl<HTMLTextAreaElement>(props)
-    return <chakra.textarea ref={ref} __css={styles} {...inputProps} />
-  },
-)
+const Textarea: React.FC<TextAreaProps> = forwardRef((props, ref) => {
+  const styles = useStyleConfig("Textarea", props)
+  const inputProps = useFormControl<HTMLTextAreaElement>(props)
+  return <chakra.textarea ref={ref} __css={styles} {...inputProps} />
+})
 
-export const TextAreaExample = () => (
+export const TextAreaExample: React.FC = () => (
   <FormControl id="first-name" isInvalid>
     <FormLabel>First name</FormLabel>
     <Textarea placeholder="First Name" />
@@ -80,15 +77,13 @@ export const TextAreaExample = () => (
 
 type SelectProps = Omit<PropsOf<"select">, OmittedTypes> & FormControlOptions
 
-const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
-  (props, ref) => {
-    const styles = useMultiStyleConfig("Select", props)
-    const inputProps = useFormControl<HTMLSelectElement>(props)
-    return <chakra.select ref={ref} __css={styles.field} {...inputProps} />
-  },
-)
+const Select: React.FC<SelectProps> = forwardRef((props, ref) => {
+  const styles = useMultiStyleConfig("Select", props)
+  const inputProps = useFormControl<HTMLSelectElement>(props)
+  return <chakra.select ref={ref} __css={styles.field} {...inputProps} />
+})
 
-export const SelectExample = () => (
+export const SelectExample: React.FC = () => (
   <FormControl id="first-name" isInvalid>
     <FormLabel>First name</FormLabel>
     <Select>
@@ -108,7 +103,7 @@ export const SelectExample = () => (
  * You can style the label when the input is focused,
  * simply pass the `_focus` pseudo prop
  */
-export const StylingFocus = () => (
+export const StylingFocus: React.FC = () => (
   <FormControl id="first-name">
     <FormLabel _focus={{ color: "blue.600" }}>First name</FormLabel>
     <Input placeholder="First Name" width="100%" />

--- a/packages/form-control/tests/form-control.test.tsx
+++ b/packages/form-control/tests/form-control.test.tsx
@@ -1,4 +1,4 @@
-import { chakra, PropsOf, useStyleConfig } from "@chakra-ui/system"
+import { chakra, PropsOf, useStyleConfig, forwardRef } from "@chakra-ui/system"
 import { fireEvent, render } from "@chakra-ui/test-utils"
 import * as React from "react"
 import {
@@ -16,7 +16,7 @@ type OmittedTypes = "disabled" | "required" | "readOnly"
 type InputProps = Omit<PropsOf<typeof chakra.input>, OmittedTypes> &
   FormControlOptions
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+const Input: React.FC<InputProps> = forwardRef((props, ref) => {
   const inputProps = useFormControl<HTMLInputElement>(props)
   return <chakra.input ref={ref} {...inputProps} />
 })

--- a/packages/icon/src/create-icon.tsx
+++ b/packages/icon/src/create-icon.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Icon, IconProps } from "./icon"
 import { __DEV__ } from "@chakra-ui/utils"
+import { forwardRef } from "@chakra-ui/system"
 
 interface CreateIconOptions {
   /**
@@ -30,7 +31,7 @@ export function createIcon(options: CreateIconOptions) {
     displayName,
   } = options
 
-  const Comp = React.forwardRef((props: IconProps, ref: React.Ref<any>) => {
+  const Comp: React.FC<IconProps> = forwardRef((props, ref) => {
     return (
       <Icon ref={ref} viewBox={viewBox} {...props}>
         {path ?? <path fill="currentColor" d={pathDefinition} />}

--- a/packages/icon/src/icon.tsx
+++ b/packages/icon/src/icon.tsx
@@ -1,4 +1,4 @@
-import { chakra, PropsOf } from "@chakra-ui/system"
+import { chakra, PropsOf, forwardRef } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
@@ -23,10 +23,7 @@ const fallbackIcon = {
 
 export type IconProps = PropsOf<typeof chakra.svg>
 
-export const Icon = React.forwardRef(function Icon(
-  props: IconProps,
-  ref: React.Ref<any>,
-) {
+export const Icon: React.FC<IconProps> = forwardRef((props, ref) => {
   const {
     as: element,
     boxSize = "1em",

--- a/packages/image/src/image.tsx
+++ b/packages/image/src/image.tsx
@@ -1,4 +1,4 @@
-import { chakra, PropsOf, SystemProps } from "@chakra-ui/system"
+import { chakra, PropsOf, SystemProps, forwardRef } from "@chakra-ui/system"
 import { omit, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useImage, UseImageProps } from "./use-image"
@@ -52,10 +52,7 @@ export type ImageProps = UseImageProps &
  *
  * @see Docs https://chakra-ui.com/components/image
  */
-export const Image = React.forwardRef(function Image(
-  props: ImageProps,
-  ref: React.Ref<any>,
-) {
+export const Image: React.FC<ImageProps> = forwardRef((props, ref) => {
   const {
     fallbackSrc,
     fallback,

--- a/packages/input/src/input-addon.tsx
+++ b/packages/input/src/input-addon.tsx
@@ -1,4 +1,4 @@
-import { chakra, PropsOf, useStyles } from "@chakra-ui/system"
+import { chakra, PropsOf, useStyles, forwardRef } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
@@ -37,25 +37,24 @@ export type InputAddonProps = PropsOf<typeof StyledAddon> & {
  * Element to append or prepend to an input
  */
 
-export const InputAddon = React.forwardRef(function InputAddon(
-  props: InputAddonProps,
-  ref: React.Ref<any>,
-) {
-  const { placement = "left", ...rest } = props
-  const placementStyles = placements[placement] ?? {}
-  const styles = useStyles()
+export const InputAddon: React.FC<InputAddonProps> = forwardRef(
+  (props, ref) => {
+    const { placement = "left", ...rest } = props
+    const placementStyles = placements[placement] ?? {}
+    const styles = useStyles()
 
-  return (
-    <StyledAddon
-      ref={ref}
-      {...rest}
-      __css={{
-        ...styles.addon,
-        ...placementStyles,
-      }}
-    />
-  )
-})
+    return (
+      <StyledAddon
+        ref={ref}
+        {...rest}
+        __css={{
+          ...styles.addon,
+          ...placementStyles,
+        }}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   InputAddon.displayName = "InputAddon"
@@ -67,19 +66,18 @@ if (__DEV__) {
  * Element to append to the left of an input
  */
 
-export const InputLeftAddon = React.forwardRef(function InputLeftAddon(
-  props: InputAddonProps,
-  ref: React.Ref<any>,
-) {
-  return (
-    <InputAddon
-      ref={ref}
-      placement="left"
-      {...props}
-      className={cx("chakra-input__left-addon", props.className)}
-    />
-  )
-})
+export const InputLeftAddon: React.FC<InputAddonProps> = forwardRef(
+  (props, ref) => {
+    return (
+      <InputAddon
+        ref={ref}
+        placement="left"
+        {...props}
+        className={cx("chakra-input__left-addon", props.className)}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   InputLeftAddon.displayName = "InputLeftAddon"
@@ -94,19 +92,18 @@ InputLeftAddon.groupId = "InputLeftAddon"
  * Element to append to the right of an input
  */
 
-export const InputRightAddon = React.forwardRef(function InputRightAddon(
-  props: InputAddonProps,
-  ref: React.Ref<any>,
-) {
-  return (
-    <InputAddon
-      ref={ref}
-      placement="right"
-      {...props}
-      className={cx("chakra-input__right-addon", props.className)}
-    />
-  )
-})
+export const InputRightAddon: React.FC<InputAddonProps> = forwardRef(
+  (props, ref) => {
+    return (
+      <InputAddon
+        ref={ref}
+        placement="right"
+        {...props}
+        className={cx("chakra-input__right-addon", props.className)}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   InputRightAddon.displayName = "InputRightAddon"

--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -1,4 +1,4 @@
-import { chakra, PropsOf, useStyles } from "@chakra-ui/system"
+import { chakra, PropsOf, useStyles, forwardRef } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
@@ -16,10 +16,7 @@ const StyledElement = chakra("div", {
   },
 })
 
-const InputElement = React.forwardRef(function InputElement(
-  props: InputElementProps,
-  ref: React.Ref<any>,
-) {
+const InputElement: React.FC<InputElementProps> = forwardRef((props, ref) => {
   const { placement = "left", ...rest } = props
 
   const styles = useStyles()
@@ -43,17 +40,21 @@ if (__DEV__) {
   InputElement.displayName = "InputElement"
 }
 
-export const InputLeftElement = React.forwardRef(function InputLeftElement(
-  props: InputElementProps,
-  ref: React.Ref<any>,
-) {
-  const { className, ...rest } = props
-  const _className = cx("chakra-input__left-element", className)
+export const InputLeftElement: React.FC<InputElementProps> = forwardRef(
+  (props, ref) => {
+    const { className, ...rest } = props
+    const _className = cx("chakra-input__left-element", className)
 
-  return (
-    <InputElement ref={ref} placement="left" className={_className} {...rest} />
-  )
-})
+    return (
+      <InputElement
+        ref={ref}
+        placement="left"
+        className={_className}
+        {...rest}
+      />
+    )
+  },
+)
 
 //@ts-ignore
 InputLeftElement.groupId = "InputLeftElement"
@@ -62,22 +63,21 @@ if (__DEV__) {
   InputLeftElement.displayName = "InputLeftElement"
 }
 
-export const InputRightElement = React.forwardRef(function InputRightElement(
-  props: InputElementProps,
-  ref: React.Ref<any>,
-) {
-  const { className, ...rest } = props
-  const _className = cx("chakra-input__right-element", className)
+export const InputRightElement: React.FC<InputElementProps> = forwardRef(
+  (props, ref) => {
+    const { className, ...rest } = props
+    const _className = cx("chakra-input__right-element", className)
 
-  return (
-    <InputElement
-      ref={ref}
-      placement="right"
-      className={_className}
-      {...rest}
-    />
-  )
-})
+    return (
+      <InputElement
+        ref={ref}
+        placement="right"
+        className={_className}
+        {...rest}
+      />
+    )
+  },
+)
 
 //@ts-ignore
 InputRightElement.groupId = "InputRightElement"

--- a/packages/input/src/input-group.tsx
+++ b/packages/input/src/input-group.tsx
@@ -5,76 +5,76 @@ import {
   useMultiStyleConfig,
   omitThemingProps,
   StylesProvider,
+  forwardRef,
 } from "@chakra-ui/system"
 import { cx, __DEV__, getValidChildren } from "@chakra-ui/utils"
 import * as React from "react"
 
 export type InputGroupProps = PropsOf<typeof chakra.div> & ThemingProps
 
-export const InputGroup = React.forwardRef(function InputGroup(
-  props: InputGroupProps,
-  ref: React.Ref<any>,
-) {
-  const styles = useMultiStyleConfig("Input", props)
-  const { children, className, ...rest } = omitThemingProps(props)
+export const InputGroup: React.FC<InputGroupProps> = forwardRef(
+  (props, ref) => {
+    const styles = useMultiStyleConfig("Input", props)
+    const { children, className, ...rest } = omitThemingProps(props)
 
-  const _className = cx("chakra-input__group", className)
-  const stylesRef = React.useRef<InputGroupProps>({})
+    const _className = cx("chakra-input__group", className)
+    const stylesRef = React.useRef<InputGroupProps>({})
 
-  const validChildren = getValidChildren(children)
+    const validChildren = getValidChildren(children)
 
-  const input: any = styles.field
+    const input: any = styles.field
 
-  validChildren.forEach((child: any) => {
-    if (!styles) return
+    validChildren.forEach((child: any) => {
+      if (!styles) return
 
-    if (child.type.groupId === "InputLeftElement") {
-      stylesRef.current.paddingLeft = input.height ?? input.h
-    }
+      if (child.type.groupId === "InputLeftElement") {
+        stylesRef.current.paddingLeft = input.height ?? input.h
+      }
 
-    if (child.type.groupId === "InputRightElement") {
-      stylesRef.current.paddingRight = input.height ?? input.h
-    }
+      if (child.type.groupId === "InputRightElement") {
+        stylesRef.current.paddingRight = input.height ?? input.h
+      }
 
-    if (child.type.groupId === "InputRightAddon") {
-      stylesRef.current.borderRightRadius = 0
-    }
+      if (child.type.groupId === "InputRightAddon") {
+        stylesRef.current.borderRightRadius = 0
+      }
 
-    if (child.type.groupId === "InputLeftAddon") {
-      stylesRef.current.borderLeftRadius = 0
-    }
-  })
+      if (child.type.groupId === "InputLeftAddon") {
+        stylesRef.current.borderLeftRadius = 0
+      }
+    })
 
-  const clones = validChildren.map((child: any) => {
-    const theming = { size: props.size, variant: props.variant }
-    const { pl, paddingLeft, pr, paddingRight } = child.props
+    const clones = validChildren.map((child: any) => {
+      const theming = { size: props.size, variant: props.variant }
+      const { pl, paddingLeft, pr, paddingRight } = child.props
 
-    return child.type.groupId !== "Input"
-      ? React.cloneElement(child, theming)
-      : React.cloneElement(child, {
-          ...theming,
-          paddingLeft: pl ?? paddingLeft ?? stylesRef.current?.paddingLeft,
-          paddingRight: pr ?? paddingRight ?? stylesRef.current?.paddingRight,
-          borderLeftRadius: stylesRef.current?.borderLeftRadius,
-          borderRightRadius: stylesRef.current?.borderRightRadius,
-        })
-  })
+      return child.type.groupId !== "Input"
+        ? React.cloneElement(child, theming)
+        : React.cloneElement(child, {
+            ...theming,
+            paddingLeft: pl ?? paddingLeft ?? stylesRef.current?.paddingLeft,
+            paddingRight: pr ?? paddingRight ?? stylesRef.current?.paddingRight,
+            borderLeftRadius: stylesRef.current?.borderLeftRadius,
+            borderRightRadius: stylesRef.current?.borderRightRadius,
+          })
+    })
 
-  return (
-    <chakra.div
-      className={_className}
-      ref={ref}
-      __css={{
-        width: "100%",
-        display: "flex",
-        position: "relative",
-      }}
-      {...rest}
-    >
-      <StylesProvider value={styles}>{clones}</StylesProvider>
-    </chakra.div>
-  )
-})
+    return (
+      <chakra.div
+        className={_className}
+        ref={ref}
+        __css={{
+          width: "100%",
+          display: "flex",
+          position: "relative",
+        }}
+        {...rest}
+      >
+        <StylesProvider value={styles}>{clones}</StylesProvider>
+      </chakra.div>
+    )
+  },
+)
 
 if (__DEV__) {
   InputGroup.displayName = "InputGroup"

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -43,7 +43,7 @@ export type InputProps = Omit<PropsOf<typeof chakra.input>, Omitted> &
  *
  * Element that allows users enter single valued data.
  */
-export const Input = forwardRef<InputProps>(function Input(props, ref) {
+export const Input: React.FC<InputProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Input", props)
   const realProps = omitThemingProps(props)
   const input = useFormControl<HTMLInputElement>(realProps)

--- a/packages/layout/src/aspect-ratio.tsx
+++ b/packages/layout/src/aspect-ratio.tsx
@@ -1,6 +1,6 @@
 import { cx, __DEV__, mapResponsive } from "@chakra-ui/utils"
 import * as React from "react"
-import { chakra, PropsOf, ResponsiveValue } from "@chakra-ui/system"
+import { chakra, PropsOf, ResponsiveValue, forwardRef } from "@chakra-ui/system"
 
 interface AspectRatioOptions {
   /**
@@ -19,52 +19,51 @@ export type AspectRatioProps = PropsOf<typeof chakra.div> & AspectRatioOptions
  *
  * @see Docs https://chakra-ui.com/components/aspect-ratio
  */
-export const AspectRatio = React.forwardRef(function AspectRatio(
-  props: AspectRatioProps,
-  ref: React.Ref<any>,
-) {
-  const { ratio = 4 / 3, children, className, ...rest } = props
+export const AspectRatio: React.FC<AspectRatioProps> = forwardRef(
+  (props, ref) => {
+    const { ratio = 4 / 3, children, className, ...rest } = props
 
-  // enforce single child
-  const child = React.Children.only(children)
+    // enforce single child
+    const child = React.Children.only(children)
 
-  const _className = cx("chakra-aspect-ratio", className)
+    const _className = cx("chakra-aspect-ratio", className)
 
-  return (
-    <chakra.div
-      ref={ref}
-      position="relative"
-      className={_className}
-      _before={{
-        height: 0,
-        content: `""`,
-        display: "block",
-        paddingBottom: mapResponsive(ratio, (r) => `${(1 / r) * 100}%`),
-      }}
-      __css={{
-        "& > *": {
-          overflow: "hidden",
-          position: "absolute",
-          top: "0",
-          right: "0",
-          bottom: "0",
-          left: "0",
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          width: "100%",
-          height: "100%",
-        },
-        "& > img, & > video": {
-          objectFit: "cover",
-        },
-      }}
-      {...rest}
-    >
-      {child}
-    </chakra.div>
-  )
-})
+    return (
+      <chakra.div
+        ref={ref}
+        position="relative"
+        className={_className}
+        _before={{
+          height: 0,
+          content: `""`,
+          display: "block",
+          paddingBottom: mapResponsive(ratio, (r) => `${(1 / r) * 100}%`),
+        }}
+        __css={{
+          "& > *": {
+            overflow: "hidden",
+            position: "absolute",
+            top: "0",
+            right: "0",
+            bottom: "0",
+            left: "0",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            width: "100%",
+            height: "100%",
+          },
+          "& > img, & > video": {
+            objectFit: "cover",
+          },
+        }}
+        {...rest}
+      >
+        {child}
+      </chakra.div>
+    )
+  },
+)
 
 if (__DEV__) {
   AspectRatio.displayName = "AspectRatio"

--- a/packages/layout/src/badge.tsx
+++ b/packages/layout/src/badge.tsx
@@ -5,6 +5,7 @@ import {
   useStyleConfig,
   omitThemingProps,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { __DEV__, cx } from "@chakra-ui/utils"
 
@@ -16,10 +17,7 @@ export type BadgeProps = PropsOf<typeof chakra.span> & ThemingProps
  *
  * @see Docs https://chakra-ui.com/components/badge
  */
-export const Badge = React.forwardRef(function Badge(
-  props: BadgeProps,
-  ref: React.Ref<any>,
-) {
+export const Badge: React.FC<BadgeProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Badge", props)
   const { className, ...rest } = omitThemingProps(props)
 

--- a/packages/layout/src/box.tsx
+++ b/packages/layout/src/box.tsx
@@ -38,7 +38,7 @@ export type SquareProps = Omit<BoxProps, Omitted> & {
   centerContent?: boolean
 }
 
-export const Square = forwardRef<SquareProps>(function Square(props, ref) {
+export const Square: React.FC<SquareProps> = forwardRef((props, ref) => {
   const { size, centerContent = true, ...rest } = props
   const centerStyles: SystemStyleObject = centerContent
     ? { display: "flex", alignItems: "center", justifyContent: "center" }
@@ -62,7 +62,7 @@ if (__DEV__) {
   Square.displayName = "Square"
 }
 
-export const Circle = forwardRef<SquareProps>(function Circle(props, ref) {
+export const Circle: React.FC<SquareProps> = forwardRef((props, ref) => {
   const { size, ...rest } = props
   return <Square size={size as any} ref={ref} borderRadius="9999px" {...rest} />
 })

--- a/packages/layout/src/code.tsx
+++ b/packages/layout/src/code.tsx
@@ -5,6 +5,7 @@ import {
   useStyleConfig,
   omitThemingProps,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { __DEV__, cx } from "@chakra-ui/utils"
 
@@ -15,10 +16,7 @@ export type CodeProps = PropsOf<typeof chakra.code> & ThemingProps
  *
  * @see Docs https://chakra-ui.com/components/code
  */
-export const Code = React.forwardRef(function Code(
-  props: CodeProps,
-  ref: React.Ref<any>,
-) {
+export const Code: React.FC<CodeProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Code", props)
   const { className, ...rest } = omitThemingProps(props)
 

--- a/packages/layout/src/container.tsx
+++ b/packages/layout/src/container.tsx
@@ -1,4 +1,10 @@
-import { chakra, PropsOf, useTheme, SystemStyleObject } from "@chakra-ui/system"
+import {
+  chakra,
+  PropsOf,
+  useTheme,
+  SystemStyleObject,
+  forwardRef,
+} from "@chakra-ui/system"
 import {
   cx,
   Dict,
@@ -25,10 +31,7 @@ export type ContainerProps = PropsOf<typeof chakra.div> & {
  *
  * It also sets a default max-width of `60ch` (60 characters).
  */
-export const Container = React.forwardRef(function Container(
-  props: ContainerProps,
-  ref: React.Ref<any>,
-) {
+export const Container: React.FC<ContainerProps> = forwardRef((props, ref) => {
   const {
     maxWidth,
     width,

--- a/packages/layout/src/divider.tsx
+++ b/packages/layout/src/divider.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { chakra, PropsOf } from "@chakra-ui/system"
+import { chakra, PropsOf, forwardRef } from "@chakra-ui/system"
 import { __DEV__, cx } from "@chakra-ui/utils"
 
 /**
@@ -9,10 +9,7 @@ import { __DEV__, cx } from "@chakra-ui/utils"
  *
  * @see Docs https://chakra-ui.com/components/divider
  */
-export const Divider = React.forwardRef(function Divider(
-  props: DividerProps,
-  ref: React.Ref<any>,
-) {
+export const Divider: React.FC<DividerProps> = forwardRef((props, ref) => {
   const { className, orientation = "horizontal", ...rest } = props
 
   const styles = {

--- a/packages/layout/src/flex.tsx
+++ b/packages/layout/src/flex.tsx
@@ -43,7 +43,7 @@ export type FlexProps = PropsOf<typeof chakra.div> & FlexOptions
  *
  * @see Docs https://chakra-ui.com/components/flex
  */
-export const Flex = forwardRef<FlexProps>(function Flex(props, ref) {
+export const Flex: React.FC<FlexProps> = forwardRef((props, ref) => {
   const { direction, align, justify, wrap, basis, grow, ...rest } = props
   return (
     <chakra.div

--- a/packages/layout/src/grid.tsx
+++ b/packages/layout/src/grid.tsx
@@ -12,7 +12,7 @@ export type GridProps = PropsOf<typeof chakra.div> & GridOptions
  *
  * @see Docs https://chakra-ui.com/components/grid
  */
-export const Grid = forwardRef<GridProps>(function Grid(props, ref) {
+export const Grid: React.FC<GridProps> = forwardRef((props, ref) => {
   const {
     area,
     templateAreas,

--- a/packages/layout/src/heading.tsx
+++ b/packages/layout/src/heading.tsx
@@ -11,7 +11,7 @@ import { __DEV__, cx } from "@chakra-ui/utils"
 
 export type HeadingProps = PropsOf<typeof chakra.h2> & ThemingProps
 
-export const Heading = forwardRef<HeadingProps>(function Heading(props, ref) {
+export const Heading: React.FC<HeadingProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Heading", props)
   const { className, ...rest } = omitThemingProps(props)
 

--- a/packages/layout/src/kbd.tsx
+++ b/packages/layout/src/kbd.tsx
@@ -5,6 +5,7 @@ import {
   useStyleConfig,
   omitThemingProps,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { __DEV__, cx } from "@chakra-ui/utils"
 
@@ -22,10 +23,7 @@ export type KbdProps = PropsOf<typeof chakra.kbd> & ThemingProps
  *
  * @see Docs https://chakra-ui.com/components/kbd
  */
-export const Kbd = React.forwardRef(function Kbd(
-  props: KbdProps,
-  ref: React.Ref<any>,
-) {
+export const Kbd: React.FC<KbdProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Kbd", props)
   const { className, ...rest } = omitThemingProps(props)
 

--- a/packages/layout/src/link.tsx
+++ b/packages/layout/src/link.tsx
@@ -35,7 +35,7 @@ export type LinkProps = PropsOf<typeof chakra.a> & LinkOptions & ThemingProps
  * @see Docs https://chakra-ui.com/components/link
  */
 
-export const Link = forwardRef<LinkProps>(function Link(props, ref) {
+export const Link: React.FC<LinkProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Link", props)
   const { className, isExternal, ...rest } = omitThemingProps(props)
 

--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -25,7 +25,7 @@ export type ListProps = PropsOf<typeof chakra.ul> & ListOptions
  *
  * @see Docs https://chakra-ui.com/components/list
  */
-export const List = forwardRef<ListProps>(function List(props, ref) {
+export const List: React.FC<ListProps> = forwardRef((props, ref) => {
   const {
     children,
     styleType = "none",
@@ -61,10 +61,7 @@ if (__DEV__) {
   List.displayName = "List"
 }
 
-export const OrderedList = forwardRef<ListProps>(function OrderedList(
-  props,
-  ref,
-) {
+export const OrderedList: React.FC<ListProps> = forwardRef((props, ref) => {
   return (
     <List ref={ref} as="ol" styleType="decimal" marginLeft="1em" {...props} />
   )
@@ -74,10 +71,7 @@ if (__DEV__) {
   OrderedList.displayName = "OrderedList"
 }
 
-export const UnorderedList = forwardRef<ListProps>(function UnorderedList(
-  props,
-  ref,
-) {
+export const UnorderedList: React.FC<ListProps> = forwardRef((props, ref) => {
   return (
     <List ref={ref} as="ul" styleType="bullet" marginLeft="1em" {...props} />
   )
@@ -94,7 +88,7 @@ export type ListItemProps = PropsOf<typeof ListItem>
  *
  * Used to render a list item
  */
-export const ListItem = (props: PropsOf<typeof chakra.li>) => (
+export const ListItem: React.FC<PropsOf<typeof chakra.li>> = (props) => (
   <chakra.li {...props} />
 )
 
@@ -107,10 +101,7 @@ if (__DEV__) {
  *
  * Used to render an icon beside the list item text
  */
-export const ListIcon = React.forwardRef(function ListIcon(
-  props: IconProps,
-  ref: React.Ref<any>,
-) {
+export const ListIcon: React.FC<IconProps> = forwardRef((props, ref) => {
   return (
     <Icon
       ref={ref}

--- a/packages/layout/src/simple-grid.tsx
+++ b/packages/layout/src/simple-grid.tsx
@@ -36,27 +36,33 @@ export type SimpleGridProps = GridProps & SimpleGridOptions
  *
  * @see Docs https://chakra-ui.com/components/simplegrid
  */
-export const SimpleGrid = React.forwardRef(function SimpleGrid(
-  props: SimpleGridProps,
-  ref: React.Ref<any>,
-) {
-  const { columns, spacingX, spacingY, spacing, minChildWidth, ...rest } = props
+export const SimpleGrid: React.FC<SimpleGridProps> = forwardRef(
+  (props, ref) => {
+    const {
+      columns,
+      spacingX,
+      spacingY,
+      spacing,
+      minChildWidth,
+      ...rest
+    } = props
 
-  const templateColumns = Boolean(minChildWidth)
-    ? widthToColumns(minChildWidth)
-    : countToColumns(columns)
+    const templateColumns = Boolean(minChildWidth)
+      ? widthToColumns(minChildWidth)
+      : countToColumns(columns)
 
-  return (
-    <Grid
-      ref={ref}
-      gap={spacing}
-      columnGap={spacingX}
-      rowGap={spacingY}
-      templateColumns={templateColumns}
-      {...rest}
-    />
-  )
-})
+    return (
+      <Grid
+        ref={ref}
+        gap={spacing}
+        columnGap={spacingX}
+        rowGap={spacingY}
+        templateColumns={templateColumns}
+        {...rest}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   SimpleGrid.displayName = "SimpleGrid"

--- a/packages/layout/src/stack.tsx
+++ b/packages/layout/src/stack.tsx
@@ -55,7 +55,7 @@ export type StackProps = PropsOf<typeof chakra.div> & StackOptions
 
 export type StackDividerProps = PropsOf<typeof chakra.div>
 
-export const StackDivider = (props: PropsOf<typeof chakra.div>) => (
+export const StackDivider: React.FC<PropsOf<typeof chakra.div>> = (props) => (
   <chakra.div
     className="chakra-stack__item"
     __css={{
@@ -69,7 +69,7 @@ export const StackDivider = (props: PropsOf<typeof chakra.div>) => (
   />
 )
 
-export const StackItem = (props: PropsOf<typeof chakra.div>) => (
+export const StackItem: React.FC<PropsOf<typeof chakra.div>> = (props) => (
   <chakra.div
     className="chakra-stack__item"
     __css={{ display: "inline-block", flex: 0 }}
@@ -88,7 +88,7 @@ export const StackItem = (props: PropsOf<typeof chakra.div>) => (
  * @see Docs https://chakra-ui.com/components/stack
  *
  */
-export const Stack = forwardRef<StackProps>(function Stack(props, ref) {
+export const Stack: React.FC<StackProps> = forwardRef((props, ref) => {
   const {
     direction = "column",
     align,
@@ -199,10 +199,7 @@ if (__DEV__) {
 /**
  * A view that arranges its children in a horizontal line.
  */
-export const HStack = React.forwardRef(function HStack(
-  props: StackProps,
-  ref: React.Ref<any>,
-) {
+export const HStack: React.FC<StackProps> = forwardRef((props, ref) => {
   return <Stack align="center" {...props} direction="row" ref={ref} />
 })
 
@@ -213,10 +210,7 @@ if (__DEV__) {
 /**
  * A view that arranges its children in a vertical line.
  */
-export const VStack = React.forwardRef(function VStack(
-  props: StackProps,
-  ref: React.Ref<any>,
-) {
+export const VStack: React.FC<StackProps> = forwardRef((props, ref) => {
   return <Stack align="center" {...props} direction="column" ref={ref} />
 })
 

--- a/packages/layout/src/text.tsx
+++ b/packages/layout/src/text.tsx
@@ -16,7 +16,7 @@ export type TextProps = PropsOf<typeof chakra.p> & ThemingProps
  *
  * @see Docs https://chakra-ui.com/components/text
  */
-export const Text = forwardRef<TextProps>(function Text(props, ref) {
+export const Text: React.FC<TextProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Text", props)
   const { className, ...rest } = omitThemingProps(props)
 

--- a/packages/layout/src/wrap.tsx
+++ b/packages/layout/src/wrap.tsx
@@ -1,4 +1,11 @@
-import { chakra, css, PropsOf, SystemProps, useTheme } from "@chakra-ui/system"
+import {
+  chakra,
+  css,
+  PropsOf,
+  SystemProps,
+  useTheme,
+  forwardRef,
+} from "@chakra-ui/system"
 import { getValidChildren, mapResponsive, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
@@ -33,10 +40,7 @@ export type WrapProps = DivProps & {
  *
  * @see Docs https://chakra-ui.com/components/wrap
  */
-export const Wrap = React.forwardRef(function Wrap(
-  props: WrapProps,
-  ref: React.Ref<any>,
-) {
+export const Wrap: React.FC<WrapProps> = forwardRef((props, ref) => {
   const {
     spacing = "0.5rem",
     children,

--- a/packages/media-query/src/media-query.tsx
+++ b/packages/media-query/src/media-query.tsx
@@ -15,7 +15,7 @@ interface VisibilityProps {
  * React component to control the visibility of it's
  * children based on the current breakpoint
  */
-function Visibility(props: VisibilityProps) {
+const Visibility: React.FC<VisibilityProps> = (props) => {
   const { breakpoint, hide, children } = props
   const [show] = useMediaQuery(breakpoint)
   const isVisible = hide ? !show : show
@@ -26,7 +26,7 @@ function Visibility(props: VisibilityProps) {
 
 export type HideProps = ShowProps
 
-export function Hide(props: HideProps) {
+export const Hide: React.FC<HideProps> = (props) => {
   const query = useQuery(props)
   return (
     <Visibility breakpoint={query} hide={true}>
@@ -46,7 +46,7 @@ export interface ShowProps {
   children?: React.ReactNode
 }
 
-export function Show(props: ShowProps) {
+export const Show: React.FC<ShowProps> = (props) => {
   const query = useQuery(props)
   return <Visibility breakpoint={query}>{props.children}</Visibility>
 }

--- a/packages/menu/src/menu.transition.tsx
+++ b/packages/menu/src/menu.transition.tsx
@@ -13,7 +13,7 @@ export interface MenuTransitionProps {
   styles?: TransitionProps["styles"]
 }
 
-export function MenuTransition(props: MenuTransitionProps) {
+export const MenuTransition: React.FC<MenuTransitionProps> = (props) => {
   const { children, styles } = props
   const menu = useMenuContext()
 

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -40,7 +40,7 @@ export type MenuProps = UseMenuProps &
  * Menu provides context, state, and focus management
  * to its sub-components. It doesn't render any DOM node.
  */
-export function Menu(props: MenuProps) {
+export const Menu: React.FC<MenuProps> = (props) => {
   const styles = useMultiStyleConfig("Menu", props)
   const realProps = omitThemingProps(props)
 
@@ -65,54 +65,52 @@ if (__DEV__) {
 
 export type MenuButtonProps = PropsOf<typeof chakra.button>
 
-const StyledMenuButton = React.forwardRef(function StyledMenuButton(
-  props: PropsOf<typeof chakra.button>,
-  ref: Ref<any>,
-) {
-  const styles = useStyles()
-  return (
-    <chakra.button
-      ref={ref}
-      {...props}
-      __css={{
-        display: "inline-flex",
-        appearance: "none",
-        alignItems: "center",
-        outline: 0,
-        transition: "all 250ms",
-        ...styles.button,
-      }}
-    />
-  )
-})
+const StyledMenuButton: React.FC<PropsOf<typeof chakra.button>> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
+    return (
+      <chakra.button
+        ref={ref}
+        {...props}
+        __css={{
+          display: "inline-flex",
+          appearance: "none",
+          alignItems: "center",
+          outline: 0,
+          transition: "all 250ms",
+          ...styles.button,
+        }}
+      />
+    )
+  },
+)
 
 /**
  * The trigger for the menu list. Must be a direct child of `Menu`.
  */
-export const MenuButton = forwardRef<MenuButtonProps>(function MenuButton(
-  props,
-  ref,
-) {
-  const { children, as: Comp, ...otherProps } = props
+export const MenuButton: React.FC<MenuButtonProps> = forwardRef(
+  (props, ref) => {
+    const { children, as: Comp, ...otherProps } = props
 
-  const ownProps = useMenuButton(otherProps)
-  const ownRef = mergeRefs(ref, ownProps.ref)
+    const ownProps = useMenuButton(otherProps)
+    const ownRef = mergeRefs(ref, ownProps.ref)
 
-  const Wrapper = Comp || StyledMenuButton
+    const Wrapper = Comp || StyledMenuButton
 
-  return (
-    <Wrapper {...ownProps} ref={ownRef}>
-      <chakra.span
-        __css={{
-          pointerEvents: "none",
-          flex: "1",
-        }}
-      >
-        {props.children}
-      </chakra.span>
-    </Wrapper>
-  )
-})
+    return (
+      <Wrapper {...ownProps} ref={ownRef}>
+        <chakra.span
+          __css={{
+            pointerEvents: "none",
+            flex: "1",
+          }}
+        >
+          {props.children}
+        </chakra.span>
+      </Wrapper>
+    )
+  },
+)
 
 if (__DEV__) {
   MenuButton.displayName = "MenuButton"
@@ -122,10 +120,7 @@ if (__DEV__) {
 
 export type MenuListProps = PropsOf<typeof chakra.div>
 
-export const MenuList = React.forwardRef(function MenuList(
-  props: MenuListProps,
-  ref: Ref<any>,
-) {
+export const MenuList: React.FC<MenuListProps> = forwardRef((props, ref) => {
   const menulist = useMenuList(props)
   const styles = useStyles()
   return (
@@ -146,30 +141,29 @@ if (__DEV__) {
 
 //////////////////////////////////////////////////////////////////////////
 
-const StyledMenuItem = React.forwardRef(function StyledMenuItem(
-  props: PropsOf<typeof chakra.button>,
-  ref: Ref<any>,
-) {
-  const styles = useStyles()
-  return (
-    <chakra.button
-      ref={ref}
-      {...props}
-      __css={{
-        textDecoration: "none",
-        color: "inherit",
-        userSelect: "none",
-        display: "flex",
-        width: "100%",
-        alignItems: "center",
-        textAlign: "left",
-        flex: "0 0 auto",
-        outline: 0,
-        ...styles.item,
-      }}
-    />
-  )
-})
+const StyledMenuItem: React.FC<PropsOf<typeof chakra.button>> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
+    return (
+      <chakra.button
+        ref={ref}
+        {...props}
+        __css={{
+          textDecoration: "none",
+          color: "inherit",
+          userSelect: "none",
+          display: "flex",
+          width: "100%",
+          alignItems: "center",
+          textAlign: "left",
+          flex: "0 0 auto",
+          outline: 0,
+          ...styles.item,
+        }}
+      />
+    )
+  },
+)
 
 interface MenuItemOptions extends Omit<UseMenuItemProps, "context"> {
   /**
@@ -188,10 +182,7 @@ interface MenuItemOptions extends Omit<UseMenuItemProps, "context"> {
 
 export type MenuItemProps = PropsOf<typeof StyledMenuItem> & MenuItemOptions
 
-export const MenuItem = forwardRef<MenuItemProps>(function MenuItem(
-  props,
-  ref,
-) {
+export const MenuItem: React.FC<MenuItemProps> = forwardRef((props, ref) => {
   const {
     icon,
     iconSpacing = "0.75rem",
@@ -234,7 +225,7 @@ export type MenuItemOptionProps = Omit<UseMenuOptionProps, "context"> &
     iconSpacing?: SystemProps["mr"]
   }
 
-const CheckIcon = (props: PropsOf<"svg">) => (
+const CheckIcon: React.FC<PropsOf<"svg">> = (props) => (
   <svg viewBox="0 0 14 14" width="1em" height="1em" {...props}>
     <polygon
       fill="currentColor"
@@ -243,8 +234,8 @@ const CheckIcon = (props: PropsOf<"svg">) => (
   </svg>
 )
 
-export const MenuItemOption = forwardRef<MenuItemOptionProps>(
-  function MenuItemOption(props, ref) {
+export const MenuItemOption: React.FC<MenuItemOptionProps> = forwardRef(
+  (props, ref) => {
     const { icon, iconSpacing = "0.75rem", ...htmlProps } = props
 
     const ownProps = useMenuOption(htmlProps)
@@ -273,7 +264,7 @@ if (__DEV__) {
 export type MenuOptionGroupProps = UseMenuOptionGroupProps &
   Omit<MenuGroupProps, "value" | "default" | "onChange">
 
-export const MenuOptionGroup = (props: MenuOptionGroupProps) => {
+export const MenuOptionGroup: React.FC<MenuOptionGroupProps> = (props) => {
   const { children, ...rest } = useMenuOptionGroup(props)
   return <MenuGroup title={props.title} children={children} {...rest} />
 }
@@ -286,7 +277,7 @@ if (__DEV__) {
 
 export type MenuGroupProps = PropsOf<typeof chakra.p>
 
-export const MenuGroup = (props: MenuGroupProps) => {
+export const MenuGroup: React.FC<MenuGroupProps> = (props) => {
   const { title, children, className, ...rest } = props
 
   const _className = cx("chakra-menu__group__title", className)
@@ -310,7 +301,7 @@ if (__DEV__) {
 
 //////////////////////////////////////////////////////////////////////////
 
-export const MenuCommand = (props: PropsOf<typeof chakra.span>) => {
+export const MenuCommand: React.FC<PropsOf<typeof chakra.span>> = (props) => {
   const styles = useStyles()
   return (
     <chakra.span
@@ -327,7 +318,7 @@ if (__DEV__) {
 
 //////////////////////////////////////////////////////////////////////////
 
-export function MenuIcon(props: PropsOf<typeof chakra.span>) {
+export const MenuIcon: React.FC<PropsOf<typeof chakra.span>> = (props) => {
   const { className, children, ...rest } = props
 
   const child = React.Children.only(children)
@@ -361,7 +352,7 @@ if (__DEV__) {
 
 export type MenuDividerProps = PropsOf<typeof chakra.hr>
 
-export const MenuDivider = (props: MenuDividerProps) => {
+export const MenuDivider: React.FC<MenuDividerProps> = (props) => {
   const { className, ...rest } = props
   const _className = cx("chakra-menu__divider", className)
   return (

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -16,7 +16,7 @@ import {
   runIfFn,
   __DEV__,
 } from "@chakra-ui/utils"
-import React, { ReactElement, Ref, useMemo } from "react"
+import React, { ReactElement, useMemo } from "react"
 import {
   MenuProvider,
   useMenu,

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -11,7 +11,7 @@ import {
   useStyles,
 } from "@chakra-ui/system"
 import { callAllHandlers, cx, __DEV__ } from "@chakra-ui/utils"
-import React, { ReactNode, Ref, useEffect } from "react"
+import React, { ReactNode, useEffect } from "react"
 import { RemoveScroll } from "react-remove-scroll"
 import { ModalContextProvider, useModalContext } from "./context"
 import { useModal, UseModalProps } from "./use-modal"

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -47,7 +47,7 @@ export interface ModalProps extends UseModalProps, ThemingProps {
  *
  * It doesn't render any DOM node.
  */
-export function Modal(props: ModalProps) {
+export const Modal: React.FC<ModalProps> = (props) => {
   const { getContainer, children } = props
 
   const styles = useMultiStyleConfig("Modal", props)
@@ -85,36 +85,35 @@ export type ModalContentProps = PropsOf<typeof chakra.section>
  * React component used to group modal's content. It has all the
  * necessary `aria-*` properties to indicate that it's a modal modal
  */
-export const ModalContent = React.forwardRef(function ModalContent(
-  props: ModalContentProps,
-  ref: Ref<any>,
-) {
-  const { className, children, ...otherProps } = props
+export const ModalContent: React.FC<ModalContentProps> = forwardRef(
+  (props, ref) => {
+    const { className, children, ...otherProps } = props
 
-  const { getContentProps } = useModalContext()
+    const { getContentProps } = useModalContext()
 
-  const content = getContentProps(otherProps, ref)
-  const _className = cx("chakra-modal__content", className)
+    const content = getContentProps(otherProps, ref)
+    const _className = cx("chakra-modal__content", className)
 
-  const styles = useStyles()
+    const styles = useStyles()
 
-  return (
-    <chakra.section
-      className={_className}
-      {...content}
-      __css={{
-        display: "flex",
-        flexDirection: "column",
-        position: "relative",
-        width: "100%",
-        outline: 0,
-        ...styles.content,
-      }}
-    >
-      {children}
-    </chakra.section>
-  )
-})
+    return (
+      <chakra.section
+        className={_className}
+        {...content}
+        __css={{
+          display: "flex",
+          flexDirection: "column",
+          position: "relative",
+          width: "100%",
+          outline: 0,
+          ...styles.content,
+        }}
+      >
+        {children}
+      </chakra.section>
+    )
+  },
+)
 
 if (__DEV__) {
   ModalContent.displayName = "ModalContent"
@@ -130,60 +129,59 @@ export type ModalOverlayProps = PropsOf<typeof chakra.div>
  *
  * @see Docs https://chakra-ui.com/components/modal
  */
-export const ModalOverlay = React.forwardRef(function ModalOverlay(
-  props: ModalOverlayProps,
-  ref: Ref<any>,
-) {
-  const { className, children, ...otherProps } = props
+export const ModalOverlay: React.FC<ModalOverlayProps> = forwardRef(
+  (props, ref) => {
+    const { className, children, ...otherProps } = props
 
-  const {
-    getOverlayProps,
-    autoFocus,
-    trapFocus,
-    dialogRef,
-    initialFocusRef,
-    blockScrollOnMount,
-    allowPinchZoom,
-    finalFocusRef,
-    returnFocusOnClose,
-  } = useModalContext()
+    const {
+      getOverlayProps,
+      autoFocus,
+      trapFocus,
+      dialogRef,
+      initialFocusRef,
+      blockScrollOnMount,
+      allowPinchZoom,
+      finalFocusRef,
+      returnFocusOnClose,
+    } = useModalContext()
 
-  const overlay = getOverlayProps(otherProps, ref)
-  const _className = cx("chakra-modal__overlay", className)
+    const overlay = getOverlayProps(otherProps, ref)
+    const _className = cx("chakra-modal__overlay", className)
 
-  const styles = useStyles()
+    const styles = useStyles()
 
-  return (
-    <FocusLock
-      autoFocus={autoFocus}
-      isDisabled={!trapFocus}
-      initialFocusRef={initialFocusRef}
-      finalFocusRef={finalFocusRef}
-      restoreFocus={returnFocusOnClose}
-      contentRef={dialogRef}
-    >
-      <RemoveScroll
-        allowPinchZoom={allowPinchZoom}
-        enabled={blockScrollOnMount}
+    return (
+      <FocusLock
+        autoFocus={autoFocus}
+        isDisabled={!trapFocus}
+        initialFocusRef={initialFocusRef}
+        finalFocusRef={finalFocusRef}
+        restoreFocus={returnFocusOnClose}
+        contentRef={dialogRef}
       >
-        <chakra.div
-          {...overlay}
-          className={_className}
-          __css={{
-            width: "100vw",
-            height: "100vh",
-            position: "fixed",
-            left: 0,
-            top: 0,
-            ...styles.overlay,
-          }}
+        <RemoveScroll
+          allowPinchZoom={allowPinchZoom}
+          enabled={blockScrollOnMount}
         >
-          {children}
-        </chakra.div>
-      </RemoveScroll>
-    </FocusLock>
-  )
-})
+          <chakra.div
+            {...overlay}
+            className={_className}
+            __css={{
+              width: "100vw",
+              height: "100vh",
+              position: "fixed",
+              left: 0,
+              top: 0,
+              ...styles.overlay,
+            }}
+          >
+            {children}
+          </chakra.div>
+        </RemoveScroll>
+      </FocusLock>
+    )
+  },
+)
 
 if (__DEV__) {
   ModalOverlay.displayName = "ModalOverlay"
@@ -198,39 +196,38 @@ export type ModalHeaderProps = PropsOf<typeof chakra.header>
  *
  * @see Docs https://chakra-ui.com/components/modal
  */
-export const ModalHeader = React.forwardRef(function ModalHeader(
-  props: ModalHeaderProps,
-  ref: Ref<any>,
-) {
-  const { className, ...rest } = props
+export const ModalHeader: React.FC<ModalHeaderProps> = forwardRef(
+  (props, ref) => {
+    const { className, ...rest } = props
 
-  const { headerId, setHeaderMounted } = useModalContext()
+    const { headerId, setHeaderMounted } = useModalContext()
 
-  /**
-   * Notify us if this component was rendered or used
-   * so we can append `aria-labelledby` automatically
-   */
-  useEffect(() => {
-    setHeaderMounted(true)
-    return () => setHeaderMounted(false)
-  }, [setHeaderMounted])
+    /**
+     * Notify us if this component was rendered or used
+     * so we can append `aria-labelledby` automatically
+     */
+    useEffect(() => {
+      setHeaderMounted(true)
+      return () => setHeaderMounted(false)
+    }, [setHeaderMounted])
 
-  const _className = cx("chakra-modal__header", className)
-  const styles = useStyles()
+    const _className = cx("chakra-modal__header", className)
+    const styles = useStyles()
 
-  return (
-    <chakra.header
-      ref={ref}
-      className={_className}
-      id={headerId}
-      {...rest}
-      __css={{
-        flex: 0,
-        ...styles.header,
-      }}
-    />
-  )
-})
+    return (
+      <chakra.header
+        ref={ref}
+        className={_className}
+        id={headerId}
+        {...rest}
+        __css={{
+          flex: 0,
+          ...styles.header,
+        }}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   ModalHeader.displayName = "ModalHeader"
@@ -245,10 +242,7 @@ export type ModalBodyProps = PropsOf<typeof chakra.div>
  *
  * @see Docs https://chakra-ui.com/components/modal
  */
-export const ModalBody = forwardRef(function ModalBody(
-  props: ModalBodyProps,
-  ref: Ref<any>,
-) {
+export const ModalBody: React.FC<ModalBodyProps> = forwardRef((props, ref) => {
   const { className, ...rest } = props
   const { bodyId, setBodyMounted } = useModalContext()
 
@@ -286,7 +280,7 @@ if (__DEV__) {
  *
  * @see Docs https://chakra-ui.com/components/modal
  */
-export const ModalFooter = (props: PropsOf<typeof chakra.footer>) => {
+export const ModalFooter: React.FC<PropsOf<typeof chakra.footer>> = (props) => {
   const styles = useStyles()
   return (
     <chakra.footer
@@ -314,30 +308,29 @@ if (__DEV__) {
  * to pass the `onClick` to it, it's reads the `onClose` action from the
  * modal context.
  */
-export const ModalCloseButton = React.forwardRef(function ModalCloseButton(
-  props: CloseButtonProps,
-  ref: Ref<any>,
-) {
-  const { onClick, className, ...rest } = props
-  const { onClose } = useModalContext()
+export const ModalCloseButton: React.FC<CloseButtonProps> = forwardRef(
+  (props, ref) => {
+    const { onClick, className, ...rest } = props
+    const { onClose } = useModalContext()
 
-  const _className = cx("chakra-modal__close-btn", className)
+    const _className = cx("chakra-modal__close-btn", className)
 
-  return (
-    <CloseButton
-      ref={ref}
-      position="absolute"
-      top="8px"
-      right="12px"
-      className={_className}
-      onClick={callAllHandlers(onClick, (event) => {
-        event.stopPropagation()
-        onClose()
-      })}
-      {...rest}
-    />
-  )
-})
+    return (
+      <CloseButton
+        ref={ref}
+        position="absolute"
+        top="8px"
+        right="12px"
+        className={_className}
+        onClick={callAllHandlers(onClick, (event) => {
+          event.stopPropagation()
+          onClose()
+        })}
+        {...rest}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   ModalCloseButton.displayName = "ModalCloseButton"

--- a/packages/number-input/src/icons.tsx
+++ b/packages/number-input/src/icons.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Icon, IconProps } from "@chakra-ui/icon"
 
-export const TriangleDownIcon = (props: IconProps) => (
+export const TriangleDownIcon: React.FC<IconProps> = (props) => (
   <Icon viewBox="0 0 24 24" {...props}>
     <path
       fill="currentColor"
@@ -10,7 +10,7 @@ export const TriangleDownIcon = (props: IconProps) => (
   </Icon>
 )
 
-export const TriangleUpIcon = (props: IconProps) => (
+export const TriangleUpIcon: React.FC<IconProps> = (props) => (
   <Icon viewBox="0 0 24 24" {...props}>
     <path
       fill="currentColor"

--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -64,24 +64,27 @@ export type NumberInputProps = UseNumberInputProps &
  *
  * @see Docs http://chakra-ui.com/numberinput
  */
-export const NumberInput = React.forwardRef(function NumberInput(
-  props: NumberInputProps,
-  ref: React.Ref<any>,
-) {
-  const styles = useMultiStyleConfig("NumberInput", props)
-  const inputProps = omitThemingProps(props)
+export const NumberInput: React.FC<NumberInputProps> = forwardRef(
+  (props, ref) => {
+    const styles = useMultiStyleConfig("NumberInput", props)
+    const inputProps = omitThemingProps(props)
 
-  const { htmlProps, ...context } = useNumberInput(inputProps)
-  const _context = React.useMemo(() => context, [context])
+    const { htmlProps, ...context } = useNumberInput(inputProps)
+    const _context = React.useMemo(() => context, [context])
 
-  return (
-    <NumberInputProvider value={_context}>
-      <StylesProvider value={styles}>
-        <chakra.div ref={ref} {...htmlProps} __css={{ position: "relative" }} />
-      </StylesProvider>
-    </NumberInputProvider>
-  )
-})
+    return (
+      <NumberInputProvider value={_context}>
+        <StylesProvider value={styles}>
+          <chakra.div
+            ref={ref}
+            {...htmlProps}
+            __css={{ position: "relative" }}
+          />
+        </StylesProvider>
+      </NumberInputProvider>
+    )
+  },
+)
 
 if (__DEV__) {
   NumberInput.displayName = "NumberInput"
@@ -99,30 +102,29 @@ export type NumberInputStepperProps = PropsOf<typeof chakra.div>
  *
  * @see Docs http://chakra-ui.com/components/number-input
  */
-export const NumberInputStepper = React.forwardRef(function NumberInputStepper(
-  props: NumberInputStepperProps,
-  ref: React.Ref<any>,
-) {
-  const styles = useStyles()
-  return (
-    <chakra.div
-      aria-hidden
-      ref={ref}
-      {...props}
-      __css={{
-        display: "flex",
-        flexDirection: "column",
-        position: "absolute",
-        top: "0",
-        right: "0px",
-        margin: "1px",
-        height: "calc(100% - 2px)",
-        zIndex: 1,
-        ...styles.stepperGroup,
-      }}
-    />
-  )
-})
+export const NumberInputStepper: React.FC<NumberInputStepperProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
+    return (
+      <chakra.div
+        aria-hidden
+        ref={ref}
+        {...props}
+        __css={{
+          display: "flex",
+          flexDirection: "column",
+          position: "absolute",
+          top: "0",
+          right: "0px",
+          margin: "1px",
+          height: "calc(100% - 2px)",
+          zIndex: 1,
+          ...styles.stepperGroup,
+        }}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   NumberInputStepper.displayName = "NumberInputStepper"
@@ -141,8 +143,8 @@ export type NumberInputFieldProps = PropsOf<typeof chakra.input>
  *
  * @see Docs http://chakra-ui.com/numberinput
  */
-export const NumberInputField = forwardRef<NumberInputFieldProps>(
-  function NumberInputField(props, ref) {
+export const NumberInputField: React.FC<NumberInputFieldProps> = forwardRef(
+  (props, ref) => {
     const { getInputProps } = useNumberInputContext()
     const input = getInputProps({ ...props, ref })
     const styles = useStyles()
@@ -192,11 +194,8 @@ export type NumberDecrementStepperProps = PropsOf<typeof StyledStepper>
  *
  * It renders a `div` with `role=button` by default
  */
-export const NumberDecrementStepper = React.forwardRef(
-  function NumberDecrementStepper(
-    props: NumberDecrementStepperProps,
-    ref: React.Ref<any>,
-  ) {
+export const NumberDecrementStepper: React.FC<NumberDecrementStepperProps> = forwardRef(
+  (props, ref) => {
     const styles = useStyles()
     const { getDecrementButtonProps } = useNumberInputContext()
     const decrement = getDecrementButtonProps({ ...props, ref })
@@ -222,11 +221,8 @@ export type NumberIncrementStepperProps = PropsOf<typeof StyledStepper>
  *
  * It renders a `div` with `role=button` by default
  */
-export const NumberIncrementStepper = forwardRef(
-  function NumberIncrementStepper(
-    props: NumberIncrementStepperProps,
-    ref: React.Ref<any>,
-  ) {
+export const NumberIncrementStepper: React.FC<NumberIncrementStepperProps> = forwardRef(
+  (props, ref) => {
     const { getIncrementButtonProps } = useNumberInputContext()
     const increment = getIncrementButtonProps({ ...props, ref })
     const styles = useStyles()

--- a/packages/pin-input/src/pin-input.tsx
+++ b/packages/pin-input/src/pin-input.tsx
@@ -3,6 +3,7 @@ import {
   PropsOf,
   ThemingProps,
   useStyleConfig,
+  forwardRef,
   omitThemingProps,
 } from "@chakra-ui/system"
 import { cx, __DEV__, getValidChildren } from "@chakra-ui/utils"
@@ -38,7 +39,7 @@ export type PinInputProps = UsePinInputProps &
     children: React.ReactNode
   }
 
-export function PinInput(props: PinInputProps) {
+export const PinInput: React.FC<PinInputProps> = (props) => {
   const styles = useStyleConfig("PinInput", props)
 
   const { children, ...otherProps } = omitThemingProps(props)
@@ -57,18 +58,17 @@ if (__DEV__) {
 
 export type PinInputFieldProps = PropsOf<typeof chakra.input>
 
-export const PinInputField = React.forwardRef(function PinInputField(
-  props: PinInputFieldProps,
-  ref: React.Ref<any>,
-) {
-  const inputProps = usePinInputField({ ref, ...props })
-  return (
-    <chakra.input
-      {...inputProps}
-      className={cx("chakra-pin-input", props.className)}
-    />
-  )
-})
+export const PinInputField: React.FC<PinInputFieldProps> = forwardRef(
+  (props, ref) => {
+    const inputProps = usePinInputField({ ref, ...props })
+    return (
+      <chakra.input
+        {...inputProps}
+        className={cx("chakra-pin-input", props.className)}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   PinInputField.displayName = "PinInputField"

--- a/packages/popover/src/popover.transition.tsx
+++ b/packages/popover/src/popover.transition.tsx
@@ -13,7 +13,7 @@ export interface PopoverTransitionProps {
   styles?: TransitionProps["styles"]
 }
 
-export function PopoverTransition(props: PopoverTransitionProps) {
+export const PopoverTransition: React.FC<PopoverTransitionProps> = (props) => {
   const { children, styles } = props
 
   const popover = usePopoverContext()

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -7,6 +7,7 @@ import {
   ThemingProps,
   useMultiStyleConfig,
   useStyles,
+  forwardRef,
 } from "@chakra-ui/system"
 import {
   createContext,
@@ -42,7 +43,7 @@ export type PopoverProps = UsePopoverProps &
  * Popover is used to bring attention to specific user interface elements,
  * typically to suggest an action or to guide users through a new experience.
  */
-export function Popover(props: PopoverProps) {
+export const Popover: React.FC<PopoverProps> = (props) => {
   const styles = useMultiStyleConfig("Popover", props)
 
   const { children, ...otherProps } = omitThemingProps(props)
@@ -85,29 +86,28 @@ export type PopoverContentProps = PropsOf<typeof chakra.section>
  * PopoverContent includes all accessibility
  * requirements for a popover
  */
-export const PopoverContent = React.forwardRef(function PopoverContent(
-  props: PopoverContentProps,
-  ref: Ref<any>,
-) {
-  const { getPopoverProps } = usePopoverContext()
-  const popoverProps = getPopoverProps(props, ref)
+export const PopoverContent: React.FC<PopoverContentProps> = forwardRef(
+  (props, ref) => {
+    const { getPopoverProps } = usePopoverContext()
+    const popoverProps = getPopoverProps(props, ref)
 
-  const styles = useStyles()
-  const contentStyles = {
-    position: "relative",
-    display: "flex",
-    flexDirection: "column",
-    ...styles.content,
-  }
+    const styles = useStyles()
+    const contentStyles = {
+      position: "relative",
+      display: "flex",
+      flexDirection: "column",
+      ...styles.content,
+    }
 
-  return (
-    <chakra.section
-      className={cx("chakra-popover__content")}
-      {...popoverProps}
-      __css={contentStyles}
-    />
-  )
-})
+    return (
+      <chakra.section
+        className={cx("chakra-popover__content")}
+        {...popoverProps}
+        __css={contentStyles}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   PopoverContent.displayName = "PopoverContent"
@@ -119,29 +119,28 @@ export type PopoverHeaderProps = PropsOf<typeof chakra.header>
  * PopoverHeader is the accessible header or label
  * for the popover's content and it's first announced by screenreaders.
  */
-export const PopoverHeader = React.forwardRef(function PopoverHeader(
-  props: PopoverHeaderProps,
-  ref: Ref<any>,
-) {
-  const { headerId, setHasHeader } = usePopoverContext()
+export const PopoverHeader: React.FC<PopoverHeaderProps> = forwardRef(
+  (props, ref) => {
+    const { headerId, setHasHeader } = usePopoverContext()
 
-  useEffect(() => {
-    setHasHeader.on()
-    return () => setHasHeader.off()
-  }, [setHasHeader])
+    useEffect(() => {
+      setHasHeader.on()
+      return () => setHasHeader.off()
+    }, [setHasHeader])
 
-  const styles = useStyles()
+    const styles = useStyles()
 
-  return (
-    <chakra.header
-      {...props}
-      className={cx("chakra-popover__header", props.className)}
-      id={headerId}
-      ref={ref}
-      __css={styles.header}
-    />
-  )
-})
+    return (
+      <chakra.header
+        {...props}
+        className={cx("chakra-popover__header", props.className)}
+        id={headerId}
+        ref={ref}
+        __css={styles.header}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   PopoverHeader.displayName = "PopoverHeader"
@@ -153,35 +152,36 @@ export type PopoverBodyProps = PropsOf<typeof chakra.div>
  * PopoverBody is the main content area for the popover. Should contain
  * at least one interactive element.
  */
-export const PopoverBody = React.forwardRef(function PopoverBody(
-  props: PopoverBodyProps,
-  ref: Ref<any>,
-) {
-  const { bodyId, setHasBody } = usePopoverContext()
+export const PopoverBody: React.FC<PopoverBodyProps> = forwardRef(
+  (props, ref) => {
+    const { bodyId, setHasBody } = usePopoverContext()
 
-  useEffect(() => {
-    setHasBody.on()
-    return () => setHasBody.off()
-  }, [setHasBody])
+    useEffect(() => {
+      setHasBody.on()
+      return () => setHasBody.off()
+    }, [setHasBody])
 
-  const styles = useStyles()
+    const styles = useStyles()
 
-  return (
-    <chakra.div
-      {...props}
-      className={cx("chakra-popover__body", props.className)}
-      id={bodyId}
-      ref={ref}
-      __css={styles.body}
-    />
-  )
-})
+    return (
+      <chakra.div
+        {...props}
+        className={cx("chakra-popover__body", props.className)}
+        id={bodyId}
+        ref={ref}
+        __css={styles.body}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   PopoverBody.displayName = "PopoverBody"
 }
 
-export function PopoverFooter(props: PropsOf<typeof chakra.footer>) {
+export const PopoverFooter: React.FC<PropsOf<typeof chakra.footer>> = (
+  props,
+) => {
   const styles = useStyles()
   return (
     <chakra.footer
@@ -198,7 +198,7 @@ if (__DEV__) {
 
 export type PopoverCloseButtonProps = CloseButtonProps
 
-export function PopoverCloseButton(props: CloseButtonProps) {
+export const PopoverCloseButton: React.FC<CloseButtonProps> = (props) => {
   const { onClose } = usePopoverContext()
   return (
     <CloseButton
@@ -220,7 +220,7 @@ if (__DEV__) {
 
 export type PopoverArrowProps = PropsOf<typeof chakra.div>
 
-export function PopoverArrow(props: PopoverArrowProps) {
+export const PopoverArrow: React.FC<PopoverArrowProps> = (props) => {
   const { getArrowProps } = usePopoverContext()
   const arrowProps = getArrowProps(props)
 

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -16,7 +16,7 @@ import {
   runIfFn,
   __DEV__,
 } from "@chakra-ui/utils"
-import React, { Children, cloneElement, Ref, useEffect } from "react"
+import React, { Children, cloneElement, useEffect } from "react"
 import { usePopover, UsePopoverProps, UsePopoverReturn } from "./use-popover"
 
 const [PopoverProvider, usePopoverContext] = createContext<UsePopoverReturn>({

--- a/packages/popper/stories/popper.stories.tsx
+++ b/packages/popper/stories/popper.stories.tsx
@@ -50,7 +50,7 @@ export default {
 export const Basic = () => {
   const disclosure = useDisclosure()
 
-  const { popper, reference, placement } = usePopper({
+  const { popper, reference } = usePopper({
     placement: "bottom-end",
     forceUpdate: disclosure.isOpen,
   })

--- a/packages/portal/src/portal-manager.tsx
+++ b/packages/portal/src/portal-manager.tsx
@@ -39,7 +39,7 @@ export interface PortalManagerProps {
  *
  * Inspired by BaseWeb's LayerManager component
  */
-export function PortalManager(props: PortalManagerProps) {
+export const PortalManager: React.FC<PortalManagerProps> = (props) => {
   const { children, zIndex } = props
 
   /**

--- a/packages/portal/src/portal.tsx
+++ b/packages/portal/src/portal.tsx
@@ -39,7 +39,7 @@ export interface PortalProps {
  *
  * @see Docs https://chakra-ui.com/components/portal
  */
-export function Portal(props: PortalProps) {
+export const Portal: React.FC<PortalProps> = (props) => {
   const { onMount, onUnmount, children, getContainer } = props
 
   /**

--- a/packages/progress/src/circular-progress.tsx
+++ b/packages/progress/src/circular-progress.tsx
@@ -5,7 +5,7 @@ import { isUndefined, __DEV__, StringOrNumber } from "@chakra-ui/utils"
 
 type CircleProps = PropsOf<typeof chakra.circle>
 
-const Circle = (props: CircleProps) => (
+const Circle: React.FC<CircleProps> = (props) => (
   <chakra.circle cx={50} cy={50} r={42} fill="transparent" {...props} />
 )
 
@@ -18,7 +18,7 @@ type ShapeProps = PropsOf<typeof chakra.svg> & {
   isIndeterminate?: boolean
 }
 
-function Shape(props: ShapeProps) {
+const Shape: React.FC<ShapeProps> = (props) => {
   const { size, isIndeterminate, ...rest } = props
   return (
     <chakra.svg
@@ -95,7 +95,7 @@ export type CircularProgressProps = PropsOf<typeof chakra.div> &
  * @see Docs https://chakra-ui.com/components/progress
  * @todo add theming support for circular progress
  */
-export function CircularProgress(props: CircularProgressProps) {
+export const CircularProgress: React.FC<CircularProgressProps> = (props) => {
   const {
     size = "48px",
     max = 100,

--- a/packages/progress/src/progress.tsx
+++ b/packages/progress/src/progress.tsx
@@ -21,7 +21,7 @@ import {
  * ProgressLabel is used to show the numeric value of the progress.
  * @see Docs https://chakra-ui.com/components/progress
  */
-export const ProgressLabel = (props: PropsOf<typeof chakra.div>) => {
+export const ProgressLabel: React.FC<PropsOf<typeof chakra.div>> = (props) => {
   const styles = useStyles()
   const labelStyles = {
     top: "50%",
@@ -52,7 +52,7 @@ export type ProgressFilledTrackProps = PropsOf<typeof chakra.div> &
  *
  * @see Docs https://chakra-ui.com/components/progress
  */
-function ProgressFilledTrack(props: ProgressFilledTrackProps) {
+const ProgressFilledTrack: React.FC<ProgressFilledTrackProps> = (props) => {
   const { min, max, value, ...rest } = props
   const progress = getProgressProps({ value, min, max })
 
@@ -116,7 +116,7 @@ export type ProgressProps = ProgressOptions &
  *
  * @see Docs https://chakra-ui.com/components/progress
  */
-export function Progress(props: ProgressProps) {
+export const Progress: React.FC<ProgressProps> = (props) => {
   const {
     value,
     min = 0,

--- a/packages/radio/src/radio-group.tsx
+++ b/packages/radio/src/radio-group.tsx
@@ -33,46 +33,45 @@ export type RadioGroupProps = UseRadioGroupProps &
  *
  * @see Docs https://chakra-ui.com/components/radio
  */
-export const RadioGroup = forwardRef(function RadioGroup(
-  props: RadioGroupProps,
-  ref: React.Ref<any>,
-) {
-  const {
-    colorScheme,
-    size,
-    variant,
-    children,
-    className,
-    ...otherProps
-  } = props
-
-  const { value, onChange, getRootProps, name, htmlProps } = useRadioGroup(
-    otherProps,
-  )
-
-  const group = React.useMemo(
-    () => ({
-      name,
-      size,
-      onChange,
+export const RadioGroup: React.FC<RadioGroupProps> = forwardRef(
+  (props, ref) => {
+    const {
       colorScheme,
-      value,
+      size,
       variant,
-    }),
-    [size, name, onChange, colorScheme, value, variant],
-  )
+      children,
+      className,
+      ...otherProps
+    } = props
 
-  const groupProps = getRootProps(htmlProps, ref)
-  const _className = cx("chakra-radio-group", className)
+    const { value, onChange, getRootProps, name, htmlProps } = useRadioGroup(
+      otherProps,
+    )
 
-  return (
-    <RadioGroupProvider value={group}>
-      <chakra.div {...groupProps} className={_className}>
-        {children}
-      </chakra.div>
-    </RadioGroupProvider>
-  )
-})
+    const group = React.useMemo(
+      () => ({
+        name,
+        size,
+        onChange,
+        colorScheme,
+        value,
+        variant,
+      }),
+      [size, name, onChange, colorScheme, value, variant],
+    )
+
+    const groupProps = getRootProps(htmlProps, ref)
+    const _className = cx("chakra-radio-group", className)
+
+    return (
+      <RadioGroupProvider value={group}>
+        <chakra.div {...groupProps} className={_className}>
+          {children}
+        </chakra.div>
+      </RadioGroupProvider>
+    )
+  },
+)
 
 if (__DEV__) {
   RadioGroup.displayName = "RadioGroup"

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -5,6 +5,7 @@ import {
   SystemProps,
   ThemingProps,
   useMultiStyleConfig,
+  forwardRef,
   omitThemingProps,
 } from "@chakra-ui/system"
 import { cx, split, __DEV__ } from "@chakra-ui/utils"
@@ -34,10 +35,7 @@ export type RadioProps = UseRadioProps &
  * several options.
  * @see Docs https://chakra-ui.com/components/radio
  */
-export const Radio = React.forwardRef(function Radio(
-  props: RadioProps,
-  ref: React.Ref<any>,
-) {
+export const Radio: React.FC<RadioProps> = forwardRef((props, ref) => {
   const group = useRadioGroupContext()
   const styles = useMultiStyleConfig("Radio", { ...group, ...props })
 

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -8,7 +8,7 @@ import {
   forwardRef,
   omitThemingProps,
 } from "@chakra-ui/system"
-import { cx, split, __DEV__ } from "@chakra-ui/utils"
+import { split, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useRadioGroupContext } from "./radio-group"
 import { useRadio, UseRadioProps } from "./use-radio"

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -6,6 +6,7 @@ import {
   PropsOf,
   useMultiStyleConfig,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { cx, split, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -17,27 +18,26 @@ export type SelectFieldProps = Omit<PropsOf<typeof chakra.select>, Omitted> & {
   isDisabled?: boolean
 }
 
-export const SelectField = React.forwardRef(function SelectField(
-  props: SelectFieldProps,
-  ref: React.Ref<any>,
-) {
-  const { children, placeholder, className, isDisabled, ...rest } = props
-  const select = useFormControl<HTMLSelectElement>(rest)
+export const SelectField: React.FC<SelectFieldProps> = forwardRef(
+  (props, ref) => {
+    const { children, placeholder, className, isDisabled, ...rest } = props
+    const select = useFormControl<HTMLSelectElement>(rest)
 
-  return (
-    <chakra.select
-      {...select}
-      {...(rest as any)}
-      ref={ref}
-      paddingRight="2rem"
-      className={cx("chakra-select", className)}
-      disabled={isDisabled}
-    >
-      {placeholder && <option value="">{placeholder}</option>}
-      {children}
-    </chakra.select>
-  )
-})
+    return (
+      <chakra.select
+        {...select}
+        {...(rest as any)}
+        ref={ref}
+        paddingRight="2rem"
+        className={cx("chakra-select", className)}
+        disabled={isDisabled}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {children}
+      </chakra.select>
+    )
+  },
+)
 
 if (__DEV__) {
   SelectField.displayName = "SelectField"
@@ -89,10 +89,7 @@ export type SelectProps = SelectFieldProps &
 /**
  * React component used to select one item from a list of options.
  */
-export const Select = React.forwardRef(function Select(
-  props: SelectProps,
-  ref: React.Ref<any>,
-) {
+export const Select: React.FC<SelectProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Select", props)
 
   const { rootProps, placeholder, icon, color, ...rest } = omitThemingProps(
@@ -138,7 +135,7 @@ if (__DEV__) {
   Select.displayName = "Select"
 }
 
-export const DefaultIcon = (props: PropsOf<"svg">) => (
+export const DefaultIcon: React.FC<PropsOf<"svg">> = (props) => (
   <svg viewBox="0 0 24 24" {...props}>
     <path
       fill="currentColor"
@@ -164,7 +161,7 @@ const IconWrapper = chakra("div", {
 
 type SelectIconProps = PropsOf<typeof IconWrapper>
 
-function SelectIcon(props: SelectIconProps) {
+const SelectIcon: React.FC<SelectIconProps> = (props) => {
   const { children = <DefaultIcon />, ...rest } = props
 
   const clone = React.cloneElement(children as any, {

--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -4,6 +4,7 @@ import {
   keyframes,
   useStyleConfig,
   ThemingProps,
+  forwardRef,
   omitThemingProps,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
@@ -62,10 +63,7 @@ const fade = keyframes({
   to: { opacity: 1 },
 })
 
-export const Skeleton = React.forwardRef(function Skeleton(
-  props: SkeletonProps,
-  ref: React.Ref<any>,
-) {
+export const Skeleton: React.FC<SkeletonProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Skeleton", props)
 
   const {
@@ -119,7 +117,7 @@ export type SkeletonTextProps = SkeletonProps & {
   endColor?: SkeletonProps["endColor"]
 }
 
-export function SkeletonText(props: SkeletonTextProps) {
+export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
   const {
     noOfLines = 3,
     spacing = "0.5rem",
@@ -161,9 +159,10 @@ if (__DEV__) {
   SkeletonText.displayName = "SkeletonText"
 }
 
-export const SkeletonCircle = ({ size = "2rem", ...rest }: SkeletonProps) => (
-  <Skeleton borderRadius="full" boxSize={size} {...rest} />
-)
+export const SkeletonCircle: React.FC<SkeletonProps> = ({
+  size = "2rem",
+  ...rest
+}) => <Skeleton borderRadius="full" boxSize={size} {...rest} />
 
 if (__DEV__) {
   SkeletonCircle.displayName = "SkeletonCircle"

--- a/packages/skip-nav/src/index.tsx
+++ b/packages/skip-nav/src/index.tsx
@@ -4,6 +4,7 @@ import {
   useStyleConfig,
   omitThemingProps,
   SystemStyleObject,
+  forwardRef,
 } from "@chakra-ui/system"
 import { __DEV__, merge } from "@chakra-ui/utils"
 import * as React from "react"
@@ -33,17 +34,16 @@ const baseStyle: SystemStyleObject = {
 /**
  * Renders a link that remains hidden until focused to skip to the main content.
  */
-export const SkipNavLink = React.forwardRef(function SkipNavLink(
-  props: SkipNavLinkProps,
-  ref: React.Ref<any>,
-) {
-  const styles = useStyleConfig("SkipLink", props)
-  const { id = fallbackId, ...rest } = omitThemingProps(props)
+export const SkipNavLink: React.FC<SkipNavLinkProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyleConfig("SkipLink", props)
+    const { id = fallbackId, ...rest } = omitThemingProps(props)
 
-  const linkStyles = merge({}, baseStyle, styles)
+    const linkStyles = merge({}, baseStyle, styles)
 
-  return <chakra.a {...rest} ref={ref} href={`#${id}`} __css={linkStyles} />
-})
+    return <chakra.a {...rest} ref={ref} href={`#${id}`} __css={linkStyles} />
+  },
+)
 
 if (__DEV__) {
   SkipNavLink.displayName = "SkipNavLink"
@@ -54,15 +54,14 @@ export type SkipNavContentProps = PropsOf<"div">
 /**
  * Renders a div as the target for the link.
  */
-export const SkipNavContent = React.forwardRef(function SkipNavContent(
-  props: SkipNavContentProps,
-  ref: React.Ref<any>,
-) {
-  const { id = fallbackId, ...rest } = props
-  return (
-    <div ref={ref} id={id} tabIndex={-1} style={{ outline: 0 }} {...rest} />
-  )
-})
+export const SkipNavContent: React.FC<SkipNavContentProps> = forwardRef(
+  (props, ref) => {
+    const { id = fallbackId, ...rest } = props
+    return (
+      <div ref={ref} id={id} tabIndex={-1} style={{ outline: 0 }} {...rest} />
+    )
+  },
+)
 
 if (__DEV__) {
   SkipNavContent.displayName = "SkipNavContent"

--- a/packages/slider/src/slider.tsx
+++ b/packages/slider/src/slider.tsx
@@ -6,6 +6,7 @@ import {
   omitThemingProps,
   StylesProvider,
   useStyles,
+  forwardRef,
 } from "@chakra-ui/system"
 import { createContext, __DEV__, cx } from "@chakra-ui/utils"
 import * as React from "react"
@@ -32,10 +33,7 @@ export type SliderProps = UseSliderProps &
  * @see Docs     https://chakra-ui.com/components/slider
  * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#slider
  */
-export const Slider = React.forwardRef(function Slider(
-  props: SliderProps,
-  ref: React.Ref<any>,
-) {
+export const Slider: React.FC<SliderProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Slider", props)
   const realProps = omitThemingProps(props)
 
@@ -78,7 +76,7 @@ export type SliderThumbProps = PropsOf<typeof chakra.div>
  * Slider component that acts as the handle used to select predefined
  * values by dragging its handle along the track
  */
-export function SliderThumb(props: SliderThumbProps) {
+export const SliderThumb: React.FC<SliderThumbProps> = (props) => {
   const { getThumbProps } = useSliderContext()
 
   const styles = useStyles()
@@ -110,7 +108,7 @@ if (__DEV__) {
 
 export type SliderTrackProps = PropsOf<typeof chakra.div>
 
-export function SliderTrack(props: SliderTrackProps) {
+export const SliderTrack: React.FC<SliderTrackProps> = (props) => {
   const { getTrackProps } = useSliderContext()
 
   const styles = useStyles()
@@ -138,7 +136,7 @@ if (__DEV__) {
 
 export type SliderInnerTrackProps = PropsOf<typeof chakra.div>
 
-export function SliderFilledTrack(props: SliderInnerTrackProps) {
+export const SliderFilledTrack: React.FC<SliderInnerTrackProps> = (props) => {
   const { getInnerTrackProps } = useSliderContext()
 
   const styles = useStyles()
@@ -173,7 +171,7 @@ export type SliderMarkProps = PropsOf<typeof chakra.div> & { value: number }
  *
  * @see Docs https://chakra-ui.com/components/slider
  */
-export function SliderMark(props: SliderMarkProps) {
+export const SliderMark: React.FC<SliderMarkProps> = (props) => {
   const { getMarkerProps } = useSliderContext()
   const markProps = getMarkerProps(props)
   return (

--- a/packages/spinner/src/spinner.tsx
+++ b/packages/spinner/src/spinner.tsx
@@ -5,6 +5,7 @@ import {
   useStyleConfig,
   omitThemingProps,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { __DEV__, cx } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
@@ -61,10 +62,7 @@ export type SpinnerProps = PropsOf<typeof chakra.div> &
  *
  * @see Docs https://chakra-ui.com/components/spinner
  */
-export const Spinner = React.forwardRef(function Spinner(
-  props: SpinnerProps,
-  ref: React.Ref<any>,
-) {
+export const Spinner: React.FC<SpinnerProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Spinner", props)
 
   const {

--- a/packages/stat/src/stat.tsx
+++ b/packages/stat/src/stat.tsx
@@ -7,6 +7,7 @@ import {
   ThemingProps,
   useMultiStyleConfig,
   useStyles,
+  forwardRef,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
@@ -14,10 +15,7 @@ import * as React from "react"
 
 export type StatLabelProps = PropsOf<typeof chakra.dt>
 
-export const StatLabel = React.forwardRef(function StatLabel(
-  props: StatLabelProps,
-  ref: React.Ref<any>,
-) {
+export const StatLabel: React.FC<StatLabelProps> = forwardRef((props, ref) => {
   const styles = useStyles()
   return (
     <chakra.dt
@@ -35,21 +33,20 @@ if (__DEV__) {
 
 export type StatHelpTextProps = PropsOf<typeof chakra.p>
 
-export const StatHelpText = React.forwardRef(function StatHelpText(
-  props: StatHelpTextProps,
-  ref: React.Ref<any>,
-) {
-  const styles = useStyles()
+export const StatHelpText: React.FC<StatHelpTextProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
 
-  return (
-    <chakra.p
-      ref={ref}
-      {...props}
-      className={cx("chakra-stat__help-text", props.className)}
-      __css={styles.helpText}
-    />
-  )
-})
+    return (
+      <chakra.p
+        ref={ref}
+        {...props}
+        className={cx("chakra-stat__help-text", props.className)}
+        __css={styles.helpText}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   StatHelpText.displayName = "StatHelpText"
@@ -57,30 +54,29 @@ if (__DEV__) {
 
 export type StatNumberProps = PropsOf<typeof chakra.dd>
 
-export const StatNumber = React.forwardRef(function StatNumber(
-  props: StatNumberProps,
-  ref: React.Ref<any>,
-) {
-  const styles = useStyles()
-  return (
-    <chakra.dd
-      ref={ref}
-      {...props}
-      className={cx("chakra-stat__number", props.className)}
-      __css={{
-        ...styles.number,
-        fontFeatureSettings: "pnum",
-        fontVariantNumeric: "proportional-nums",
-      }}
-    />
-  )
-})
+export const StatNumber: React.FC<StatNumberProps> = forwardRef(
+  (props, ref) => {
+    const styles = useStyles()
+    return (
+      <chakra.dd
+        ref={ref}
+        {...props}
+        className={cx("chakra-stat__number", props.className)}
+        __css={{
+          ...styles.number,
+          fontFeatureSettings: "pnum",
+          fontVariantNumeric: "proportional-nums",
+        }}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   StatNumber.displayName = "StatNumber"
 }
 
-export function StatDownArrow(props: IconProps) {
+export const StatDownArrow: React.FC<IconProps> = (props) => {
   return (
     <Icon color="red.400" {...props}>
       <path
@@ -95,7 +91,7 @@ if (__DEV__) {
   StatDownArrow.displayName = "StatDownArrow"
 }
 
-export const StatUpArrow = (props: IconProps) => (
+export const StatUpArrow: React.FC<IconProps> = (props) => (
   <Icon color="green.400" {...props}>
     <path
       fill="currentColor"
@@ -112,7 +108,7 @@ export type StatArrowProps = IconProps & {
   type?: "increase" | "decrease"
 }
 
-export function StatArrow(props: StatArrowProps) {
+export const StatArrow: React.FC<StatArrowProps> = (props) => {
   const { type, "aria-label": ariaLabel, ...rest } = props
   const styles = useStyles()
 
@@ -134,10 +130,7 @@ if (__DEV__) {
 
 export type StatProps = PropsOf<typeof chakra.div> & ThemingProps
 
-export const Stat = React.forwardRef(function Stat(
-  props: StatProps,
-  ref: React.Ref<any>,
-) {
+export const Stat: React.FC<StatProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Stat", props)
   const { className, children, ...rest } = omitThemingProps(props)
 
@@ -154,25 +147,24 @@ if (__DEV__) {
   Stat.displayName = "Stat"
 }
 
-export const StatGroup = React.forwardRef(function StatGroup(
-  props: PropsOf<typeof chakra.div>,
-  ref: React.Ref<any>,
-) {
-  return (
-    <chakra.div
-      {...props}
-      ref={ref}
-      role="group"
-      className={cx("chakra-stat__group", props.className)}
-      __css={{
-        display: "flex",
-        flexWrap: "wrap",
-        justifyContent: "space-around",
-        alignItems: "flex-start",
-      }}
-    />
-  )
-})
+export const StatGroup: React.FC<PropsOf<typeof chakra.div>> = forwardRef(
+  (props, ref) => {
+    return (
+      <chakra.div
+        {...props}
+        ref={ref}
+        role="group"
+        className={cx("chakra-stat__group", props.className)}
+        __css={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "space-around",
+          alignItems: "flex-start",
+        }}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   StatGroup.displayName = "StatGroup"

--- a/packages/switch/src/switch.tsx
+++ b/packages/switch/src/switch.tsx
@@ -5,6 +5,7 @@ import {
   useMultiStyleConfig,
   omitThemingProps,
   ThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { cx, dataAttr, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -15,10 +16,7 @@ export type SwitchProps = Omit<UseCheckboxProps, "isIndeterminate"> &
   Omit<PropsOf<typeof chakra.label>, Omitted> &
   ThemingProps
 
-export const Switch = React.forwardRef(function Switch(
-  props: SwitchProps,
-  ref: React.Ref<any>,
-) {
+export const Switch: React.FC<SwitchProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Switch", props)
 
   const realProps = omitThemingProps(props)

--- a/packages/system/src/providers.tsx
+++ b/packages/system/src/providers.tsx
@@ -13,7 +13,7 @@ export interface ThemeProviderProps {
   theme: Dict
 }
 
-export function ThemeProvider(props: ThemeProviderProps) {
+export const ThemeProvider: React.FC<ThemeProviderProps> = (props) => {
   const { children, theme } = props
   const outerTheme = React.useContext(ThemeContext) as Dict
   const mergedTheme = merge({}, outerTheme, theme)
@@ -42,7 +42,7 @@ export type ChakraProviderProps = ThemeProviderProps & {
   storageManager?: StorageManager
 }
 
-export function ChakraProvider(props: ChakraProviderProps) {
+export const ChakraProvider: React.FC<ChakraProviderProps> = (props) => {
   const { theme, children, storageManager } = props
 
   if (!theme) {
@@ -71,7 +71,7 @@ const [StylesProvider, useStyles] = createContext<Dict<SystemStyleObject>>({
 
 export { StylesProvider, useStyles }
 
-export function GlobalStyle() {
+export const GlobalStyle = () => {
   const { colorMode } = useColorMode()
   return (
     <Global

--- a/packages/system/stories/system.stories.tsx
+++ b/packages/system/stories/system.stories.tsx
@@ -1,5 +1,5 @@
 /**@jsx jsx */
-import { chakra, jsx, useStyleConfig } from "../src"
+import { chakra, jsx } from "../src"
 
 export default {
   title: "styled",

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -47,10 +47,7 @@ export type TabsProps = UseTabsProps &
  * Provides context and logic for all tabs components. It doesn't render
  * any DOM node.
  */
-export const Tabs = React.forwardRef(function Tabs(
-  props: TabsProps,
-  ref: Ref<any>,
-) {
+export const Tabs: React.FC<TabsProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Tabs", props)
   const { children, className, ...otherProps } = omitThemingProps(props)
 
@@ -82,7 +79,7 @@ export type TabProps = UseTabProps & PropsOf<typeof chakra.button>
  * Tab button used to activate a specific tab panel. It renders a `button`,
  * and is responsible for automatic and manual selection modes.
  */
-export const Tab = forwardRef<TabProps>(function Tab(props, ref) {
+export const Tab: React.FC<TabProps> = forwardRef((props, ref) => {
   const styles = useStyles()
   const tabProps = useTab({ ...props, ref })
 
@@ -114,10 +111,7 @@ export type TabListProps = Omit<UseTabListProps, "context"> &
  * TabList is used to manage a list of tab buttons. It renders a `div` by default,
  * and is responsible the keyboard interaction between tabs.
  */
-export const TabList = React.forwardRef(function TabList(
-  props: TabListProps,
-  ref: Ref<any>,
-) {
+export const TabList: React.FC<TabListProps> = forwardRef((props, ref) => {
   const tablistProps = useTabList({ ...props, ref })
 
   const styles = useStyles()
@@ -145,10 +139,7 @@ export type TabPanelProps = PropsOf<typeof chakra.div>
  * TabPanel
  * Used to render the content for a specific tab.
  */
-export const TabPanel = React.forwardRef(function TabPanel(
-  props: TabPanelProps,
-  ref: Ref<any>,
-) {
+export const TabPanel: React.FC<TabPanelProps> = forwardRef((props, ref) => {
   const panelProps = useTabPanel({ ...props, ref })
   const styles = useStyles()
 
@@ -175,10 +166,7 @@ export type TabPanelsProps = PropsOf<typeof chakra.div>
  *
  * It renders a `div` by default.
  */
-export const TabPanels = React.forwardRef(function TabPanels(
-  props: TabPanelsProps,
-  ref: Ref<any>,
-) {
+export const TabPanels: React.FC<TabPanelsProps> = forwardRef((props, ref) => {
   const panelsProps = useTabPanels(props)
   return (
     <chakra.div
@@ -201,28 +189,27 @@ export type TabIndicatorProps = PropsOf<typeof chakra.div>
  * Used to render an active tab indicator that animates between
  * selected tabs.
  */
-export const TabIndicator = React.forwardRef(function TabIndicator(
-  props: TabIndicatorProps,
-  ref: Ref<any>,
-) {
-  const indicatorStyle = useTabIndicator()
-  const style = {
-    ...props.style,
-    ...indicatorStyle,
-  }
+export const TabIndicator: React.FC<TabIndicatorProps> = forwardRef(
+  (props, ref) => {
+    const indicatorStyle = useTabIndicator()
+    const style = {
+      ...props.style,
+      ...indicatorStyle,
+    }
 
-  const styles = useStyles()
+    const styles = useStyles()
 
-  return (
-    <chakra.div
-      ref={ref}
-      {...props}
-      className={cx("chakra-tabs__tab-indicator", props.className)}
-      style={style}
-      __css={styles.indicator}
-    />
-  )
-})
+    return (
+      <chakra.div
+        ref={ref}
+        {...props}
+        className={cx("chakra-tabs__tab-indicator", props.className)}
+        style={style}
+        __css={styles.indicator}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   TabIndicator.displayName = "TabIndicator"

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -9,7 +9,7 @@ import {
   useStyles,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
-import React, { Ref, ReactNode, useMemo } from "react"
+import React, { ReactNode, useMemo } from "react"
 import {
   TabsProvider,
   useTab,

--- a/packages/tag/src/tag.tsx
+++ b/packages/tag/src/tag.tsx
@@ -19,7 +19,7 @@ export type TagProps = PropsOf<typeof chakra.span> & ThemingProps
  * To style the tag globally, change the styles in `theme.components.Tag`
  * @see Docs https://chakra-ui.com/components/tag
  */
-export const Tag = forwardRef<TagProps>(function Tag(props, ref) {
+export const Tag: React.FC<TagProps> = forwardRef((props, ref) => {
   const styles = useMultiStyleConfig("Tag", props)
   const _props = omitThemingProps(props)
 
@@ -44,7 +44,7 @@ if (__DEV__) {
 
 export type TagLabelProps = PropsOf<typeof chakra.span>
 
-export function TagLabel(props: TagLabelProps) {
+export const TagLabel: React.FC<TagLabelProps> = (props) => {
   const styles = useStyles()
   return <chakra.span isTruncated {...props} __css={styles.label} />
 }
@@ -53,7 +53,7 @@ if (__DEV__) {
   TagLabel.displayName = "TagLabel"
 }
 
-export const TagLeftIcon = (props: IconProps) => (
+export const TagLeftIcon: React.FC<IconProps> = (props) => (
   <Icon verticalAlign="top" marginRight="0.5rem" {...props} />
 )
 
@@ -61,7 +61,7 @@ if (__DEV__) {
   TagLeftIcon.displayName = "TagLeftIcon"
 }
 
-export const TagRightIcon = (props: IconProps) => (
+export const TagRightIcon: React.FC<IconProps> = (props) => (
   <Icon verticalAlign="top" marginLeft="0.5rem" {...props} />
 )
 
@@ -69,7 +69,7 @@ if (__DEV__) {
   TagRightIcon.displayName = "TagRightIcon"
 }
 
-const TagCloseIcon = (props: IconProps) => (
+const TagCloseIcon: React.FC<IconProps> = (props) => (
   <Icon verticalAlign="inherit" viewBox="0 0 512 512" {...props}>
     <path
       fill="currentColor"
@@ -93,7 +93,7 @@ export type TagCloseButtonProps = Omit<
  * TagCloseButton is used to close "remove" the tag
  * @see Docs https://chakra-ui.com/components/tag
  */
-export const TagCloseButton = (props: TagCloseButtonProps) => {
+export const TagCloseButton: React.FC<TagCloseButtonProps> = (props) => {
   const { isDisabled, children = <TagCloseIcon />, ...rest } = props
 
   const styles = useStyles()

--- a/packages/test-utils/src/test-utils.tsx
+++ b/packages/test-utils/src/test-utils.tsx
@@ -11,7 +11,7 @@ expect.addSnapshotSerializer(serializer)
 
 expect.extend(toHaveNoViolations)
 
-const AllProviders = ({ children }: { children?: React.ReactNode }) => (
+const AllProviders: React.FC = ({ children }) => (
   <ThemeProvider theme={theme}>
     <CSSReset />
     <GlobalStyle />

--- a/packages/textarea/src/textarea.tsx
+++ b/packages/textarea/src/textarea.tsx
@@ -41,10 +41,7 @@ export type TextareaProps = Omit<PropsOf<typeof chakra.textarea>, Omitted> &
  * Textarea is used to enter an amount of text that's longer than a single line
  * @see Docs https://chakra-ui.com/components/textarea
  */
-export const Textarea = forwardRef<TextareaProps>(function Textarea(
-  props,
-  ref,
-) {
+export const Textarea: React.FC<TextareaProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Textarea", props)
   const { className, rows, ...otherProps } = omitThemingProps(props)
 

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -11,7 +11,7 @@ export interface ToastProps extends ToastOptions {
   requestClose?: boolean
 }
 
-export function Toast(props: ToastProps) {
+export const Toast: React.FC<ToastProps> = (props) => {
   const {
     id,
     message,
@@ -127,6 +127,6 @@ export function Toast(props: ToastProps) {
   )
 }
 
-if(__DEV__) {
+if (__DEV__) {
   Toast.displayName = "Toast"
 }

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -66,7 +66,7 @@ export interface UseToastOptions {
 
 export type IToast = UseToastOptions
 
-const Toast = (props: any) => {
+const Toast: React.FC<any> = (props) => {
   const { status, variant, id, title, isClosable, onClose, description } = props
 
   return (
@@ -120,7 +120,7 @@ export function useToast() {
     const toastImpl = function (options: UseToastOptions) {
       const { render } = options
 
-      const Message = (props: RenderProps) => (
+      const Message: React.FC<RenderProps> = (props) => (
         <ThemeProvider theme={theme}>
           {isFunction(render) ? (
             render(props)

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -3,7 +3,7 @@ import {
   AlertDescription,
   AlertIcon,
   AlertTitle,
-  STATUSES,
+  AlertStatus,
 } from "@chakra-ui/alert"
 import { CloseButton } from "@chakra-ui/close-button"
 import { chakra, ThemeProvider, useTheme } from "@chakra-ui/system"
@@ -50,7 +50,7 @@ export interface UseToastOptions {
   /**
    * The status of the toast.
    */
-  status?: keyof typeof STATUSES
+  status?: AlertStatus
   /**
    * The `id` of the toast.
    *

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -5,6 +5,7 @@ import {
   ThemingProps,
   useStyleConfig,
   omitThemingProps,
+  forwardRef,
 } from "@chakra-ui/system"
 import { isString, omit, pick, __DEV__, mergeRefs } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
@@ -48,10 +49,7 @@ export type TooltipProps = PropsOf<typeof chakra.div> &
  * @see Docs     https://chakra-ui.com/components/tooltip
  * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#tooltip
  */
-export const Tooltip = React.forwardRef(function Tooltip(
-  props: TooltipProps,
-  ref: React.Ref<any>,
-) {
+export const Tooltip: React.FC<TooltipProps> = forwardRef((props, ref) => {
   const styles = useStyleConfig("Tooltip", props)
   const realProps = omitThemingProps(props)
 

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -7,7 +7,7 @@ import {
   omitThemingProps,
   forwardRef,
 } from "@chakra-ui/system"
-import { isString, omit, pick, __DEV__, mergeRefs } from "@chakra-ui/utils"
+import { isString, omit, pick, __DEV__ } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
 import * as React from "react"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"

--- a/packages/transition/src/fade.tsx
+++ b/packages/transition/src/fade.tsx
@@ -12,7 +12,7 @@ const styles: TransitionStyles = {
   exiting: { opacity: 0 },
 }
 
-export function Fade(props: FadeProps) {
+export const Fade: React.FC<FadeProps> = (props) => {
   const { timeout = 150, ...rest } = props
   return (
     <Transition

--- a/packages/transition/src/hidden-transition.tsx
+++ b/packages/transition/src/hidden-transition.tsx
@@ -25,7 +25,7 @@ export type HiddenTransitionProps = Pick<
   appear?: boolean
 }
 
-export function HiddenTransition(props: HiddenTransitionProps) {
+export const HiddenTransition: React.FC<HiddenTransitionProps> = (props) => {
   const {
     nodeRef,
     children,

--- a/packages/transition/src/scale-fade.tsx
+++ b/packages/transition/src/scale-fade.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import {__DEV__} from "@chakra-ui/utils";
+import { __DEV__ } from "@chakra-ui/utils"
 import { Transition, TransitionProps } from "./transition"
 
 function getTransitionStyles(initialScale: number) {
@@ -26,7 +26,7 @@ export type ScaleFadeProps = Omit<TransitionProps, "styles" | "timeout"> & {
   timeout?: number
 }
 
-export const ScaleFade = (props: ScaleFadeProps) => {
+export const ScaleFade: React.FC<ScaleFadeProps> = (props) => {
   const { initialScale = 0.9, timeout = 150, ...rest } = props
   const styles = getTransitionStyles(initialScale)
 
@@ -41,6 +41,6 @@ export const ScaleFade = (props: ScaleFadeProps) => {
   )
 }
 
-if(__DEV__) {
+if (__DEV__) {
   ScaleFade.displayName = "ScaleFade"
 }

--- a/packages/transition/src/slide-fade.tsx
+++ b/packages/transition/src/slide-fade.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import {__DEV__} from "@chakra-ui/utils";
+import { __DEV__ } from "@chakra-ui/utils"
 import { Transition, TransitionProps } from "./transition"
 
 export interface SlideFadeProps
@@ -31,7 +31,7 @@ function getTransitionStyles(initialOffset: string) {
   }
 }
 
-export const SlideFade = (props: SlideFadeProps) => {
+export const SlideFade: React.FC<SlideFadeProps> = (props) => {
   const { initialOffset = "20px", timeout = 150, ...rest } = props
 
   const styles = getTransitionStyles(initialOffset)
@@ -46,7 +46,6 @@ export const SlideFade = (props: SlideFadeProps) => {
   )
 }
 
-
-if(__DEV__) {
+if (__DEV__) {
   SlideFade.displayName = "SlideFade"
 }

--- a/packages/transition/src/slide.tsx
+++ b/packages/transition/src/slide.tsx
@@ -76,7 +76,7 @@ export type SlideProps = Omit<TransitionProps, "styles" | "timeout"> & {
   timeout?: number
 }
 
-export function Slide(props: SlideProps) {
+export const Slide: React.FC<SlideProps> = (props) => {
   const { placement = "left", timeout = 150, children, ...rest } = props
 
   const styles = getTransitionStyles(placement)

--- a/packages/transition/src/transition.tsx
+++ b/packages/transition/src/transition.tsx
@@ -33,7 +33,7 @@ export type TransitionStyles = {
 
 export type { TransitionStatus }
 
-export function Transition(props: TransitionProps) {
+export const Transition: React.FC<TransitionProps> = (props) => {
   const {
     styles,
     in: inProp,

--- a/tooling/cra-template-typescript/template/src/ColorModeSwitcher.tsx
+++ b/tooling/cra-template-typescript/template/src/ColorModeSwitcher.tsx
@@ -9,7 +9,7 @@ import { FaMoon, FaSun } from "react-icons/fa"
 
 type ColorModeSwitcherProps = Omit<IconButtonProps, "aria-label">
 
-export const ColorModeSwitcher = (props: ColorModeSwitcherProps) => {
+export const ColorModeSwitcher: React.FC<ColorModeSwitcherProps> = (props) => {
   const { toggleColorMode } = useColorMode()
   const text = useColorModeValue("dark", "light")
   const SwitchIcon = useColorModeValue(FaMoon, FaSun)


### PR DESCRIPTION
First PR of the series mentioned here: https://github.com/chakra-ui/chakra-ui/pull/1430#issuecomment-667027589

should fix #1445 and #1387 

would be great if you could lend an eye too :) @santialbo thank you for your regex work, without it, it would've taken longer than the 2.5 hrs!

additional patterns I checked and fixed:
- duplicate forwardRef definitions ( React.forwardRef & @chakra-ui/system)
- linebreaks the regex couldnt cover
- remove additional named function definition within an arrow function; unecessary for displayNames 

the next step will be replacing React.FC with our version which only optionally adds children. we'll expose this type from `core` ideally, too.