### PR TITLE
feat(input): Add zIndex: 1 to focused input (v0 behaviour)

### DIFF
--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -79,6 +79,7 @@ const input = multiStyleConfig({
             cursor: "not-allowed",
           },
           _focus: {
+            zIndex: 1,
             borderColor: getColor(theme, fc),
             boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
           },


### PR DESCRIPTION
This brings the v1 input element in line with the v0 input element's behaviour of raising it's zIndex when it's focused. This is useful for when you have multiple inputs stacked on top of each other.

For reference, this is the `_focus` style for the v0 input: https://github.com/chakra-ui/chakra-ui/blob/v0/packages/chakra-ui/src/Input/styles.js#L45

Here's a comparison of the behaviour of v0 and v1 inputs:

**v0**

![fac6e3ebd7dfe6aced0457ca4d8c011f](https://user-images.githubusercontent.com/1216917/89738049-72ef7a00-da2a-11ea-9efa-f5652c58801f.gif)

**v1**

![4ad7d80dfc1078d5a32be34bc4c51189](https://user-images.githubusercontent.com/1216917/89738030-53f0e800-da2a-11ea-91fc-14aaca55bfc8.gif)
