### PR TITLE
fix(alert): improve layout and text/icon alignment

### DIFF
--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -55,7 +55,7 @@ export const Alert = forwardRef<AlertProps, "div">(function Alert(props, ref) {
   const alertStyles = {
     width: "100%",
     display: "flex",
-    alignItems: "center",
+    alignItems: "flex-start",
     position: "relative",
     overflow: "hidden",
     ...styles.container,
@@ -81,12 +81,17 @@ export interface AlertTitleProps extends PropsOf<typeof chakra.div> {}
 export const AlertTitle = forwardRef<AlertTitleProps, "div">(
   function AlertTitle(props, ref) {
     const styles = useStyles()
+    const titleStyles = {
+      display: "inline-block",
+      ...styles.title,
+    }
+
     return (
       <chakra.div
         ref={ref}
         {...props}
         className={cx("chakra-alert__title", props.className)}
-        __css={styles.title}
+        __css={titleStyles}
       />
     )
   },
@@ -98,7 +103,7 @@ export const AlertDescription = forwardRef<AlertDescriptionProps, "div">(
   function AlertDescription(props, ref) {
     const styles = useStyles()
     const descriptionStyles = {
-      display: "inline-block",
+      display: "inline",
       ...styles.description,
     }
 

--- a/packages/alert/tests/__snapshots__/alert.test.tsx.snap
+++ b/packages/alert/tests/__snapshots__/alert.test.tsx.snap
@@ -8,10 +8,10 @@ exports[`matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   position: relative;
   overflow: hidden;
   padding-left: 1rem;
@@ -24,7 +24,7 @@ exports[`matches snapshot 1`] = `
 .emotion-1 {
   margin-right: 0.75rem;
   width: 1.25rem;
-  height: 1.25rem;
+  height: 1.5rem;
   color: #3182ce;
   display: inherit;
 }
@@ -42,12 +42,15 @@ exports[`matches snapshot 1`] = `
 }
 
 .emotion-2 {
+  display: inline-block;
   font-weight: 700;
-  line-height: normal;
+  line-height: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .emotion-3 {
-  display: inline-block;
+  display: inline;
+  line-height: 1.5rem;
 }
 
 <div

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -10,12 +10,16 @@ const baseStyle = {
   },
   title: {
     fontWeight: "bold",
-    lineHeight: "normal",
+    lineHeight: 6,
+    mr: 2,
+  },
+  description: {
+    lineHeight: 6,
   },
   icon: {
     mr: 3,
     w: 5,
-    h: 5,
+    h: 6,
   },
 }
 

--- a/website/pages/docs/feedback/alert.mdx
+++ b/website/pages/docs/feedback/alert.mdx
@@ -113,6 +113,7 @@ kinds of layouts. Here's an example of a custom alert style and layout:
   status="success"
   variant="subtle"
   flexDirection="column"
+  alignItems="center"
   justifyContent="center"
   textAlign="center"
   height="200px"
@@ -124,6 +125,21 @@ kinds of layouts. Here's an example of a custom alert style and layout:
   <AlertDescription maxWidth="sm">
     Thanks for submitting your application. Our team will get back to you soon.
   </AlertDescription>
+</Alert>
+```
+
+Alerts can also incorporate other Chakra components. Here's an example of an alert with wrapping description text:
+
+```jsx
+<Alert status="success">
+  <AlertIcon />
+  <Box flex="1">
+    <AlertTitle>Success!</AlertTitle>
+    <AlertDescription display="block">
+      Your application has been received. We will review your application and respond within the next 48 hours.
+    </AlertDescription>
+  </Box>
+  <CloseButton position="absolute" right="8px" top="8px" />
 </Alert>
 ```
 


### PR DESCRIPTION
This PR improves the `Alert` component's layout consistency, addressing #1619 and previously included with #1611.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Documentation content changes
- [x] Other (please describe): Design

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## What is the current behavior?

Presently, `AlertTitle` and `AlertDescription` have slightly different line heights, and behave inconsistently depending on the content provided. A few of the [stories](https://github.com/chakra-ui/chakra-ui/blob/develop/packages/alert/stories/alert.stories.tsx) for this component use additional markup with varying results. This PR attempts to reconcile some of these issues.

<img width="650" alt="Screen Shot 2020-09-08 at 2 18 16 PM" src="https://user-images.githubusercontent.com/180438/92532057-5179dd80-f1e4-11ea-8e8c-6aefc8bc3bd0.png">

<img width="600" alt="Screen Shot 2020-09-08 at 2 19 54 PM" src="https://user-images.githubusercontent.com/180438/92532103-69516180-f1e4-11ea-830b-8e22ebcc74d3.png">

<img width="621" alt="Screen Shot 2020-08-11 at 9 40 41 AM" src="https://user-images.githubusercontent.com/180438/89929512-2472e480-dbbe-11ea-91a1-57bf07475b0a.png">

`AlertTitle` and `AlertDescription` present as inline as a side-effect of the alert container's flex styling, but then present with a line break when placed inside another div element:

<img width="611" alt="Screen Shot 2020-09-08 at 2 20 36 PM" src="https://user-images.githubusercontent.com/180438/92532134-766e5080-f1e4-11ea-8bf7-d7186e9346d4.png">

## What is the new behavior?

<img width="609" alt="Screen Shot 2020-09-08 at 2 14 59 PM" src="https://user-images.githubusercontent.com/180438/92532308-e1b82280-f1e4-11ea-9172-d69b594cdb7e.png">

This update will ensure `AlertTitle` and `AlertDescription` are presented inline by default, unless explicitly overridden:

<img width="600" alt="Screen Shot 2020-09-08 at 2 15 08 PM" src="https://user-images.githubusercontent.com/180438/92532311-e41a7c80-f1e4-11ea-9043-c1a7bd56903d.png">

<img width="607" alt="Screen Shot 2020-09-08 at 2 15 24 PM" src="https://user-images.githubusercontent.com/180438/92532319-e7ae0380-f1e4-11ea-989e-341e987af7ee.png">

## Does this introduce a breaking change?

- [x] No

## Other notes

Toasts also inherit these updates, since they use the `Alert` component under the hood.

**Before:**

<img width="469" alt="Screen Shot 2020-09-08 at 2 00 27 PM" src="https://user-images.githubusercontent.com/180438/92532202-a289d180-f1e4-11ea-8232-7851a1741af3.png">

**After:**

<img width="474" alt="Screen Shot 2020-09-08 at 2 02 39 PM" src="https://user-images.githubusercontent.com/180438/92532344-f4325c00-f1e4-11ea-90ed-11d3c7c9b655.png">
