### PR TITLE
Refactor: Remove as infer to speed up intellisense

### DIFF
--- a/packages/pin-input/src/pin-input.tsx
+++ b/packages/pin-input/src/pin-input.tsx
@@ -60,7 +60,7 @@ if (__DEV__) {
 export interface PinInputFieldProps extends PropsOf<typeof chakra.input> {}
 
 export const PinInputField = forwardRef<PinInputFieldProps, "input">(
-  function PinInputField(props, ref) {
+  function PinInputField(props, ref: any) {
     const inputProps = usePinInputField({ ref, ...props })
     return (
       <chakra.input

--- a/packages/system/src/forward-ref.tsx
+++ b/packages/system/src/forward-ref.tsx
@@ -2,6 +2,7 @@
  * All credit goes to Chance (Reach UI), and Haz (Reakit) for this
  */
 import * as React from "react"
+import { ChakraProps } from "."
 
 export type AssignableRef<T> =
   | {
@@ -12,13 +13,9 @@ export type AssignableRef<T> =
 
 type As<P = any> = React.ElementType<P>
 
-export type PropsWithAs<T extends As, P> = P &
-  Omit<React.ComponentPropsWithRef<T>, "as" | "color" | keyof P> & {
-    as?: T
-  }
-
-export type PropsFromAs<T extends As, P> = (PropsWithAs<T, P> & { as: T }) &
-  PropsWithAs<T, P>
+export type PropsWithAs<P> = P & {
+  as?: As
+}
 
 export type ComponentWithForwardedRef<
   T extends React.ElementType,
@@ -27,13 +24,16 @@ export type ComponentWithForwardedRef<
   P & React.HTMLProps<React.ElementType<T>> & React.ComponentPropsWithRef<T>
 >
 
-export interface ComponentWithAs<T extends As, P> {
-  <TT extends As>(props: PropsWithAs<TT, P>): React.ReactElement | null
-  (props: PropsWithAs<T, P>): React.ReactElement | null
+export interface ChakraComponent<T extends As, P> {
+  (
+    props: { as?: As } & Omit<React.ComponentProps<T>, keyof P> &
+      Omit<ChakraProps, keyof P> &
+      P,
+  ): React.ReactElement | null
   displayName?: string
-  propTypes?: React.WeakValidationMap<PropsWithAs<T, P>>
+  propTypes?: React.WeakValidationMap<PropsWithAs<P>>
   contextTypes?: React.ValidationMap<any>
-  defaultProps?: Partial<PropsWithAs<T, P>>
+  defaultProps?: Partial<PropsWithAs<P>>
   /**
    * @private
    */
@@ -42,12 +42,9 @@ export interface ComponentWithAs<T extends As, P> {
 
 export function forwardRef<P, T extends As>(
   comp: (
-    props: PropsFromAs<T, Omit<P, "children" | "as">>,
+    props: { as?: As } & React.ComponentProps<T> & P & ChakraProps,
     ref: React.RefObject<any>,
   ) => React.ReactElement | null,
-) {
-  return (React.forwardRef(comp as any) as unknown) as ComponentWithAs<
-    T,
-    Omit<P, "children" | "as">
-  >
+): ChakraComponent<T, P> {
+  return React.forwardRef(comp as any) as any
 }

--- a/packages/system/src/system.ts
+++ b/packages/system/src/system.ts
@@ -36,7 +36,10 @@ const base = cast((baseStyle: any) => (props: any) =>
   css(baseStyle)(props.theme),
 )
 
-export function styled<T extends As, P = {}>(component: T, options?: Options) {
+export function styled<T extends As, P = {}>(
+  component: T,
+  options?: Options,
+): ChakraComponent<T, P> {
   const { baseStyle, ...styledOptions } = options || {}
   return createStyled(component as any, {
     ...styledOptions,

--- a/packages/system/src/system.types.ts
+++ b/packages/system/src/system.types.ts
@@ -2,7 +2,9 @@ import { ColorMode } from "@chakra-ui/color-mode"
 import { SystemProps, SystemStyleObject } from "@chakra-ui/styled-system"
 import { Dict } from "@chakra-ui/utils"
 import * as React from "react"
-import { ComponentWithAs } from "./forward-ref"
+import { ChakraComponent } from "./forward-ref"
+
+export { ChakraComponent }
 
 interface ColorModeProps {
   colorMode?: ColorMode
@@ -69,9 +71,6 @@ export type As = React.ElementType<any>
 export type PropsOf<T extends As> = React.ComponentProps<T>
 
 export type WithChakra<P> = P & ChakraProps
-
-export interface ChakraComponent<T extends As, P>
-  extends ComponentWithAs<T, WithChakra<P>> {}
 
 export interface UseStyleConfigOptions<P = {}> {
   parts?: string[]

--- a/packages/system/src/system.utils.ts
+++ b/packages/system/src/system.utils.ts
@@ -18,6 +18,7 @@ import { FunctionInterpolation } from "@emotion/core"
  */
 export const domElements = [
   "a",
+  "video",
   "article",
   "aside",
   "blockquote",


### PR DESCRIPTION
Now it takes much less time to populate auto completion suggestions, 

We can still do much better typing the component directly instead of relying on `forwardRef` and `ChakraComponent`, after that intellisense is instantaneous

Closes #1582 
