### PR TITLE
docs: add `IconButton` to migration doc

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -352,6 +352,27 @@ with other icons:
 import { createIcon, MoonIcon, SunIcon } from "@chakra-ui/icons"
 ```
 
+### Icon Button
+
+- We've unified the usage of all icon props to only accept a React element.
+  Update all icon names used in `icon` to the equivalent icon
+  React element.
+
+> Replacement logic: If `icon` is `email`, then replace it with
+> `<EmailIcon/>` from Chakra.
+
+```diff
+import { PhoneIcon } from "@chakra-ui/core"
+
+- <IconButton icon="phone">Call</IconButton>
++ <IconButton icon={<PhoneIcon />}>Call</IconButton>
+```
+
+**This reduces the effort needed to use custom icons, eliminates TypeScript
+errors, and reduces unused icons bloating your app.**
+
+- Renamed `variantColor` to `colorScheme`
+
 ### Skeleton
 
 Renamed `colorStart` and `colorEnd` props to `startColor` and `endColor`


### PR DESCRIPTION
IconButton wasn't mentioned in the migration doc, so I've added a section for it.