### PR TITLE
docs(popover): remove closeOnBlur tab note

### DIFF
--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -58,7 +58,7 @@ export interface UsePopoverProps {
   placement?: Placement
   /**
    * If `true`, the popover will close when you blur out it by
-   * clicking outside or tabbing out
+   * clicking outside.
    */
   closeOnBlur?: boolean
   /**

--- a/website/pages/docs/overlay/popover.mdx
+++ b/website/pages/docs/overlay/popover.mdx
@@ -395,8 +395,8 @@ possible placement values.
 - Hitting the `Esc` key while the popover is open and focus is within the
   `PopoverContent`, will close the popover. If you set `closeOnEsc` to `false`,
   it will not close.
-- Clicking outside or blurring out of the `PopoverContent` closes the popover.
-  If you set `closeOnBlur` to `false`, it will not close.
+- Clicking outside of the `PopoverContent` closes the popover. If you set
+  `closeOnBlur` to `false`, it will not close.
 
 ### ARIA Attributes
 
@@ -428,7 +428,7 @@ possible placement values.
 | `trigger`            | `hover`, `click`                                               | `click`  | The interaction that triggers the popover.                                                                                                                                                                                 |
 | `placement`          | `PopperJS.placement`                                           | `bottom` | The placement of the popover.                                                                                                                                                                                              |
 | `returnFocusOnClose` | `boolean`                                                      | `true`   | If `true`, the popover will return focus to the trigger when it closes                                                                                                                                                     |
-| `closeOnBlur`        | `boolean`                                                      | `true`   | If `true`, the popover will close when you blur out it by clicking outside or tabbing out                                                                                                                                  |
+| `closeOnBlur`        | `boolean`                                                      | `true`   | If `true`, the popover will close when you blur out it by clicking outside                                                                                                                                                 |
 | `closeOnEsc`         | `boolean`                                                      | `true`   | If `true`, close the popover when the `esc` key is pressed                                                                                                                                                                 |
 | `children`           | `React.ReactNode`, `(props: InternalState) => React.ReactNode` |          | The children of the popover                                                                                                                                                                                                |
 | `gutter`             | `number`                                                       | `4`      | The gap (in pixels) to apply between the popover and the target. Used by `popper.js`                                                                                                                                       |


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Fix comment

## What is the current behavior?

The docs jsdoc of the `closeOnBlur` prop for `Popover` says "If `true`, the popover will close when you blur out it by clicking outside or tabbing out".

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the reference to "tabbing out".

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is currently functionality that doesn't actually exist and—since we're using `useInteractOutside` from `react-aria`—we don't have an easy way to implement. We should remove this from the docs and jsdoc until we actually have that behavior in place.