### PR TITLE
fix(website): add missing docs/components to the sidebar

### DIFF
--- a/website/configs/docs-sidebar.ts
+++ b/website/configs/docs-sidebar.ts
@@ -312,6 +312,45 @@ const sidebar = {
             },
           ],
         },
+        {
+          title: "Other Components",
+          path: "/docs/components",
+          open: true,
+          routes: [
+            {
+              title: "Accordion",
+              path: "/docs/components/accordion",
+            },
+            {
+              title: "Breadcrumb",
+              path: "/docs/components/breadcrumb",
+            },
+            {
+              title: "Close Button",
+              path: "/docs/components/close-button",
+            },
+            {
+              title: "Collapse",
+              path: "/docs/components/collapse",
+            },
+            {
+              title: "Icon",
+              path: "/docs/components/icon",
+            },
+            {
+              title: "Link",
+              path: "/docs/components/link",
+            },
+            {
+              title: "Tabs",
+              path: "/docs/components/tabs",
+            },
+            {
+              title: "Visually Hidden",
+              path: "/docs/components/visually-hidden",
+            },
+          ],
+        },
       ],
     },
   ],


### PR DESCRIPTION
This PR adds the docs in `pages/docs/components` to the sidebar. Poor things were missing!

![image](https://user-images.githubusercontent.com/1954752/90833023-1edf7200-e315-11ea-9dce-d0883609df75.png)
