### PR TITLE
fix(menu): hide menu using opacity and pointerEvents

### DIFF
--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -272,7 +272,9 @@ export function useMenuList(props: UseMenuListProps) {
     tabIndex: -1,
     role: "menu",
     id: menuId,
-    hidden: !isOpen,
+    ...(isOpen
+      ? { opacity: 1, pointerEvents: "auto" }
+      : { opacity: 0, pointerEvents: "none" }),
     "aria-orientation": "vertical" as React.AriaAttributes["aria-orientation"],
     "data-placement": placement,
     style: { ...popper.style, ...props.style },
@@ -376,6 +378,7 @@ export function useMenuItem(props: UseMenuItemProps) {
     focusedIndex,
     closeOnSelect,
     onClose,
+    isOpen,
     menuRef,
   } = menu
 
@@ -431,7 +434,7 @@ export function useMenuItem(props: UseMenuItemProps) {
         focus(ref.current)
       }
     } else {
-      if (document.activeElement !== menuRef.current) {
+      if (document.activeElement !== menuRef.current && isOpen) {
         menuRef.current?.focus()
       }
     }

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -275,6 +275,7 @@ export function useMenuList(props: UseMenuListProps) {
     ...(isOpen
       ? { opacity: 1, pointerEvents: "auto" }
       : { opacity: 0, pointerEvents: "none" }),
+    "aria-hidden": isOpen ? false : true,
     "aria-orientation": "vertical" as React.AriaAttributes["aria-orientation"],
     "data-placement": placement,
     style: { ...popper.style, ...props.style },


### PR DESCRIPTION
Description: https://github.com/chakra-ui/chakra-ui/issues/1820

## With custom React spring animation
https://www.loom.com/share/15e6a690213f41f2b3f4c19deb51a0ec

## Without animation
https://www.loom.com/share/c7d1ff2679cf4909a54915dc62b5515a

* As a side note, I think this a code smell that there's too much coupling between `MenuTransition` and the `Menu`. After these changes `MenuTransition` can probably be simplified