### PR TITLE
docs(tabs): add props section

### DIFF
--- a/website/pages/docs/components/tabs.mdx
+++ b/website/pages/docs/components/tabs.mdx
@@ -502,3 +502,28 @@ function Example() {
 |           | `aria-orientation` | Set to vertical or horizontal based on the value of the `orientation` prop. |
 |           | `role="tablist"`   | Indicates that it's a tablist                                               |
 |           | `aria-labelledby`  | Set to the `id` of the `Tab` that labels the `TabPanel`.                    |
+
+## Props
+
+### Tabs Props
+
+Tabs composes `Box` so you call pass all `Box` related props.
+
+| Name           | Type                                                                              | Default      | Description                                                                                                                      |
+| -------------- | --------------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `onChange`     | `(index: number) => void`                                                         |              | The callback to update the active tab index.                                                                                     |
+| `index`        | `number`                                                                          |              | The controlled index of the tabs.                                                                                                |
+| `defaultIndex` | `number`                                                                          |              | The index of the initial active tab.                                                                                             |
+| `isManual`     | `boolean`                                                                         |              | If `true`, keyboard navigation changes focus between tabs but doesn't activate it. User will have to press `Enter` to active it. |
+| `children`     | `React.ReactNode`                                                                 |              | The children of the switch.                                                                                                      |
+| `variant`      | `line`,`enclosed`,`enclosed-colored`, `soft-rounded`, `solid-rounded`, `unstyled` | `line`       | The visual style of the tab.                                                                                                     |
+| `variantColor` | `string`                                                                          |              | The primary color to use for the selected variant. Use a color key in `theme.colors`.                                            |
+| `size`         | `sm`,`md`,`lg`                                                                    | `md`         | The visual size of the tabs.                                                                                                     |
+| `orientation`  | `horizontal`,`vertical`                                                           | `horizontal` | The orientation of the tabs.                                                                                                     |
+| `isFitted`     | `boolean`                                                                         |              | If `true`, the tabs will stretch to fill the available space.                                                                    |
+
+### Tab Props
+
+| Name         | Type      | Default | Description                          |
+| ------------ | --------- | ------- | ------------------------------------ |
+| `isDisabled` | `boolean` |         | If `true`, the tab will be disabled. |


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The available props section for the Tabs component is entirely missing on the v1 docs page.

Fixes: #2175 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added `props` section to tabs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
