### PR TITLE
docs: Initialze isOpen hook to false to prevent undefined problems.

### DIFF
--- a/website/pages/docs/overlay/alert-dialog.mdx
+++ b/website/pages/docs/overlay/alert-dialog.mdx
@@ -54,7 +54,7 @@ to prevent users from accidentally confirming the destructive action.
 
 ```jsx
 function AlertDialogExample() {
-  const [isOpen, setIsOpen] = React.useState()
+  const [isOpen, setIsOpen] = React.useState(false)
   const onClose = () => setIsOpen(false)
   const cancelRef = React.useRef()
 


### PR DESCRIPTION
By doing the following in line 57, 

`const [isOpen, setIsOpen] = React.useState(false)`

`setIsOpen` will have the type `React.Dispatch<(prevState: undefined) => undefined>`.

This would give us a type error at line 58 as `useIsOpen` expects an undefined rather than a boolean. To fix this, we simply just pass `false` into `useState`. Now `setIsOpen` will have `React.Dispatch<React.SetStateAction<boolean>>`, which is what we expect.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

Tests not needed as its just changing documentation.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`setIsOpen` has type `React.Dispatch<(prevState: undefined) => undefined>` we want the type to be `React.Dispatch<React.SetStateAction<boolean>>`. 

Issue Number: N/A

## What is the new behavior?

`setIsOpen`now has type `React.Dispatch<React.SetStateAction<boolean>>`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A
