### PR TITLE
chore(website): add docs:deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "version:next": "lerna version --exact --force-publish=* --preid rc",
     "release:next": "lerna publish from-package --dist-tag next",
     "docs": "yarn workspace @chakra-ui/docs",
+    "docs:deploy": "yarn build && yarn docs:build && cp -r website/public .",
     "docs:build": "yarn members:gen && yarn docs build",
     "docs:start": "yarn docs start",
     "core": "yarn workspace @chakra-ui/core",


### PR DESCRIPTION
This PR fixes an issue where the `public/` directory wasn't correctly copied to deployments by `vercel.` The `public/` directory needs to be in the root directory in order for it to find it, so I added a command to `cp` to that directory to the root. 

As part of this change I updated the build command in the Vercel project settings to `yarn docs:deploy`.

Thanks to @jmiazga for the assist on this one!