### PR TITLE
fix(modal): fix ModalFooter to use the forwardRef utility

### DIFF
--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -276,6 +276,8 @@ if (__DEV__) {
   ModalBody.displayName = "ModalBody"
 }
 
+export interface ModalFooterProps extends PropsOf<typeof chakra.footer> {}
+
 /**
  * ModalFooter
  *
@@ -283,22 +285,27 @@ if (__DEV__) {
  *
  * @see Docs https://chakra-ui.com/components/modal
  */
-export const ModalFooter: React.FC<PropsOf<typeof chakra.footer>> = (props) => {
-  const styles = useStyles()
-  return (
-    <chakra.footer
-      {...props}
-      __css={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "flex-end",
-        flex: 0,
-        ...styles.footer,
-      }}
-      className={cx("chakra-modal__footer", props.className)}
-    />
-  )
-}
+export const ModalFooter = forwardRef<ModalFooterProps, "footer">(
+  function ModalFooter(props, ref) {
+    const { className, ...rest } = props
+    const _className = cx("chakra-modal__footer", className)
+    const styles = useStyles()
+    return (
+      <chakra.footer
+        ref={ref}
+        {...rest}
+        __css={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+          flex: 0,
+          ...styles.footer,
+        }}
+        className={_className}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   ModalFooter.displayName = "ModalFooter"


### PR DESCRIPTION
I wasn't able to do the following because of the typings (which I could do with the `ModalHeader`).
```
  <ModalFooter as={Stack} direction="row">...</ModalFooter>
```
Looking into the code I found that the footer was defined diferently than the header and the body. This PR fixes this incosistency by using the same method as the other components.