### PR TITLE
docs: updated transition section for modal and alert dialog

### DIFF
--- a/website/pages/docs/overlay/alert-dialog.mdx
+++ b/website/pages/docs/overlay/alert-dialog.mdx
@@ -97,8 +97,8 @@ function AlertDialogExample() {
 
 ### Adding transitions
 
-The modal doesn't come with any transitions by default so you can manage this
-yourself. Chakra exports two transition components (`SlideFade` and `Fade`) to
+The `AlertDialog` doesn't come with any transitions by default so you can manage this
+yourself. Chakra exports four transition components (`Fade`, `ScaleFade`, `Slide`, and `SlideFade`) to
 provide simple transitions.
 
 > When adding transitions, kindly pay attention to the `timeout` for the overlay

--- a/website/pages/docs/overlay/modal.mdx
+++ b/website/pages/docs/overlay/modal.mdx
@@ -304,10 +304,58 @@ function VerticallyCenter() {
 }
 ```
 
-### Using custom transitions
+### Adding transitions
 
-The `Modal` component comes with simple fade transition, but you can edit this
-by updating the modal transitions defined in the theme.
+The `Modal` doesn't come with any transitions by default so you can manage this
+yourself. Chakra exports four transition components (`Fade`, `ScaleFade`, `Slide`, and `SlideFade`) to
+provide simple transitions.
+
+> When adding transitions, kindly pay attention to the `timeout` for the overlay
+> and content transitions. In this example, `Fade` transitions slower than the
+> `SlideFade` for it to work correctly.
+
+```jsx
+function TransitionExample() {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const cancelRef = React.useRef()
+
+  return (
+    <>
+      <Button onClick={onOpen}>Open Modal</Button>
+      <Fade timeout={300} in={isOpen}>
+        {(styles) => (
+          <Modal
+            leastDestructiveRef={cancelRef}
+            onClose={onClose}
+            isOpen={true}
+            isCentered
+          >
+            <ModalOverlay style={styles}>
+              <SlideFade timeout={150} in={isOpen} unmountOnExit={false}>
+                {(styles) => (
+                  <ModalContent style={styles}>
+                    <ModalHeader>Modal Title</ModalHeader>
+                    <ModalCloseButton />
+                    <ModalBody>
+                      <Lorem count={2} />
+                    </ModalBody>
+                    <ModalFooter>
+                      <Button colorScheme="blue" mr={3} onClick={onClose}>
+                        Close
+                      </Button>
+                      <Button variant="ghost">Secondary Action</Button>
+                    </ModalFooter>
+                  </ModalContent>
+                )}
+              </SlideFade>
+            </ModalOverlay>
+          </Modal>
+        )}
+      </Fade>
+    </>
+  )
+}
+```
 
 ### Modal overflow behavior
 


### PR DESCRIPTION
Expanded the `Modal` docs to provide more information and an example on adding transitions. Updated the `AlertDialog` docs with the correct transition components.

Fixes #1551 