### PR TITLE
docs(menu,popover): add isLazy prop for menu and popover

### DIFF
--- a/website/pages/docs/overlay/menu.mdx
+++ b/website/pages/docs/overlay/menu.mdx
@@ -199,9 +199,9 @@ component.
 
 ### Lazily mounting MenuItem
 
-By default, the `Menu` component renders all `MenuItem` to the DOM, meaning that invisible menu items are still rendered but are hidden by styles.
+By default, the `Menu` component renders all children of "MenuList" to the DOM, meaning that invisible menu items are still rendered but are hidden by styles.
 
-If you want to defer rendering of each menu item until that menu is open, you can use the `isLazy` prop. This is useful if your menus require heavy performance, or make network calls on mount that should only happen when the component is displayed.
+If you want to defer rendering of each children of "MenuList" until that menu is open, you can use the `isLazy` prop. This is useful if your menus require heavy performance, or make network calls on mount that should only happen when the component is displayed.
 
 ```jsx live=false
 <Menu isLazy>
@@ -324,15 +324,15 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
 
 ### Menu Props
 
-| Name          | Type                 | Default | Description                                                  |
-| ------------- | -------------------- | ------- | ------------------------------------------------------------ |
-| children      | `React.ReactNode`    |         | The children of the menu must be `MenuButton` and `MenuList` |
-| isOpen        | `boolean`            |         | If `true`, the menu will be opened                           |
-| autoSelect    | `boolean`            | `true`  | The menu will select the first enabled item when it opens    |
-| closeOnBlur   | `boolean`            | `true`  | If `true`, the menu will close on outside click or blur      |
-| closeOnSelect | `boolean`            | `true`  | If `true`, the menu will close on menu item select           |
-| placement     | `PopperJS.placement` |         | The placement of the `MenuList`                              |
-| isLazy        | `boolean`            |         | If `true`, the MenuItem will render until the menu is open.  |
+| Name          | Type                 | Default | Description                                                           |
+| ------------- | -------------------- | ------- | --------------------------------------------------------------------- |
+| children      | `React.ReactNode`    |         | The children of the menu must be `MenuButton` and `MenuList`          |
+| isOpen        | `boolean`            |         | If `true`, the menu will be opened                                    |
+| autoSelect    | `boolean`            | `true`  | The menu will select the first enabled item when it opens             |
+| closeOnBlur   | `boolean`            | `true`  | If `true`, the menu will close on outside click or blur               |
+| closeOnSelect | `boolean`            | `true`  | If `true`, the menu will close on menu item select                    |
+| placement     | `PopperJS.placement` |         | The placement of the `MenuList`                                       |
+| isLazy        | `boolean`            |         | If `true`, children of "MenuList" will render until the menu is open. |
 
 ### MenuButton Props
 

--- a/website/pages/docs/overlay/menu.mdx
+++ b/website/pages/docs/overlay/menu.mdx
@@ -197,6 +197,31 @@ component.
 </Menu>
 ```
 
+### Lazily mounting MenuItem
+
+By default, the `Menu` component renders all `MenuItem` to the DOM, meaning that invisible menu items are still rendered but are hidden by styles.
+
+If you want to defer rendering of each menu item until that menu is open, you can use the `isLazy` prop. This is useful if your menus require heavy performance, or make network calls on mount that should only happen when the component is displayed.
+
+```jsx live=false
+<Menu isLazy>
+  <MenuButton size="sm" colorScheme="teal">
+    Open menu
+  </MenuButton>
+  <MenuList>
+    {/* initially mounted */}
+    <MenuItem>Menu 1</MenuItem>
+    {/* initially mounted */}
+    <MenuItem>New Window</MenuItem>
+    {/* initially mounted */}
+    <MenuItem>Open Closed Tab</MenuItem>
+    {/* initially mounted */}
+    <MenuItem>Open File</MenuItem>
+    </MenuList>
+  <MenuList>
+</Menu>
+```
+
 ### Rendering menu in a portal
 
 To render menus in a portal, import the `Portal` component and wrap the
@@ -307,6 +332,7 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
 | closeOnBlur   | `boolean`            | `true`  | If `true`, the menu will close on outside click or blur      |
 | closeOnSelect | `boolean`            | `true`  | If `true`, the menu will close on menu item select           |
 | placement     | `PopperJS.placement` |         | The placement of the `MenuList`                              |
+| isLazy        | `boolean`            |         | If `true`, the MenuItem will render until the menu is open.  |
 
 ### MenuButton Props
 

--- a/website/pages/docs/overlay/popover.mdx
+++ b/website/pages/docs/overlay/popover.mdx
@@ -373,6 +373,33 @@ possible placement values.
 </Popover>
 ```
 
+### Lazily mounting Popover
+
+By default, the `Popover` component renders popover content to the DOM, 
+meaning that invisible popover contents are still rendered but are hidden by styles.
+
+If you want to defer rendering of popover content until that Popover is opened, 
+you can use the `isLazy` prop. This is useful if your popover content require heavy performance, 
+or make network calls on mount that should only happen when the component is displayed.
+
+```jsx
+<Popover isLazy>
+  <PopoverTrigger>
+    <Button>Click me</Button>
+  </PopoverTrigger>
+  <PopoverContent>
+    <PopoverHeader fontWeight="semibold">Popover placement</PopoverHeader>
+    <PopoverArrow />
+    <PopoverCloseButton />
+    <PopoverBody>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore.
+    </PopoverBody>
+  </PopoverContent>
+</Popover>
+```
+
+
 ## Accessiblity
 
 > When you see the word _"trigger"_, it's referring to the `children` of
@@ -435,6 +462,7 @@ possible placement values.
 | `usePortal`          | `boolean`                                                      | `false`  | If `true` the popover is displayed with a `Portal`. Rendering content inside a Portal allows the popover content to escape the physical bounds of its parent while still being positioned correctly relative to its target |
 | `onOpen`             | `() => void`                                                   |          | Callback fired when the popover opens                                                                                                                                                                                      |
 | `onClose`            | `() => void`                                                   |          | Callback fired when the popover closes                                                                                                                                                                                     |
+| `isLazy`             | `boolean`                                                      |          | If `true`, the ppover content will render until the popover is open.                                                                                                                                                       |
 
 ### Other Props
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: [ISSUE NUMBER]

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- add isLazy prop for `Menu` component

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
related issue #2146 