### PR TITLE
fix Cannot read property 'height' of undefined

### DIFF
--- a/packages/input/src/input-group.tsx
+++ b/packages/input/src/input-group.tsx
@@ -29,11 +29,11 @@ export const InputGroup = forwardRef<InputGroupProps, "div">(
     validChildren.forEach((child: any) => {
       if (!styles) return
 
-      if (child.type.id === "InputLeftElement") {
+      if (input && child.type.id === "InputLeftElement") {
         stylesRef.current.paddingLeft = input.height ?? input.h
       }
 
-      if (child.type.id === "InputRightElement") {
+      if (input && child.type.id === "InputRightElement") {
         stylesRef.current.paddingRight = input.height ?? input.h
       }
 


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When rendering `InputLeftElement` using https://github.com/hashicorp/next-mdx-remote I'm getting this error:

```
TypeError: Cannot read property 'height' of undefined
    at /Users/adelnizamutdinov/Projects/sumptus/node_modules/@chakra-ui/input/dist/cjs/input-group.js:39:62
    at Array.forEach (<anonymous>)
    at Object.InputGroup [as render] (/Users/adelnizamutdinov/Projects/sumptus/node_modules/@chakra-ui/input/dist/cjs/input-group.js:33:17)
```

Issue Number: N/A

## What is the new behavior?

I want to point out to maintainers that there's an issue, but I'm not comfortable enough with codesandbox to create a repro 😞

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

