### PR TITLE
Performance: Add isLazy property to Tabs

### DIFF
--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -57,6 +57,12 @@ export interface UseTabsProps {
    * The id of the tab
    */
   id?: string
+  /**
+   * Performance 🚀:
+   * If `true`, the MenuItem rendering will be deferred
+   * until the menu is open.
+   */
+  isLazy?: boolean
 }
 
 /**
@@ -74,6 +80,7 @@ export function useTabs(props: UseTabsProps) {
     onChange,
     index,
     isManual,
+    isLazy,
     orientation = "horizontal",
     ...htmlProps
   } = props
@@ -157,6 +164,7 @@ export function useTabs(props: UseTabsProps) {
     setSelectedIndex,
     setFocusedIndex,
     isManual,
+    isLazy,
     orientation,
     enabledDomContext,
     domContext,
@@ -378,8 +386,11 @@ export function useTabPanels<P extends UseTabPanelsProps>(props: P) {
  */
 export function useTabPanel(props: Dict) {
   const { isSelected, id, ...htmlProps } = props
+  const { isLazy } = useTabsContext()
+
   return {
     ...htmlProps,
+    children: !isLazy || isSelected ? props.children : null,
     role: "tabpanel",
     hidden: !isSelected,
     id,

--- a/packages/tabs/tests/tabs.test.tsx
+++ b/packages/tabs/tests/tabs.test.tsx
@@ -1,4 +1,4 @@
-import { axe, fireEvent, render } from "@chakra-ui/test-utils"
+import { axe, fireEvent, render, screen } from "@chakra-ui/test-utils"
 import * as React from "react"
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from "../src"
 
@@ -138,4 +138,31 @@ test("focuses the correct tab with manual keyboard navigation", async () => {
   expect(tab2).toHaveFocus()
   expect(tab2).not.toHaveAttribute("aria-selected")
   expect(panel2).not.toBeVisible()
+})
+
+test("renders only the currently active tab panel if isLazy", () => {
+  render(
+    <Tabs isLazy>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <p>Panel 1</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Panel 2</p>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>,
+  )
+
+  expect(screen.getByText("Panel 1")).toBeInTheDocument()
+  expect(screen.queryByText("Panel 2")).not.toBeInTheDocument()
+
+  fireEvent.click(screen.getByText("Tab 2"))
+
+  expect(screen.queryByText("Panel 1")).not.toBeInTheDocument()
+  expect(screen.getByText("Panel 2")).toBeInTheDocument()
 })

--- a/website/pages/docs/components/tabs.mdx
+++ b/website/pages/docs/components/tabs.mdx
@@ -310,6 +310,31 @@ tab by pressing <kbd>Space</kbd> or <kbd>Enter</kbd>.
 </Tabs>
 ```
 
+### Lazily mounting tab panels
+
+By default, the Tabs component renders all tabs to the DOM If you'd like to only mount the contents of a `TabPanel` to the DOM at once.
+If you want to defer rendering of content until the tab is activated/clicked/selected, you can use the `isLazy` property.
+In this way, the tab content will not be mounted to the DOM until it is open.
+
+```jsx
+<Tabs isLazy>
+  <TabList>
+    <Tab>One</Tab>
+    <Tab>Two</Tab>
+  </TabList>
+  <TabPanels>
+    {/* initially mounted */}
+    <TabPanel>
+      <p>one!</p>
+    </TabPanel>
+    {/* initially not mounted */}
+    <TabPanel>
+      <p>two!</p>
+    </TabPanel>
+  </TabPanels>
+</Tabs>
+```
+
 ### Controlled Tabs
 
 Like form inputs, a tab's state can be controlled. Make sure to include an

--- a/website/pages/docs/components/tabs.mdx
+++ b/website/pages/docs/components/tabs.mdx
@@ -312,9 +312,9 @@ tab by pressing <kbd>Space</kbd> or <kbd>Enter</kbd>.
 
 ### Lazily mounting tab panels
 
-By default, the Tabs component renders all tabs to the DOM If you'd like to only mount the contents of a `TabPanel` to the DOM at once.
-If you want to defer rendering of content until the tab is activated/clicked/selected, you can use the `isLazy` property.
-In this way, the tab content will not be mounted to the DOM until it is open.
+By default, the `Tabs` component renders all tabs content to the DOM, meaning that invisible tabs are still rendered but are hidden by styles.
+
+If you want to defer rendering of each tab until that tab is selected, you can use the `isLazy` prop. This is useful if your tabs require heavy performance, or make network calls on mount that should only happen when the component is displayed.
 
 ```jsx
 <Tabs isLazy>


### PR DESCRIPTION
### Description
Add `isLazy` property to `Tabs` to only mount the contents of a TabPanel to the DOM when the tab is activated/clicked/selected.

### Linked Issues
Fixes #1384

### How has this been tested?
A new test has been added in `packages/tabs/tests/tabs.test.tsx`

#
Related:  #1118
