### PR TITLE
Fixes useBreakpoint on Safari < 14.0

### DIFF
--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -84,7 +84,7 @@ export function useBreakpoint(defaultBreakpoint?: string) {
     return () => {
       // clean up 2: for safety
       listeners.forEach(({ mediaQuery, handleChange }) => {
-        mediaQuery.removeEventListener("change", handleChange)
+        mediaQuery.removeListener(handleChange)
       })
       listeners.clear()
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

useBreakpoint breaks in any old version of Safari, the issue was reported and fixed here:

https://github.com/chakra-ui/chakra-ui/issues/2117

But the submitted fix was only partial, the second cleanup also needed to use the old removeListener function.

Fixes: 2117

## What is the new behavior?

- useBreakpoint works as expected in Safari, using the old style addListener / removeListener functions.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
