### PR TITLE
chore(styled-system): migrate to csstype v3

### DIFF
--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@chakra-ui/utils": "1.0.0-rc.1",
     "@styled-system/core": "5.1.2",
-    "csstype": "2.6.9"
+    "csstype": "3.0.2"
   },
   "peerDependencies": {
     "react": "16.x"

--- a/packages/styled-system/src/config/background.ts
+++ b/packages/styled-system/src/config/background.ts
@@ -55,75 +55,75 @@ export interface BackgroundProps {
   /**
    * The CSS `background` property
    */
-  bg?: ResponsiveValue<CSS.BackgroundProperty<Length>>
+  bg?: ResponsiveValue<CSS.Property.Background<Length>>
   /**
    * The CSS `background` property
    */
-  background?: ResponsiveValue<CSS.BackgroundProperty<Length>>
+  background?: ResponsiveValue<CSS.Property.Background<Length>>
   /**
    * The CSS `background-color` property
    */
-  bgColor?: ResponsiveValue<CSS.BackgroundColorProperty>
+  bgColor?: ResponsiveValue<CSS.Property.BackgroundColor>
   /**
    * The CSS `background-color` property
    */
-  backgroundColor?: ResponsiveValue<CSS.BackgroundColorProperty>
+  backgroundColor?: ResponsiveValue<CSS.Property.BackgroundColor>
   /**
    * The CSS `background-image` property
    */
-  backgroundImage?: ResponsiveValue<CSS.BackgroundImageProperty>
+  backgroundImage?: ResponsiveValue<CSS.Property.BackgroundImage>
   /**
    * The CSS `background-blend-mode` property
    */
-  backgroundBlendMode?: ResponsiveValue<CSS.BackgroundBlendModeProperty>
+  backgroundBlendMode?: ResponsiveValue<CSS.Property.BackgroundBlendMode>
   /**
    * The CSS `background-blend-mode` property
    */
-  bgBlendMode?: ResponsiveValue<CSS.BackgroundBlendModeProperty>
+  bgBlendMode?: ResponsiveValue<CSS.Property.BackgroundBlendMode>
   /**
    * The CSS `background-size` property
    */
-  backgroundSize?: ResponsiveValue<CSS.BackgroundSizeProperty<Length>>
+  backgroundSize?: ResponsiveValue<CSS.Property.BackgroundSize<Length>>
   /**
    * The CSS `background-position` property
    */
-  bgPos?: ResponsiveValue<CSS.BackgroundPositionProperty<Length>>
+  bgPos?: ResponsiveValue<CSS.Property.BackgroundPosition<Length>>
   /**
    * The CSS `background-position` property
    */
-  backgroundPosition?: ResponsiveValue<CSS.BackgroundPositionProperty<Length>>
+  backgroundPosition?: ResponsiveValue<CSS.Property.BackgroundPosition<Length>>
   /**
    * The CSS `background-image` property
    */
-  bgImage?: ResponsiveValue<CSS.BackgroundImageProperty>
+  bgImage?: ResponsiveValue<CSS.Property.BackgroundImage>
   /**
    * The CSS `background-image` property
    */
-  bgImg?: ResponsiveValue<CSS.BackgroundImageProperty>
+  bgImg?: ResponsiveValue<CSS.Property.BackgroundImage>
   /**
    * The CSS `background-repeat` property
    */
-  bgRepeat?: ResponsiveValue<CSS.BackgroundRepeatProperty>
+  bgRepeat?: ResponsiveValue<CSS.Property.BackgroundRepeat>
   /**
    * The CSS `background-repeat` property
    */
-  backgroundRepeat?: ResponsiveValue<CSS.BackgroundRepeatProperty>
+  backgroundRepeat?: ResponsiveValue<CSS.Property.BackgroundRepeat>
   /**
    * The CSS `background-size` property
    */
-  bgSize?: ResponsiveValue<CSS.BackgroundSizeProperty<Length>>
+  bgSize?: ResponsiveValue<CSS.Property.BackgroundSize<Length>>
   /**
    * The CSS `background-attachment` property
    */
-  bgAttachment?: ResponsiveValue<CSS.BackgroundAttachmentProperty>
+  bgAttachment?: ResponsiveValue<CSS.Property.BackgroundAttachment>
   /**
    * The CSS `background-attachment` property
    */
-  backgroundAttachment?: ResponsiveValue<CSS.BackgroundAttachmentProperty>
+  backgroundAttachment?: ResponsiveValue<CSS.Property.BackgroundAttachment>
   /**
    * The CSS `background-position` property
    */
-  bgPosition?: ResponsiveValue<CSS.BackgroundPositionProperty<Length>>
+  bgPosition?: ResponsiveValue<CSS.Property.BackgroundPosition<Length>>
 }
 
 export const background = system(config)

--- a/packages/styled-system/src/config/border.ts
+++ b/packages/styled-system/src/config/border.ts
@@ -175,172 +175,172 @@ export interface BorderProps {
   /**
    * The CSS `border` property
    */
-  border?: ResponsiveValue<CSS.BorderProperty<Length>>
+  border?: ResponsiveValue<CSS.Property.Border<Length>>
   /**
    * The CSS `border-width` property
    */
-  borderWidth?: ResponsiveValue<CSS.BorderWidthProperty<Length>>
+  borderWidth?: ResponsiveValue<CSS.Property.BorderWidth<Length>>
   /**
    * The CSS `border-style` property
    */
-  borderStyle?: ResponsiveValue<CSS.BorderStyleProperty>
+  borderStyle?: ResponsiveValue<CSS.Property.BorderStyle>
   /**
    * The CSS `border-color` property
    */
-  borderColor?: ResponsiveValue<CSS.BorderTopColorProperty>
+  borderColor?: ResponsiveValue<CSS.Property.BorderTopColor>
   /**
    * The CSS `border-radius` property
    */
-  borderRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-radius` property
    * @deprecated
    */
-  rounded?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  rounded?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-top` property
    */
-  borderTop?: ResponsiveValue<CSS.BorderTopProperty<Length>>
+  borderTop?: ResponsiveValue<CSS.Property.BorderTop<Length>>
   /**
    * The CSS `border-top-width` property
    */
-  borderTopWidth?: ResponsiveValue<CSS.BorderWidthProperty<Length>>
+  borderTopWidth?: ResponsiveValue<CSS.Property.BorderWidth<Length>>
   /**
    * The CSS `border-bottom-width` property
    */
-  borderBottomWidth?: ResponsiveValue<CSS.BorderWidthProperty<Length>>
+  borderBottomWidth?: ResponsiveValue<CSS.Property.BorderWidth<Length>>
   /**
    * The CSS `border-left-width` property
    */
-  borderLeftWidth?: ResponsiveValue<CSS.BorderWidthProperty<Length>>
+  borderLeftWidth?: ResponsiveValue<CSS.Property.BorderWidth<Length>>
   /**
    * The CSS `border-right-width` property
    */
-  borderRightWidth?: ResponsiveValue<CSS.BorderWidthProperty<Length>>
+  borderRightWidth?: ResponsiveValue<CSS.Property.BorderWidth<Length>>
   /**
    * The CSS `border-top-style` property
    */
-  borderTopStyle?: ResponsiveValue<CSS.BorderTopStyleProperty>
+  borderTopStyle?: ResponsiveValue<CSS.Property.BorderTopStyle>
   /**
    * The CSS `border-bottom-style` property
    */
-  borderBottomStyle?: ResponsiveValue<CSS.BorderBottomStyleProperty>
+  borderBottomStyle?: ResponsiveValue<CSS.Property.BorderBottomStyle>
   /**
    * The CSS `border-left-style` property
    */
-  borderLeftStyle?: ResponsiveValue<CSS.BorderLeftStyleProperty>
+  borderLeftStyle?: ResponsiveValue<CSS.Property.BorderLeftStyle>
   /**
    * The CSS `border-right-styles` property
    */
-  borderRightStyle?: ResponsiveValue<CSS.BorderRightStyleProperty>
+  borderRightStyle?: ResponsiveValue<CSS.Property.BorderRightStyle>
   /**
    * The CSS `border-top-color` property
    */
-  borderTopColor?: ResponsiveValue<CSS.BorderTopColorProperty>
+  borderTopColor?: ResponsiveValue<CSS.Property.BorderTopColor>
   /**
    * The CSS `border-bottom-color` property
    */
-  borderBottomColor?: ResponsiveValue<CSS.BorderBottomColorProperty>
+  borderBottomColor?: ResponsiveValue<CSS.Property.BorderBottomColor>
   /**
    * The CSS `border-left-color` property
    */
-  borderLeftColor?: ResponsiveValue<CSS.BorderLeftColorProperty>
+  borderLeftColor?: ResponsiveValue<CSS.Property.BorderLeftColor>
   /**
    * The CSS `border-right-color` property
    */
-  borderRightColor?: ResponsiveValue<CSS.BorderRightColorProperty>
+  borderRightColor?: ResponsiveValue<CSS.Property.BorderRightColor>
   /**
    * The CSS `border-right` property
    */
-  borderRight?: ResponsiveValue<CSS.BorderRightProperty<Length>>
+  borderRight?: ResponsiveValue<CSS.Property.BorderRight<Length>>
   /**
    * The CSS `border-bottom` property
    */
-  borderBottom?: ResponsiveValue<CSS.BorderBottomProperty<Length>>
+  borderBottom?: ResponsiveValue<CSS.Property.BorderBottom<Length>>
   /**
    * The CSS `border-left` property
    */
-  borderLeft?: ResponsiveValue<CSS.BorderLeftProperty<Length>>
+  borderLeft?: ResponsiveValue<CSS.Property.BorderLeft<Length>>
   /**
    * The CSS `border-top-radius` property
    */
-  borderTopRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderTopRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-top-radius` property
    * @deprecated
    */
-  roundedTop?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedTop?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-right-radius` property
    */
-  borderRightRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderRightRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-right-radius` property
    * @deprecated
    */
-  roundedRight?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedRight?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-bottom-radius` property
    */
-  borderBottomRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderBottomRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-bottom-radius` property
    * @deprecated
    */
-  roundedBottom?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedBottom?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-left-radius` property
    */
-  borderLeftRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderLeftRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-left-radius` property
    * @deprecated
    */
-  roundedLeft?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedLeft?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-top-left-radius` property
    */
-  borderTopLeftRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderTopLeftRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-top-left-radius` property
    * @deprecated
    */
-  roundedTopLeft?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedTopLeft?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-top-right-radius` property
    */
-  borderTopRightRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderTopRightRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-top-right-radius` property
    * @deprecated
    */
-  roundedTopRight?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedTopRight?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-bottom-left-radius` property
    */
-  borderBottomLeftRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderBottomLeftRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-bottom-left-radius` property
    * @deprecated
    */
-  roundedBottomLeft?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedBottomLeft?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-bottom-right-radius` property
    */
-  borderBottomRightRadius?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  borderBottomRightRadius?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-bottom-right-radius` property
    * @deprecated
    */
-  roundedBottomRight?: ResponsiveValue<CSS.BorderRadiusProperty<Length>>
+  roundedBottomRight?: ResponsiveValue<CSS.Property.BorderRadius<Length>>
   /**
    * The CSS `border-right` and `border-left` property
    */
-  borderX?: ResponsiveValue<CSS.BorderProperty<Length>>
+  borderX?: ResponsiveValue<CSS.Property.Border<Length>>
   /**
    * The CSS `border-top` and `border-bottom` property
    */
-  borderY?: ResponsiveValue<CSS.BorderProperty<Length>>
+  borderY?: ResponsiveValue<CSS.Property.Border<Length>>
 }
 
 export const border = system(config)

--- a/packages/styled-system/src/config/color.ts
+++ b/packages/styled-system/src/config/color.ts
@@ -29,23 +29,23 @@ export interface ColorProps {
   /**
    * The CSS `color` property
    */
-  textColor?: ResponsiveValue<CSS.ColorProperty>
+  textColor?: ResponsiveValue<CSS.Property.Color>
   /**
    * The CSS `color` property
    */
-  color?: ResponsiveValue<CSS.ColorProperty>
+  color?: ResponsiveValue<CSS.Property.Color>
   /**
    * The CSS `fill` property for icon svgs and paths
    */
-  fill?: ResponsiveValue<CSS.ColorProperty>
+  fill?: ResponsiveValue<CSS.Property.Color>
   /**
    * The CSS `stroke` property for icon svgs and paths
    */
-  stroke?: ResponsiveValue<CSS.ColorProperty>
+  stroke?: ResponsiveValue<CSS.Property.Color>
   /**
    * The CSS `opacity` property
    */
-  opacity?: ResponsiveValue<CSS.GlobalsNumber>
+  opacity?: ResponsiveValue<CSS.Property.Opacity>
 }
 
 export const color = system(config)

--- a/packages/styled-system/src/config/flexbox.ts
+++ b/packages/styled-system/src/config/flexbox.ts
@@ -31,59 +31,59 @@ export interface FlexboxProps {
   /**
    * The CSS `align-items` property
    */
-  alignItems?: ResponsiveValue<CSS.AlignItemsProperty>
+  alignItems?: ResponsiveValue<CSS.Property.AlignItems>
   /**
    * The CSS `align-content` property
    */
-  alignContent?: ResponsiveValue<CSS.AlignContentProperty>
+  alignContent?: ResponsiveValue<CSS.Property.AlignContent>
   /**
    * The CSS `justify-items` property
    */
-  justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty>
+  justifyItems?: ResponsiveValue<CSS.Property.JustifyItems>
   /**
    * The CSS `justify-content` property
    */
-  justifyContent?: ResponsiveValue<CSS.JustifyContentProperty>
+  justifyContent?: ResponsiveValue<CSS.Property.JustifyContent>
   /**
    * The CSS `flex-wrap` property
    */
-  flexWrap?: ResponsiveValue<CSS.FlexWrapProperty>
+  flexWrap?: ResponsiveValue<CSS.Property.FlexWrap>
   /**
    * The CSS `flex-basis` property
    */
-  flexBasis?: ResponsiveValue<CSS.FlexBasisProperty<Length>>
+  flexBasis?: ResponsiveValue<CSS.Property.FlexBasis<Length>>
   /**
    * The CSS `flex-direction` property
    */
-  flexDirection?: ResponsiveValue<CSS.FlexDirectionProperty>
+  flexDirection?: ResponsiveValue<CSS.Property.FlexDirection>
   /**
    * The CSS `flex-direction` property
    */
-  flexDir?: ResponsiveValue<CSS.FlexDirectionProperty>
+  flexDir?: ResponsiveValue<CSS.Property.FlexDirection>
   /**
    * The CSS `flex` property
    */
-  flex?: ResponsiveValue<CSS.FlexProperty<Length>>
+  flex?: ResponsiveValue<CSS.Property.Flex<Length>>
   /**
    * The CSS `justify-self` property
    */
-  justifySelf?: ResponsiveValue<CSS.JustifySelfProperty>
+  justifySelf?: ResponsiveValue<CSS.Property.JustifySelf>
   /**
    * The CSS `align-self` property
    */
-  alignSelf?: ResponsiveValue<CSS.AlignSelfProperty>
+  alignSelf?: ResponsiveValue<CSS.Property.AlignSelf>
   /**
    * The CSS `order` property
    */
-  order?: ResponsiveValue<CSS.GlobalsNumber>
+  order?: ResponsiveValue<CSS.Property.Order>
   /**
    * The CSS `flex-grow` property
    */
-  flexGrow?: ResponsiveValue<CSS.GlobalsNumber>
+  flexGrow?: ResponsiveValue<CSS.Property.FlexGrow>
   /**
    * The CSS `flex-shrink` property
    */
-  flexShrink?: ResponsiveValue<CSS.GlobalsNumber>
+  flexShrink?: ResponsiveValue<CSS.Property.FlexShrink>
 }
 
 export const flexbox = system(config)

--- a/packages/styled-system/src/config/grid.ts
+++ b/packages/styled-system/src/config/grid.ts
@@ -34,55 +34,57 @@ export interface GridProps {
   /**
    * The CSS `grid-gap` property
    */
-  gridGap?: ResponsiveValue<CSS.GridGapProperty<Length>>
+  gridGap?: ResponsiveValue<CSS.Property.GridGap<Length>>
   /**
    * The CSS `grid-column-gap` property
    */
-  gridColumnGap?: ResponsiveValue<CSS.GridColumnGapProperty<Length>>
+  gridColumnGap?: ResponsiveValue<CSS.Property.GridColumnGap<Length>>
   /**
    * The CSS `grid-row-gap` property
    */
-  gridRowGap?: ResponsiveValue<CSS.GridRowGapProperty<Length>>
+  gridRowGap?: ResponsiveValue<CSS.Property.GridRowGap<Length>>
   /**
    * The CSS `grid-column` property
    */
-  gridColumn?: ResponsiveValue<CSS.GridColumnProperty>
+  gridColumn?: ResponsiveValue<CSS.Property.GridColumn>
   /**
    * The CSS `grid-row` property
    */
-  gridRow?: ResponsiveValue<CSS.GridRowProperty>
+  gridRow?: ResponsiveValue<CSS.Property.GridRow>
   /**
    * The CSS `grid-auto-flow` property
    */
-  gridAutoFlow?: ResponsiveValue<CSS.GridAutoFlowProperty>
+  gridAutoFlow?: ResponsiveValue<CSS.Property.GridAutoFlow>
   /**
    * The CSS `grid-auto-columns` property
    */
-  gridAutoColumns?: ResponsiveValue<CSS.GridAutoColumnsProperty<Length>>
+  gridAutoColumns?: ResponsiveValue<CSS.Property.GridAutoColumns<Length>>
   /**
    * The CSS `grid-auto-rows` property
    */
-  gridAutoRows?: ResponsiveValue<CSS.GridAutoRowsProperty<Length>>
+  gridAutoRows?: ResponsiveValue<CSS.Property.GridAutoRows<Length>>
   /**
    * The CSS `grid-template-columns` property
    */
-  gridTemplateColumns?: ResponsiveValue<CSS.GridTemplateColumnsProperty<Length>>
+  gridTemplateColumns?: ResponsiveValue<
+    CSS.Property.GridTemplateColumns<Length>
+  >
   /**
    * The CSS `grid-template-rows` property
    */
-  gridTemplateRows?: ResponsiveValue<CSS.GridTemplateRowsProperty<Length>>
+  gridTemplateRows?: ResponsiveValue<CSS.Property.GridTemplateRows<Length>>
   /**
    * The CSS `grid-template-areas` property
    */
-  gridTemplateAreas?: ResponsiveValue<CSS.GridTemplateAreasProperty>
+  gridTemplateAreas?: ResponsiveValue<CSS.Property.GridTemplateAreas>
   /**
    * The CSS `grid-areas` property
    */
-  gridArea?: ResponsiveValue<CSS.GridAreaProperty>
+  gridArea?: ResponsiveValue<CSS.Property.GridArea>
   /**
    * The CSS `place-items` property
    */
-  placeItems?: ResponsiveValue<CSS.PlaceItemsProperty>
+  placeItems?: ResponsiveValue<CSS.Property.PlaceItems>
 }
 
 export const grid = system(config)

--- a/packages/styled-system/src/config/layout.ts
+++ b/packages/styled-system/src/config/layout.ts
@@ -81,83 +81,83 @@ export interface LayoutProps {
   /**
    * The CSS `display` property
    */
-  display?: ResponsiveValue<CSS.DisplayProperty>
+  display?: ResponsiveValue<CSS.Property.Display>
   /**
    * The CSS `display` property
    */
-  d?: ResponsiveValue<CSS.DisplayProperty>
+  d?: ResponsiveValue<CSS.Property.Display>
   /**
    * The CSS `width` property
    */
-  width?: ResponsiveValue<CSS.WidthProperty<Length>>
+  width?: ResponsiveValue<CSS.Property.Width<Length>>
   /**
    * The CSS `width` property
    */
-  w?: ResponsiveValue<CSS.WidthProperty<Length>>
+  w?: ResponsiveValue<CSS.Property.Width<Length>>
   /**
    * The CSS `width` and `height` property
    */
-  boxSize?: ResponsiveValue<CSS.WidthProperty<Length>>
+  boxSize?: ResponsiveValue<CSS.Property.Width<Length>>
   /**
    * The CSS `max-width` property
    */
-  maxWidth?: ResponsiveValue<CSS.MaxWidthProperty<Length>>
+  maxWidth?: ResponsiveValue<CSS.Property.MaxWidth<Length>>
   /**
    * The CSS `max-width` property
    */
-  maxW?: ResponsiveValue<CSS.MaxWidthProperty<Length>>
+  maxW?: ResponsiveValue<CSS.Property.MaxWidth<Length>>
   /**
    * The CSS `min-width` property
    */
-  minWidth?: ResponsiveValue<CSS.MinWidthProperty<Length>>
+  minWidth?: ResponsiveValue<CSS.Property.MinWidth<Length>>
   /**
    * The CSS `min-width` property
    */
-  minW?: ResponsiveValue<CSS.MinWidthProperty<Length>>
+  minW?: ResponsiveValue<CSS.Property.MinWidth<Length>>
   /**
    * The CSS `height` property
    */
-  height?: ResponsiveValue<CSS.HeightProperty<Length>>
+  height?: ResponsiveValue<CSS.Property.Height<Length>>
   /**
    * The CSS `height` property
    */
-  h?: ResponsiveValue<CSS.HeightProperty<Length>>
+  h?: ResponsiveValue<CSS.Property.Height<Length>>
   /**
    * The CSS `max-height` property
    */
-  maxHeight?: ResponsiveValue<CSS.MaxHeightProperty<Length>>
+  maxHeight?: ResponsiveValue<CSS.Property.MaxHeight<Length>>
   /**
    * The CSS `max-height` property
    */
-  maxH?: ResponsiveValue<CSS.MaxHeightProperty<Length>>
+  maxH?: ResponsiveValue<CSS.Property.MaxHeight<Length>>
   /**
    * The CSS `min-height` property
    */
-  minHeight?: ResponsiveValue<CSS.MinHeightProperty<Length>>
+  minHeight?: ResponsiveValue<CSS.Property.MinHeight<Length>>
   /**
    * The CSS `min-height` property
    */
-  minH?: ResponsiveValue<CSS.MinHeightProperty<Length>>
+  minH?: ResponsiveValue<CSS.Property.MinHeight<Length>>
   /**
    * The CSS `vertical-align` property
    */
-  verticalAlign?: ResponsiveValue<CSS.VerticalAlignProperty<Length>>
+  verticalAlign?: ResponsiveValue<CSS.Property.VerticalAlign<Length>>
   /**
    * The CSS `overflow` property
    */
-  overflow?: ResponsiveValue<CSS.OverflowProperty>
+  overflow?: ResponsiveValue<CSS.Property.Overflow>
   /**
    * The CSS `overflow-x` property
    */
-  overflowX?: ResponsiveValue<CSS.OverflowXProperty>
+  overflowX?: ResponsiveValue<CSS.Property.OverflowX>
   /**
    * The CSS `overflow-y` property
    */
-  overflowY?: ResponsiveValue<CSS.OverflowYProperty>
+  overflowY?: ResponsiveValue<CSS.Property.OverflowY>
   /**
    * The CSS `box-sizing` property
    */
-  boxSizing?: CSS.BoxSizingProperty
+  boxSizing?: CSS.Property.BoxSizing
 }
 
 export const layout = system(config)

--- a/packages/styled-system/src/config/list.ts
+++ b/packages/styled-system/src/config/list.ts
@@ -15,23 +15,23 @@ const config: Config = {
 }
 
 export interface ListProps {
-  listStyleType?: ResponsiveValue<CSS.ListStyleTypeProperty>
+  listStyleType?: ResponsiveValue<CSS.Property.ListStyleType>
   /**
    * The CSS `list-style-position` property
    */
-  listStylePosition?: ResponsiveValue<CSS.ListStylePositionProperty>
+  listStylePosition?: ResponsiveValue<CSS.Property.ListStylePosition>
   /**
    * The CSS `list-style-position` property
    */
-  listStylePos?: ResponsiveValue<CSS.ListStylePositionProperty>
+  listStylePos?: ResponsiveValue<CSS.Property.ListStylePosition>
   /**
    * The CSS `list-style-image` property
    */
-  listStyleImage?: ResponsiveValue<CSS.ListStyleImageProperty>
+  listStyleImage?: ResponsiveValue<CSS.Property.ListStyleImage>
   /**
    * The CSS `list-style-image` property
    */
-  listStyleImg?: ResponsiveValue<CSS.ListStyleImageProperty>
+  listStyleImg?: ResponsiveValue<CSS.Property.ListStyleImage>
 }
 
 export const list = system(config)

--- a/packages/styled-system/src/config/others.ts
+++ b/packages/styled-system/src/config/others.ts
@@ -20,47 +20,47 @@ export interface OtherProps {
   /**
    * The CSS `animation` property
    */
-  animation?: ResponsiveValue<CSS.AnimationProperty>
+  animation?: ResponsiveValue<CSS.Property.Animation>
   /**
    * The CSS `appearance` property
    */
-  appearance?: ResponsiveValue<CSS.AppearanceProperty>
+  appearance?: ResponsiveValue<CSS.Property.Appearance>
   /**
    * The CSS `visibility` property
    */
-  visibility?: ResponsiveValue<CSS.VisibilityProperty>
+  visibility?: ResponsiveValue<CSS.Property.Visibility>
   /**
    * The CSS `user-select` property
    */
-  userSelect?: ResponsiveValue<CSS.UserSelectProperty>
+  userSelect?: ResponsiveValue<CSS.Property.UserSelect>
   /**
    * The CSS `pointer-events` property
    */
-  pointerEvents?: ResponsiveValue<CSS.PointerEventsProperty>
+  pointerEvents?: ResponsiveValue<CSS.Property.PointerEvents>
   /**
    * The CSS `cursor` property
    */
-  cursor?: ResponsiveValue<CSS.CursorProperty>
+  cursor?: ResponsiveValue<CSS.Property.Cursor>
   /**
    * The CSS `resize` property
    */
-  resize?: ResponsiveValue<CSS.ResizeProperty>
+  resize?: ResponsiveValue<CSS.Property.Resize>
   /**
    * The CSS `object-fit` property
    */
-  objectFit?: ResponsiveValue<CSS.ObjectFitProperty>
+  objectFit?: ResponsiveValue<CSS.Property.ObjectFit>
   /**
    * The CSS `object-psition` property
    */
-  objectPosition?: ResponsiveValue<CSS.ObjectPositionProperty<Length>>
+  objectPosition?: ResponsiveValue<CSS.Property.ObjectPosition<Length>>
   /**
    * The CSS `float` property
    */
-  float?: ResponsiveValue<CSS.FloatProperty>
+  float?: ResponsiveValue<CSS.Property.Float>
   /**
    * The CSS `will-change` property
    */
-  willChange?: ResponsiveValue<CSS.WillChangeProperty>
+  willChange?: ResponsiveValue<CSS.Property.WillChange>
 }
 
 export const others = system(config)

--- a/packages/styled-system/src/config/outline.ts
+++ b/packages/styled-system/src/config/outline.ts
@@ -18,15 +18,15 @@ export interface OutlineProps {
   /**
    * The CSS `outline` property
    */
-  outline?: ResponsiveValue<CSS.OutlineProperty<Length>>
+  outline?: ResponsiveValue<CSS.Property.Outline<Length>>
   /**
    * The CSS `outline-offset` property
    */
-  outlineOffset?: ResponsiveValue<CSS.OutlineOffsetProperty<Length>>
+  outlineOffset?: ResponsiveValue<CSS.Property.OutlineOffset<Length>>
   /**
    * The CSS `outline-color` property
    */
-  outlineColor?: ResponsiveValue<CSS.OutlineColorProperty>
+  outlineColor?: ResponsiveValue<CSS.Property.OutlineColor>
 }
 
 export const outline = system(config)

--- a/packages/styled-system/src/config/position.ts
+++ b/packages/styled-system/src/config/position.ts
@@ -55,43 +55,43 @@ export interface PositionProps {
   /**
    * The CSS `z-index` property
    */
-  zIndex?: ResponsiveValue<string | CSS.ZIndexProperty>
+  zIndex?: ResponsiveValue<string | CSS.Property.ZIndex>
   /**
    * The CSS `top` property
    */
-  top?: ResponsiveValue<CSS.TopProperty<Length>>
+  top?: ResponsiveValue<CSS.Property.Top<Length>>
   /**
    * The CSS `right` property
    */
-  right?: ResponsiveValue<CSS.RightProperty<Length>>
+  right?: ResponsiveValue<CSS.Property.Right<Length>>
   /**
    * The CSS `bottom` property
    */
-  bottom?: ResponsiveValue<CSS.BottomProperty<Length>>
+  bottom?: ResponsiveValue<CSS.Property.Bottom<Length>>
   /**
    * The CSS `left` property
    */
-  left?: ResponsiveValue<CSS.LeftProperty<Length>>
+  left?: ResponsiveValue<CSS.Property.Left<Length>>
   /**
    * The CSS `left`, `right`, `top`, `bottom` property
    */
-  inset?: ResponsiveValue<CSS.LeftProperty<Length>>
+  inset?: ResponsiveValue<CSS.Property.Left<Length>>
   /**
    * The CSS `left`, and `right` property
    */
-  insetX?: ResponsiveValue<CSS.LeftProperty<Length>>
+  insetX?: ResponsiveValue<CSS.Property.Left<Length>>
   /**
    * The CSS `top`, and `bottom` property
    */
-  insetY?: ResponsiveValue<CSS.LeftProperty<Length>>
+  insetY?: ResponsiveValue<CSS.Property.Left<Length>>
   /**
    * The CSS `position` property
    */
-  pos?: ResponsiveValue<CSS.PositionProperty>
+  pos?: ResponsiveValue<CSS.Property.Position>
   /**
    * The CSS `position` property
    */
-  position?: ResponsiveValue<CSS.PositionProperty>
+  position?: ResponsiveValue<CSS.Property.Position>
 }
 
 export const position = system(config)

--- a/packages/styled-system/src/config/shadow.ts
+++ b/packages/styled-system/src/config/shadow.ts
@@ -24,15 +24,15 @@ export interface ShadowProps {
   /**
    * The `box-shadow` property
    */
-  boxShadow?: ResponsiveValue<CSS.BoxShadowProperty | number>
+  boxShadow?: ResponsiveValue<CSS.Property.BoxShadow | number>
   /**
    * The `box-shadow` property
    */
-  shadow?: ResponsiveValue<CSS.BoxShadowProperty | number>
+  shadow?: ResponsiveValue<CSS.Property.BoxShadow | number>
   /**
    * The `text-shadow` property
    */
-  textShadow?: ResponsiveValue<CSS.TextShadowProperty | number>
+  textShadow?: ResponsiveValue<CSS.Property.TextShadow | number>
 }
 
 export const shadow = system(config)

--- a/packages/styled-system/src/config/space.ts
+++ b/packages/styled-system/src/config/space.ts
@@ -138,115 +138,115 @@ export interface SpaceProps {
   /**
    * Margin on top, left, bottom and right
    */
-  m?: ResponsiveValue<CSS.MarginProperty<Length>>
+  m?: ResponsiveValue<CSS.Property.Margin<Length>>
   /**
    * Margin on top, left, bottom and right
    */
-  margin?: ResponsiveValue<CSS.MarginProperty<Length>>
+  margin?: ResponsiveValue<CSS.Property.Margin<Length>>
   /**
    * Margin on top
    */
-  mt?: ResponsiveValue<CSS.MarginProperty<Length>>
+  mt?: ResponsiveValue<CSS.Property.Margin<Length>>
   /**
    * Margin on top
    */
-  marginTop?: ResponsiveValue<CSS.MarginTopProperty<Length>>
+  marginTop?: ResponsiveValue<CSS.Property.MarginTop<Length>>
   /**
    * Margin on right
    */
-  mr?: ResponsiveValue<CSS.MarginRightProperty<Length>>
+  mr?: ResponsiveValue<CSS.Property.MarginRight<Length>>
   /**
    * Margin on right
    */
-  marginRight?: ResponsiveValue<CSS.MarginRightProperty<Length>>
+  marginRight?: ResponsiveValue<CSS.Property.MarginRight<Length>>
   /**
    * Margin on bottom
    */
-  mb?: ResponsiveValue<CSS.MarginBottomProperty<Length>>
+  mb?: ResponsiveValue<CSS.Property.MarginBottom<Length>>
   /**
    * Margin on bottom
    */
-  marginBottom?: ResponsiveValue<CSS.MarginBottomProperty<Length>>
+  marginBottom?: ResponsiveValue<CSS.Property.MarginBottom<Length>>
   /**
    * Margin on left
    */
-  ml?: ResponsiveValue<CSS.MarginLeftProperty<Length>>
+  ml?: ResponsiveValue<CSS.Property.MarginLeft<Length>>
   /**
    * Margin on left
    */
-  marginLeft?: ResponsiveValue<CSS.MarginLeftProperty<Length>>
+  marginLeft?: ResponsiveValue<CSS.Property.MarginLeft<Length>>
   /**
    * Margin on left and right
    */
-  mx?: ResponsiveValue<CSS.MarginProperty<Length>>
+  mx?: ResponsiveValue<CSS.Property.Margin<Length>>
   /**
    * Margin on left and right
    */
-  marginX?: ResponsiveValue<CSS.MarginProperty<Length>>
+  marginX?: ResponsiveValue<CSS.Property.Margin<Length>>
   /**
    * Margin on top and bottom
    */
-  my?: ResponsiveValue<CSS.MarginProperty<Length>>
+  my?: ResponsiveValue<CSS.Property.Margin<Length>>
   /**
    * Margin on top and bottom
    */
-  marginY?: ResponsiveValue<CSS.MarginProperty<Length>>
+  marginY?: ResponsiveValue<CSS.Property.Margin<Length>>
   /**
    * Padding on top, left, bottom and right
    */
-  p?: ResponsiveValue<CSS.PaddingProperty<Length>>
+  p?: ResponsiveValue<CSS.Property.Padding<Length>>
   /**
    * Padding on top, left, bottom and right
    */
-  padding?: ResponsiveValue<CSS.PaddingProperty<Length>>
+  padding?: ResponsiveValue<CSS.Property.Padding<Length>>
   /**
    * Padding on top
    */
-  pt?: ResponsiveValue<CSS.PaddingTopProperty<Length>>
+  pt?: ResponsiveValue<CSS.Property.PaddingTop<Length>>
   /**
    * Padding on top
    */
-  paddingTop?: ResponsiveValue<CSS.PaddingTopProperty<Length>>
+  paddingTop?: ResponsiveValue<CSS.Property.PaddingTop<Length>>
   /**
    * Padding on right
    */
-  pr?: ResponsiveValue<CSS.PaddingRightProperty<Length>>
+  pr?: ResponsiveValue<CSS.Property.PaddingRight<Length>>
   /**
    * Padding on right
    */
-  paddingRight?: ResponsiveValue<CSS.PaddingRightProperty<Length>>
+  paddingRight?: ResponsiveValue<CSS.Property.PaddingRight<Length>>
   /**
    * Padding on bottom
    */
-  pb?: ResponsiveValue<CSS.PaddingBottomProperty<Length>>
+  pb?: ResponsiveValue<CSS.Property.PaddingBottom<Length>>
   /**
    * Padding on bottom
    */
-  paddingBottom?: ResponsiveValue<CSS.PaddingBottomProperty<Length>>
+  paddingBottom?: ResponsiveValue<CSS.Property.PaddingBottom<Length>>
   /**
    * Padding on left
    */
-  pl?: ResponsiveValue<CSS.PaddingLeftProperty<Length>>
+  pl?: ResponsiveValue<CSS.Property.PaddingLeft<Length>>
   /**
    * Padding on left
    */
-  paddingLeft?: ResponsiveValue<CSS.PaddingLeftProperty<Length>>
+  paddingLeft?: ResponsiveValue<CSS.Property.PaddingLeft<Length>>
   /**
    * Padding on left and right
    */
-  px?: ResponsiveValue<CSS.PaddingProperty<Length>>
+  px?: ResponsiveValue<CSS.Property.Padding<Length>>
   /**
    * Padding on left and right
    */
-  paddingX?: ResponsiveValue<CSS.PaddingProperty<Length>>
+  paddingX?: ResponsiveValue<CSS.Property.Padding<Length>>
   /**
    * Padding on top and bottom
    */
-  py?: ResponsiveValue<CSS.PaddingProperty<Length>>
+  py?: ResponsiveValue<CSS.Property.Padding<Length>>
   /**
    * Padding on top and bottom
    */
-  paddingY?: ResponsiveValue<CSS.PaddingProperty<Length>>
+  paddingY?: ResponsiveValue<CSS.Property.Padding<Length>>
 }
 
 /**

--- a/packages/styled-system/src/config/transform.ts
+++ b/packages/styled-system/src/config/transform.ts
@@ -11,11 +11,11 @@ export interface TransformProps {
   /**
    * The CSS `transform` property
    */
-  transform?: ResponsiveValue<CSS.TransformProperty>
+  transform?: ResponsiveValue<CSS.Property.Transform>
   /**
    * The CSS `transform-origin` property
    */
-  transformOrigin?: ResponsiveValue<CSS.TransformOriginProperty<Length>>
+  transformOrigin?: ResponsiveValue<CSS.Property.TransformOrigin<Length>>
 }
 
 export const transform = system(config)

--- a/packages/styled-system/src/config/transition.ts
+++ b/packages/styled-system/src/config/transition.ts
@@ -22,16 +22,16 @@ export interface TransitionProps {
   /**
    * The CSS `transition` property
    */
-  transition?: ResponsiveValue<CSS.TransitionProperty>
+  transition?: ResponsiveValue<CSS.Property.Transition>
   /**
    * The CSS `transition-property` property
    */
-  transitionProperty?: ResponsiveValue<CSS.TransitionPropertyProperty>
+  transitionProperty?: ResponsiveValue<CSS.Property.TransitionProperty>
   /**
    * The CSS `transition-timing-function` property
    */
   transitionTimingFunction?: ResponsiveValue<
-    CSS.TransitionTimingFunctionProperty
+    CSS.Property.TransitionTimingFunction
   >
   /**
    * The CSS `transition-duration` property

--- a/packages/styled-system/src/config/typography.ts
+++ b/packages/styled-system/src/config/typography.ts
@@ -45,55 +45,55 @@ export interface TypographyProps {
   /**
    * The CSS `line-height` property
    */
-  lineHeight?: ResponsiveValue<CSS.LineHeightProperty<Length>>
+  lineHeight?: ResponsiveValue<CSS.Property.LineHeight<Length>>
   /**
    * The CSS `line-height` property
    */
-  letterSpacing?: ResponsiveValue<CSS.LetterSpacingProperty<Length>>
+  letterSpacing?: ResponsiveValue<CSS.Property.LetterSpacing<Length>>
   /**
    * The CSS `font-size` property
    */
-  fontSize?: ResponsiveValue<CSS.FontSizeProperty<Length>>
+  fontSize?: ResponsiveValue<CSS.Property.FontSize<Length>>
   /**
    * The CSS `font-family` property
    */
-  fontFamily?: ResponsiveValue<CSS.FontFamilyProperty>
+  fontFamily?: ResponsiveValue<CSS.Property.FontFamily>
   /**
    * The CSS `text-align` property
    */
-  textAlign?: ResponsiveValue<CSS.TextAlignProperty>
+  textAlign?: ResponsiveValue<CSS.Property.TextAlign>
   /**
    * The CSS `font-style` property
    */
-  fontStyle?: ResponsiveValue<CSS.FontStyleProperty>
+  fontStyle?: ResponsiveValue<CSS.Property.FontStyle>
   /**
    * The CSS `word-break` property
    */
-  wordBreak?: ResponsiveValue<CSS.WordBreakProperty>
+  wordBreak?: ResponsiveValue<CSS.Property.WordBreak>
   /**
    * The CSS `overflow-wrap` property
    */
-  overflowWrap?: ResponsiveValue<CSS.OverflowWrapProperty>
+  overflowWrap?: ResponsiveValue<CSS.Property.OverflowWrap>
   /**
    * The CSS `text-overflow` property
    */
-  textOverflow?: ResponsiveValue<CSS.TextOverflowProperty>
+  textOverflow?: ResponsiveValue<CSS.Property.TextOverflow>
   /**
    * The CSS `text-transform` property
    */
-  textTransform?: ResponsiveValue<CSS.TextTransformProperty>
+  textTransform?: ResponsiveValue<CSS.Property.TextTransform>
   /**
    * The CSS `white-space` property
    */
-  whiteSpace?: ResponsiveValue<CSS.WhiteSpaceProperty>
+  whiteSpace?: ResponsiveValue<CSS.Property.WhiteSpace>
   /**
    * The CSS `text-decoration` property
    */
-  textDecoration?: ResponsiveValue<CSS.TextDecorationProperty<Length>>
+  textDecoration?: ResponsiveValue<CSS.Property.TextDecoration<Length>>
   /**
    * The CSS `text-decoration` property
    */
-  textDecor?: ResponsiveValue<CSS.TextDecorationProperty<Length>>
+  textDecor?: ResponsiveValue<CSS.Property.TextDecoration<Length>>
 }
 
 export const typography = system(config)

--- a/packages/styled-system/src/css.types.ts
+++ b/packages/styled-system/src/css.types.ts
@@ -2,13 +2,11 @@ import { ResponsiveValue } from "./utils"
 import { Omit, Dict } from "@chakra-ui/utils"
 import { Pseudos } from "./pseudo"
 import {
-  BoxShadowProperty,
-  FontWeightProperty,
+  Property,
   PropertiesFallback,
   Pseudos as CSSPseudos,
   StandardProperties,
   SvgProperties,
-  ZIndexProperty,
 } from "csstype"
 
 type CSS = PropertiesFallback<number | string>
@@ -90,9 +88,9 @@ interface AliasesCSSProperties {
 }
 
 interface OverwriteCSSProperties {
-  boxShadow?: BoxShadowProperty | number
-  fontWeight?: FontWeightProperty | string
-  zIndex?: ZIndexProperty | string
+  boxShadow?: Property.BoxShadow | number
+  fontWeight?: Property.FontWeight | string
+  zIndex?: Property.ZIndex | string
 }
 
 interface AllSystemCSSProperties

--- a/packages/styled-system/src/parser.types.ts
+++ b/packages/styled-system/src/parser.types.ts
@@ -39,20 +39,20 @@ interface Component {
 
 export interface BaseTheme {
   breakpoints?: Record<string, Length> | Length[]
-  space?: ThemeValue<CSS.MarginProperty<Length>>
-  fontSizes?: ThemeValue<CSS.FontSizeProperty<Length>>
-  colors?: ThemeValue<CSS.ColorProperty>
-  fonts?: ThemeValue<CSS.FontFamilyProperty>
-  fontWeights?: ThemeValue<CSS.FontWeightProperty>
-  lineHeights?: ThemeValue<CSS.LineHeightProperty<Length>>
-  letterSpacings?: ThemeValue<CSS.LetterSpacingProperty<Length>>
-  sizes?: ThemeValue<CSS.HeightProperty<Length> | CSS.WidthProperty<Length>>
-  borders?: ThemeValue<CSS.BorderProperty<Length>>
-  borderStyles?: ThemeValue<CSS.BorderStyleProperty>
-  borderWidths?: ThemeValue<CSS.BorderWidthProperty<Length>>
-  radii?: ThemeValue<CSS.BorderRadiusProperty<Length>>
-  shadows?: ThemeValue<CSS.BoxShadowProperty>
-  zIndices?: ThemeValue<CSS.ZIndexProperty>
+  space?: ThemeValue<CSS.Property.Margin<Length>>
+  fontSizes?: ThemeValue<CSS.Property.FontSize<Length>>
+  colors?: ThemeValue<CSS.Property.Color>
+  fonts?: ThemeValue<CSS.Property.FontFamily>
+  fontWeights?: ThemeValue<CSS.Property.FontWeight>
+  lineHeights?: ThemeValue<CSS.Property.LineHeight<Length>>
+  letterSpacings?: ThemeValue<CSS.Property.LetterSpacing<Length>>
+  sizes?: ThemeValue<CSS.Property.Height<Length> | CSS.Property.Width<Length>>
+  borders?: ThemeValue<CSS.Property.Border<Length>>
+  borderStyles?: ThemeValue<CSS.Property.BorderStyle>
+  borderWidths?: ThemeValue<CSS.Property.BorderWidth<Length>>
+  radii?: ThemeValue<CSS.Property.BorderRadius<Length>>
+  shadows?: ThemeValue<CSS.Property.BoxShadow>
+  zIndices?: ThemeValue<CSS.Property.ZIndex>
   components?: {
     [component: string]: Component
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8293,20 +8293,15 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
-  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+csstype@3.0.2, csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
-
-csstype@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
-  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
The purpose of this PR is to bring TypeScript hack for autocompletion for literal string/number unions with csstype v3 [https://github.com/frenic/csstype](https://github.com/frenic/csstype)

## chakra-ui - csstype v2 without any literal string/number unions
![Screenshot from 2020-08-09 14-25-15](https://user-images.githubusercontent.com/62163604/89728577-59fdbd80-da58-11ea-955c-9df383dc2567.png)

## Latest React 16.9 with csstype v3
![Screenshot from 2020-08-09 14-25-47](https://user-images.githubusercontent.com/62163604/89728579-5b2eea80-da58-11ea-9a19-9262a4f185ad.png)
===
##  chakra-ui - csstype v3
![Screenshot from 2020-08-09 15-53-44](https://user-images.githubusercontent.com/62163604/89728596-89142f00-da58-11ea-85bc-160a3bafab15.png)
