### PR TITLE
fix: useStyleConfig omit children when merging

### DIFF
--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -1,5 +1,5 @@
 import { SystemStyleObject } from "@chakra-ui/styled-system"
-import { filterUndefined, get, merge, runIfFn } from "@chakra-ui/utils"
+import { filterUndefined, get, merge, runIfFn, omit } from "@chakra-ui/utils"
 import { useMemo, useRef } from "react"
 import isEqual from "react-fast-compare"
 import { useChakra } from "./hooks"
@@ -27,7 +27,7 @@ export function useStyleConfig(themeKey: any, props: any, opts: any) {
   const mergedProps = merge(
     { theme, colorMode },
     styleConfig?.defaultProps ?? {},
-    filterUndefined(rest),
+    filterUndefined(omit(rest, ["children"])),
   )
 
   /**


### PR DESCRIPTION
- fixes #2012

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

please see https://github.com/chakra-ui/chakra-ui/issues/2012#issuecomment-691458782 for more info

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Its a perf improvement for non-Preact projects too, for some reason it simply doesn't occur in React though.