### PR TITLE
style(input-element): remove z-index

### DIFF
--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -13,7 +13,6 @@ const StyledElement = chakra("div", {
     justifyContent: "center",
     position: "absolute",
     top: "0",
-    zIndex: 2,
   },
 })
 


### PR DESCRIPTION
Resolves #1497

This `z-index` has been in place for quite a long time, but I'm not sure what purpose it's serving. 