### PR TITLE
feat(toast): allow toast.closeAll position selection

### DIFF
--- a/packages/toast/src/toast-manager.tsx
+++ b/packages/toast/src/toast-manager.tsx
@@ -1,7 +1,8 @@
 import { objectKeys } from "@chakra-ui/utils"
 import * as React from "react"
 import { Toast } from "./toast"
-import {
+import type {
+  CloseAllToastsOptions,
   ToastId,
   ToastMessage,
   ToastOptions,
@@ -9,16 +10,16 @@ import {
 } from "./toast.types"
 import { findToast, getToastPosition } from "./toast.utils"
 
-export interface Methods {
+export interface ToastMethods {
   notify: (message: ToastMessage, options: CreateToastOptions) => ToastId
-  closeAll: () => void
+  closeAll: (options?: CloseAllToastsOptions) => void
   close: (id: ToastId) => void
   update: (id: ToastId, options: CreateToastOptions) => void
   isActive: (id: ToastId) => boolean
 }
 
 interface Props {
-  notify: (methods: Methods) => void
+  notify: (methods: ToastMethods) => void
 }
 
 type State = { [K in ToastPosition]: ToastOptions[] }
@@ -119,13 +120,14 @@ export class ToastManager extends React.Component<Props, State> {
   }
 
   /**
-   * Close all toasts at once
+   * Close all toasts at once.
+   * If given positions, will only close those.
    */
-  closeAll = () => {
+  closeAll = ({ positions }: CloseAllToastsOptions = {}) => {
     // only one setState here for perf reasons
     // instead of spamming this.closeToast
     this.setState((prev) => {
-      const positions: ToastPosition[] = [
+      const allPositions: ToastPosition[] = [
         "bottom",
         "bottom-right",
         "bottom-left",
@@ -134,7 +136,9 @@ export class ToastManager extends React.Component<Props, State> {
         "top-right",
       ]
 
-      return positions.reduce((carry, position) => {
+      const positionsToClose = positions ?? allPositions
+
+      return positionsToClose.reduce((carry, position) => {
         carry[position] = prev[position].map((toast) => ({
           ...toast,
           requestClose: true,

--- a/packages/toast/src/toast.class.tsx
+++ b/packages/toast/src/toast.class.tsx
@@ -1,17 +1,22 @@
 import { isBrowser } from "@chakra-ui/utils"
 import * as React from "react"
 import { render } from "react-dom"
-import { Methods, ToastManager } from "./toast-manager"
-import { ToastId, ToastMessage, ToastOptions } from "./toast.types"
+import { ToastMethods, ToastManager } from "./toast-manager"
+import type {
+  CloseAllToastsOptions,
+  ToastId,
+  ToastMessage,
+  ToastOptions,
+} from "./toast.types"
 
 const portalId = "chakra-toast-portal"
 
 class Toaster {
-  private createToast?: Methods["notify"]
-  private removeAll?: Methods["closeAll"]
-  private closeToast?: Methods["close"]
-  private updateToast?: Methods["update"]
-  private isToastActive?: Methods["isActive"]
+  private createToast?: ToastMethods["notify"]
+  private removeAll?: ToastMethods["closeAll"]
+  private closeToast?: ToastMethods["close"]
+  private updateToast?: ToastMethods["update"]
+  private isToastActive?: ToastMethods["isActive"]
 
   /**
    * Initialize the manager and mount it in the DOM
@@ -40,7 +45,7 @@ class Toaster {
     render(<ToastManager notify={this.bindFunctions} />, portal)
   }
 
-  private bindFunctions = (methods: Methods) => {
+  private bindFunctions = (methods: ToastMethods) => {
     this.createToast = methods.notify
     this.removeAll = methods.closeAll
     this.closeToast = methods.close
@@ -55,8 +60,8 @@ class Toaster {
     this.closeToast?.(id)
   }
 
-  closeAll = () => {
-    this.removeAll?.()
+  closeAll = (options: CloseAllToastsOptions) => {
+    this.removeAll?.(options)
   }
 
   update = (id: ToastId, options: Partial<ToastOptions> = {}) => {

--- a/packages/toast/src/toast.class.tsx
+++ b/packages/toast/src/toast.class.tsx
@@ -60,7 +60,7 @@ class Toaster {
     this.closeToast?.(id)
   }
 
-  closeAll = (options: CloseAllToastsOptions) => {
+  closeAll = (options?: CloseAllToastsOptions) => {
     this.removeAll?.(options)
   }
 

--- a/packages/toast/src/toast.types.ts
+++ b/packages/toast/src/toast.types.ts
@@ -70,3 +70,5 @@ export type ToastState = { [K in ToastPosition]: ToastOptions[] }
 export type Status = "default" | "success" | "error" | "warning" | "info"
 
 export type UpdateFn = (val: ToastState) => void
+
+export type CloseAllToastsOptions = { positions?: ToastPosition[] }

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import useToast from "../src"
+import useToast from "../src/use-toast"
 import { Button, ButtonGroup } from "@chakra-ui/button"
 import { chakra, useColorMode } from "@chakra-ui/system"
 import { Alert } from "@chakra-ui/alert"
@@ -180,6 +180,38 @@ export const ColorModeBug = () => {
         Click me!
       </Button>
       <Button onClick={() => toggleColorMode()}>Toggle Mode</Button>
+    </>
+  )
+}
+
+export const CloseAllTopLeftToasts = () => {
+  const toast = useToast()
+
+  const positions = [
+    "top-left",
+    "top",
+    "top-right",
+    "bottom-left",
+    "bottom",
+    "bottom-right",
+  ] as const
+
+  return (
+    <>
+      <Button
+        onClick={() => {
+          positions.forEach((position) => {
+            toast({ position, title: p })
+          })
+        }}
+      >
+        Trigger
+      </Button>
+
+      <hr />
+      <Button onClick={() => toast.closeAll({ positions: ["top-left"] })}>
+        close all top-left
+      </Button>
     </>
   )
 }

--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -96,6 +96,9 @@ function Example() {
   }
 
   function closeAll() {
+    // you may optionally pass an object of positions to exclusively close
+    // keeping other positions opened
+    // e.g. `{ positions: ['bottom'] }`
     toast.closeAll()
   }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Using `toast.closeAll()` always closes all toasts. 

## What is the new behavior?

You may now pass `...cloaseAll({ positions: ['bottom'] })` to only close selected positions, keeping other toasts intact.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
