### PR TITLE
fix(toast): improve type and layout style with relative units from theme

### DIFF
--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -79,20 +79,19 @@ const Toast: React.FC<any> = (props) => {
       status={status}
       variant={variant}
       id={id}
-      textAlign="left"
-      boxShadow="lg"
-      borderRadius="md"
       alignItems="start"
+      borderRadius="md"
+      boxShadow="lg"
       margin={2}
       paddingRight={8}
+      textAlign="left"
+      width="auto"
     >
       <AlertIcon />
       <chakra.div flex="1">
         {title && <AlertTitle>{title}</AlertTitle>}
         {description && (
-          <AlertDescription marginTop="px" lineHeight="short">
-            {description}
-          </AlertDescription>
+          <AlertDescription display="block">{description}</AlertDescription>
         )}
       </chakra.div>
       {isClosable && (
@@ -100,8 +99,8 @@ const Toast: React.FC<any> = (props) => {
           size="sm"
           onClick={onClose}
           position="absolute"
-          right="4px"
-          top="4px"
+          right={1}
+          top={1}
         />
       )}
     </Alert>


### PR DESCRIPTION
This PR fixes the alignment issue in #1183, preventing the right edge of right-aligned toasts from getting cut off.

### Previous

<img width="1125" alt="Screen Shot 2020-09-08 at 1 47 40 PM" src="https://user-images.githubusercontent.com/180438/92526575-9567e500-f1da-11ea-97bf-d7675df74fea.png">

---

### Updated

<img width="1121" alt="Screen Shot 2020-09-08 at 1 48 51 PM" src="https://user-images.githubusercontent.com/180438/92526660-b8929480-f1da-11ea-939d-437f58b8e310.png">