### PR TITLE
Set width and height for heroes

### DIFF
--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -355,7 +355,8 @@ const HomePage = ({ members, sponsors }) => {
                 {members.map((i) => (
                   <Img
                     key={i.login}
-                    htmlWidth="80px"
+                    width="80px"
+                    height="80px"
                     rounded="full"
                     alt={i.name}
                     src={i.avatar_url}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

On safari there's a rather amusing bug that makes "Chakra Heroes" look very
L
O
N
G

<img width="1242" alt="Screenshot 2020-09-03 at 08 55 55" src="https://user-images.githubusercontent.com/7349341/92076793-ce135300-edc3-11ea-8d26-4ce33c550d61.png">

Issue Number: N/A

## What is the new behavior?

Image sizes are fixed to specific width and height

<img width="1242" alt="Screenshot 2020-09-03 at 08 55 59" src="https://user-images.githubusercontent.com/7349341/92076817-dff4f600-edc3-11ea-8fbe-a8d207f17bc1.png">

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
