### PR TITLE
docs(installation): add CRA templates guide note

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -5,6 +5,9 @@ description: How to install and set up Chakra UI in your local project
 
 **First, you need to install Chakra UI**
 
+> For `create-react-app` installation instructions, see the
+> [official CRA templates guide](/guides/integrations/with-cra) instead.
+
 ```bash
 npm i @chakra-ui/core@next
 


### PR DESCRIPTION
This PR adds a note to the Installation page pointing CRA users to the official CRA templates guide.

![image](https://user-images.githubusercontent.com/1954752/89735936-e9dd4080-da33-11ea-8dde-012650de17f0.png)
