### PR TITLE
fix(tooltip-arrow-padding): introduce arrowPadding prop

### DIFF
--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -18,6 +18,11 @@ export interface UsePopperProps {
   flip?: boolean
   arrowSize?: number
   arrowShadowColor?: string
+  /**
+   * The distance of the arrow to its next border (numeric)
+   * E.g. arrowPadding = borderRadius * 2
+   */
+  arrowPadding?: number
   eventsEnabled?: boolean
   modifiers?: Modifier<any, any>[]
 }
@@ -31,6 +36,7 @@ export function usePopper(props: UsePopperProps = {}) {
     forceUpdate = true,
     flip = true,
     arrowSize = 10,
+    arrowPadding,
     arrowShadowColor,
     gutter = arrowSize,
     eventsEnabled = true,
@@ -97,7 +103,10 @@ export function usePopper(props: UsePopperProps = {}) {
           {
             name: "arrow",
             enabled: Boolean(arrowRef.current),
-            options: { element: arrowRef.current },
+            options: {
+              element: arrowRef.current,
+              padding: arrowPadding,
+            },
           },
           {
             name: "updateState",
@@ -128,6 +137,7 @@ export function usePopper(props: UsePopperProps = {}) {
     offset,
     preventOverflow,
     eventsEnabled,
+    arrowPadding,
   ])
 
   useSafeLayoutEffect(() => {

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useRef } from "react"
 export interface UseTooltipProps
   extends Pick<
     UsePopperProps,
-    "arrowSize" | "modifiers" | "gutter" | "offset"
+    "arrowSize" | "arrowPadding" | "modifiers" | "gutter" | "offset"
   > {
   /**
    * Delay (in ms) before showing the tooltip
@@ -67,6 +67,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
     isOpen: isOpenProp,
     defaultIsOpen,
     arrowSize = 10,
+    arrowPadding = 4,
     modifiers,
     isDisabled,
     gutter,
@@ -85,6 +86,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
     forceUpdate: isOpen,
     placement,
     arrowSize,
+    arrowPadding,
     modifiers,
     gutter,
     offset,

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -231,3 +231,45 @@ export const withDefaultIsOpenProp = () => (
     </button>
   </Tooltip>
 )
+
+export const withAllPlacements = () => {
+  const allPlacements = [
+    "top",
+    "bottom",
+    "right",
+    "left",
+    "top-start",
+    "top-end",
+    "bottom-start",
+    "bottom-end",
+    "right-start",
+    "right-end",
+    "left-start",
+    "left-end",
+    "auto",
+    "auto-start",
+    "auto-end",
+  ] as const
+
+  return (
+    <>
+      {allPlacements.map((placement) => (
+        <Tooltip
+          key={placement}
+          hasArrow
+          isOpen
+          placement={placement}
+          label={placement}
+        >
+          <div
+            style={{
+              background: "#f0f0f0",
+              marginBottom: "5rem",
+              height: "3rem",
+            }}
+          />
+        </Tooltip>
+      ))}
+    </>
+  )
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Tooltip arrows are overflowing the Tooltip due borderRadii.

Fix #1863 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The [Popper modifier `arrow.padding`](https://popper.js.org/docs/v2/modifiers/arrow/#padding) takes care of exactly this issue. With the new property `arrowPadding` on the UsePopperProps the user can override the default of `4`. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

![image](https://user-images.githubusercontent.com/16899513/93025371-b62aa300-f5fd-11ea-97f6-9c8e9fdc3245.png)
