### PR TITLE
fix(input-element): increase z-index

### DIFF
--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -13,7 +13,7 @@ const StyledElement = chakra("div", {
     justifyContent: "center",
     position: "absolute",
     top: "0",
-    zIndex: 1,
+    zIndex: 2,
   },
 })
 

--- a/packages/input/tests/__snapshots__/input.test.tsx.snap
+++ b/packages/input/tests/__snapshots__/input.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Elements inside input render correctly 1`] = `
   justify-content: center;
   position: absolute;
   top: 0;
-  z-index: 1;
+  z-index: 2;
 }
 
 .emotion-1 {
@@ -117,7 +117,7 @@ exports[`Elements inside input render correctly 1`] = `
   justify-content: center;
   position: absolute;
   top: 0;
-  z-index: 1;
+  z-index: 2;
 }
 
 <div


### PR DESCRIPTION
Fixes #1900 

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

See #1900

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `InputElement` has a `z-index` of `2`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is a naive solution. Without a `_groupFocusWithin` pseudoselector, we don't have a good way to apply `z-index` only when the `input` is focused.

I'd be happy to create that if we'd rather go with that.