### PR TITLE
docs(menu): remove submenu from menu docs

### DIFF
--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -171,37 +171,3 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
   </MenuList>
 </Menu>
 ```
-
-## Added support for nested menus or submenus
-
-```jsx
-const PreferencesMenu = forwardRef((props, ref) => {
-  return (
-    <Menu>
-      <MenuButton ref={ref} {...props}>
-        Preferences
-      </MenuButton>
-      <MenuList>
-        <MenuItem>Settings</MenuItem>
-        <MenuItem isDisabled>Extensions</MenuItem>
-        <MenuSeparator />
-        <MenuItem>Keyboard shortcuts</MenuItem>
-      </MenuList>
-    </Menu>
-  )
-})
-
-function NestedMenu() {
-  return (
-    <Menu>
-      <MenuButton>Code</MenuButton>
-      <MenuList>
-        <MenuItem>About Visual Studio Code</MenuItem>
-        <MenuItem>Check for Updates...</MenuItem>
-        <MenuSeparator />
-        <MenuItem as={PreferencesMenu} />
-      </MenuList>
-    </Menu>
-  )
-}
-```

--- a/packages/menu/migration.md
+++ b/packages/menu/migration.md
@@ -2,40 +2,6 @@
 
 ## New Features ⚡️
 
-Added support for nested menus or submenus
-
-```jsx
-const PreferencesMenu = forwardRef((props, ref) => {
-  return (
-    <Menu>
-      <MenuButton ref={ref} {...props}>
-        Preferences
-      </MenuButton>
-      <MenuList>
-        <MenuItem>Settings</MenuItem>
-        <MenuItem isDisabled>Extensions</MenuItem>
-        <MenuSeparator />
-        <MenuItem>Keyboard shortcuts</MenuItem>
-      </MenuList>
-    </Menu>
-  )
-})
-
-function Example() {
-  return (
-    <Menu>
-      <MenuButton>Code</MenuButton>
-      <MenuList>
-        <MenuItem>About Visual Studio Code</MenuItem>
-        <MenuItem>Check for Updates...</MenuItem>
-        <MenuSeparator />
-        <MenuItem as={PreferencesMenu} />
-      </MenuList>
-    </Menu>
-  )
-}
-```
-
 Support for menu icons and commands (or hotkeys
 
 ```jsx

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -63,9 +63,7 @@ if (__DEV__) {
   Menu.displayName = "Menu"
 }
 
-export type MenuButtonProps = PropsOf<typeof chakra.button> & {
-  submenuIcon?: ReactElement
-}
+export type MenuButtonProps = PropsOf<typeof chakra.button>
 
 const StyledMenuButton = React.forwardRef(function StyledMenuButton(
   props: PropsOf<typeof chakra.button>,
@@ -95,7 +93,7 @@ export const MenuButton = forwardRef<MenuButtonProps>(function MenuButton(
   props,
   ref,
 ) {
-  const { children, submenuIcon, as: Comp, ...otherProps } = props
+  const { children, as: Comp, ...otherProps } = props
 
   const ownProps = useMenuButton(otherProps)
   const ownRef = mergeRefs(ref, ownProps.ref)

--- a/website/docs/components/menu.mdx
+++ b/website/docs/components/menu.mdx
@@ -193,43 +193,6 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
 </Menu>
 ```
 
-### Nested menus
-
-```jsx manual=true
-const Submenu = React.forwardRef((props, ref) => (
-  <Menu>
-    <MenuButton ref={ref} {...props}>
-      Other
-    </MenuButton>
-    <Portal>
-      <MenuList>
-        <MenuItem>Twitter</MenuItem>
-        <MenuItem>Facebook</MenuItem>
-      </MenuList>
-    </Portal>
-  </Menu>
-))
-
-const WithNestedMenu = () => (
-  <Menu>
-    <MenuButton size="sm" colorScheme="teal">
-      Open menu
-    </MenuButton>
-    <Portal>
-      <MenuList>
-        <MenuItem command="⌘T">New Tab</MenuItem>
-        <MenuItem command="⌘N">New Window</MenuItem>
-        <MenuItem command="⌘⇧N">Open Closed Tab</MenuItem>
-        <MenuItem as={Submenu} />
-        <MenuItem command="⌘O">Open File...</MenuItem>
-      </MenuList>
-    </Portal>
-  </Menu>
-)
-
-render(<WithNestedMenu />)
-```
-
 ## Accessibility
 
 ### Keyboard Interaction

--- a/website/docs/migration.mdx
+++ b/website/docs/migration.mdx
@@ -616,40 +616,6 @@ We've renamed the props from `colorStart` and `colorEnd` to `startColor` and
 
 #### Features
 
-- Added support for nested menus or submenus
-
-```jsx live=false
-const PreferencesMenu = forwardRef((props, ref) => {
-  return (
-    <Menu>
-      <MenuButton ref={ref} {...props}>
-        Preferences
-      </MenuButton>
-      <MenuList>
-        <MenuItem>Settings</MenuItem>
-        <MenuItem isDisabled>Extensions</MenuItem>
-        <MenuSeparator />
-        <MenuItem>Keyboard shortcuts</MenuItem>
-      </MenuList>
-    </Menu>
-  )
-})
-
-function Example() {
-  return (
-    <Menu>
-      <MenuButton>Code</MenuButton>
-      <MenuList>
-        <MenuItem>About Visual Studio Code</MenuItem>
-        <MenuItem>Check for Updates...</MenuItem>
-        <MenuSeparator />
-        <MenuItem as={PreferencesMenu} />
-      </MenuList>
-    </Menu>
-  )
-}
-```
-
 - Added support for menu icons and commands (or hotkeys)
 
 ```jsx live=false


### PR DESCRIPTION
Resolves #1506 

This PR removes the `submenuIcon` prop and removes all references to the nested menus/submenus concept from the docs.