### PR TITLE
fix(skeletontext): added isLoaded to skeletontext

### DIFF
--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -119,6 +119,7 @@ export interface SkeletonTextProps extends SkeletonProps {
   skeletonHeight?: SkeletonProps["height"]
   startColor?: SkeletonProps["startColor"]
   endColor?: SkeletonProps["endColor"]
+  isLoaded?: SkeletonProps["isLoaded"]
 }
 
 export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
@@ -129,6 +130,8 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
     className,
     startColor,
     endColor,
+    isLoaded,
+    children,
     ...rest
   } = props
 
@@ -145,16 +148,19 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
 
   return (
     <chakra.div className={_className} {...rest}>
-      {numbers.map((number) => (
-        <Skeleton
-          key={number}
-          height={skeletonHeight}
-          mb={number === numbers.length ? "0" : spacing}
-          width={getWidth(number)}
-          startColor={startColor}
-          endColor={endColor}
-        />
-      ))}
+      {isLoaded
+        ? children
+        : numbers.map((number) => (
+            <Skeleton
+              key={number}
+              height={skeletonHeight}
+              mb={number === numbers.length ? "0" : spacing}
+              width={getWidth(number)}
+              startColor={startColor}
+              endColor={endColor}
+              isLoaded={isLoaded}
+            />
+          ))}
     </chakra.div>
   )
 }

--- a/packages/skeleton/stories/skeleton.stories.tsx
+++ b/packages/skeleton/stories/skeleton.stories.tsx
@@ -79,10 +79,13 @@ export const WithIsLoaded = () => {
       <chakra.div h="100px" borderWidth="1px">
         Content
       </chakra.div>
-      <Skeleton w="100px" isLoaded={hasLoaded}>
+      <Skeleton w="100px" isLoaded={hasLoaded} mt={2}>
         <span>Chakra ui is cool</span>
       </Skeleton>
-      <chakra.div h="100px" borderWidth="1px">
+      <SkeletonText isLoaded={hasLoaded} mt={2}>
+        <p>Chakra ui is cool</p>
+      </SkeletonText>
+      <chakra.div h="100px" borderWidth="1px" mt={2}>
         Content
       </chakra.div>
     </chakra.div>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If the `isLoaded` prop is passed to the `SkeletonText` component, the console produces the following error:

```
Warning: React does not recognize the `isLoaded` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isloaded` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Additionally, the `isLoaded` prop will not toggle the skeleton's status.

Issue Number: N/A

## What is the new behavior?

`isLoaded` on `SkeletonText` now reveals its children if `true`, and the console error is no longer reduced.

## Does this introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I also updated the storybook to show the fix in action.
