### PR TITLE
Feat/improve breakpoints dx

### DIFF
--- a/packages/theme-tools/src/breakpoints.ts
+++ b/packages/theme-tools/src/breakpoints.ts
@@ -1,0 +1,20 @@
+export interface BaseBreakpointConfig extends Record<string, string> {
+  sm: string
+  md: string
+  lg: string
+  xl: string
+}
+
+export type Breakpoints<T = BaseBreakpointConfig> = string[] & T
+
+export const createBreakpoints = <T extends BaseBreakpointConfig>(
+  config: T,
+): Breakpoints<T> => {
+  const sorted = Object.fromEntries(
+    Object.entries(config).sort((a, b) =>
+      parseInt(a[1]) > parseInt(b[1]) ? 1 : -1,
+    ),
+  ) as T
+
+  return Object.assign(Object.values(sorted), sorted)
+}

--- a/packages/theme-tools/src/index.ts
+++ b/packages/theme-tools/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./color"
 export * from "./component"
+export * from "./breakpoints"

--- a/packages/theme-tools/tests/breakpoints.test.ts
+++ b/packages/theme-tools/tests/breakpoints.test.ts
@@ -1,0 +1,103 @@
+import { createBreakpoints } from "../src"
+
+const defaultBreakpoints = {
+  sm: "30em",
+  md: "48em",
+  lg: "62em",
+  xl: "80em",
+}
+
+describe("createBreakpoints", () => {
+  test("returns an array", () => {
+    expect(createBreakpoints(defaultBreakpoints)).toBeInstanceOf(Array)
+  })
+
+  test("sorts by value size", () => {
+    const reversedDefaults = Object.fromEntries(
+      Object.entries(defaultBreakpoints).reverse(),
+    )
+
+    const expectedResult = createBreakpoints(defaultBreakpoints)
+
+    const result = createBreakpoints(reversedDefaults)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(result).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+
+  test("accepts further breakpoints", () => {
+    const xxl = "116em"
+
+    const extendedBreakpoints = {
+      ...defaultBreakpoints,
+      xxl,
+    }
+
+    const expectedResult = [
+      extendedBreakpoints.sm,
+      extendedBreakpoints.md,
+      extendedBreakpoints.lg,
+      extendedBreakpoints.xl,
+      xxl,
+    ]
+
+    const result = createBreakpoints(extendedBreakpoints)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(extendedBreakpoints).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+
+  test("works with px", () => {
+    const breakpoints = {
+      sm: "300px",
+      md: "480px",
+      lg: "620px",
+      xl: "800px",
+    }
+
+    const expectedResult = [
+      breakpoints.sm,
+      breakpoints.md,
+      breakpoints.lg,
+      breakpoints.xl,
+    ]
+
+    const result = createBreakpoints(breakpoints)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(breakpoints).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+
+  test("works with rem", () => {
+    const breakpoints = {
+      sm: "30rem",
+      md: "48rem",
+      lg: "62rem",
+      xl: "80rem",
+    }
+
+    const expectedResult = [
+      breakpoints.sm,
+      breakpoints.md,
+      breakpoints.lg,
+      breakpoints.xl,
+    ]
+
+    const result = createBreakpoints(breakpoints)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(breakpoints).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+})

--- a/packages/theme/src/foundations/breakpoints.ts
+++ b/packages/theme/src/foundations/breakpoints.ts
@@ -1,15 +1,13 @@
+import { createBreakpoints } from "@chakra-ui/theme-tools"
+
 /**
  * Breakpoints for responsive design
  */
-const breakpoints: any = ["30em", "48em", "62em", "80em"]
-
-/**
- * This is needed for object responsive breakpoints to work.
- * At the moment, we require the keys to be `sm`, `md`, `lg` and `xl`
- */
-breakpoints.sm = breakpoints[0]
-breakpoints.md = breakpoints[1]
-breakpoints.lg = breakpoints[2]
-breakpoints.xl = breakpoints[3]
+const breakpoints = createBreakpoints({
+  sm: "30em",
+  md: "48em",
+  lg: "62em",
+  xl: "80em",
+})
 
 export default breakpoints

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -2,11 +2,8 @@ import foundations from "./foundations"
 import components from "./components"
 import styles from "./styles"
 
-export {
-  Breakpoints,
-  BaseBreakpointConfig,
-  createBreakpoints,
-} from "@chakra-ui/theme-tools"
+export type { Breakpoints, BaseBreakpointConfig } from "@chakra-ui/theme-tools"
+export { createBreakpoints } from "@chakra-ui/theme-tools"
 
 export const theme = {
   ...foundations,

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -2,6 +2,12 @@ import foundations from "./foundations"
 import components from "./components"
 import styles from "./styles"
 
+export {
+  Breakpoints,
+  BaseBreakpointConfig,
+  createBreakpoints,
+} from "@chakra-ui/theme-tools"
+
 export const theme = {
   ...foundations,
   components,

--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -125,8 +125,8 @@ only one prop to manage this, you can rename it to `boxSize`.
 
 **You may safely skip this if you didn't customize your breakpoints.**
 
-To provide easier extensibility and typesafety, breakpoints now need to be an
-object:
+To provide easier extensibility and typesafety, breakpoints should now be
+created through `createBreakpoints` by passing an object:
 
 ```diff
 + import { createBreakpoints, extendTheme } from "@chakra-ui/core"

--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -121,6 +121,45 @@ only one prop to manage this, you can rename it to `boxSize`.
 > in some components (e.g. Button), it means the visual size and in others (e.g
 > Box), it means **width and height**.
 
+### 6. Update theme breakpoints
+
+**You may safely skip this if you didn't customize your breakpoints.**
+
+To provide easier extensibility and typesafety, breakpoints now need to be an
+object:
+
+```diff
++ import { createBreakpoints, extendTheme } from "@chakra-ui/core"
+
+
++ const breakpoints = createBreakpoints({
++   sm: "30em",
++   md: "48em",
++   lg: "62em",
++   xl: "80em",
++ })
+
+
+const overrides = {
+- breakpoints: ["30em", "48em", "62em", "80em"]
++ breakpoints,
+}
+
++ const customTheme = extendTheme(overrides)
+```
+
+**Please note that unless you plan overriding all components, `sm` to `xl` are
+required.**
+
+You may of course add for example `xxl` or other breakpoints in between -
+`createBreakpoints` will sort in ascending order. It is adviseable to not mix
+css units.
+
+> **Reason:** Previously, breakpoints on a theme had to be an array with your
+> breakpoints in ascending order which made it hard to reference which value was
+> correlating to `md` etc. On top, you had to manually manipulate the array by
+> defining properties on it, which was often overlooked and not typesafe.
+
 ---
 
 ## Component Updates


### PR DESCRIPTION
Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

 Previously, breakpoints on a theme had to be an array with your breakpoints in ascending order which made it hard to reference which value was correlating to md etc. On top, you had to manually manipulate the array by defining properties on it, which was often overlooked and not typesafe.

Issue Number: fixes #1954

To provide easier extensibility and typesafety, breakpoints now need to be an object.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

As described in the new docs and above, when customizing `theme.breakpoints`, you're now supposed to use `createBreakpoints` and pass an object.