### PR TITLE
fix: mock out useId for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
+const path = require("path")
+
+const setup = path.join(__dirname, "jest.setup.js")
+
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
   collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
   transform: { ".(ts|tsx)$": "ts-jest/dist" },
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect", setup],
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,15 @@
+let id = 0
+
+/*
+ * Mock out the `useId` function for consistent results in snapshots.
+ */
+beforeEach(() => {
+  jest.unmock("@chakra-ui/hooks")
+  const hooks = require("@chakra-ui/hooks")
+  hooks.useId = (idProp = ++id, prefix) =>
+    prefix ? `${prefix}-${idProp}` : idProp
+})
+
+afterEach(() => {
+  id = 0
+})

--- a/packages/accordion/jest.config.js
+++ b/packages/accordion/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/alert/jest.config.js
+++ b/packages/alert/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/avatar/jest.config.js
+++ b/packages/avatar/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/breadcrumb/jest.config.js
+++ b/packages/breadcrumb/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/button/jest.config.js
+++ b/packages/button/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/checkbox/jest.config.js
+++ b/packages/checkbox/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/clickable/jest.config.js
+++ b/packages/clickable/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/close-button/jest.config.js
+++ b/packages/close-button/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/collapse/jest.config.js
+++ b/packages/collapse/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/color-mode/jest.config.js
+++ b/packages/color-mode/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/control-box/jest.config.js
+++ b/packages/control-box/jest.config.js
@@ -1,10 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
-  },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/counter/jest.config.js
+++ b/packages/counter/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/css-reset/jest.config.js
+++ b/packages/css-reset/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/descendant/jest.config.js
+++ b/packages/descendant/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/drawer/jest.config.js
+++ b/packages/drawer/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/editable/jest.config.js
+++ b/packages/editable/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/focus-lock/jest.config.js
+++ b/packages/focus-lock/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/form-control/jest.config.js
+++ b/packages/form-control/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/hooks/jest.config.js
+++ b/packages/hooks/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/icon/jest.config.js
+++ b/packages/icon/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/icons/jest.config.js
+++ b/packages/icons/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/image/jest.config.js
+++ b/packages/image/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/input/jest.config.js
+++ b/packages/input/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/layout/jest.config.js
+++ b/packages/layout/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/live-region/jest.config.js
+++ b/packages/live-region/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/media-query/jest.config.js
+++ b/packages/media-query/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/menu/jest.config.js
+++ b/packages/menu/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/modal/jest.config.js
+++ b/packages/modal/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/number-input/jest.config.js
+++ b/packages/number-input/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/pin-input/jest.config.js
+++ b/packages/pin-input/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/pin-input/tests/__snapshots__/pin-input.test.tsx.snap
+++ b/packages/pin-input/tests/__snapshots__/pin-input.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`PinInput renders correctly 1`] = `
   <input
     aria-label="Please enter your pin code"
     autocomplete="not-allowed"
-    id="pin-input-1-0"
+    id="pin-input-2-0"
     inputmode="numeric"
     placeholder="○"
     value=""
@@ -13,7 +13,7 @@ exports[`PinInput renders correctly 1`] = `
   <input
     aria-label="Please enter your pin code"
     autocomplete="not-allowed"
-    id="pin-input-1-1"
+    id="pin-input-2-1"
     inputmode="numeric"
     placeholder="○"
     value=""
@@ -21,7 +21,7 @@ exports[`PinInput renders correctly 1`] = `
   <input
     aria-label="Please enter your pin code"
     autocomplete="not-allowed"
-    id="pin-input-1-2"
+    id="pin-input-2-2"
     inputmode="numeric"
     placeholder="○"
     value=""
@@ -29,7 +29,7 @@ exports[`PinInput renders correctly 1`] = `
   <input
     aria-label="Please enter your pin code"
     autocomplete="not-allowed"
-    id="pin-input-1-3"
+    id="pin-input-2-3"
     inputmode="numeric"
     placeholder="○"
     value=""

