### PR TITLE
feat(docs): add size hints in Text's and Heading's documentation

### DIFF
--- a/website/pages/docs/typography/heading.mdx
+++ b/website/pages/docs/typography/heading.mdx
@@ -5,6 +5,7 @@ description: Headings are used for rendering headlines.
 ---
 
 import ComponentLinks from "../../../src/components/component-links"
+import { Box } from "@chakra-ui/core"
 
 Headings are used for rendering headlines.
 
@@ -40,22 +41,22 @@ decrease in size for smaller screens.
 ```jsx
 <Stack spacing={3}>
   <Heading as="h1" size="2xl">
-    In love with React & Next
+    (2xl) In love with React & Next
   </Heading>
   <Heading as="h2" size="xl">
-    In love with React & Next
+    (xl) In love with React & Next
   </Heading>
   <Heading as="h3" size="lg">
-    In love with React & Next
+    (lg) In love with React & Next
   </Heading>
   <Heading as="h4" size="md">
-    In love with React & Next
+    (md) In love with React & Next
   </Heading>
   <Heading as="h5" size="sm">
-    In love with React & Next
+    (sm) In love with React & Next
   </Heading>
   <Heading as="h6" size="xs">
-    In love with React & Next
+    (xs) In love with React & Next
   </Heading>
 </Stack>
 ```

--- a/website/pages/docs/typography/text.mdx
+++ b/website/pages/docs/typography/text.mdx
@@ -29,16 +29,16 @@ To increase the font size of the text, you can pass the `fontSize` prop.
 
 ```jsx
 <Stack spacing={3}>
-  <Text fontSize="6xl">In love with React & Next</Text>
-  <Text fontSize="5xl">In love with React & Next</Text>
-  <Text fontSize="4xl">In love with React & Next</Text>
-  <Text fontSize="3xl">In love with React & Next</Text>
-  <Text fontSize="2xl">In love with React & Next</Text>
-  <Text fontSize="xl">In love with React & Next</Text>
-  <Text fontSize="lg">In love with React & Next</Text>
-  <Text fontSize="md">In love with React & Next</Text>
-  <Text fontSize="sm">In love with React & Next</Text>
-  <Text fontSize="xs">In love with React & Next</Text>
+  <Text fontSize="6xl">(6xl) In love with React & Next</Text>
+  <Text fontSize="5xl">(5xl) In love with React & Next</Text>
+  <Text fontSize="4xl">(4xl) In love with React & Next</Text>
+  <Text fontSize="3xl">(3xl) In love with React & Next</Text>
+  <Text fontSize="2xl">(2xl) In love with React & Next</Text>
+  <Text fontSize="xl">(xl) In love with React & Next</Text>
+  <Text fontSize="lg">(lg) In love with React & Next</Text>
+  <Text fontSize="md">(md) In love with React & Next</Text>
+  <Text fontSize="sm">(sm) In love with React & Next</Text>
+  <Text fontSize="xs">(xs) In love with React & Next</Text>
 </Stack>
 ```
 


### PR DESCRIPTION
Hi! This is my first contribution to Chakra UI!

This PR adds little hints on the side of the `<Text />` and `<Heading />` documentation that correspond to the appropriate size. It makes it easier to know which size corresponds to which line of the example, instead of having to count!

Before:
![image](https://user-images.githubusercontent.com/1344906/89739824-91865d00-da8c-11ea-833d-72085dcc67c5.png)
![image](https://user-images.githubusercontent.com/1344906/89739843-a06d0f80-da8c-11ea-9e86-523ac82e9e7f.png)

After:
![image](https://user-images.githubusercontent.com/1344906/89739853-b11d8580-da8c-11ea-8f32-7234d659fcd9.png)
![image](https://user-images.githubusercontent.com/1344906/89739862-cabecd00-da8c-11ea-88c0-cb390867a42f.png)
