### PR TITLE
chore(issue-templates): add js+ts codesandbox template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,6 +18,11 @@ happen.
 **Link to minimal reproduction** Please provide a codesandbox link or GitHub
 repo with a minimal reproduction of the issue.
 
+- JavaScript CodeSandbox template:
+  https://codesandbox.io/s/github/chakra-ui/codesandbox-react-js-template/tree/master
+- TypeScript CodeSandbox template:
+  https://codesandbox.io/s/github/chakra-ui/codesandbox-react-ts-template/tree/master
+
 **Steps to Reproduce** Clear and concise reproduction instructions are important
 for us to be able to triage your issue in a timely manner.
 


### PR DESCRIPTION
This PR adds a link to codesandbox js+ts templates to the bug report issue template. Hopefully this will make it easier for users to provide reproductions when creating issues.

This templates mirror our https://github.com/chakra-ui/codesandbox-react-js-template and https://github.com/chakra-ui/codesandbox-react-ts-template repos.