### PR TITLE
fix(input): input & select in flushed variant has no borderColor

### DIFF
--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -141,7 +141,8 @@ function variantFlushed(props: Record<string, any>) {
 
   return {
     field: {
-      borderBottom: "1px solid inherit",
+      borderBottom: "1px solid",
+      borderColor: "inherit",
       borderRadius: 0,
       pl: 0,
       pr: 0,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The input's `borderBottom` property contained "inherit" as part of it's value. Only individual properties such as `borderColor` can "inherit". This caused an issue when trying to update borderColor with theme object.

Fixes: #2113 

## What is the new behavior?

Small change, added borderColor property with "inherit" value for input and select.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
