### PR TITLE
fix: Zero-out number input wrapper z-index

### DIFF
--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -82,7 +82,10 @@ export const NumberInput = forwardRef<NumberInputProps, "div">(
           <chakra.div
             ref={ref}
             {...htmlProps}
-            __css={{ position: "relative" }}
+            __css={{
+              position: "relative",
+              zIndex: 0
+            }}
           />
         </StylesProvider>
       </NumberInputProvider>


### PR DESCRIPTION
The number input component renders its `Stepper` children with a `zIndex` of 1: https://github.com/chakra-ui/chakra-ui/blob/develop/packages/number-input/src/number-input.tsx#L125

This causes issues with the steppers appearing above other absolutely-positioned elements with a lower `zIndex` or that appear before the number input in the HTML stack.

Here's a GIF of the bug in action:

![5d98f1868f434ab00768050c5cb6ce28](https://user-images.githubusercontent.com/1216917/90711665-27bd3e80-e256-11ea-98c7-58296bfd25d8.gif)

By setting `zIndex: 0` on the wrapper component, its children won't render above other elements like this:

![1b9cbb4e832e12e5eedda4a8e1f95653](https://user-images.githubusercontent.com/1216917/90711732-576c4680-e256-11ea-88f6-9dd055d08de3.gif)
