### PR TITLE
fix(spinner): sharp spinner on server-side rendering caused by misconfigured borderRadius property

### DIFF
--- a/packages/spinner/src/spinner.tsx
+++ b/packages/spinner/src/spinner.tsx
@@ -83,7 +83,7 @@ export const Spinner = React.forwardRef(function Spinner(
     display: "inline-block",
     borderColor: "currentColor",
     borderStyle: "solid",
-    borderRadius: "full",
+    borderRadius: "99999px",
     borderWidth: thickness,
     borderBottomColor: emptyColor,
     borderLeftColor: emptyColor,


### PR DESCRIPTION
I have a product that take a long time to render and notice something regarding to spinner that spinner is a square a while before changing back to circle spinner. ([demo here](https://youtu.be/T-MKy_Vw24s))

It is because that when on server-side it recognize as `border-radius: full` instead of `border-radius: 99999...px`. So, this is minor style fix for that