--- a/packages/popover/jest.config.js
+++ b/packages/popover/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/popper/jest.config.js
+++ b/packages/popper/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/portal/jest.config.js
+++ b/packages/portal/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/progress/jest.config.js
+++ b/packages/progress/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/radio/jest.config.js
+++ b/packages/radio/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/select/jest.config.js
+++ b/packages/select/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/skeleton/jest.config.js
+++ b/packages/skeleton/jest.config.js
@@ -1,10 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
-  },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/skip-nav/jest.config.js
+++ b/packages/skip-nav/jest.config.js
@@ -1,10 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
-  },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/slider/jest.config.js
+++ b/packages/slider/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/spinner/jest.config.js
+++ b/packages/spinner/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/stat/jest.config.js
+++ b/packages/stat/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/styled-system/jest.config.js
+++ b/packages/styled-system/jest.config.js
@@ -1,10 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
-  },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/switch/jest.config.js
+++ b/packages/switch/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/system/jest.config.js
+++ b/packages/system/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/tabs/jest.config.js
+++ b/packages/tabs/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/tag/jest.config.js
+++ b/packages/tag/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/textarea/jest.config.js
+++ b/packages/textarea/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/theme-tools/jest.config.js
+++ b/packages/theme-tools/jest.config.js
@@ -1,10 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
-  },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/theme/jest.config.js
+++ b/packages/theme/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/toast/jest.config.js
+++ b/packages/toast/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/tooltip/jest.config.js
+++ b/packages/tooltip/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/tooltip/tests/__snapshots__/tooltip.test.tsx.snap
+++ b/packages/tooltip/tests/__snapshots__/tooltip.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`matches snapshot when hovererd 1`] = `
 exports[`should show on mouseover if isDisabled has a falsy value 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="tooltip-66"
+    aria-describedby="tooltip-6"
   >
     Hover me
   </button>
@@ -31,7 +31,7 @@ exports[`should show on mouseover if isDisabled has a falsy value 1`] = `
 exports[`shows on mouseover and closes on mouseout 1`] = `
 <DocumentFragment>
   <button
-    aria-describedby="tooltip-42"
+    aria-describedby="tooltip-6"
   >
     Hover me
   </button>

--- a/packages/tooltip/tests/tooltip.test.tsx
+++ b/packages/tooltip/tests/tooltip.test.tsx
@@ -13,6 +13,12 @@ import { Tooltip } from "../src"
 const buttonLabel = "Hover me"
 const tooltipLabel = "tooltip label"
 
+beforeAll(() => {
+  jest.unmock("@chakra-ui/hooks")
+  const hooks = require("@chakra-ui/hooks")
+  hooks.useId = (id?: any) => id || "REACT-ID"
+})
+
 const DummyComponent = (props: Omit<TooltipProps, "children">) => (
   <Tooltip label={tooltipLabel} {...props}>
     <button>{buttonLabel}</button>

--- a/packages/tooltip/tests/tooltip.test.tsx
+++ b/packages/tooltip/tests/tooltip.test.tsx
@@ -13,12 +13,6 @@ import { Tooltip } from "../src"
 const buttonLabel = "Hover me"
 const tooltipLabel = "tooltip label"
 
-beforeAll(() => {
-  jest.unmock("@chakra-ui/hooks")
-  const hooks = require("@chakra-ui/hooks")
-  hooks.useId = (id?: any) => id || "REACT-ID"
-})
-
 const DummyComponent = (props: Omit<TooltipProps, "children">) => (
   <Tooltip label={tooltipLabel} {...props}>
     <button>{buttonLabel}</button>

--- a/packages/transition/jest.config.js
+++ b/packages/transition/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }

--- a/packages/visually-hidden/jest.config.js
+++ b/packages/visually-hidden/jest.config.js
@@ -1,8 +1,5 @@
+const baseConfig = require("../../jest.config")
+
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
-  transform: { ".(ts|tsx)$": "ts-jest/dist" },
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  ...baseConfig,
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Tests inconsistently fail due to the use of `useId`. It generates a number starting from `0` so that we can have unique ids for aria purposes, but this causes tests with snapshots to fail because the number if different based on the number of tests or order of the tests.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `useId` is now mocked out before each test, and the unique number is reset to `0` for each test.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
