### PR TITLE
fix(core): flip load order of CSSReset and GlobalStyles

### DIFF
--- a/packages/core/src/chakra-provider.tsx
+++ b/packages/core/src/chakra-provider.tsx
@@ -52,8 +52,8 @@ export const ChakraProvider: React.FC<ChakraProviderProps> = (props) => {
         useSystemColorMode={theme?.config?.useSystemColorMode}
         storageManager={storageManager}
       >
-        <GlobalStyle />
         {resetCSS && <CSSReset />}
+        <GlobalStyle />
         {portalConfig ? (
           <PortalManager zIndex={portalConfig?.zIndex}>
             {children}


### PR DESCRIPTION
This PR offers a possible fix for #1608, flipping the load order of `CSSReset` and `GlobalStyles` in `ChakraProvider`. This issue surfaced as a side-effect of a recent improvement. More context is available on the [issue](https://github.com/chakra-ui/chakra-ui/issues/1608).

One observation from debugging this, is that it seems like the correct way to apply the CSS reset going forward is to use the `resetCSS` prop on `ChakraProvider`, rather than including the `<CSSReset />` component directly – is that correct?