### PR TITLE
chore(website): fix 'git log' error and add --follow flag

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -48,6 +48,8 @@ async function getLastEdited(filePath) {
       "log",
       "-1",
       "--format=%ct, %an",
+      "--follow",
+      "--",
       filePath,
     ])
     return getTimestampAndAuthor(stdout)


### PR DESCRIPTION
This PR fixes the `git log` error when running the website, and adds the `--follow` flag which makes `git` follow file renames when sourcing log information.