### PR TITLE
docs: fix package name in the migration guide

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -51,9 +51,9 @@ code, you can safely remove them and update Chakra UI to v1.
 ```diff
 "dependencies": {
   "@chakra-ui/core": "next",
+-  "@emotion/core": "10.x",
 -  "@emotion/styled": "10.X",
--  "@emotion/theming": "10.x",
--  "@emotion/core": "10.x"
+-  "emotion-theming": "10.x"
 }
 ```
 


### PR DESCRIPTION
Just a trivial typo. It should be `emotion-theming` instead of `@emotion/theming`.
By default the packages are ordered alphabetically, so I also updated the ordering here.