### PR TITLE
docs: fix GitHub links

### DIFF
--- a/website/pages/guides/how-to-create-a-guide.mdx
+++ b/website/pages/guides/how-to-create-a-guide.mdx
@@ -82,6 +82,6 @@ following documentation from the GitHub website:
 [mdx]: https://mdxjs.com/getting-started
 [how-to-fork-and-pr]: https://jarv.is/notes/how-to-pull-request-fork-github/
 [working-with-forks]:
-  https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks
+  https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/working-with-forks
 [creating-a-pull-request]:
-  https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks
+  https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

On the [How to create a guide](https://next.chakra-ui.com/guides/how-to-create-a-guide) documentation page, the final two links on the page link to the same URL.

## What is the new behavior?

I've provided the correct URL for the [_Creating a pull request from a fork_](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork) link.

Additionally, GitHub has introduced a new documentation website, https://docs.github.com (details [here](https://github.blog/2020-07-02-how-we-launched-docs-github-com/)).  I've updated both links with new URLs for the same content.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
