### PR TITLE
test(number-input): update number-input, input, select and textarea snapshot due background

### DIFF
--- a/packages/input/tests/__snapshots__/input.test.tsx.snap
+++ b/packages/input/tests/__snapshots__/input.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Elements inside input render correctly 1`] = `
   border-radius: 0.25rem;
   border: 1px solid;
   border-color: inherit;
-  background: #FFFFFF;
+  background: inherit;
   padding-left: 2.5rem;
   padding-right: 2.5rem;
 }
@@ -199,7 +199,7 @@ exports[`addons render correctly 1`] = `
   border-radius: 0.25rem;
   border: 1px solid;
   border-color: inherit;
-  background: #FFFFFF;
+  background: inherit;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-top-right-radius: 0;
@@ -313,7 +313,7 @@ exports[`renders correctly 1`] = `
   border-radius: 0.25rem;
   border: 1px solid;
   border-color: inherit;
-  background: #FFFFFF;
+  background: inherit;
 }
 
 .emotion-0:hover,

--- a/packages/number-input/tests/__snapshots__/number-input.test.tsx.snap
+++ b/packages/number-input/tests/__snapshots__/number-input.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`should render correctly 1`] = `
   border-radius: 0.25rem;
   border: 1px solid;
   border-color: inherit;
-  background: #FFFFFF;
+  background: inherit;
 }
 
 .emotion-0:hover,

--- a/packages/select/tests/__snapshots__/select.test.tsx.snap
+++ b/packages/select/tests/__snapshots__/select.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Select renders correctly 1`] = `
   border-radius: 0.25rem;
   border: 1px solid;
   border-color: inherit;
-  background: #FFFFFF;
+  background: inherit;
   padding-right: 2rem;
 }
 

--- a/packages/textarea/tests/__snapshots__/text-area.test.tsx.snap
+++ b/packages/textarea/tests/__snapshots__/text-area.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Textarea renders correctly 1`] = `
   border-radius: 0.25rem;
   border: 1px solid;
   border-color: inherit;
-  background: #FFFFFF;
+  background: inherit;
 }
 
 .emotion-0:hover,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Just update a test snapshot for the `NumberInput`, `Input`, `Select` and `TextArea`. 
The background color changed from `#FFF` to `inherit`.

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Failing test due invalid snapshot

## What is the new behavior?

Green test

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
