### PR TITLE
fix(accordion): move item props to accordion context

### DIFF
--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -50,13 +50,13 @@ export interface AccordionProps
  * @see Docs https://chakra-ui.com/components/accordion
  */
 export const Accordion = forwardRef<AccordionProps, "div">(function Accordion(
-  props,
+  { children, ...props },
   ref,
 ) {
   const styles = useMultiStyleConfig("Accordion", props)
   const _props = omitThemingProps(props)
 
-  const { children, htmlProps, ...context } = useAccordion(_props)
+  const { htmlProps, ...context } = useAccordion(_props)
 
   const _context = useMemo(
     () => ({ ...context, reduceMotion: !!props.reduceMotion }),

--- a/packages/accordion/src/use-accordion.ts
+++ b/packages/accordion/src/use-accordion.ts
@@ -7,21 +7,13 @@ import {
   Dict,
   getNextIndex,
   getPrevIndex,
-  getValidChildren,
   isArray,
   mergeRefs,
   removeItem,
   __DEV__,
   createContext,
 } from "@chakra-ui/utils"
-import {
-  Ref,
-  ReactNode,
-  useCallback,
-  cloneElement,
-  useRef,
-  useState,
-} from "react"
+import { Ref, ReactNode, useCallback, useRef, useState } from "react"
 import * as warn from "./warning"
 
 export type ExpandedIndex = number | number[]
@@ -64,7 +56,6 @@ export function useAccordion(props: UseAccordionProps) {
     index: indexProp,
     allowMultiple,
     allowToggle,
-    children,
     ...htmlProps
   } = props
 
@@ -108,40 +99,32 @@ export function useAccordion(props: UseAccordionProps) {
   })
 
   /**
-   * Filter out invalid children (null, false), in the case
-   * of conditional rendering
+   * Gets the `isOpen` and `onChange` props for a child accordion item based on
+   * the child's index.
+   *
+   * @param idx {number} The index of the child accordion item
    */
-  const validChildren = getValidChildren(children)
-
-  /**
-   * Clone the accordion items and pass them the `onChange`
-   * and `isOpen`
-   */
-  const _children = validChildren.map((child, idx) => {
-    const isExpanded = isArray(index) ? index.includes(idx) : index === idx
-
-    return cloneElement(child, {
-      isOpen: isExpanded,
-      onChange: (isOpen: boolean) => {
-        if (allowMultiple && isArray(index)) {
-          const nextState = isOpen
-            ? addItem(index, idx)
-            : removeItem(index, idx)
-          setIndex(nextState)
-        } else {
-          if (isOpen) {
-            setIndex(idx)
-          } else if (allowToggle) {
-            setIndex(-1)
-          }
+  const getItemProps = (idx: number) => {
+    const isOpen = isArray(index) ? index.includes(idx) : index === idx
+    const onChange = (isOpen: boolean) => {
+      if (allowMultiple && isArray(index)) {
+        const nextState = isOpen ? addItem(index, idx) : removeItem(index, idx)
+        setIndex(nextState)
+      } else {
+        if (isOpen) {
+          setIndex(idx)
+        } else if (allowToggle) {
+          setIndex(-1)
         }
-      },
-    })
-  })
+      }
+    }
+
+    return { isOpen, onChange }
+  }
 
   return {
-    children: _children,
     htmlProps,
+    getItemProps,
     focusedIndex,
     setFocusedIndex,
     domContext,
@@ -166,10 +149,6 @@ export { AccordionProvider, useAccordionContext }
 
 export interface UseAccordionItemProps {
   /**
-   * If `true`, expands the accordion in the controlled mode.
-   */
-  isOpen?: boolean
-  /**
    * If `true`, the accordion item will be disabled.
    */
   isDisabled?: boolean
@@ -181,10 +160,6 @@ export interface UseAccordionItemProps {
    * A unique id for the accordion item.
    */
   id?: string
-  /**
-   * The callback fired when the accordion is expanded/collapsed.
-   */
-  onChange?: (isOpen: boolean) => void
 }
 
 /**
@@ -194,18 +169,15 @@ export interface UseAccordionItemProps {
  * for an accordion item and it's children
  */
 export function useAccordionItem(props: UseAccordionItemProps) {
-  const { isDisabled, isFocusable, onChange, isOpen, id, ...htmlProps } = props
+  const { isDisabled, isFocusable, id, ...htmlProps } = props
 
-  const { domContext, focusedIndex, setFocusedIndex } = useAccordionContext()
+  const {
+    getItemProps,
+    domContext,
+    focusedIndex,
+    setFocusedIndex,
+  } = useAccordionContext()
   const { descendants } = domContext
-
-  const onOpen = () => {
-    onChange?.(true)
-  }
-
-  const onClose = () => {
-    onChange?.(false)
-  }
 
   const buttonRef = useRef<HTMLElement>(null)
 
@@ -226,6 +198,16 @@ export function useAccordionItem(props: UseAccordionItemProps) {
     disabled: isDisabled,
     focusable: isFocusable,
   })
+
+  const { isOpen, onChange } = getItemProps(index)
+
+  const onOpen = () => {
+    onChange?.(true)
+  }
+
+  const onClose = () => {
+    onChange?.(false)
+  }
 
   const shouldFocus = index === focusedIndex
 

--- a/packages/accordion/stories/accordion.stories.tsx
+++ b/packages/accordion/stories/accordion.stories.tsx
@@ -135,3 +135,51 @@ export const stylingExpanded = () => (
     </AccordionItem>
   </Accordion>
 )
+
+const Fruit = ({ name }) => {
+  return (
+    <AccordionItem>
+      <AccordionButton>
+        <chakra.div flex="1" textAlign="left">
+          {name}
+        </chakra.div>
+        <AccordionIcon />
+      </AccordionButton>
+      <AccordionPanel>A {name} lives here</AccordionPanel>
+    </AccordionItem>
+  )
+}
+
+export function MappedMultiple() {
+  const [allowMultiple, setAllowMultiple] = React.useState(true)
+  const fruits = [{ name: "Apple" }, { name: "Orange" }, { name: "Banana" }]
+
+  return (
+    <div>
+      <button onClick={() => setAllowMultiple((allow) => !allow)}>
+        Set "allowMultiple" to {allowMultiple ? "false" : "true"}
+      </button>
+      {/* 'allowMulitple' is false, so it should only allow one item open at once */}
+      <Accordion allowMultiple={allowMultiple} defaultIndex={[0]}>
+        {fruits.map((item) => (
+          <Fruit key={item.name} name={item.name} />
+        ))}
+
+        {/* However if we remove the 'map' above and use the data below, 'allowMulitple'
+      set to false will work */}
+        {/* <AccordionItem>
+          <AccordionHeader>dd</AccordionHeader>
+          <AccordionPanel>Price: aa</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionHeader>dd</AccordionHeader>
+          <AccordionPanel>Price: aa</AccordionPanel>
+        </AccordionItem>
+        <AccordionItem>
+          <AccordionHeader>dd</AccordionHeader>
+          <AccordionPanel>Price: aa</AccordionPanel>
+        </AccordionItem> */}
+      </Accordion>
+    </div>
+  )
+}


### PR DESCRIPTION
Resolves #1691

I'll allow the commit message to explain the issue and what this PR changes:

Before this change, `Accordion` passed the `isOpen` and `onChange` props
to its `AccordionItem` children by inject is props via
`React.cloneElement`. This method of props injection caused two issues:

- `AccordionItem` children could only be rendered as direct children of
  `Accordion`
- `AccordionItem` children rendered as a mapped array could not receive
  their corresponding props, breaking the functionality of the accordion

This changes moves the `isOpen` and `onChange` props into a props getter
created in `useAccordion`. This props getter takes an accordion item's
`index` (determined in `useAccordionItem` via `useDescendant`) to
determine these values. This props getter is then attached to
`AccordionContext`.

The props getter is then accessed via `AccordionContext` inside
`useAccordionItem` and passed the item's index. This allows the item to
function anywhere inside the `Accordion` tree, whether as direct
children or not, and as part of a mapped array.

---

I opened this as a draft because I wanted to make sure this change would be acceptable to us. This would mean that users could no longer directly pass `isOpen` and `onChange` as props to an `AccordionItem`, though I see no reason that they would need to do this anyway.

I also don't intend to keep the story in place. It's just so you can see an example of it working. If you use this story without the change, the accordion does nothing. I'd probably replace it with a test instead.