### PR TITLE
fix: forward theme.config in Gatsby plugin

### DIFF
--- a/tooling/gatsby-plugin-chakra-ui/gatsby-browser.js
+++ b/tooling/gatsby-plugin-chakra-ui/gatsby-browser.js
@@ -12,14 +12,20 @@ export const wrapRootElement = (
   { element },
   { isResettingCSS = true, isUsingColorMode = true, portalZIndex = 40 },
 ) => {
-  const ModeProvider = isUsingColorMode ? ColorModeProvider : React.Fragment
+  const content = (
+    <>
+      {isResettingCSS && <CSSReset />}
+      <GlobalStyle />
+      <PortalManager zIndex={portalZIndex}>{element}</PortalManager>
+    </>
+  )
   return (
     <ThemeProvider theme={theme}>
-      <ModeProvider>
-        {isResettingCSS && <CSSReset />}
-        <GlobalStyle />
-        <PortalManager zIndex={portalZIndex}>{element}</PortalManager>
-      </ModeProvider>
+      {isUsingColorMode ? (
+        <ColorModeProvider options={theme.config}>{content}</ColorModeProvider>
+      ) : (
+        content
+      )}
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
This change is required since https://github.com/chakra-ui/chakra-ui/commit/097c783a00736a119b253fb26316c7538de929c5 moved `ColorModeProvider`'s `useSystemColorMode` option from a non-required prop to a property of a new `option` prop. If `gatsby-plugin-chakra-ui` is used without setting `isUsingColorMode` to false, we get the following error:

> TypeError: Cannot read property 'useSystemColorMode' of undefined

This happens because `gatsby-plugin-chakra-ui` doesn't pass any `options` prop to the `ColorModeProvider`, and [there isn't a default value for that prop](https://github.com/chakra-ui/chakra-ui/commit/097c783a00736a119b253fb26316c7538de929c5#diff-d296f0384fcd423d710d49ec1d834d32R57). So I decided to just pass `theme.config` [as it's currently done in `ChakraProvider`](https://github.com/chakra-ui/chakra-ui/blob/develop/packages/core/src/chakra-provider.tsx#L60).

I made a simple reproduction of this error here: https://codesandbox.io/s/silly-cohen-1uckh?file=/src/pages/index.js