### PR TITLE
fix(color-mode): catch when localStorage is disabled

### DIFF
--- a/packages/color-mode/src/storage-manager.ts
+++ b/packages/color-mode/src/storage-manager.ts
@@ -13,16 +13,32 @@ export interface StorageManager {
  */
 export const localStorageManager: StorageManager = {
   get(init?) {
-    const exist =
-      isStorageSupported && !!window.localStorage.getItem(storageKey)
+    try {
+      const exist =
+        isStorageSupported && !!window.localStorage.getItem(storageKey)
 
-    const value = exist ? window.localStorage.getItem(storageKey) : init
+      const value = exist ? window.localStorage.getItem(storageKey) : init
 
-    return value as ColorMode | undefined
+      return value as ColorMode | undefined
+    } catch (err) {
+      console.warn(
+        "localStorage is disabled and color mode might not work as expected.",
+        "Please check your Browser Settings.",
+        err,
+      )
+    }
   },
   set(value) {
-    if (isStorageSupported) {
-      window.localStorage.setItem(storageKey, value)
+    try {
+      if (isStorageSupported) {
+        window.localStorage.setItem(storageKey, value)
+      }
+    } catch (err) {
+      console.warn(
+        "localStorage is disabled and color mode might not work as expected.",
+        "Please check your Browser Settings.",
+        err,
+      )
     }
   },
 }

--- a/packages/color-mode/tests/use-color-mode-state.test.ts
+++ b/packages/color-mode/tests/use-color-mode-state.test.ts
@@ -1,0 +1,18 @@
+import { renderHook } from "@chakra-ui/test-utils"
+import { useColorModeState } from "../src/use-color-mode-state"
+
+test("should warn instead of throwing when localStorage is disabled", () => {
+  console.warn = jest.fn()
+  Object.defineProperty(window, "localStorage", {
+    get: jest.fn(() => {
+      throw "SecurityError: The operation is insecure."
+    }),
+  })
+
+  const { result } = renderHook(() =>
+    useColorModeState({ initialColorMode: "light" }),
+  )
+  const [mode, setMode] = result.current
+  expect(mode).toBe("light")
+  expect(console.warn).toHaveBeenCalled()
+})


### PR DESCRIPTION
This PR catches error when localStorage is disabled by browser setting. Currently, when localStorageManager tries to access disabled localStorage, it throws an error.
 
On Google Chrome,
```
Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
```

On FireFox,
```
window.localStorage is null
```

Instead, it will output warning to console.

Reference: This is how [theme-ui](https://github.com/system-ui/theme-ui) handle this type of error. https://github.com/system-ui/theme-ui/blob/a96e723bad9c0d8b03c858698045acf01587cf9d/packages/color-modes/src/index.js#L9-L32
