### PR TITLE
Amend InitializeColorMode steps for Next.js

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -270,7 +270,7 @@ const theme = {
   Here's how to add it for Next.js:
 
 ```jsx live=false
-// pages/_app.js
+// pages/_document.js
 import { InitializeColorMode } from "@chakra-ui/core"
 
 export default class Document extends NextDocument {


### PR DESCRIPTION
This should occur in `_document.js`, not `_app.js`.

See https://nextjs.org/docs/advanced-features/custom-document for further guidelines on customising the `_document`.