### PR TITLE
docs: document usage of close/closeAll instance methods

### DIFF
--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -79,6 +79,48 @@ function Example() {
 }
 ```
 
+## Closing Toasts
+
+Toasts can be closed imperatively, individually (via the `close` instance
+method) or all together (via the `closeAll` instance method).
+
+```jsx
+function Example() {
+  const toast = useToast()
+  const toastIdRef = React.useRef()
+
+  function close() {
+    if (toastIdRef.current) {
+      toast.close(toastIdRef.current)
+    }
+  }
+
+  function closeAll() {
+    toast.closeAll()
+  }
+
+  function addToast() {
+    toastIdRef.current = toast({ description: "some text" })
+  }
+
+  return (
+    <Stack isInline spacing={2}>
+      <Button onClick={addToast} type="button">
+        Toast
+      </Button>
+
+      <Button onClick={close} type="button" variant="outline">
+        Close last toast
+      </Button>
+
+      <Button onClick={closeAll} type="button" variant="outline">
+        Close all toasts
+      </Button>
+    </Stack>
+  )
+}
+```
+
 ## Success
 
 ```jsx


### PR DESCRIPTION
## Pull request type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Docs do not explain the usage of the `close` and `closeAll` instance methods on the `toast` object.

@ljosberinn I might be missing something here, but I don't think the `closeAll` method is working as I thought it should be in the example story. Any ideas?

#63 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No