### PR TITLE
Add useDisclosure to imports

### DIFF
--- a/website/pages/docs/overlay/drawer.mdx
+++ b/website/pages/docs/overlay/drawer.mdx
@@ -33,6 +33,7 @@ import {
   DrawerOverlay,
   DrawerContent,
   DrawerCloseButton,
+  useDisclosure,
 } from "@chakra-ui/core"
 ```
 


### PR DESCRIPTION
Many of the examples shown make use of the `useDisclosure` hook. If we are expecting a new developer to be able to copy and paste the code displayed here and have this *just work* then I think it makes sense to add the `useDisclosure` hook to the import example otherwise the developer needs to read up on where that hook can be imported from.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Docs

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

No behaviour changes

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

^

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
