### PR TITLE
Fix/use media query

### DIFF
--- a/examples/create-react-app/src/Logo.tsx
+++ b/examples/create-react-app/src/Logo.tsx
@@ -1,5 +1,10 @@
 import React from "react"
-import { Image, ImageProps, keyframes } from "@chakra-ui/core"
+import {
+  Image,
+  ImageProps,
+  keyframes,
+  usePrefersReducedMotion,
+} from "@chakra-ui/core"
 import logo from "./logo.svg"
 
 const spin = keyframes`
@@ -7,14 +12,12 @@ const spin = keyframes`
   to { transform: rotate(360deg); }
 `
 
-export const Logo = (props: ImageProps) => (
-  <Image
-    css={{
-      "@media (prefers-reduced-motion: no-preference)": {
-        animation: `${spin} infinite 20s linear`,
-      },
-    }}
-    src={logo}
-    {...props}
-  />
-)
+export const Logo = (props: ImageProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const animation = prefersReducedMotion
+    ? undefined
+    : `${spin} infinite 20s linear`
+
+  return <Image animation={animation} src={logo} {...props} />
+}

--- a/examples/nextjs-typescript/components/Logo.tsx
+++ b/examples/nextjs-typescript/components/Logo.tsx
@@ -1,41 +1,50 @@
-import { keyframes, IconProps, chakra } from "@chakra-ui/core"
+import {
+  keyframes,
+  IconProps,
+  chakra,
+  usePrefersReducedMotion,
+} from "@chakra-ui/core"
 
 const spin = keyframes`
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 `
 
-export const Logo = (props: IconProps) => (
-  <chakra.svg
-    width="582"
-    height="582"
-    viewBox="0 0 582 582"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    css={{
-      "@media (prefers-reduced-motion: no-preference)": {
-        animation: `${spin} infinite 20s linear`,
-      },
-    }}
-    {...props}
-  >
-    <rect width="582" height="582" rx="291" fill="url(#paint0_linear)" />
-    <path
-      d="M157.521 303.421l198.36-196.995c3.706-3.68 9.669.799 7.168 5.383L289.22 247.123c-1.647 3.018.538 6.698 3.976 6.698h127.586c4.11 0 6.095 5.036 3.09 7.84L200.293 470.326c-4.009 3.741-9.976-1.53-6.757-5.97l105.837-146.005c2.17-2.994.031-7.187-3.667-7.187H160.713c-4.043 0-6.06-4.894-3.192-7.743z"
-      fill="#fff"
-    />
-    <defs>
-      <linearGradient
-        id="paint0_linear"
-        x1="291"
-        y1="0"
-        x2="291"
-        y2="582"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stop-color="#7BCBD4" />
-        <stop offset="1" stop-color="#29C6B7" />
-      </linearGradient>
-    </defs>
-  </chakra.svg>
-)
+export const Logo = (props: IconProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const animation = prefersReducedMotion
+    ? undefined
+    : `${spin} infinite 20s linear`
+
+  return (
+    <chakra.svg
+      width="582"
+      height="582"
+      viewBox="0 0 582 582"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      animation={animation}
+      {...props}
+    >
+      <rect width="582" height="582" rx="291" fill="url(#paint0_linear)" />
+      <path
+        d="M157.521 303.421l198.36-196.995c3.706-3.68 9.669.799 7.168 5.383L289.22 247.123c-1.647 3.018.538 6.698 3.976 6.698h127.586c4.11 0 6.095 5.036 3.09 7.84L200.293 470.326c-4.009 3.741-9.976-1.53-6.757-5.97l105.837-146.005c2.17-2.994.031-7.187-3.667-7.187H160.713c-4.043 0-6.06-4.894-3.192-7.743z"
+        fill="#fff"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear"
+          x1="291"
+          y1="0"
+          x2="291"
+          y2="582"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#7BCBD4" />
+          <stop offset="1" stop-color="#29C6B7" />
+        </linearGradient>
+      </defs>
+    </chakra.svg>
+  )
+}

--- a/packages/media-query/src/media-query.hook.tsx
+++ b/packages/media-query/src/media-query.hook.tsx
@@ -3,9 +3,8 @@ import { useMediaQuery } from "./use-media-query"
 /**
  * React hook used to get the user's animation preference.
  */
-export function useAnimationPreference() {
-  const isReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)")
-  return !isReducedMotion
+export function usePrefersReducedMotion() {
+  return useMediaQuery("(prefers-reduced-motion: reduce)")
 }
 
 /**

--- a/packages/media-query/src/media-query.hook.tsx
+++ b/packages/media-query/src/media-query.hook.tsx
@@ -3,16 +3,21 @@ import { useMediaQuery } from "./use-media-query"
 /**
  * React hook used to get the user's animation preference.
  */
-export function usePrefersReducedMotion() {
-  return useMediaQuery("(prefers-reduced-motion: reduce)")
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion] = useMediaQuery(
+    "(prefers-reduced-motion: reduce)",
+  )
+  return prefersReducedMotion
 }
 
 /**
  * React hook for getting the user's color mode preference.
  */
-export function useColorModePreference() {
-  const isLight = useMediaQuery("(prefers-color-scheme: light)")
-  const isDark = useMediaQuery("(prefers-color-scheme: dark)")
+export function useColorModePreference(): "dark" | "light" | undefined {
+  const [isDark, isLight] = useMediaQuery([
+    "(prefers-color-scheme: light)",
+    "(prefers-color-scheme: dark)",
+  ])
 
   if (isLight) return "light"
   if (isDark) return "dark"

--- a/packages/media-query/src/media-query.tsx
+++ b/packages/media-query/src/media-query.tsx
@@ -17,7 +17,7 @@ interface VisibilityProps {
  */
 const Visibility: React.FC<VisibilityProps> = (props) => {
   const { breakpoint, hide, children } = props
-  const show = useMediaQuery(breakpoint)
+  const [show] = useMediaQuery(breakpoint)
   const isVisible = hide ? !show : show
 
   const rendered = isVisible ? children : null

--- a/packages/media-query/src/media-query.tsx
+++ b/packages/media-query/src/media-query.tsx
@@ -17,7 +17,7 @@ interface VisibilityProps {
  */
 const Visibility: React.FC<VisibilityProps> = (props) => {
   const { breakpoint, hide, children } = props
-  const [show] = useMediaQuery(breakpoint)
+  const show = useMediaQuery(breakpoint)
   const isVisible = hide ? !show : show
 
   const rendered = isVisible ? children : null

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { isBrowser } from "@chakra-ui/utils"
 
-const isSupported = (api: string) => isBrowser && api in window
 const useSafeLayoutEffect = isBrowser ? React.useLayoutEffect : React.useEffect
 
 /**
@@ -9,14 +8,15 @@ const useSafeLayoutEffect = isBrowser ? React.useLayoutEffect : React.useEffect
  *
  * @param query the media query to match
  */
-export function useMediaQuery(query: string) {
-  const [matches, setMatches] = React.useState(() => {
-    if (!isSupported("matchMedia")) return false
-    return !!window.matchMedia(query).matches
-  })
+export function useMediaQuery(query: string): boolean {
+  const isSupported = isBrowser && "matchMedia" in window
+
+  const [matches, setMatches] = React.useState(
+    isSupported ? !!window.matchMedia(query).matches : false,
+  )
 
   useSafeLayoutEffect(() => {
-    if (!isSupported("matchMedia")) return
+    if (!isSupported) return
 
     const mediaQueryList = window.matchMedia(query)
     const listener = () => setMatches(!!mediaQueryList.matches)
@@ -30,5 +30,5 @@ export function useMediaQuery(query: string) {
     }
   }, [query])
 
-  return [matches, setMatches] as const
+  return matches
 }

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -8,25 +8,38 @@ const useSafeLayoutEffect = isBrowser ? React.useLayoutEffect : React.useEffect
  *
  * @param query the media query to match
  */
-export function useMediaQuery(query: string): boolean {
+export function useMediaQuery(query: string | string[]): boolean[] {
+  const queries = Array.isArray(query) ? query : [query]
   const isSupported = isBrowser && "matchMedia" in window
 
   const [matches, setMatches] = React.useState(
-    isSupported ? !!window.matchMedia(query).matches : false,
+    queries.map((query) => (isSupported ? !!window.matchMedia(query) : false)),
   )
 
   useSafeLayoutEffect(() => {
-    if (!isSupported) return
+    if (!isSupported) {
+      return
+    }
 
-    const mediaQueryList = window.matchMedia(query)
-    const listener = () => setMatches(!!mediaQueryList.matches)
+    const mediaQueryList = queries.map((query) => window.matchMedia(query))
 
-    mediaQueryList.addListener(listener)
+    const listenerList = mediaQueryList.map((mediaQuery, index) => {
+      const listener = () =>
+        setMatches((prev) =>
+          prev.map((prevValue, idx) =>
+            index === idx ? !!mediaQuery.matches : prevValue,
+          ),
+        )
 
-    listener()
+      mediaQuery.addListener(listener)
+
+      return listener
+    })
 
     return () => {
-      mediaQueryList.removeListener(listener)
+      mediaQueryList.forEach((mediaQuery, index) => {
+        mediaQuery.removeListener(listenerList[index])
+      })
     }
   }, [query])
 

--- a/tooling/cra-template-typescript/template/src/Logo.tsx
+++ b/tooling/cra-template-typescript/template/src/Logo.tsx
@@ -1,5 +1,11 @@
 import * as React from "react"
-import { chakra, keyframes, ImageProps, forwardRef } from "@chakra-ui/core"
+import {
+  chakra,
+  keyframes,
+  ImageProps,
+  forwardRef,
+  usePrefersReducedMotion,
+} from "@chakra-ui/core"
 import logo from "./logo.svg"
 
 const spin = keyframes`
