### PR TITLE
Change default UnorderedList styleType to initial

### DIFF
--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -81,7 +81,7 @@ export const UnorderedList = forwardRef<ListProps, "ul">(function UnorderedList(
 ) {
   const { as, ...rest } = props
   return (
-    <List ref={ref} as="ul" styleType="bullet" marginLeft="1em" {...rest} />
+    <List ref={ref} as="ul" styleType="initial" marginLeft="1em" {...rest} />
   )
 })
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In Firefox, `UnorderedList` currently renders with numbers (due to incompatibility of `"bullet"`)

![image](https://user-images.githubusercontent.com/7349341/93463596-a4444b00-f8f0-11ea-9c97-c0b8a3c52f66.png)


## What is the new behavior?

To resolve this, the `styleType` is instead set to the default (or `initial`) browser for `ul`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
