### PR TITLE
fix: don't call onClose in onInteractOutside if menu isn't opened

### DIFF
--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -127,6 +127,7 @@ export function useMenu(props: UseMenuProps) {
     ref: menuRef,
     onInteractOutside: (event) => {
       if (
+        isOpen &&
         closeOnBlur &&
         !buttonRef.current?.contains(event.target as HTMLElement)
       ) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Fixes #2011 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The anonymous func passed to `onInteractOutside` of `useInteractOutside ` in `useMenu` hook was updated

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Made a small investigation of the issue: #2011.  Both menus have their outside click listeners. While they share the same state for `isOpen` prop, a click on the first menu item is handled by `onClose` of the second menu which closes the first. 

See below screenshots:
Click 1 on button;
Click 2 on Menu item.
FF (doesn't fire onClick listener on a MenuItem, just forces closing): https://prnt.sc/uh0e3n 
Chrome: https://prnt.sc/uh0flo