@@ -7,15 +13,12 @@ const spin = keyframes`
   to { transform: rotate(360deg); }
 `
 
-export const Logo = forwardRef<ImageProps, "img">((props, ref) => (
-  <chakra.img
-    css={{
-      "@media (prefers-reduced-motion: no-preference)": {
-        animation: `${spin} infinite 20s linear`,
-      },
-    }}
-    src={logo}
-    ref={ref}
-    {...props}
-  />
-))
+export const Logo = forwardRef<ImageProps, "img">((props, ref) => {
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const animation = prefersReducedMotion
+    ? undefined
+    : `${spin} infinite 20s linear`
+
+  return <chakra.img animation={animation} src={logo} ref={ref} {...props} />
+})

--- a/tooling/cra-template/template/src/Logo.js
+++ b/tooling/cra-template/template/src/Logo.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, keyframes } from '@chakra-ui/core';
+import { Image, keyframes, usePrefersReducedMotion } from '@chakra-ui/core';
 import logo from './logo.svg';
 
 const spin = keyframes`
@@ -7,14 +7,12 @@ const spin = keyframes`
   to { transform: rotate(360deg); }
 `;
 
-export const Logo = props => (
-  <Image
-    css={{
-      '@media (prefers-reduced-motion: no-preference)': {
-        animation: `${spin} infinite 20s linear`,
-      },
-    }}
-    src={logo}
-    {...props}
-  />
-);
+export const Logo = props => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const animation = prefersReducedMotion
+    ? undefined
+    : `${spin} infinite 20s linear`;
+
+  return <Image animation={animation} src={logo} {...props} />;
+};

--- a/website/configs/docs-sidebar.ts
+++ b/website/configs/docs-sidebar.ts
@@ -198,6 +198,10 @@ const sidebar = {
               title: "useTheme",
               path: "/docs/hooks/use-theme",
             },
+            {
+              title: "usePrefersReducedMotion",
+              path: "/docs/hooks/use-prefers-reduced-motion",
+            },
           ],
         },
         {

--- a/website/configs/docs-sidebar.ts
+++ b/website/configs/docs-sidebar.ts
@@ -195,6 +195,10 @@ const sidebar = {
               path: "/docs/hooks/use-disclosure",
             },
             {
+              title: "useMediaQuery",
+              path: "/docs/hooks/use-media-query",
+            },
+            {
               title: "useTheme",
               path: "/docs/hooks/use-theme",
             },

--- a/website/pages/docs/hooks/use-media-query.mdx
+++ b/website/pages/docs/hooks/use-media-query.mdx
@@ -1,0 +1,43 @@
+---
+title: useMediaQuery
+package: "@chakra-ui/hooks"
+description: "React hook to detect media queries"
+---
+
+`useMediaQuery` is a custom hook to help detecting whether a media query
+currently matches.
+
+[Learn more about the API and its backgrounds.](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)
+
+## Import
+
+```js
+import { useMediaQuery } from "@chakra-ui/core"
+```
+
+## Return value
+
+The `useMediaQuery` hook returns a boolean, indicating whether the given query
+matches.
+
+> Keep in mind this API relies on the users browser support of
+> `window.matchMedia` and will always return `false` if it is not supported or
+> does not exist (e.g. during serverside rendering).
+
+## Usage
+
+```jsx live=false
+import { Text, useMediaQuery } from "@chakra-ui/core"
+
+function Example() {
+  const isDisplayingInBrowser = useMediaQuery("(display-mode: browser)")
+
+  return (
+    <Text>
+      {isDisplayingInBrowser
+        ? "rendering in a browser"
+        : "rendering on something else, e.g. PWA"}
+    </Text>
+  )
+}
+```

--- a/website/pages/docs/hooks/use-media-query.mdx
+++ b/website/pages/docs/hooks/use-media-query.mdx
@@ -4,8 +4,8 @@ package: "@chakra-ui/hooks"
 description: "React hook to detect media queries"
 ---
 
-`useMediaQuery` is a custom hook to help detecting whether a media query
-currently matches.
+`useMediaQuery` is a custom hook to help detecting whether a single media query
+or multiple media queries individually match.
 
 [Learn more about the API and its backgrounds.](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)
 
@@ -17,8 +17,12 @@ import { useMediaQuery } from "@chakra-ui/core"
 
 ## Return value
 
-The `useMediaQuery` hook returns a boolean, indicating whether the given query
-matches.
+The `useMediaQuery` hook returns an array of booleans, indicating whether the
+given query matches or queries match.
+
+Why an array? `useMediaQuery` accepts both a string and an array of strings, but
+will always return an array. This way, you can combine multiple media queries
+which will be individually matched in a single call.
 
 > Keep in mind this API relies on the users browser support of
 > `window.matchMedia` and will always return `false` if it is not supported or
@@ -26,18 +30,37 @@ matches.
 
 ## Usage
 
-```jsx live=false
-import { Text, useMediaQuery } from "@chakra-ui/core"
-
+```jsx
 function Example() {
-  const isDisplayingInBrowser = useMediaQuery("(display-mode: browser)")
+  const [isLargerThan1280] = useMediaQuery("(min-width: 1280px)")
 
   return (
     <Text>
-      {isDisplayingInBrowser
-        ? "rendering in a browser"
-        : "rendering on something else, e.g. PWA"}
+      {isLargerThan1280 ? "larger than 1280px" : "smaller than 1280px"}
     </Text>
   )
+}
+```
+
+```jsx
+function Example() {
+  const [isLargerThanHD, isDisplayingInBrowser] = useMediaQuery([
+    "(min-width: 1920px)",
+    "(display-mode: browser)",
+  ])
+
+  function determineText() {
+    if (isLargerThanHD) {
+      return `high resolution you got there ${
+        isDisplayingInBrowser ? "in your browser" : "on your screen"
+      }`
+    }
+
+    return isDisplayingInBrowser
+      ? "rendering in a browser"
+      : "rendering on something else, e.g. PWA"
+  }
+
+  return <Text>{determineText()}</Text>
 }
 ```

