### PR TITLE
Fix: useBreakpoint - mediaQuery undefined in safari (issue: #2117)

### DIFF
--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -68,8 +68,8 @@ export function useBreakpoint(defaultBreakpoint?: string) {
         update(mediaQuery, breakpoint)
       }
 
-      // add media query-listender
-      mediaQuery.addEventListener("change", handleChange)
+      // add media query-listener
+      mediaQuery.addListener(handleChange)
 
       // push the media query list handleChange
       // so we can use it to remove Listener
@@ -77,7 +77,7 @@ export function useBreakpoint(defaultBreakpoint?: string) {
 
       return () => {
         // clean up 1
-        mediaQuery.removeEventListener("change", handleChange)
+        mediaQuery.removeListener(handleChange)
       }
     })
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #2111

## What is the new behavior?

- useBreakpointValue should now work in Safari

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
