### PR TITLE
Add `thumbFocusCapture` prop to `use-slider`

### DIFF
--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -103,6 +103,11 @@ export interface UseSliderProps {
    */
   getAriaValueText?(value: number): string
   /**
+   * If `false`, the slider handle will not capture focus when value changes.
+   * @default true
+   */
+  thumbFocusCapture?: boolean
+  /**
    * The static string to use used for `aria-valuetext`
    */
   "aria-valuetext"?: string
@@ -149,6 +154,7 @@ export function useSlider(props: UseSliderProps) {
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
     name,
+    thumbFocusCapture = true,
     ...htmlProps
   } = props
 
@@ -374,7 +380,7 @@ export function useSlider(props: UseSliderProps) {
   }
 
   useUpdateEffect(() => {
-    if (thumbRef.current) {
+    if (thumbRef.current && thumbFocusCapture) {
       focus(thumbRef.current)
     }
   }, [value])

--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -106,7 +106,7 @@ export interface UseSliderProps {
    * If `false`, the slider handle will not capture focus when value changes.
    * @default true
    */
-  thumbFocusCapture?: boolean
+  focusThumbOnChange?: boolean
   /**
    * The static string to use used for `aria-valuetext`
    */
@@ -154,7 +154,7 @@ export function useSlider(props: UseSliderProps) {
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
     name,
-    thumbFocusCapture = true,
+    focusThumbOnChange = true,
     ...htmlProps
   } = props
 
@@ -380,7 +380,7 @@ export function useSlider(props: UseSliderProps) {
   }
 
   useUpdateEffect(() => {
-    if (thumbRef.current && thumbFocusCapture) {
+    if (thumbRef.current && focusThumbOnChange) {
       focus(thumbRef.current)
     }
   }, [value])

--- a/website/pages/docs/form/slider.mdx
+++ b/website/pages/docs/form/slider.mdx
@@ -77,11 +77,11 @@ customize its styles.
 </Slider>
 ```
 
-### Getting value after slide in done
+### Getting the final value when dragging the slider
 
-Added support for the `onChangeEnd` prop. Dragging the slider can trigger lots
-of updates and user might only be interested in the final result after sliding
-is complete.
+Dragging the slider can trigger lots of updates and the user might only 
+be interested in the final result after sliding is complete. You can use 
+`onChangeEnd` for this. 
 
 ```jsx live=false
 <Slider onChangeEnd={(val) => console.log(val)}>
@@ -92,6 +92,20 @@ is complete.
 </Slider>
 ```
 
+### Configure thumb focus with `focusThumbOnChange`
+
+By default `SliderThumb` will receive focus whenever `value` changes. You can 
+opt-out of this behavior by setting `focusThumbOnChange=false`.  This is 
+normally used with a "controlled" slider value.
+
+```jsx live=false
+<Slider value={value} focusThumbOnChange={false}>
+  <SliderTrack>
+    <SliderFilledTrack />
+  </SliderTrack>
+  <SliderThumb />
+</Slider>
+```
 ### useSlider
 
 We've exported the `useSlider` hook to help users manage and build custom slider


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

See below

Issue Number: N/A

## What is the new behavior?

Adds a boolean `thumbFocusCapture` to `use-slider` so users can opt-out of the default behavior where the slider thumb captures focus on every value change - expected use-case is with a controlled slider that shares a page with other elements require focus for user input.  Without it the slider will continually "steal" focus by default.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
