### PR TITLE
docs(accordion): remove reference to AccordionItem defaultIsOpen prop

### DIFF
--- a/website/pages/docs/components/accordion.mdx
+++ b/website/pages/docs/components/accordion.mdx
@@ -257,12 +257,11 @@ toggle (expand or collapse) the accordion.
 
 ### AccordionItem Props
 
-| Name          | Type                                      | Default | Description                                                                                               |
-| ------------- | ----------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
-| defaultIsOpen | `boolean`                                 |         | If `true`, expands the accordion by on initial mount.                                                     |
-| id            | `string`                                  |         | A unique `id` for the accordion item.                                                                     |
-| isDisabled    | `boolean`                                 |         | If `true`, the accordion header will be disabled.                                                         |
-| children      | `ReactNode`, `(RenderProps) => ReactNode` |         | The content of the accordion. The children must be the `AccordionButton` and `AccordionPanel` components. |
+| Name       | Type                                      | Default | Description                                                                                               |
+| ---------- | ----------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| id         | `string`                                  |         | A unique `id` for the accordion item.                                                                     |
+| isDisabled | `boolean`                                 |         | If `true`, the accordion header will be disabled.                                                         |
+| children   | `ReactNode`, `(RenderProps) => ReactNode` |         | The content of the accordion. The children must be the `AccordionButton` and `AccordionPanel` components. |
 
 <br />
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes #2103 

## What is the new behavior?

Removed the `defaultIsOpen` prop from the `AccordionItem` props table.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
