### PR TITLE
chore(cra-templates): add lint scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "license": "MIT",
   "scripts": {
-    "lint:types": "lerna exec --parallel \"tsc --noEmit\"",
     "contrib:add": "all-contributors add",
     "contrib:gen": "all-contributors generate",
     "prestart": "yarn && yarn bootstrap",
@@ -31,6 +30,7 @@
     "build": "lerna run build --ignore @chakra-ui/test-utils --no-private --stream",
     "test": "lerna run test --no-private --stream",
     "lint": "lerna run lint --no-private --stream",
+    "lint:types": "lerna exec --parallel \"tsc --noEmit\"",
     "storybook": "start-storybook -p 6006",
     "clean": "lerna clean --yes && rm -rf node_modules",
     "bootstrap": "lerna bootstrap --use-workspaces",

--- a/tooling/cra-template-typescript/package.json
+++ b/tooling/cra-template-typescript/package.json
@@ -27,5 +27,10 @@
   "files": [
     "template",
     "template.json"
-  ]
+  ],
+  "scripts": {
+    "lint": "concurrently yarn:lint:*",
+    "lint:src": "eslint template/src --ext .ts,.tsx --config ../../.eslintrc",
+    "lint:types": "tsc --noEmit"
+  }
 }

--- a/tooling/cra-template-typescript/tsconfig.json
+++ b/tooling/cra-template-typescript/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["typings.ts", "template/src"]
+}

--- a/tooling/cra-template-typescript/typings.ts
+++ b/tooling/cra-template-typescript/typings.ts
@@ -1,0 +1,11 @@
+declare module "*.svg" {
+  const content: any
+  export default content
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare namespace NodeJS {
+  export interface ProcessEnv {
+    [key: string]: string
+  }
+}

--- a/tooling/cra-template/package.json
+++ b/tooling/cra-template/package.json
@@ -26,5 +26,9 @@
   "files": [
     "template",
     "template.json"
-  ]
+  ],
+  "scripts": {
+    "lint": "concurrently yarn:lint:*",
+    "lint:src": "eslint template/src --ext .js,.jsx --config ../../.eslintrc"
+  }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Workflow changes

## What is the current behavior?

`cra-template` and `cra-template-typescript` don't have a `lint` script defined, so they are not type-checked or linted during the pipelines.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added `lint` script to `cra-template` that runs `eslint` on `js, jsx` files in `template/src`
- Added `lint` script to `cra-template-typescript` that runs `eslint` and `tsc --noEmit` on files in `template/src`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I had to introduce `tsconfig.json` and a `typings.ts` file to `cra-template-typescript` to get linting and type-checking to work. These files won't be added to projects generated from the template, so they have no end-user effect.