### PR TITLE
docs: added not about RadioButtonGroup being deprecated

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -474,8 +474,9 @@ Due to accessibility reasons, we've deprecated the `isDisabled` prop for `Link`.
 - Deprecated the `isFullWidth` prop. The `Radio` takes up the width of the
   parent by default.
 
-- Deprecated `RadioButton` component. Use the `useRadio` hook to create custom
+- Deprecated the `RadioButton` component. Use the `useRadio` hook to create custom
   radio buttons.
+  Learn more about [creating custom radio buttons](/docs/form/radio#custom-radio-buttons).
 
 - The `useRadio` hook is exported with state and focus management logic for use
   in creating tailor-made radio component for your application
@@ -484,6 +485,9 @@ Due to accessibility reasons, we've deprecated the `isDisabled` prop for `Link`.
 
 - Deprecated the `isFullWidth` prop. The `RadioGroup` takes up the width of the
   parent by default.
+
+- Deprecated the `RadioButtonGroup` component. Use the `useRadioGroup` hook to control a group of custom radio buttons.
+  Learn more about [creating custom radio buttons](/docs/form/radio#custom-radio-buttons).
 
 - To allow for better Radio group layout, the `RadioGroup` component no longer
   supports every style prop. You can only pass `size`, `variant`, and


### PR DESCRIPTION
Added note in the migration guide about `RadioButtonGroup` being deprecated. Also added a link to the documentation around the hooks that replace it.

Fixes #1650 