### PR TITLE
fix onChange callback activation on NumberInput

### DIFF
--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -245,7 +245,9 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
      * - sanitize the value by using parseFloat and some Regex
      * - used to round value to computed precision or decimal points
      */
-    counter.cast(next)
+    if (counter.value !== next) {
+      counter.cast(next)
+    }
   }, [counter, max, min])
 
   const onBlur = useCallback(() => {


### PR DESCRIPTION
### Description

Fixes #1649:
> When number input is not empty, `onChange` callback is fired on each input blur, regardless of whether there was an actual change/input.
> 
> Happens both in controlled and uncontrolled mode.
> 
> Reproduction: https://codesandbox.io/s/numberinput-onchange-is-called-on-every-blur-1s72h?file=/src/index.js
> Version: 1.0.0-rc.2 (does not happen in v0.8.0)

### How has this been tested?
It was tested with the [mentioned sample code (Reproduction)](https://codesandbox.io/s/numberinput-onchange-is-called-on-every-blur-1s72h?file=/src/index.js)