### PR TITLE
:memo: migration guide use defaultIsOpen instead of isOpen

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -655,7 +655,7 @@ import "focus-visible/dist/focus-visible"
 
 ```diff
 - const { isOpen, onToggle } = useDisclosure(true);
-+ const { isOpen, onToggle } = useDisclosure({isOpen: true});
++ const { isOpen, onToggle } = useDisclosure({defaultIsOpen: true});
 ```
 
 


### PR DESCRIPTION
In my previous PR #2061 I by mistaken wrote `isOpen` instead of `defaultIsOpen` for `useDisclosure` hook which prevents updates caused by `onClose`, `onOpen` and `onToggle`
This may cause problems since v0.x had behaviour similar to `defaultIsOpen` which will allow user to modify on using hook functions

Sorry for confusion :sweat_smile:

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)
- [x] NA

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
NA
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
NA

<!-- Please describe the behavior or changes that are being added by this PR. -->


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
