### PR TITLE
docs: add depreciation of psuedobox in migration guide, update formatting/consistency of style-props doc

### DIFF
--- a/website/pages/docs/features/style-props.mdx
+++ b/website/pages/docs/features/style-props.mdx
@@ -49,7 +49,7 @@ import { Box } from "@chakra-ui/core"
 ### Color and background color
 
 ```jsx live=false
-import { Box } from "@chakra-ui/core";
+import { Box } from "@chakra-ui/core"
 
 // picks up a nested color value using dot notation
 // => `theme.colors.gray[50]`
@@ -75,7 +75,7 @@ import { Box } from "@chakra-ui/core";
 ### Typography
 
 ```jsx live=false
-import { Text } from "@chakra-ui/core";
+import { Text } from "@chakra-ui/core"
 
 // font-size of `theme.fontSizes.md`
 <Text fontSize="md" />
@@ -105,13 +105,16 @@ import { Text } from "@chakra-ui/core";
 ### Layout, width and height
 
 ```jsx live=false
-import { Box } from "@chakra-ui/core";
+import { Box } from "@chakra-ui/core"
 
 // verbose
-<Box width="100%" height={32} />;
+<Box width="100%" height={32} />
 
 // shorthand
-<Box w="100%" h="32px" />;
+<Box w="100%" h="32px" />
+
+// use theme sizing
+<Box boxSize="sm" />
 
 // width `50%`
 <Box w={1/2} />
@@ -348,7 +351,7 @@ import { Box, Text } from "@chakra-ui/core"
 import { Button } from "@chakra-ui/core"
 
 // :hover style
-;<Button
+<Button
   colorScheme="teal"
   _hover={{
     background: "white",
@@ -357,6 +360,15 @@ import { Button } from "@chakra-ui/core"
 >
   Hover me
 </Button>
+
+// apply :hover over parent element
+<Box>
+  <Box
+    _hover={{ fontWeight: 'semibold' }}
+    _groupHover={{ color: 'tomato' }}
+  >
+  </Box>
+</Box>
 ```
 
 | Prop             | CSS Property                                                             | Theme Field |

--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -121,6 +121,26 @@ only one prop to manage this, you can rename it to `boxSize`.
 > in some components (e.g. Button), it means the visual size and in others (e.g
 > Box), it means **width and height**.
 
+### 6. Replace PseudoBox elements
+
+`PseudoBox` is now deprecated and its props can now be directly applied to
+`Box`. Replace all `PseudoBox` components with `Box`.
+
+```diff
+-   <PseudoBox
++   <Box
+    >
+-    <PseudoBox
++     <Box
+        _hover={{ fontWeight: 'semibold' }}
+        _groupHover={{ color: 'tomato' }}
+      >
+-      </PseudoBox>
++      </Box>
+-    </PseudoBox>
++    </Box>
+```
+
 ---
 
 ## Component Updates


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

* Lack of explicit guidance to replace PsuedoBox on migration guide (although noted in features list, it should probably be included as part of the migration steps)
* Minor formatting/consistency issues with semicolons on the style-props

Issue Number: N/A

## What is the new behavior?

* Adding a step 6 in the migration guide to be explicit about deprecating `PsuedoBox` 
* Clean up semicolons on `style-props.mdx` for consistency with the rest of the documentation (note Prettier seems to be automatically adding a semicolon if a single HTML element is displayed in conjunction with an `import` statement so adding another example prevents that behavior) 
* Added an example on how to use `boxSize` to align with the guidance on the migration guide 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Just noted a few consistency issues on the docs as I was migrating my app. I'm really enjoying using this library so appreciate all the effort!