### PR TITLE
fix(Icon): custom icon library viewBox

### DIFF
--- a/packages/icon/src/icon.tsx
+++ b/packages/icon/src/icon.tsx
@@ -48,15 +48,16 @@ export const Icon = forwardRef<IconProps, "svg">(function Icon(props, ref) {
     className: _className,
   }
 
+  const _viewBox = viewBox ?? fallbackIcon.viewBox
+
   /**
    * If you're using an icon library like `react-icons`
    */
   if (element && typeof element !== "string") {
-    return <chakra.svg as={element} {...shared} {...rest} />
+    return <chakra.svg as={element} viewBox={_viewBox} {...shared} {...rest} />
   }
 
   const _path = (children ?? fallbackIcon.path) as React.ReactNode
-  const _viewBox = viewBox ?? fallbackIcon.viewBox
 
   return (
     <chakra.svg verticalAlign="middle" viewBox={_viewBox} {...shared} {...rest}>


### PR DESCRIPTION
When I passing `viewBox` prop to change icon library default viewBox, still is got default `0 0 24 24`, so I hoisting `_viewBox` argument.