### PR TITLE
docs(accordion): remove references to some AccordionItem props

### DIFF
--- a/website/pages/docs/components/accordion.mdx
+++ b/website/pages/docs/components/accordion.mdx
@@ -246,24 +246,22 @@ toggle (expand or collapse) the accordion.
 
 ### Accordion Props
 
-| Name          | Type                              | Default | Description                                                                                               |
-| ------------- | --------------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
-| allowMultiple | `boolean`                         |         | If `true`, multiple accordion items can be expanded at once.                                              |
-| allowToggle   | `boolean`                         |         | If `true`, any expanded accordion item can be collapsed again.                                            |
-| index         | `NumberOrArrayOfNumber`           |         | The index(es) of the expanded accordion item                                                              |
-| defaultIndex  | `NumberOrArrayOfNumber`           |         | The initial index(es) of the expanded accordion item. Must be an array for `allowMultiple={true}` to function.                                                      |
-| onChange      | `(NumberOrArrayOfNumber) => void` |         | The callback invoked when accordion items are expanded or collapsed.                                      |
-| children      | `ReactNode`                       |         | The content of the accordion. The children must be the `AccordionButton` and `AccordionPanel` components. |
+| Name          | Type                              | Default | Description                                                                                                    |
+| ------------- | --------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
+| allowMultiple | `boolean`                         |         | If `true`, multiple accordion items can be expanded at once.                                                   |
+| allowToggle   | `boolean`                         |         | If `true`, any expanded accordion item can be collapsed again.                                                 |
+| index         | `NumberOrArrayOfNumber`           |         | The index(es) of the expanded accordion item                                                                   |
+| defaultIndex  | `NumberOrArrayOfNumber`           |         | The initial index(es) of the expanded accordion item. Must be an array for `allowMultiple={true}` to function. |
+| onChange      | `(NumberOrArrayOfNumber) => void` |         | The callback invoked when accordion items are expanded or collapsed.                                           |
+| children      | `ReactNode`                       |         | The content of the accordion. The children must be the `AccordionButton` and `AccordionPanel` components.      |
 
 ### AccordionItem Props
 
 | Name          | Type                                      | Default | Description                                                                                               |
 | ------------- | ----------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
-| isOpen        | `boolean`                                 |         | If `true`, expands the accordion in the controlled mode.                                                  |
 | defaultIsOpen | `boolean`                                 |         | If `true`, expands the accordion by on initial mount.                                                     |
 | id            | `string`                                  |         | A unique `id` for the accordion item.                                                                     |
 | isDisabled    | `boolean`                                 |         | If `true`, the accordion header will be disabled.                                                         |
-| onChange      | `(NumberOrArrayOfNumber) => void`         |         | The callback fired when the accordion is expanded/collapsed.                                              |
 | children      | `ReactNode`, `(RenderProps) => ReactNode` |         | The content of the accordion. The children must be the `AccordionButton` and `AccordionPanel` components. |
 
 <br />


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`AccordionItem` no longer has the `isOpen` and `onChange` props as part of its api, but these are still documented.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed references to `isOpen` and `onChange` in the props table

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
