### PR TITLE
Feat/improve breakpoints dx

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,9 @@ module.exports = {
   transform: { ".(ts|tsx)$": "ts-jest/dist" },
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  globals: {
+    "ts-jest": {
+      tsConfig: "tsconfig.json",
+    },
+  },
 }

--- a/packages/alert/tests/__snapshots__/alert.test.tsx.snap
+++ b/packages/alert/tests/__snapshots__/alert.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`matches snapshot 1`] = `
 .emotion-1 {
   margin-right: 0.75rem;
   width: 1.25rem;
-  height: 1.25rem;
+  height: 1.5rem;
   color: #3182ce;
   display: inherit;
 }
@@ -43,11 +43,13 @@ exports[`matches snapshot 1`] = `
 
 .emotion-2 {
   font-weight: 700;
-  line-height: normal;
+  line-height: 1.5rem;
+  margin-right: 0.5rem;
 }
 
 .emotion-3 {
   display: inline;
+  line-height: 1.5rem;
 }
 
 <div

--- a/packages/media-query/package.json
+++ b/packages/media-query/package.json
@@ -56,6 +56,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": "1.0.0-rc.3",
+    "@chakra-ui/theme": "1.0.0-rc.3",
     "react": "16.x"
   }
 }

--- a/packages/media-query/src/create-media-query.ts
+++ b/packages/media-query/src/create-media-query.ts
@@ -1,52 +1,61 @@
-import { Dict, isNumber, breakpoints as bps } from "@chakra-ui/utils"
+import { isNumber } from "@chakra-ui/utils"
 import calculateMeasurement from "calculate-measurement"
+import type { Breakpoints } from "@chakra-ui/theme"
 
