### PR TITLE
fix: MenuButton flex-basis in IE11

### DIFF
--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -102,7 +102,7 @@ export const MenuButton = forwardRef<MenuButtonProps, "button">(
         <chakra.span
           __css={{
             pointerEvents: "none",
-            flex: "1",
+            flex: "1 1 auto",
           }}
         >
           {props.children}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

IE 11 has problems with `flex: 1`. Flex basis is set to 0 and flex-grow is ignores, which results in a width of 0. The `span` element inside the `MenuButton` uses `flex: 1`, which results in a broken layout:

<img width="206" alt="Screenshot 2020-09-16 at 10 35 17" src="https://user-images.githubusercontent.com/6564077/93314388-f8c0cb00-f809-11ea-85c3-dd21abee0281.png">

(Screenshots from the docs page)

Issue Number: N/A

## What is the new behavior?

`flex-basis` will be set to auto, which allows IE to calculate the correct element width and fixes the layout issue:

<img width="188" alt="Screenshot 2020-09-16 at 10 35 05" src="https://user-images.githubusercontent.com/6564077/93314543-2f96e100-f80a-11ea-8d07-2b3f532ec0d9.png">

(Screenshots from the docs page)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
