### PR TITLE
fix(website): enable team github links

### DIFF
--- a/website/pages/team.tsx
+++ b/website/pages/team.tsx
@@ -37,7 +37,7 @@ function Member({ member }) {
     name,
     twitter_username: twitterUsername,
     blog: websiteUrl,
-    html_url: url,
+    url,
   } = member
 
   return (


### PR DESCRIPTION
This changes an issue where team GitHub links didn't link to anything. Thanks @ljosberinn for catching that.