### PR TITLE
feat: unset button hover styles when disabled

### DIFF
--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -155,6 +155,23 @@ export const WithLoading = () => (
   </Stack>
 )
 
+export const withDisabled = () => (
+  <HStack spacing="24px">
+    <Button isDisabled colorScheme="teal" variant="solid">
+      Button
+    </Button>
+    <Button isDisabled colorScheme="teal" variant="outline">
+      Button
+    </Button>
+    <Button isDisabled colorScheme="teal" variant="ghost">
+      Button
+    </Button>
+    <Button isDisabled colorScheme="teal" variant="link">
+      Button
+    </Button>
+  </HStack>
+)
+
 export const customComposition = () => (
   <Button
     size="md"

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -22,7 +22,12 @@ function variantGhost(props: Dict) {
   if (c === "gray") {
     return {
       color: mode(`inherit`, `whiteAlpha.900`)(props),
-      _hover: { bg: mode(`gray.100`, `whiteAlpha.200`)(props) },
+      _hover: {
+        bg: mode(`gray.100`, `whiteAlpha.200`)(props),
+        _disabled: {
+          bg: "transparent",
+        },
+      },
       _active: { bg: mode(`gray.200`, `whiteAlpha.300`)(props) },
     }
   }
@@ -35,6 +40,9 @@ function variantGhost(props: Dict) {
     bg: "transparent",
     _hover: {
       bg: mode(`${c}.50`, darkHoverBg)(props),
+      _disabled: {
+        bg: "transparent",
+      },
     },
     _active: {
       bg: mode(`${c}.100`, darkActiveBg)(props),
@@ -81,7 +89,12 @@ function variantSolid(props: Dict) {
   if (c === "gray")
     return {
       bg: mode(`gray.100`, `whiteAlpha.200`)(props),
-      _hover: { bg: mode(`gray.200`, `whiteAlpha.300`)(props) },
+      _hover: {
+        bg: mode(`gray.200`, `whiteAlpha.300`)(props),
+        _disabled: {
+          bg: mode(`gray.100`, `whiteAlpha.200`)(props),
+        },
+      },
       _active: { bg: mode(`gray.300`, `whiteAlpha.400`)(props) },
     }
 
@@ -94,7 +107,12 @@ function variantSolid(props: Dict) {
   return {
     bg: mode(bg, `${c}.200`)(props),
     color: mode(color, `gray.800`)(props),
-    _hover: { bg: mode(hoverBg, `${c}.300`)(props) },
+    _hover: {
+      bg: mode(hoverBg, `${c}.300`)(props),
+      _disabled: {
+        bg: mode(bg, `${c}.200`)(props),
+      },
+    },
     _active: { bg: mode(activeBg, `${c}.400`)(props) },
   }
 }
@@ -106,7 +124,12 @@ function variantLink(props: Dict) {
     height: "auto",
     lineHeight: "normal",
     color: mode(`${c}.500`, `${c}.200`)(props),
-    _hover: { textDecoration: "underline" },
+    _hover: {
+      textDecoration: "underline",
+      _disabled: {
+        textDecoration: "none",
+      },
+    },
     _active: {
       color: mode(`${c}.700`, `${c}.500`)(props),
     },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)
- [x] Story added

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Buttons receive hover styles when disabled.

![pre-button-disabled-hover](https://user-images.githubusercontent.com/2268424/93734158-75451680-fc1b-11ea-86b7-9c07755d60b4.gif)

Issue Number: N/A

## What is the new behavior?

Buttons hover styles are overriden with default styles when disabled.

![button-disabled-hover](https://user-images.githubusercontent.com/2268424/93734196-a02f6a80-fc1b-11ea-9dfa-570feb489832.gif)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

A better approach may be to set the hover styles via `:hover:enabled` but would require a change to the [pseudoselectors](https://github.com/chakra-ui/chakra-ui/blob/develop/packages/styled-system/src/pseudo/pseudo.selector.ts) to support this.