### PR TITLE
docs: called out that default chakra icons need to be imported from @chakra-ui/icons

### DIFF
--- a/website/pages/docs/components/icon.mdx
+++ b/website/pages/docs/components/icon.mdx
@@ -26,6 +26,7 @@ By default, Chakra UI comes with a [set of basic interface icons](#all-icons).
 
 ```js
 import { Icon } from "@chakra-ui/core"
+import { PhoneIcon } from "@chakra-ui/icons"
 ```
 
 ## Usage
@@ -50,7 +51,7 @@ Use an icon by directly importing it with its respective name as mentioned in
 ### All Icons
 
 Here's the list of default icons that comes with Chakra UI with their respective
-`name`,
+`name`. These icons should be imported from `@chakra-ui/icons`
 
 <IconsList />
 


### PR DESCRIPTION
Noted that the default chakra icons need to be imported from `@chakra-ui/icons`

Closes #1670 