### PR TITLE
Breakout Links

### DIFF
--- a/packages/layout/src/link.tsx
+++ b/packages/layout/src/link.tsx
@@ -11,6 +11,11 @@ import { __DEV__, cx } from "@chakra-ui/utils"
 
 export interface LinkProps extends PropsOf<typeof chakra.a>, ThemingProps {
   /**
+   * If `true`, the link will stretch to the full width and height of its
+   * nearest parent whose `position` is `relative`.
+   */
+  breakout?: boolean
+  /**
    *  If `true`, the link will open in new tab
    */
   isExternal?: boolean
@@ -32,7 +37,7 @@ export interface LinkProps extends PropsOf<typeof chakra.a>, ThemingProps {
  */
 export const Link = forwardRef<LinkProps, "a">((props, ref) => {
   const styles = useStyleConfig("Link", props)
-  const { className, isExternal, ...rest } = omitThemingProps(props)
+  const { breakout, className, isExternal, ...rest } = omitThemingProps(props)
 
   return (
     <chakra.a
@@ -41,7 +46,22 @@ export const Link = forwardRef<LinkProps, "a">((props, ref) => {
       ref={ref}
       className={cx("chakra-link", className)}
       {...rest}
-      __css={styles}
+      __css={{
+        ...(breakout && {
+          position: "static",
+          "&::before": {
+            content: "''",
+            cursor: "inherit",
+            display: "block",
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+          },
+        }),
+        ...styles,
+      }}
     />
   )
 })

--- a/website/pages/docs/components/link.mdx
+++ b/website/pages/docs/components/link.mdx
@@ -49,6 +49,98 @@ import { Link } from "@chakra-ui/core"
 </Text>
 ```
 
+### Breakout Link
+
+When treating a group of content as clickable,
+[**avoid**](https://www.sarasoueidan.com/blog/nested-links/#native-markup-limitations)
+wrapping with a link.
+
+Instead, choose a single key line of text–such as a title–and use a `breakout`
+link to "stretch" the interaction, while maintaining semantic HTML.
+
+> **Note**: for a `breakout` link to stretch full size, the parent's `position`
+> must be set to `relative`.
+
+```jsx
+// Sample card from Airbnb
+
+function AirbnbExample() {
+  const property = {
+    imageUrl: "https://bit.ly/2Z4KKcF",
+    imageAlt: "Rear view of modern home with pool",
+    beds: 3,
+    baths: 2,
+    title: "Modern home in city center in the heart of historic Los Angeles",
+    formattedPrice: "$1,900.00",
+    reviewCount: 34,
+    rating: 4,
+  }
+
+  return (
+    <Box
+      position="relative"
+      maxW="sm"
+      borderWidth="1px"
+      borderRadius="lg"
+      overflow="hidden"
+    >
+      <Image src={property.imageUrl} alt={property.imageAlt} />
+
+      <Box p="6">
+        <Box d="flex" alignItems="baseline">
+          <Badge borderRadius="full" px="2" colorScheme="teal">
+            New
+          </Badge>
+          <Box
+            color="gray.500"
+            fontWeight="semibold"
+            letterSpacing="wide"
+            fontSize="xs"
+            textTransform="uppercase"
+            ml="2"
+          >
+            {property.beds} beds &bull; {property.baths} baths
+          </Box>
+        </Box>
+
+        <Box
+          mt="1"
+          fontWeight="semibold"
+          as="h4"
+          lineHeight="tight"
+          isTruncated
+        >
+          <Link href="#breakout-link" breakout>
+            {property.title}
+          </Link>
+        </Box>
+
+        <Box>
+          {property.formattedPrice}
+          <Box as="span" color="gray.600" fontSize="sm">
+            / wk
+          </Box>
+        </Box>
+
+        <Box d="flex" mt="2" alignItems="center">
+          {Array(5)
+            .fill("")
+            .map((_, i) => (
+              <StarIcon
+                key={i}
+                color={i < property.rating ? "teal.500" : "gray.300"}
+              />
+            ))}
+          <Box as="span" ml="2" color="gray.600" fontSize="sm">
+            {property.reviewCount} reviews
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+```
+
 ## Usage with Routing Library
 
 To use the `Link` with a routing library like Reach Router or React Router, all
@@ -68,7 +160,8 @@ Reach's `Link`.
 
 The Link component composes the `Box` component.
 
-| Name         | Type       | Default | Description                               |
-| ------------ | ---------- | ------- | ----------------------------------------- |
-| `isExternal` | `boolean`  |         | If `true`, the link will open in new tab. |
-| `onClick`    | `function` |         | Function called when the link is clicked. |
+| Name         | Type       | Default | Description                                                                                                         |
+| ------------ | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `breakout`   | `boolean`  |         | If `true`, the link will stretch to the full width and height of its nearest parent whose `position` is `relative`. |
+| `isExternal` | `boolean`  |         | If `true`, the link will open in new tab.                                                                           |
+| `onClick`    | `function` |         | Function called when the link is clicked.                                                                           |


### PR DESCRIPTION
One of the most common bad habits I've seen for linking "cards" of content is to wrap everything in a link. This PR aims to support `breakout` links to offer the same functionality but ensure semantic HTML

Further reading:

[<img width="557" alt="Screenshot of Tweet" src="https://user-images.githubusercontent.com/7349341/90488740-03257180-e145-11ea-8d5f-7c708fae7f8d.png">](https://twitter.com/joebell_/status/1269554122128269313)


## Examples

Here are some examples of the technique in the wild (although not using Chakra UI)

- [bbc.co.uk/news](https://bbc.co.uk/news) (article links)
- [joebell.co.uk](https://joebell.co.uk) (post links)
- [smashingmagazine.com](https://www.smashingmagazine.com/) (article links)

## Caveats

One of the side-effects for this technique is that the content can't be "selectable" (i.e with a pointing device), however this seems to be pretty trivial compared to the benefits!

## Alternative Solution

I posted a [link to the PR on Twitter](https://twitter.com/joebell_/status/1295641715903270914) and got some really useful feedback from @peduarte and @aarongarciah; mostly around the concern that this link variant relies on `position: relative` to work.

@peduarte suggested the following:

```jsx
<BreakoutContainer>
  <BreakoutLink />
</BreakoutContainer>
```

Although I do agree it would be clearer for the consumer, I'm concerned that this could cause fragmentation from `Link` and an additional element (most likely a `div`) would do more harm than good. Perhaps a `useLinkBreakoutParent()` hook could support this?

Either way there's small trade-offs, but I think as long as the docs are clear initially this could always be tweaked