### PR TITLE
fix(transition): pass nodeRef to React transition group to avoid warning

### DIFF
--- a/packages/drawer/src/drawer.tsx
+++ b/packages/drawer/src/drawer.tsx
@@ -1,5 +1,10 @@
 import * as React from "react"
-import { Slide, SlideProps, Fade } from "@chakra-ui/transition"
+import {
+  Slide,
+  SlideProps,
+  Fade,
+  TransitionChildrenProps,
+} from "@chakra-ui/transition"
 import {
   Modal,
   ModalProps,
@@ -12,13 +17,19 @@ import { forwardRef, useTheme } from "@chakra-ui/system"
 import { __DEV__ } from "@chakra-ui/utils"
 
 interface TransitionStyles {
-  content: React.CSSProperties
-  overlay: React.CSSProperties
+  content: TransitionChildrenProps
+  overlay: TransitionChildrenProps
 }
 
 const TransitionContext = React.createContext<TransitionStyles>({
-  content: {},
-  overlay: {},
+  content: {
+    style: {},
+    ref: { current: null },
+  },
+  overlay: {
+    style: {},
+    ref: { current: null },
+  },
 })
 
 TransitionContext.displayName = "TransitionContext"
@@ -89,15 +100,15 @@ export const Drawer: React.FC<DrawerProps> = (props) => {
 
 export const DrawerContent: React.FC<ModalContentProps> = forwardRef(
   (props, ref) => {
-    const { content: styles } = useTransitionContext()
+    const { content: transitionProps } = useTransitionContext()
     return (
       <ModalContent
-        ref={ref}
+        ref={ref || transitionProps.ref}
         position="fixed"
-        style={styles}
         marginTop="0"
         marginBottom="0"
         borderRadius="0"
+        style={transitionProps.style}
         {...props}
       />
     )
@@ -106,8 +117,14 @@ export const DrawerContent: React.FC<ModalContentProps> = forwardRef(
 
 export const DrawerOverlay: React.FC<ModalOverlayProps> = forwardRef(
   (props, ref) => {
-    const { overlay: styles } = useTransitionContext()
-    return <ModalOverlay style={styles} ref={ref} {...props} />
+    const { overlay: transitionProps } = useTransitionContext()
+    return (
+      <ModalOverlay
+        ref={ref || transitionProps.ref}
+        style={transitionProps.style}
+        {...props}
+      />
+    )
   },
 )
 

--- a/packages/menu/src/menu.transition.tsx
+++ b/packages/menu/src/menu.transition.tsx
@@ -2,14 +2,14 @@ import {
   Transition,
   TransitionProps,
   TransitionStyles,
+  TransitionChildrenProps,
 } from "@chakra-ui/transition"
 import { focus, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useMenuContext } from "./use-menu"
-import { SystemStyleObject } from "@chakra-ui/system"
 
 export interface MenuTransitionProps {
-  children: (styles: SystemStyleObject) => React.ReactNode
+  children: (transitionProps: TransitionChildrenProps) => React.ReactNode
   styles?: TransitionProps["styles"]
 }
 
@@ -37,29 +37,32 @@ export const MenuTransition: React.FC<MenuTransitionProps> = (props) => {
     },
   }
 
+  const ref = React.useRef<HTMLElement>()
+
   return (
     <Transition
-      onEnter={(node) => {
-        node.hidden = false
+      onEnter={() => {
+        ref.current!.hidden = false
       }}
-      onExited={(node) => {
-        node.hidden = true
-        node.style.pointerEvents = "auto"
+      onExited={() => {
+        ref.current!.hidden = true
+        ref.current!.style.pointerEvents = "auto"
         const menuEl = menu.buttonRef.current
         if (menuEl && document.activeElement !== menuEl) {
           focus(menuEl)
         }
       }}
-      onExit={(node) => {
-        node.hidden = false
+      onExit={() => {
+        ref.current!.hidden = false
       }}
-      onExiting={(node) => {
-        node.style.pointerEvents = "none"
+      onExiting={() => {
+        ref.current!.style.pointerEvents = "none"
       }}
       timeout={{ enter: 0, exit: menu.isOpen ? 200 : 100 }}
       in={menu.isOpen}
       styles={styles ?? defaultStyles}
       unmountOnExit={false}
+      nodeRef={ref}
       children={children}
     />
   )

--- a/packages/popover/src/popover.transition.tsx
+++ b/packages/popover/src/popover.transition.tsx
@@ -1,15 +1,15 @@
-import { SystemStyleObject } from "@chakra-ui/system"
 import {
   Transition,
   TransitionProps,
   TransitionStyles,
+  TransitionChildrenProps,
 } from "@chakra-ui/transition"
 import { __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { usePopoverContext } from "./popover"
 
 export interface PopoverTransitionProps {
-  children: (styles: SystemStyleObject) => React.ReactNode
+  children: (transitionProps: TransitionChildrenProps) => React.ReactNode
   styles?: TransitionProps["styles"]
 }
 
@@ -38,26 +38,29 @@ export const PopoverTransition: React.FC<PopoverTransitionProps> = (props) => {
     },
   }
 
+  const ref = React.useRef<HTMLElement>()
+
   return (
     <Transition
-      onEnter={(node) => {
-        node.hidden = false
+      onEnter={() => {
+        ref.current!.hidden = false
       }}
-      onExited={(node) => {
-        node.hidden = true
-        node.style.pointerEvents = "auto"
+      onExited={() => {
+        ref.current!.hidden = true
+        ref.current!.style.pointerEvents = "auto"
       }}
-      onExit={(node) => {
-        node.hidden = false
+      onExit={() => {
+        ref.current!.hidden = false
       }}
-      onExiting={(node) => {
-        node.style.pointerEvents = "none"
+      onExiting={() => {
+        ref.current!.style.pointerEvents = "none"
       }}
       timeout={{ enter: 0, exit: 150 }}
       in={popover.isOpen}
       styles={styles ?? defaultStyles}
       unmountOnExit={false}
       children={children}
+      nodeRef={ref}
     />
   )
 }

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -101,7 +101,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
       timeout={{ enter: 0, exit: 150 }}
       onExited={onExited}
     >
-      {(styles) => (
+      {(transitionProps) => (
         <div
           data-toast=""
           onMouseEnter={onMouseEnter}
@@ -109,8 +109,9 @@ export const Toast: React.FC<ToastProps> = (props) => {
           style={{
             willChange: "transform, height, opacity",
             ...style,
-            ...styles,
+            ...transitionProps.style,
           }}
+          ref={transitionProps.ref}
         >
           <div
             ref={ref}

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -92,7 +92,7 @@ const TransitionTooltip = ({ children }: any) => {
           },
         }}
       >
-        {(styles) => (
+        {(transitionProps) => (
           <Portal>
             <div
               {...tooltip}
@@ -103,8 +103,9 @@ const TransitionTooltip = ({ children }: any) => {
                 border: "none",
                 borderRadius: "4px",
                 padding: "0.5em 1em",
-                ...styles,
+                ...transitionProps.style,
               }}
+              ref={transitionProps.ref}
             >
               {children}
               <div {...arrow} />

--- a/packages/transition/src/slide.tsx
+++ b/packages/transition/src/slide.tsx
@@ -94,7 +94,12 @@ export const Slide: React.FC<SlideProps> = (props) => {
       timeout={{ enter: 0, exit: timeout }}
       {...rest}
     >
-      {(styles) => children({ ...positionStyles, ...styles })}
+      {(transitionProps) =>
+        children({
+          ref: transitionProps.ref,
+          style: { ...positionStyles, ...transitionProps.style },
+        })
+      }
     </Transition>
   )
 }

--- a/packages/transition/src/transition.tsx
+++ b/packages/transition/src/transition.tsx
@@ -19,10 +19,18 @@ type RTGProps = Pick<
   | "timeout"
 >
 
+export type TransitionChildrenProps = {
+  ref: React.RefObject<any>
+  style: React.CSSProperties
+}
+
 export interface TransitionProps extends RTGProps {
   transition?: string
-  children: (styles: React.CSSProperties) => React.ReactNode
+  children: (
+    transitionChildrenProps: TransitionChildrenProps,
+  ) => React.ReactNode
   styles: TransitionStyles
+  nodeRef?: React.RefObject<any>
 }
 
 export type TransitionStyleState = "init" | "entered" | "exiting"
@@ -40,6 +48,7 @@ export const Transition: React.FC<TransitionProps> = (props) => {
     timeout = 150,
     transition = `all ${timeout}ms ease-in-out`,
     children,
+    nodeRef,
     ...rest
   } = props
 
@@ -49,15 +58,23 @@ export const Transition: React.FC<TransitionProps> = (props) => {
     ...(styles as any)[state],
   })
 
+  const internalNodeRef = React.useRef<any>()
+
   return (
     <ReactTransition
       appear
       unmountOnExit
       in={inProp}
       timeout={timeout}
+      nodeRef={nodeRef || internalNodeRef}
       {...(rest as any)}
     >
-      {(state) => children(getStyle(state))}
+      {(state: TransitionStatus) =>
+        children({
+          style: getStyle(state),
+          ref: nodeRef || internalNodeRef,
+        })
+      }
     </ReactTransition>
   )
 }

--- a/packages/transition/stories/transition.stories.tsx
+++ b/packages/transition/stories/transition.stories.tsx
@@ -35,14 +35,15 @@ export function ScaleFadeExample() {
     <>
       <button onClick={() => setIsOpen((p) => !p)}>Click Me</button>
       <ScaleFade in={isOpen}>
-        {(styles) => (
+        {(transitionProps) => (
           <Modal
             style={{
-              ...styles,
+              ...transitionProps.style,
               transform: styles.transform
                 ? `${modalStyles.transform} ${styles.transform}`
                 : `${modalStyles.transform}`,
             }}
+            ref={transitionProps.ref}
           />
         )}
       </ScaleFade>
@@ -56,14 +57,15 @@ export function SlideFadeExample() {
     <>
       <button onClick={() => setIsOpen((p) => !p)}>Click Me</button>
       <SlideFade in={isOpen}>
-        {(styles) => (
+        {(transitionProps) => (
           <Modal
             style={{
-              ...styles,
+              ...transitionProps.style,
               transform: styles.transform
                 ? `${modalStyles.transform} ${styles.transform}`
                 : `${modalStyles.transform}`,
             }}
+            ref={transitionProps.ref}
           />
         )}
       </SlideFade>
@@ -76,7 +78,9 @@ export function FadeExample() {
   return (
     <>
       <button onClick={() => setIsOpen((p) => !p)}>Click Me</button>
-      <Fade in={isOpen}>{(styles) => <Modal style={styles} />}</Fade>
+      <Fade in={isOpen}>
+        {(transitionProps) => <Modal {...transitionProps} />}
+      </Fade>
     </>
   )
 }
@@ -95,7 +99,7 @@ export function SlideExample() {
     <>
       <button onClick={() => setIsOpen((p) => !p)}>Click Me</button>
       <Slide placement="bottom" in={isOpen}>
-        {(styles) => <Drawer style={styles} />}
+        {(transitionProps) => <Drawer {...transitionProps} />}
       </Slide>
     </>
   )

--- a/website/pages/docs/overlay/alert-dialog.mdx
+++ b/website/pages/docs/overlay/alert-dialog.mdx
@@ -123,8 +123,8 @@ function TransitionExample() {
           >
             <AlertDialogOverlay style={styles}>
               <SlideFade timeout={150} in={isOpen} unmountOnExit={false}>
-                {(styles) => (
-                  <AlertDialogContent style={styles}>
+                {(transitionProps) => (
+                  <AlertDialogContent {...transitionProps}>
                     <AlertDialogHeader>Discard Changes?</AlertDialogHeader>
                     <AlertDialogCloseButton />
                     <AlertDialogBody>


### PR DESCRIPTION
This change passes a reference to the Transition component, which silences a warning. This means
that the API of our Transition component has to change as well!

BREAKING CHANGE: The Transition, Slide, Fade, Scale and SlideFade components now returns an object
with a ref prop and a style prop instead of just the style object. This means you now have to spread
the children argument on the element that is being transitioned.

fix #1496