### PR TITLE
fix(avatar): avatar group shows excess even when excess isn't hit

### DIFF
--- a/packages/avatar/src/avatar-group.tsx
+++ b/packages/avatar/src/avatar-group.tsx
@@ -99,9 +99,10 @@ export const AvatarGroup = forwardRef<AvatarGroupProps, "div">(
         {...rest}
         className={cx("chakra-avatar__group", props.className)}
       >
-        {excess && (
+        {excess > 0 && (
           <chakra.span
             className="chakra-avatar__excess"
+            data-testid="avatar-excess"
             __css={excessStyles}
             children={`+${excess}`}
           />

--- a/packages/avatar/src/avatar-group.tsx
+++ b/packages/avatar/src/avatar-group.tsx
@@ -102,7 +102,6 @@ export const AvatarGroup = forwardRef<AvatarGroupProps, "div">(
         {excess > 0 && (
           <chakra.span
             className="chakra-avatar__excess"
-            data-testid="avatar-excess"
             __css={excessStyles}
             children={`+${excess}`}
           />

--- a/packages/avatar/tests/avatar-group.test.tsx
+++ b/packages/avatar/tests/avatar-group.test.tsx
@@ -24,3 +24,29 @@ test("renders a number avatar showing count of truncated avatars", () => {
   const moreLabel = tools.getByText("+3")
   expect(moreLabel).toBeInTheDocument()
 })
+
+test("does not render a number avatar showing count of truncated avatars if max is equal to avatars given", async () => {
+  const tools = render(
+    <AvatarGroup max={5}>
+      <Avatar />
+      <Avatar />
+      <Avatar />
+      <Avatar />
+    </AvatarGroup>,
+  )
+  const moreLabel = tools.queryByTestId("avatar-excess")
+  expect(moreLabel).toBeFalsy()
+})
+
+test("does not render a number avatar showing count of truncated avatars if max is more than avatars given", async () => {
+  const tools = render(
+    <AvatarGroup max={6}>
+      <Avatar />
+      <Avatar />
+      <Avatar />
+      <Avatar />
+    </AvatarGroup>,
+  )
+  const moreLabel = tools.queryByTestId("avatar-excess")
+  expect(moreLabel).toBeFalsy()
+})

--- a/packages/avatar/tests/avatar-group.test.tsx
+++ b/packages/avatar/tests/avatar-group.test.tsx
@@ -27,7 +27,7 @@ test("renders a number avatar showing count of truncated avatars", () => {
 
 test("does not render a number avatar showing count of truncated avatars if max is equal to avatars given", async () => {
   const tools = render(
-    <AvatarGroup max={5}>
+    <AvatarGroup max={4}>
       <Avatar />
       <Avatar />
       <Avatar />

--- a/packages/avatar/tests/avatar-group.test.tsx
+++ b/packages/avatar/tests/avatar-group.test.tsx
@@ -34,8 +34,8 @@ test("does not render a number avatar showing count of truncated avatars if max 
       <Avatar />
     </AvatarGroup>,
   )
-  const moreLabel = tools.queryByTestId("avatar-excess")
-  expect(moreLabel).toBeFalsy()
+  const moreLabel = tools.container.querySelector(".chakra-avatar--excess")
+  expect(moreLabel).not.toBeInTheDocument()
 })
 
 test("does not render a number avatar showing count of truncated avatars if max is more than avatars given", async () => {
@@ -47,6 +47,6 @@ test("does not render a number avatar showing count of truncated avatars if max 
       <Avatar />
     </AvatarGroup>,
   )
-  const moreLabel = tools.queryByTestId("avatar-excess")
-  expect(moreLabel).toBeFalsy()
+  const moreLabel = tools.container.querySelector(".chakra-avatar--excess")
+  expect(moreLabel).not.toBeInTheDocument()
 })


### PR DESCRIPTION
There was a bug with the Avatar Group showing excess even when excess hasn't been reached. 
This fixes https://github.com/chakra-ui/chakra-ui/issues/1666

No breaking changes.