### PR TITLE
docs: fix typo in theming

### DIFF
--- a/website/pages/docs/theming/theme.mdx
+++ b/website/pages/docs/theming/theme.mdx
@@ -251,7 +251,7 @@ Tailwind CSS. The values are proportional, so 1 spacing unit is equal to
 
 ## Sizes
 
-The `sizes` key allows you to customize the global sizeing of components you
+The `sizes` key allows you to customize the global sizing of components you
 build for your project. By default these spacing value can be referenced by the
 `width`, `height`, and `maxWidth`, `minWidth`, `maxHeight`, `minHeight` styles.
 


### PR DESCRIPTION
Correct spelling of "sizeing" to "sizing".