### PR TITLE
feature(standalone-toasts): create toasts outside of react components

### DIFF
--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -55,10 +55,11 @@
     "@reach/rect": "0.11.0"
   },
   "devDependencies": {
-    "@chakra-ui/system": "1.0.0-rc.5"
+    "@chakra-ui/system": "1.0.0-rc.5",
+    "@chakra-ui/theme": "1.0.0-rc.4"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">=1.0.0-rc.3",
+    "@chakra-ui/system": ">=1.0.0-rc.4",
     "react": "16.x",
     "react-dom": "16.x"
   }

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -49,6 +49,7 @@
     "@chakra-ui/alert": "1.0.0-rc.5",
     "@chakra-ui/close-button": "1.0.0-rc.5",
     "@chakra-ui/hooks": "1.0.0-rc.5",
+    "@chakra-ui/theme": "1.0.0-rc.5",
     "@chakra-ui/transition": "1.0.0-rc.5",
     "@chakra-ui/utils": "1.0.0-rc.5",
     "@reach/alert": "0.11.0",
@@ -56,7 +57,7 @@
   },
   "devDependencies": {
     "@chakra-ui/system": "1.0.0-rc.5",
-    "@chakra-ui/theme": "1.0.0-rc.4"
+    "@chakra-ui/theme": "1.0.0-rc.5"
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0-rc.4",

--- a/packages/toast/src/index.ts
+++ b/packages/toast/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./use-toast"
-export { default, createStandaloneToast } from "./use-toast"
+export * from "./use-toast"
 export { toast } from "./toast.class"
 export * from "./toast.types"

--- a/packages/toast/src/index.ts
+++ b/packages/toast/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./use-toast"
-export { default } from "./use-toast"
+export { default, createStandaloneToast } from "./use-toast"
 export { toast } from "./toast.class"
 export * from "./toast.types"

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -190,11 +190,11 @@ export function createStandaloneToast({
  * to show toasts in an application.
  */
 export function useToast() {
-  const { theme, colorMode, toggleColorMode } = useChakra()
-  return React.useMemo(
-    () => createStandaloneToast({ theme, colorMode, toggleColorMode }),
-    [theme, colorMode, toggleColorMode],
-  )
+  const { theme, ...colorMode } = useChakra()
+  return React.useMemo(() => createStandaloneToast({ theme, ...colorMode }), [
+    theme,
+    colorMode,
+  ])
 }
 
 export default useToast

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -11,12 +11,12 @@ import {
   ColorModeContext,
   ThemeProvider,
   useChakra,
+  ColorMode,
 } from "@chakra-ui/system"
 import { Dict, isFunction, noop } from "@chakra-ui/utils"
 import * as React from "react"
 import { toast } from "./toast.class"
 import { RenderProps, ToastId, ToastOptions } from "./toast.types"
-import { ColorMode } from "@chakra-ui/color-mode"
 
 export interface UseToastOptions {
   /**

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -1,3 +1,4 @@
+import * as React from "react"
 import type { AlertStatus } from "@chakra-ui/alert"
 import {
   Alert,
@@ -13,8 +14,8 @@ import {
   useChakra,
   ColorMode,
 } from "@chakra-ui/system"
-import { Dict, isFunction, noop } from "@chakra-ui/utils"
-import * as React from "react"
+import { isFunction, noop } from "@chakra-ui/utils"
+import defaultTheme from "@chakra-ui/theme"
 import { toast } from "./toast.class"
 import { RenderProps, ToastId, ToastOptions } from "./toast.types"
 
@@ -114,20 +115,27 @@ const defaults = {
   variant: "solid",
 } as const
 
-export type CreateStandAloneToastParam<T extends object = Dict> = {
-  theme: T
-  setColorMode?: (value: ColorMode) => void
-} & Partial<ReturnType<typeof useChakra>>
+export type CreateStandAloneToastParam = Partial<
+  {
+    setColorMode: (value: ColorMode) => void
+  } & ReturnType<typeof useChakra>
+>
 
+export const defaultStandaloneParam: Required<CreateStandAloneToastParam> = {
+  theme: defaultTheme,
+  colorMode: "light",
+  toggleColorMode: noop,
+  setColorMode: noop,
+}
 /**
  * Create a toast from outside of React Components
  */
-export function createStandaloneToast<Theme extends object = Dict>({
-  theme,
-  colorMode = "light",
-  toggleColorMode = noop,
-  setColorMode = noop,
-}: CreateStandAloneToastParam<Theme>) {
+export function createStandaloneToast({
+  theme = defaultStandaloneParam.theme,
+  colorMode = defaultStandaloneParam.colorMode,
+  toggleColorMode = defaultStandaloneParam.toggleColorMode,
+  setColorMode = defaultStandaloneParam.setColorMode,
+}: CreateStandAloneToastParam = defaultStandaloneParam) {
   const toastImpl = function (options: UseToastOptions) {
     const { render } = options
 

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -173,11 +173,15 @@ export function createStandaloneToast({
       ...opts,
       message: (props) => (
         <ThemeProvider theme={theme}>
-          {isFunction(render) ? (
-            render(props)
-          ) : (
-            <Toast {...{ ...props, ...opts }} />
-          )}
+          <ColorModeContext.Provider
+            value={{ colorMode, setColorMode, toggleColorMode }}
+          >
+            {isFunction(render) ? (
+              render(props)
+            ) : (
+              <Toast {...{ ...props, ...opts }} />
+            )}
+          </ColorModeContext.Provider>
         </ThemeProvider>
       ),
     })

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -190,11 +190,17 @@ export function createStandaloneToast({
  * to show toasts in an application.
  */
 export function useToast() {
-  const { theme, ...colorMode } = useChakra()
-  return React.useMemo(() => createStandaloneToast({ theme, ...colorMode }), [
-    theme,
-    colorMode,
-  ])
+  const { theme, setColorMode, toggleColorMode, colorMode } = useChakra()
+  return React.useMemo(
+    () =>
+      createStandaloneToast({
+        theme,
+        colorMode,
+        setColorMode,
+        toggleColorMode,
+      }),
+    [theme, setColorMode, toggleColorMode, colorMode],
+  )
 }
 
 export default useToast

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -4,7 +4,7 @@ import { createStandaloneToast } from "../src"
 import theme from "@chakra-ui/theme"
 
 test("Standalone toast renders correctly", async () => {
-  const toast = createStandaloneToast(theme)
+  const toast = createStandaloneToast({ theme })
   const title = "Yay!"
   const description = "Something awesome happened"
 

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react"
-import { render } from "@chakra-ui/test-utils"
+import { render, screen } from "@chakra-ui/test-utils"
 import { createStandaloneToast } from "../src"
 import theme from "@chakra-ui/theme"
 
@@ -21,7 +21,7 @@ test("Standalone toast renders correctly", async () => {
     return null
   }
 
-  const screen = render(<ToastContainer />)
+  render(<ToastContainer />)
 
   const allByTitle = await screen.findAllByText(title)
   const allByDescription = await screen.findAllByText(description)

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -1,10 +1,9 @@
 import React from "react"
 import { screen } from "@chakra-ui/test-utils"
 import { createStandaloneToast } from "../src"
-import theme from "@chakra-ui/theme"
 
 test("Standalone toast renders correctly", async () => {
-  const toast = createStandaloneToast({ theme })
+  const toast = createStandaloneToast()
   const title = "Yay!"
   const description = "Something awesome happened"
 

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -21,10 +21,10 @@ test("Standalone toast renders correctly", async () => {
     return null
   }
 
-  const { findAllByText } = render(<ToastContainer />)
+  const screen = render(<ToastContainer />)
 
-  const allByTitle = await findAllByText(title)
-  const allByDescription = await findAllByText(description)
+  const allByTitle = await screen.findAllByText(title)
+  const allByDescription = await screen.findAllByText(description)
 
   expect(allByTitle).toHaveLength(1)
   expect(allByDescription).toHaveLength(1)

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from "react"
-import { render, screen } from "@chakra-ui/test-utils"
+import React from "react"
+import { screen } from "@chakra-ui/test-utils"
 import { createStandaloneToast } from "../src"
 import theme from "@chakra-ui/theme"
 
@@ -8,20 +8,12 @@ test("Standalone toast renders correctly", async () => {
   const title = "Yay!"
   const description = "Something awesome happened"
 
-  const ToastContainer = () => {
-    useEffect(() => {
-      toast({
-        title,
-        description,
-        duration: 4000,
-        isClosable: true,
-      })
-    }, [])
-
-    return null
-  }
-
-  render(<ToastContainer />)
+  toast({
+    title,
+    description,
+    duration: 4000,
+    isClosable: true,
+  })
 
   const allByTitle = await screen.findAllByText(title)
   const allByDescription = await screen.findAllByText(description)

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from "react"
+import { render } from "@chakra-ui/test-utils"
+import { createStandaloneToast } from "../src"
+import theme from "@chakra-ui/theme"
+
+test("Standalone toast renders correctly", async () => {
+  const toast = createStandaloneToast(theme)
+  const title = "Yay!"
+  const description = "Something awesome happened"
+
+  const ToastContainer = () => {
+    useEffect(() => {
+      toast({
+        title,
+        description,
+        duration: 4000,
+        isClosable: true,
+      })
+    }, [])
+
+    return null
+  }
+
+  const { findAllByText } = render(<ToastContainer />)
+
+  const allByTitle = await findAllByText(title)
+  const allByDescription = await findAllByText(description)
+
+  expect(allByTitle).toHaveLength(1)
+  expect(allByDescription).toHaveLength(1)
+})

--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -223,9 +223,9 @@ Components.
 
 ```js
 import { createStandaloneToast } from "@chakra-ui/core"
-import theme from "@chakra-ui/theme"
 
-const toast = createStandaloneToast({ theme })
+const toast = createStandaloneToast()
+// const customToast = createStandaloeToast({ theme: yourCustomTheme })
 
 toast({
   title: "An error occurred.",

--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -221,7 +221,7 @@ function PositionExample() {
 Use a `createStandaloneToast` to create toasts from outside of your React Components.
 
 ```js
-import { createStandaloneToast } from "@chakra-ui/toast"
+import { createStandaloneToast } from "@chakra-ui/core"
 import theme from "@chakra-ui/theme"
 
 const toast = createStandaloneToast(theme)

--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -218,13 +218,14 @@ function PositionExample() {
 
 ## Standalone
 
-Use `createStandaloneToast` to create toasts from outside of your React Components.
+Use `createStandaloneToast` to create toasts from outside of your React
+Components.
 
 ```js
 import { createStandaloneToast } from "@chakra-ui/core"
 import theme from "@chakra-ui/theme"
 
-const toast = createStandaloneToast(theme)
+const toast = createStandaloneToast({ theme })
 
 toast({
   title: "An error occurred.",

--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -216,6 +216,25 @@ function PositionExample() {
 }
 ```
 
+## Standalone
+
+Use a `createStandaloneToast` to create toasts from outside of your React Components.
+
+```js
+import { createStandaloneToast } from "@chakra-ui/toast"
+import theme from "@chakra-ui/theme"
+
+const toast = createStandaloneToast(theme)
+
+toast({
+  title: "An error occurred.",
+  description: "Unable to create user account.",
+  status: "error",
+  duration: 9000,
+  isClosable: true,
+})
+```
+
 ## Props
 
 | Name          | Type                                                                    | Default  | Description                                                          |

--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -218,7 +218,7 @@ function PositionExample() {
 
 ## Standalone
 
-Use a `createStandaloneToast` to create toasts from outside of your React Components.
+Use `createStandaloneToast` to create toasts from outside of your React Components.
 
 ```js
 import { createStandaloneToast } from "@chakra-ui/core"


### PR DESCRIPTION
As mentioned in #1693 application code outside of the react context should be able to create a new toast.
E.g. in API abstractions or Vanilla JS files it can simplify the code.

Fix #1693

## Example 

```
import { createStandaloneToast } from "@chakra/core"

const toast = createStandaloneToast()
// const customToast = createStandaloneToast({ theme: customTheme })

const fetchUsers = async () => {
  await fetch() // ...
  toast({
    title: "Yay",
    status: "success"
  })
}
```