### PR TITLE
fix(color-mode): getColorScheme fails in test env

### DIFF
--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -83,14 +83,14 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
      */
     if (isBrowser && colorModeManager.type === "localStorage") {
       const mode = useSystemColorMode
-        ? getColorScheme()
+        ? getColorScheme(initialColorMode)
         : root.get() || colorModeManager.get()
 
       if (mode) {
         rawSetColorMode(mode)
       }
     }
-  }, [colorModeManager, useSystemColorMode])
+  }, [colorModeManager, useSystemColorMode, initialColorMode])
 
   React.useEffect(() => {
     const isDark = colorMode === "dark"

--- a/packages/color-mode/src/color-mode.utils.ts
+++ b/packages/color-mode/src/color-mode.utils.ts
@@ -29,8 +29,10 @@ export function syncBodyClassName(isDark: boolean) {
  */
 function getMediaQuery(query: string) {
   const mediaQueryList = window.matchMedia?.(query)
-  const matches = !!mediaQueryList.media === mediaQueryList.matches
-  return matches
+  if (!mediaQueryList) {
+    return undefined
+  }
+  return !!mediaQueryList.media === mediaQueryList.matches
 }
 
 export const queries = {
@@ -41,8 +43,8 @@ export const queries = {
 export const lightQuery = queries.light
 export const darkQuery = queries.dark
 
-export function getColorScheme() {
-  const isDark = getMediaQuery(queries.dark)
+export function getColorScheme(fallback?: ColorMode) {
+  const isDark = getMediaQuery(queries.dark) ?? fallback === "dark"
   return isDark ? "dark" : "light"
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A CRA project with react-scripts ^3.4.3 and chakra-ui 1.0.0-rc.5 fails in a jest test due non existing `window.matchMedia` with:

```
Error: Uncaught [TypeError: Cannot read property 'media' of undefined]
```

[see Discord Discussion](https://discordapp.com/channels/660863154703695893/758645914868514827/763026733553025036)

## What is the new behavior?

Added check for falsy return value of `const mediaQueryList = window.matchMedia?.(query)` in `getMediaQuery` with fallback to `initialColorMode`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