--- a/website/pages/docs/hooks/use-prefers-reduced-motion.mdx
+++ b/website/pages/docs/hooks/use-prefers-reduced-motion.mdx
@@ -1,0 +1,52 @@
+---
+title: usePrefersReducedMotion
+package: "@chakra-ui/hooks"
+description: "React hook to detect animation preference"
+---
+
+`usePrefersReducedMotion` is a custom hook to help detecting the users motion
+preference.
+
+[Learn more about the API and its backgrounds.](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+
+## Import
+
+```js
+import { usePrefersReducedMotion } from "@chakra-ui/core"
+```
+
+## Return value
+
+The `usePrefersReducedMotion` hook returns a boolean, indicating whether the
+user prefers reduced motion.
+
+> Keep in mind this API relies on the users browser support of
+> `window.matchMedia` and will always return `false` if it is not supported or
+> does not exist (e.g. during serverside rendering).
+
+## Usage
+
+```jsx live=false
+import {
+  Image,
+  ImageProps,
+  keyframes,
+  usePrefersReducedMotion,
+} from "@chakra-ui/core"
+import logo from "./logo.svg"
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`
+
+function Example() {
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const animation = prefersReducedMotion
+    ? undefined
+    : `${spin} infinite 20s linear`
+
+  return <Image animation={animation} src={logo} {...props} />
+}
+```


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- `useMediaQuery` always returns a tuple: `[boolean, setter]` - which makes no sense for what it supposedly does: just checking whether a query matches. You'd never want to use the setter, and, as it turns out - this functionality was unused.

- `useAnimationPreference` sounds like you receive a string or something non-booleanish, when it actually returns a boolean, being `true` if the user allows animations, `false` if the animation prefers reduced animations
  - I personally found that very confusing, and still do, even after looking at the code for a while, although its implementation is very short. Maybe just me.


## What is the new behavior?

- `useMediaQuery` now accepts both a single media query as well as an array of media queries. The API surface as such is not a breaking change, as you previously had to destructure the single boolean from the array anyways. Now you can actually use multiple! 
- renamed `useAnimationPreference` to `usePrefersReducedMotion` - this is a breaking change for `v1` only, as the hook doesn't exist in `v0`, so we wouldn't have to document it in the docs as such.
- refactored implementation of `usePrefersReducedMotion` and `useColorModePreference` to adapt to the new `useMediaQuery` possibilities
- documented both hooks in the docs since they were both undocumented before
- adjusted examples & simplified logic there (e.g. removed use of `css` prop for a more canonical way).

## Does this introduce a breaking change?

- [x] Yes, `next` only.
- [ ] No


Would love to write tests but since `matchMedia` doesn't exist in JSDOM, you'd just be testing your mock implementation :(
