### PR TITLE
docs(tabs): fix tabs onchange example colors for dark mode

### DIFF
--- a/website/pages/docs/components/tabs.mdx
+++ b/website/pages/docs/components/tabs.mdx
@@ -205,7 +205,10 @@ tabs. If you intend to control the tabs programmatically, use this with the
 
 ```jsx
 function Example() {
-  const colors = ["red.50", "teal.50", "blue.50"]
+  const colors = useColorModeValue(
+    ["red.50", "teal.50", "blue.50"],
+    ["red.900", "teal.900", "blue.900"],
+  )
   const [tabIndex, setTabIndex] = React.useState(0)
   const bg = colors[tabIndex]
   return (


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: #2050 

## What is the new behavior?

Now there's dark variants of each color being used on the dark mode for the example.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No