### PR TITLE
chore: add selectors for :only-of-type, :only-child

### DIFF
--- a/packages/styled-system/src/pseudo/pseudo.selector.ts
+++ b/packages/styled-system/src/pseudo/pseudo.selector.ts
@@ -154,6 +154,14 @@ export const pseudoSelectors = {
    */
   _odd: "&:nth-of-type(odd)",
   /**
+   * Styles for CSS Selector `&:only-of-type`
+   */
+  _onlyOfType: "&:only-of-type",
+  /**
+   * Styles for CSS Selector `&:only-child`
+   */
+  _onlyChild: "&:only-child",
+  /**
    * Styles for CSS Selector `&:first-of-type`
    */
   _first: "&:first-of-type",


### PR DESCRIPTION
MDN: [:only-of-type](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type), [:only-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-child)

I pause when I type `_only` expecting to see autocompletion and don't see anything. I haven't seen this brought up on the tracker, so I'll give it a go:

My use case was a mixture of MDXProvider heading components being reused.

Another common example is `.map()` of components, when only one item exists in the list. 

Note: There's ways to play with `_first`/`_last` and moving spacing to child components to get the intended effects of these.

Still I think from a developer friendliness some may like it. Thoughts?