-/**
- * Create a media query string from the breakpoints,
- * using a combination of `min-width` and `max-width`.
- */
-function createMediaQueries(breakpoints: Dict) {
+function createMediaQueries(breakpoints: Breakpoints): MediaQuery[] {
   /**
    * Get the non-number breakpoint keys from the provided breakpoints
+   *
+   * reverse to begin with the largest
    */
   const keys = Object.keys(breakpoints)
-
-  /**
-   * Use only the keys matching the official breakpoints names, and sort them in
-   * largest to smallest order
-   */
-  const sorted = bps.filter((bp) => keys.includes(bp)).reverse()
+    .filter((key) => Number.isNaN(Number.parseInt(key)))
+    .reverse()
 
   /**
    * create a min-max media query string
    */
-  return sorted.map((breakpoint, index) => {
+  return keys.map((breakpoint, index) => {
     const minWidth = breakpoints[breakpoint]
-    const next = sorted[index - 1] as string | undefined
+
+    const next = keys[index - 1]
     const maxWidth = next ? breakpoints[next] : undefined
 
-    let query = ""
+    const query = createMediaQueryString(minWidth, maxWidth)
 
-    if (parseInt(minWidth) >= 0) {
-      query = `(min-width: ${toMediaString(minWidth)})`
-    }
-
-    if (maxWidth) {
-      if (query) {
-        query += " and "
-      }
-      query += `(max-width: ${toMediaString(subtract(maxWidth))})`
-    }
-
-    const mediaQuery: MediaQuery = {
+    return {
       breakpoint,
       maxWidth,
       minWidth,
       query,
     }
-
-    return mediaQuery
   })
+}
+
+/**
+ * Create a media query string from the breakpoints,
+ * using a combination of `min-width` and `max-width`.
+ */
+function createMediaQueryString(minWidth: string, maxWidth?: string) {
+  const hasMinWidth = parseInt(minWidth) >= 0
+
+  if (!hasMinWidth && !maxWidth) {
+    return ""
+  }
+
+  let query = `(min-width: ${toMediaString(minWidth)})`
+
+  if (!maxWidth) {
+    return query
+  }
+
+  if (query) {
+    query += " and "
+  }
+
+  query += `(max-width: ${toMediaString(subtract(maxWidth))})`
+
+  return query
 }
 
 interface MediaQuery {

--- a/packages/media-query/src/create-media-query.ts
+++ b/packages/media-query/src/create-media-query.ts
@@ -1,16 +1,13 @@
-import { isNumber } from "@chakra-ui/utils"
+import { isNumber, isCustomBreakpoint } from "@chakra-ui/utils"
 import calculateMeasurement from "calculate-measurement"
-import type { Breakpoints } from "@chakra-ui/theme"
 
-function createMediaQueries(breakpoints: Breakpoints): MediaQuery[] {
+function createMediaQueries(breakpoints: string[]): MediaQuery[] {
   /**
    * Get the non-number breakpoint keys from the provided breakpoints
    *
    * reverse to begin with the largest
    */
-  const keys = Object.keys(breakpoints)
-    .filter((key) => Number.isNaN(Number.parseInt(key)))
-    .reverse()
+  const keys = Object.keys(breakpoints).filter(isCustomBreakpoint).reverse()
 
   /**
    * create a min-max media query string

--- a/packages/media-query/src/media-query.utils.ts
+++ b/packages/media-query/src/media-query.utils.ts
@@ -3,16 +3,18 @@ import { breakpoints } from "@chakra-ui/utils"
 export function getClosestValue(values: any, breakpoint: string) {
   let index = Object.keys(values).indexOf(breakpoint)
 
-  if (index !== -1) return values[breakpoint]
+  if (index !== -1) {
+    return values[breakpoint]
+  }
 
   let stopIndex = breakpoints.indexOf(breakpoint)
-  let hasFound = false
 
-  while (stopIndex >= 0 && !hasFound) {
+  while (stopIndex >= 0) {
     const key = breakpoints[stopIndex]
+
     if (values[key] != null) {
       index = stopIndex
-      hasFound = true
+      break
     }
     stopIndex--
   }
@@ -21,6 +23,4 @@ export function getClosestValue(values: any, breakpoint: string) {
     const key = breakpoints[index]
     return values[key]
   }
-
-  return undefined
 }

--- a/packages/media-query/src/use-breakpoint-value.ts
+++ b/packages/media-query/src/use-breakpoint-value.ts
@@ -1,6 +1,7 @@
 import { getClosestValue } from "./media-query.utils"
 import { useBreakpoint } from "./use-breakpoint"
 import { isArray, arrayToObjectNotation } from "@chakra-ui/utils"
+import { useTheme } from "@chakra-ui/system"
 
 /**
  * React hook for getting the value for the current breakpoint from the
@@ -11,7 +12,21 @@ import { isArray, arrayToObjectNotation } from "@chakra-ui/utils"
  */
 export function useBreakpointValue<T = any>(values: Record<string, T> | T[]) {
   const breakpoint = useBreakpoint()
-  if (!breakpoint) return
-  const obj = isArray(values) ? arrayToObjectNotation(values) : values
-  return getClosestValue(obj, breakpoint)
+  const { breakpoints } = useTheme()
+
+  if (!breakpoint) {
+    return
+  }
+
+  const obj = isArray(values)
+    ? Object.fromEntries(
+        Object.entries(
+          arrayToObjectNotation(values, breakpoints),
+        ).map(([_, value]) => [value, value]),
+      )
+    : values
+
+  const closest = getClosestValue(obj, breakpoint)
+
+  return closest
 }

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -69,7 +69,7 @@ export function useBreakpoint(defaultBreakpoint?: string) {
       }
 
       // add media query-listender
-      mediaQuery.addListener(handleChange)
+      mediaQuery.addEventListener("change", handleChange)
 
       // push the media query list handleChange
       // so we can use it to remove Listener
@@ -77,18 +77,18 @@ export function useBreakpoint(defaultBreakpoint?: string) {
 
       return () => {
         // clean up 1
-        mediaQuery.removeListener(handleChange)
+        mediaQuery.removeEventListener("change", handleChange)
       }
     })
 
     return () => {
       // clean up 2: for safety
       listeners.forEach(({ mediaQuery, handleChange }) => {
-        mediaQuery.removeListener(handleChange)
+        mediaQuery.removeEventListener("change", handleChange)
       })
       listeners.clear()
     }
   }, [mediaQueries, breakpoints, update])
 
-  return currentBreakpoint?.breakpoint
+  return current
 }

--- a/packages/media-query/tests/create-media-query.test.ts
+++ b/packages/media-query/tests/create-media-query.test.ts
@@ -4,10 +4,16 @@ import createMediaQueries from "../src/create-media-query"
 test("creates media queries for each named breakpoint", () => {
   expect(createMediaQueries(breakpoints)).toEqual([
     {
-      breakpoint: "xl",
+      breakpoint: "customBreakpoint",
       maxWidth: undefined,
+      minWidth: "500px",
+      query: "(min-width: 500px)",
+    },
+    {
+      breakpoint: "xl",
+      maxWidth: "500px",
       minWidth: "400px",
-      query: "(min-width: 400px)",
+      query: "(min-width: 400px) and (max-width: 499.99px)",
     },
     {
       breakpoint: "lg",

--- a/packages/media-query/tests/create-media-query.test.ts
+++ b/packages/media-query/tests/create-media-query.test.ts
@@ -33,5 +33,11 @@ test("creates media queries for each named breakpoint", () => {
       minWidth: "100px",
       query: "(min-width: 100px) and (max-width: 199.99px)",
     },
+    {
+      breakpoint: "base",
+      maxWidth: "100px",
+      minWidth: "0px",
+      query: "(min-width: 0px) and (max-width: 99.99px)",
+    },
   ])
 })

--- a/packages/media-query/tests/test-data.ts
+++ b/packages/media-query/tests/test-data.ts
@@ -1,9 +1,13 @@
-export const breakpoints: any = ["100px", "200px", "300px", "400px", "500px"]
-breakpoints.sm = breakpoints[0]
-breakpoints.md = breakpoints[1]
-breakpoints.lg = breakpoints[2]
-breakpoints.xl = breakpoints[3]
-breakpoints.customBreakpoint = breakpoints[4]
+import { createBreakpoints } from "@chakra-ui/theme-tools"
+
+export const breakpoints = createBreakpoints({
+  base: "0px",
+  sm: "100px",
+  md: "200px",
+  lg: "300px",
+  xl: "400px",
+  customBreakpoint: "500px",
+})
 
 export const theme = { breakpoints }
 

--- a/packages/media-query/tests/test-data.ts
+++ b/packages/media-query/tests/test-data.ts
@@ -1,8 +1,9 @@
-export const breakpoints: any = ["100px", "200px", "300px", "400px"]
+export const breakpoints: any = ["100px", "200px", "300px", "400px", "500px"]
 breakpoints.sm = breakpoints[0]
 breakpoints.md = breakpoints[1]
 breakpoints.lg = breakpoints[2]
 breakpoints.xl = breakpoints[3]
+breakpoints.customBreakpoint = breakpoints[4]
 
 export const theme = { breakpoints }
 
@@ -11,5 +12,6 @@ export const queries = {
   sm: "(min-width: 100px) and (max-width: 199.99px)",
   md: "(min-width: 200px) and (max-width: 299.99px)",
   lg: "(min-width: 300px) and (max-width: 399.99px)",
-  xl: "(min-width: 400px)",
+  xl: "(min-width: 400px) and (max-width: 499.99px)",
+  customBreakpoint: "(min-width: 500px)",
 }

--- a/packages/media-query/tests/use-breakpoint-value.test.tsx
+++ b/packages/media-query/tests/use-breakpoint-value.test.tsx
@@ -16,31 +16,85 @@ afterEach(() => {
 })
 
 describe("with object", () => {
-  const values = { base: "base", sm: "sm", md: "md", lg: "lg", xl: "xl" }
+  const values = {
+    base: "base",
+    sm: "sm",
+    md: "md",
+    lg: "lg",
+    xl: "xl",
+    customBreakpoint: "customBreakpoint",
+  }
 
   test("uses base value if smaller than sm", () => {
     renderWithQuery(values, queries.base)
-    expect(screen.getByText("base")).toBeInTheDocument()
+
+    Object.keys(values).forEach((key) => {
+      if (key === "base") {
+        expect(screen.getByText(key)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(key)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("sm", () => {
     renderWithQuery(values, queries.sm)
-    expect(screen.getByText("sm")).toBeInTheDocument()
+
+    Object.keys(values).forEach((key) => {
+      if (key === "sm") {
+        expect(screen.getByText(key)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(key)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("md", () => {
     renderWithQuery(values, queries.md)
-    expect(screen.getByText("md")).toBeInTheDocument()
+
+    Object.keys(values).forEach((key) => {
+      if (key === "md") {
+        expect(screen.getByText(key)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(key)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("lg", () => {
     renderWithQuery(values, queries.lg)
-    expect(screen.getByText("lg")).toBeInTheDocument()
+
+    Object.keys(values).forEach((key) => {
+      if (key === "lg") {
+        expect(screen.getByText(key)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(key)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("xl", () => {
     renderWithQuery(values, queries.xl)
-    expect(screen.getByText("xl")).toBeInTheDocument()
+
+    Object.keys(values).forEach((key) => {
+      if (key === "xl") {
+        expect(screen.getByText(key)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(key)).not.toBeInTheDocument()
+      }
+    })
+  })
+
+  test("customBreakpoint", () => {
+    renderWithQuery(values, queries.customBreakpoint)
+
+    Object.keys(values).forEach((key) => {
+      if (key === "customBreakpoint") {
+        expect(screen.getByText(key)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(key)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("base value is used if no breakpoint matches", () => {
@@ -51,7 +105,7 @@ describe("with object", () => {
 })
 
 describe("with array", () => {
-  const values = ["base", "sm", "md", "lg", "xl"]
+  const values = ["base", "sm", "md", "lg", "xl", "customBreakpoint"]
 
   test("uses base value if smaller than sm", () => {
     renderWithQuery(values, queries.base)
@@ -60,22 +114,62 @@ describe("with array", () => {
 
   test("sm", () => {
     renderWithQuery(values, queries.sm)
-    expect(screen.getByText("sm")).toBeInTheDocument()
+
+    values.forEach((value) => {
+      if (value === "sm") {
+        expect(screen.getByText(value)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(value)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("md", () => {
     renderWithQuery(values, queries.md)
-    expect(screen.getByText("md")).toBeInTheDocument()
+
+    values.forEach((value) => {
+      if (value === "md") {
+        expect(screen.getByText(value)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(value)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("lg", () => {
     renderWithQuery(values, queries.lg)
-    expect(screen.getByText("lg")).toBeInTheDocument()
+
+    values.forEach((value) => {
+      if (value === "lg") {
+        expect(screen.getByText(value)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(value)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("xl", () => {
     renderWithQuery(values, queries.xl)
-    expect(screen.getByText("xl")).toBeInTheDocument()
+
+    values.forEach((value) => {
+      if (value === "xl") {
+        expect(screen.getByText(value)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(value)).not.toBeInTheDocument()
+      }
+    })
+  })
+
+  test("customBreakpoint", () => {
+    renderWithQuery(values, queries.customBreakpoint)
+
+    values.forEach((value) => {
+      if (value === "customBreakpoint") {
+        expect(screen.getByText(value)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(value)).not.toBeInTheDocument()
+      }
+    })
   })
 
   test("uses base value if no breakpoint matches", () => {

--- a/packages/styled-system/tests/css.test.ts
+++ b/packages/styled-system/tests/css.test.ts
@@ -1,9 +1,12 @@
 import { css } from "../src/css"
+import { createBreakpoints } from "@chakra-ui/theme-tools"
 
-const breakpoints: any = ["40em", "52em", "64em"]
-breakpoints.sm = breakpoints[0]
-breakpoints.md = breakpoints[1]
-breakpoints.lg = breakpoints[2]
+const breakpoints = createBreakpoints({
+  sm: "40em",
+  md: "52em",
+  lg: "64em",
+  xl: "80em",
+})
 
 const theme = {
   breakpoints,
@@ -275,10 +278,17 @@ test("padding shorthand does not collide with nested p selector", () => {
 })
 
 test("ignores array values longer than breakpoints", () => {
+  // intentionally not using createBreakpoints here
+  // because you cant just slice off it
+  const customBreakpoints: any = ["0em", "32em", "40em"]
+  customBreakpoints.base = customBreakpoints[0]
+  customBreakpoints.sm = customBreakpoints[1]
+  customBreakpoints.lg = customBreakpoints[2]
+
   const result = css({
     width: [32, 64, 128, 256, 512],
   })({
-    breakpoints: ["32em", "40em"],
+    breakpoints: customBreakpoints,
   })
   expect(result).toEqual({
     width: 32,

--- a/packages/styled-system/tests/interpolation.test.ts
+++ b/packages/styled-system/tests/interpolation.test.ts
@@ -1,8 +1,19 @@
 import { css } from "../src"
+import { createBreakpoints } from "@chakra-ui/theme-tools"
 
 test("should handle array interpolations", () => {
-  //@ts-ignore
-  const result = css({ "&": [{ bg: "red" }, { bg: "green" }] })({})
+  const customBreakpoints = createBreakpoints({
+    sm: "40em",
+    md: "50em",
+    lg: "60em",
+    xl: "70em",
+  })
+
+  // @ts-expect-error "&" is technically disallowed
+  const result = css({ "&": [{ bg: "red" }, { bg: "green" }] })({
+    breakpoints: customBreakpoints,
+  })
+
   expect(result).toEqual({
     "&": { background: "red" },
     "@media screen and (min-width: 40em)": { "&": { background: "green" } },

--- a/packages/system/src/system.ts
+++ b/packages/system/src/system.ts
@@ -88,13 +88,11 @@ export const styleResolver: StyleResolver = ({ baseStyle }) => (props) => {
       WebkitBoxOrient: "vertical",
       WebkitLineClamp: noOfLines,
     }
-  } else {
-    if (isTruncated) {
-      truncateStyle = {
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
-      }
+  } else if (isTruncated) {
+    truncateStyle = {
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
     }
   }
 
@@ -118,12 +116,12 @@ export const styleResolver: StyleResolver = ({ baseStyle }) => (props) => {
   const computedCSS = css(finalStyles)(props.theme)
 
   // Merge the computed css object with styles in css prop
-  const cssObject = objectAssign(
+  const cssObject: Interpolation<StyleResolverProps> = objectAssign(
     computedCSS,
     isFunction(cssProp) ? cssProp(theme) : cssProp,
   )
 
-  return cssObject as Interpolation<StyleResolverProps>
+  return cssObject
 }
 
 interface StyledOptions {
@@ -135,7 +133,7 @@ interface StyledOptions {
 export function styled<T extends As, P = {}>(
   component: T,
   options?: StyledOptions,
-) {
+): ChakraComponent<T, P> {
   const { baseStyle, ...styledOptions } = options ?? {}
   const opts = { ...styledOptions, shouldForwardProp }
 
@@ -143,7 +141,7 @@ export function styled<T extends As, P = {}>(
   const interpolation = styleResolver({ baseStyle })
   const StyledComponent = _styled(interpolation)
 
-  return StyledComponent as ChakraComponent<T, P>
+  return StyledComponent
 }
 
 type ChakraJSXElements = {
@@ -161,6 +159,6 @@ export const chakra = (styled as unknown) as CreateChakraComponent &
   ChakraJSXElements
 
 domElements.forEach((tag) => {
-  //@ts-ignore
+  // @ts-expect-error
   chakra[tag] = chakra(tag)
 })

--- a/packages/theme-tools/src/breakpoints.ts
+++ b/packages/theme-tools/src/breakpoints.ts
@@ -5,16 +5,17 @@ export interface BaseBreakpointConfig extends Record<string, string> {
   xl: string
 }
 
-export type Breakpoints<T = BaseBreakpointConfig> = string[] & T
+export type Breakpoints<T = BaseBreakpointConfig> = string[] & WithBase<T>
+export type WithBase<T> = T & { base: "0em" }
 
 export const createBreakpoints = <T extends BaseBreakpointConfig>(
   config: T,
 ): Breakpoints<T> => {
   const sorted = Object.fromEntries(
-    Object.entries(config).sort((a, b) =>
+    Object.entries({ base: "0em", ...config }).sort((a, b) =>
       parseInt(a[1]) > parseInt(b[1]) ? 1 : -1,
     ),
-  ) as T
+  ) as WithBase<T>
 
   return Object.assign(Object.values(sorted), sorted)
 }

--- a/packages/theme-tools/src/breakpoints.ts
+++ b/packages/theme-tools/src/breakpoints.ts
@@ -1,0 +1,20 @@
+export interface BaseBreakpointConfig extends Record<string, string> {
+  sm: string
+  md: string
+  lg: string
+  xl: string
+}
+
+export type Breakpoints<T = BaseBreakpointConfig> = string[] & T
+
+export const createBreakpoints = <T extends BaseBreakpointConfig>(
+  config: T,
+): Breakpoints<T> => {
+  const sorted = Object.fromEntries(
+    Object.entries(config).sort((a, b) =>
+      parseInt(a[1]) > parseInt(b[1]) ? 1 : -1,
+    ),
+  ) as T
+
+  return Object.assign(Object.values(sorted), sorted)
+}

--- a/packages/theme-tools/src/index.ts
+++ b/packages/theme-tools/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./color"
 export * from "./component"
+export * from "./breakpoints"

--- a/packages/theme-tools/tests/breakpoints.test.ts
+++ b/packages/theme-tools/tests/breakpoints.test.ts
@@ -1,0 +1,103 @@
+import { createBreakpoints } from "../src"
+
+const defaultBreakpoints = {
+  sm: "30em",
+  md: "48em",
+  lg: "62em",
+  xl: "80em",
+}
+
+describe("createBreakpoints", () => {
+  test("returns an array", () => {
+    expect(createBreakpoints(defaultBreakpoints)).toBeInstanceOf(Array)
+  })
+
+  test("sorts by value size", () => {
+    const reversedDefaults = Object.fromEntries(
+      Object.entries(defaultBreakpoints).reverse(),
+    )
+
+    const expectedResult = createBreakpoints(defaultBreakpoints)
+
+    const result = createBreakpoints(reversedDefaults)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(result).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+
+  test("accepts further breakpoints", () => {
+    const xxl = "116em"
+
+    const extendedBreakpoints = {
+      ...defaultBreakpoints,
+      xxl,
+    }
+
+    const expectedResult = [
+      extendedBreakpoints.sm,
+      extendedBreakpoints.md,
+      extendedBreakpoints.lg,
+      extendedBreakpoints.xl,
+      xxl,
+    ]
+
+    const result = createBreakpoints(extendedBreakpoints)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(extendedBreakpoints).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+
+  test("works with px", () => {
+    const breakpoints = {
+      sm: "300px",
+      md: "480px",
+      lg: "620px",
+      xl: "800px",
+    }
+
+    const expectedResult = [
+      breakpoints.sm,
+      breakpoints.md,
+      breakpoints.lg,
+      breakpoints.xl,
+    ]
+
+    const result = createBreakpoints(breakpoints)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(breakpoints).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+
+  test("works with rem", () => {
+    const breakpoints = {
+      sm: "30rem",
+      md: "48rem",
+      lg: "62rem",
+      xl: "80rem",
+    }
+
+    const expectedResult = [
+      breakpoints.sm,
+      breakpoints.md,
+      breakpoints.lg,
+      breakpoints.xl,
+    ]
+
+    const result = createBreakpoints(breakpoints)
+
+    expect(result).toEqual(expect.arrayContaining(expectedResult))
+
+    Object.entries(breakpoints).forEach(([key, value]) => {
+      expect(result[key]).toBe(value)
+    })
+  })
+})

--- a/packages/theme-tools/tests/breakpoints.test.ts
+++ b/packages/theme-tools/tests/breakpoints.test.ts
@@ -1,4 +1,4 @@
-import { createBreakpoints } from "../src"
+import { createBreakpoints, BaseBreakpointConfig } from "../src"
 
 const defaultBreakpoints = {
   sm: "30em",
@@ -15,7 +15,7 @@ describe("createBreakpoints", () => {
   test("sorts by value size", () => {
     const reversedDefaults = Object.fromEntries(
       Object.entries(defaultBreakpoints).reverse(),
-    )
+    ) as BaseBreakpointConfig
 
     const expectedResult = createBreakpoints(defaultBreakpoints)
 

--- a/packages/theme/src/foundations/breakpoints.ts
+++ b/packages/theme/src/foundations/breakpoints.ts
@@ -1,15 +1,13 @@
+import { createBreakpoints } from "@chakra-ui/theme-tools"
+
 /**
  * Breakpoints for responsive design
  */
-const breakpoints: any = ["30em", "48em", "62em", "80em"]
-
-/**
- * This is needed for object responsive breakpoints to work.
- * At the moment, we require the keys to be `sm`, `md`, `lg` and `xl`
- */
-breakpoints.sm = breakpoints[0]
-breakpoints.md = breakpoints[1]
-breakpoints.lg = breakpoints[2]
-breakpoints.xl = breakpoints[3]
+const breakpoints = createBreakpoints({
+  sm: "30em",
+  md: "48em",
+  lg: "62em",
+  xl: "80em",
+})
 
 export default breakpoints

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -2,11 +2,8 @@ import foundations from "./foundations"
 import components from "./components"
 import styles from "./styles"
 
-export {
-  Breakpoints,
-  BaseBreakpointConfig,
-  createBreakpoints,
-} from "@chakra-ui/theme-tools"
+export type { Breakpoints, BaseBreakpointConfig } from "@chakra-ui/theme-tools"
+export { createBreakpoints } from "@chakra-ui/theme-tools"
 
 export const theme = {
   ...foundations,

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -2,6 +2,12 @@ import foundations from "./foundations"
 import components from "./components"
 import styles from "./styles"
 
+export {
+  Breakpoints,
+  BaseBreakpointConfig,
+  createBreakpoints,
+} from "@chakra-ui/theme-tools"
+
 export const theme = {
   ...foundations,
   components,

--- a/packages/utils/src/array.ts
+++ b/packages/utils/src/array.ts
@@ -146,3 +146,13 @@ export function getNextItemFromSearch<T>(
   // a decent fallback to the currentItem
   return currentItem
 }
+
+/**
+ * since breakpoints are defined as custom properties on an array, you may
+ * `Object.keys(theme.breakpoints)` to retrieve both regular numeric indices
+ * and custom breakpoints as string.
+ *
+ * This function returns true given a custom array property.
+ */
+export const isCustomBreakpoint = (maybeBreakpoint: string) =>
+  Number.isNaN(Number.parseInt(maybeBreakpoint))

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,7 +1,7 @@
-import { Omit, Dict } from "./types"
-import merge from "lodash.merge"
-import mergeWith from "lodash.mergewith"
-import assign from "object-assign"
+import type { Omit, Dict } from "./types"
+export { default as merge } from "lodash.merge"
+export { default as mergeWith } from "lodash.mergewith"
+export { default as objectAssign } from "object-assign"
 
 export function omit<T extends Dict, K extends keyof T>(object: T, keys: K[]) {
   const result: Dict = {}
@@ -98,5 +98,3 @@ export const filterUndefined = (object: Dict) =>
 
 export const objectKeys = <T extends Dict>(obj: T) =>
   (Object.keys(obj) as unknown) as (keyof T)[]
-
-export { merge, mergeWith, assign as objectAssign }

--- a/packages/utils/tests/array.test.ts
+++ b/packages/utils/tests/array.test.ts
@@ -10,6 +10,7 @@ import {
   getPrevIndex,
   chunk,
   getNextItemFromSearch,
+  isCustomBreakpoint,
 } from "../src"
 
 const array = [1, 2, 3, 4, 5, 6, 7, 8]
@@ -119,4 +120,22 @@ test("get next item based on search", () => {
     currentItem,
   )
   expect(result).toEqual({ value: "Vue" })
+})
+
+test.each([
+  ["base", true],
+  ["sm", true],
+  ["md", true],
+  ["lg", true],
+  ["xl", true],
+  ["xxl", true],
+  ["custom", true],
+  ["0", false],
+  ["1", false],
+  ["2", false],
+  ["3", false],
+  ["4", false],
+  ["5", false],
+])("given %s, returns %s", (given, expected) => {
+  expect(isCustomBreakpoint(given)).toBe(expected)
 })

--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -145,8 +145,8 @@ only one prop to manage this, you can rename it to `boxSize`.
 
 **You may safely skip this if you didn't customize your breakpoints.**
 
-To provide easier extensibility and typesafety, breakpoints now need to be an
-object:
+To provide easier extensibility and typesafety, breakpoints should now be
+created through `createBreakpoints` by passing an object:
 
 ```diff
 + import { createBreakpoints, extendTheme } from "@chakra-ui/core"

--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -141,6 +141,45 @@ only one prop to manage this, you can rename it to `boxSize`.
 +    </Box>
 ```
 
+### 7. Update theme breakpoints
+
+**You may safely skip this if you didn't customize your breakpoints.**
+
+To provide easier extensibility and typesafety, breakpoints now need to be an
+object:
+
+```diff
++ import { createBreakpoints, extendTheme } from "@chakra-ui/core"
+
+
++ const breakpoints = createBreakpoints({
++   sm: "30em",
++   md: "48em",
++   lg: "62em",
++   xl: "80em",
++ })
+
+
+const overrides = {
+- breakpoints: ["30em", "48em", "62em", "80em"]
++ breakpoints,
+}
+
++ const customTheme = extendTheme(overrides)
+```
+
+**Please note that unless you plan overriding all components, `sm` to `xl` are
+required.**
+
+You may of course add for example `xxl` or other breakpoints in between -
+`createBreakpoints` will sort in ascending order. It is adviseable to not mix
+css units.
+
+> **Reason:** Previously, breakpoints on a theme had to be an array with your
+> breakpoints in ascending order which made it hard to reference which value was
+> correlating to `md` etc. On top, you had to manually manipulate the array by
+> defining properties on it, which was often overlooked and not typesafe.
+
 ---
 
 ## Component Updates


### PR DESCRIPTION
Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

 Previously, breakpoints on a theme had to be an array with your breakpoints in ascending order which made it hard to reference which value was correlating to md etc. On top, you had to manually manipulate the array by defining properties on it, which was often overlooked and not typesafe.

Issue Number: fixes #1954

To provide easier extensibility and typesafety, breakpoints now need to be an object.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

As described in the new docs and above, when customizing `theme.breakpoints`, you're now supposed to use `createBreakpoints` and pass an object.

- fixed a bug in `useBreakpointValue` which wasn't working as intended given an array
- increased performance of `responsive` function used within `css` by factor 3-6x
- added support for custom breakpoints in general