### PR TITLE
fix(tooling): flip load order of CSSReset and GlobalStyles

### DIFF
--- a/tooling/gatsby-plugin-chakra-ui/gatsby-browser.js
+++ b/tooling/gatsby-plugin-chakra-ui/gatsby-browser.js
@@ -16,8 +16,8 @@ export const wrapRootElement = (
   return (
     <ThemeProvider theme={theme}>
       <ModeProvider>
-        <GlobalStyle />
         {isResettingCSS && <CSSReset />}
+        <GlobalStyle />
         <PortalManager zIndex={portalZIndex}>{element}</PortalManager>
       </ModeProvider>
     </ThemeProvider>


### PR DESCRIPTION
Flips the order of GlobalStyles and CSSReset to fix CSSReset taking precedence, same as in PR #1609

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GlobalStyle is loaded before CSSReset, making CSSReset take precedence

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Swaps the order to reset first and then load the new GlobalStyles

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
