### PR TITLE
fix(icon-props-type): make icons props optional

### DIFF
--- a/packages/icon/src/icon.tsx
+++ b/packages/icon/src/icon.tsx
@@ -21,7 +21,7 @@ const fallbackIcon = {
   viewBox: "0 0 24 24",
 }
 
-export interface IconProps extends PropsOf<typeof chakra.svg> {}
+export interface IconProps extends Partial<PropsOf<typeof chakra.svg>> {}
 
 export const Icon = forwardRef<IconProps, "svg">(function Icon(props, ref) {
   const {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

> The icons from @chakra-ui/icons@1.0.0-rc.3 are throwing the following error:
> Type '{}' is missing the following properties from type ...

Fix #1903 

## What is the new behavior?

Make all properties in `IconProps` optional with type `Partial<T>`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
