### PR TITLE
fix(skeleton): implemented noOfLines as responsive value

### DIFF
--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@chakra-ui/hooks": "1.0.0-rc.5",
+    "@chakra-ui/media-query": "1.0.0-rc.5",
     "@chakra-ui/system": "1.0.0-rc.5",
     "@chakra-ui/utils": "1.0.0-rc.5"
   },

--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -8,6 +8,7 @@ import {
   omitThemingProps,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
+import { useBreakpointValue } from "@chakra-ui/media-query";
 import * as React from "react"
 
 export interface SkeletonOptions {
@@ -54,12 +55,10 @@ const StyledSkeleton = chakra("div", {
 
 export type ISkeleton = SkeletonOptions
 
-type OmitNoOfLines<T> = Omit<T, "noOfLines">
-
 export interface SkeletonProps
-  extends OmitNoOfLines<PropsOf<typeof StyledSkeleton>>,
+  extends PropsOf<typeof StyledSkeleton>,
     SkeletonOptions,
-    OmitNoOfLines<ThemingProps> {}
+    ThemingProps {}
 
 const fade = keyframes({
   from: { opacity: 0 },
@@ -116,7 +115,6 @@ function range(count: number) {
 }
 
 export interface SkeletonTextProps extends SkeletonProps {
-  noOfLines?: number
   spacing?: SkeletonProps["margin"]
   skeletonHeight?: SkeletonProps["height"]
   startColor?: SkeletonProps["startColor"]
@@ -124,9 +122,11 @@ export interface SkeletonTextProps extends SkeletonProps {
   isLoaded?: SkeletonProps["isLoaded"]
 }
 
+const defaultNoOfLines = 3;
+
 export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
   const {
-    noOfLines = 3,
+    noOfLines = defaultNoOfLines,
     spacing = "0.5rem",
     skeletonHeight = "0.5rem",
     className,
@@ -137,10 +137,11 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
     ...rest
   } = props
 
-  const numbers = range(noOfLines)
+  const noOfLinesValue = useBreakpointValue(typeof noOfLines === 'number' ? [noOfLines] : noOfLines) || defaultNoOfLines;
+  const numbers = range(noOfLinesValue)
 
   const getWidth = (index: number) => {
-    if (noOfLines > 1) {
+    if (noOfLinesValue > 1) {
       return index === numbers.length ? "80%" : "100%"
     }
     return "100%"
@@ -154,7 +155,7 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
         ? children
         : numbers.map((number) => (
             <Skeleton
-              key={number}
+              key={numbers.length.toString() + number}
               height={skeletonHeight}
               mb={number === numbers.length ? "0" : spacing}
               width={getWidth(number)}

--- a/packages/skeleton/stories/skeleton.stories.tsx
+++ b/packages/skeleton/stories/skeleton.stories.tsx
@@ -20,7 +20,7 @@ export default {
 export const Basic = () => <Skeleton h="20px" />
 
 export const Text = () => (
-  <SkeletonText padding="20px" borderWidth="1px" borderRadius="lg" />
+  <SkeletonText padding="20px" borderWidth="1px" borderRadius="lg" noOfLines={[3, 4, 5, 6, 7]} />
 )
 
 export const AsContainer = () => (

--- a/packages/skeleton/tests/skeleton.test.tsx
+++ b/packages/skeleton/tests/skeleton.test.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import { ThemeProvider } from "@chakra-ui/system"
+import { render } from "@chakra-ui/test-utils"
+import MatchMediaMock from "jest-matchmedia-mock"
+import { SkeletonText } from "../src"
+import { queries, theme } from "./test-data"
+
+let matchMedia: any
+
+beforeAll(() => {
+  matchMedia = new MatchMediaMock()
+})
+
+afterEach(() => {
+  matchMedia.clear()
+})
+
+test("SkeletonText renders noOfLines respective to the responsive breakpoint", () => {
+  const desiredNoOfLines = 6
+
+  // sm is the second media query after base, so the SkeletonText should have the desired number of lines
+  const { container } = renderWithQuery(
+    queries.sm,
+    <SkeletonText noOfLines={[5, desiredNoOfLines, 7]} />,
+  )
+  const skeletonGroup = container.querySelector(".chakra-skeleton__group")
+  expect(skeletonGroup).not.toBeNull()
+  expect(skeletonGroup!.childElementCount).toBe(desiredNoOfLines)
+})
+
+function renderWithQuery(query: string, ui: React.ReactElement) {
+  matchMedia.useMediaQuery(query)
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+}

--- a/packages/skeleton/tests/test-data.ts
+++ b/packages/skeleton/tests/test-data.ts
@@ -1,0 +1,21 @@
+import { createBreakpoints } from "@chakra-ui/theme-tools"
+
+export const breakpoints = createBreakpoints({
+  base: "0px",
+  sm: "100px",
+  md: "200px",
+  lg: "300px",
+  xl: "400px",
+  customBreakpoint: "500px",
+})
+
+export const theme = { breakpoints }
+
+export const queries = {
+  base: "(min-width: 0px) and (max-width: 99.99px)",
+  sm: "(min-width: 100px) and (max-width: 199.99px)",
+  md: "(min-width: 200px) and (max-width: 299.99px)",
+  lg: "(min-width: 300px) and (max-width: 399.99px)",
+  xl: "(min-width: 400px) and (max-width: 499.99px)",
+  customBreakpoint: "(min-width: 500px)",
+}

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -1,4 +1,4 @@
-import { SystemProps, SystemStyleObject } from "@chakra-ui/styled-system"
+import { SystemProps, SystemStyleObject, ResponsiveValue } from "@chakra-ui/styled-system"
 import { Dict } from "@chakra-ui/utils"
 import * as React from "react"
 import { ComponentWithAs } from "./forward-ref"
@@ -38,7 +38,7 @@ export interface ChakraProps extends SystemProps {
   /**
    * Used to truncate text at a specific number of lines
    */
-  noOfLines?: number[]
+  noOfLines?: ResponsiveValue<number>
   /**
    * Used for internal css management
    * @private


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #2170 

Currently the Skeleton Component implements its own noOfLines prop instead of using the system-wide one. Therefore it's also a static value and no chakra responsive value.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- noOfLine for Skeleton.Text Component can now be passed as responsive values (different noOfLine value for different breakpoints)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
