### PR TITLE
refactor: remove lodash.merge dependency

### DIFF
--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -9,7 +9,7 @@ import {
   ThemingProps,
   useStyleConfig,
 } from "@chakra-ui/system"
-import { cx, dataAttr, merge, __DEV__ } from "@chakra-ui/utils"
+import { cx, dataAttr, mergeWith, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useButtonGroup } from "./button-group"
 
@@ -92,7 +92,7 @@ export const Button = forwardRef<ButtonProps, "button">(function Button(
    *
    * So let's read the component styles and then add `zIndex` to it.
    */
-  const _focus = merge({}, styles?.["_focus"] ?? {}, { zIndex: 1 })
+  const _focus = mergeWith({}, styles?.["_focus"] ?? {}, { zIndex: 1 })
 
   const buttonStyles: SystemStyleObject = {
     display: "inline-flex",

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -9,7 +9,7 @@ import {
   ThemingProps,
   useMultiStyleConfig,
 } from "@chakra-ui/system"
-import { cx, merge, split, __DEV__ } from "@chakra-ui/utils"
+import { cx, mergeWith, split, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
 type Omitted = "disabled" | "required" | "readOnly" | "size"
@@ -126,7 +126,7 @@ export const Select = forwardRef<SelectProps, "select">(function Select(
     color,
   }
 
-  const fieldStyles: SystemStyleObject = merge({}, styles.field, {
+  const fieldStyles: SystemStyleObject = mergeWith({}, styles.field, {
     pr: "2rem",
     _focus: { zIndex: "unset" },
   })

--- a/packages/skip-nav/src/index.tsx
+++ b/packages/skip-nav/src/index.tsx
@@ -7,7 +7,7 @@ import {
   forwardRef,
   ThemingProps,
 } from "@chakra-ui/system"
-import { __DEV__, merge } from "@chakra-ui/utils"
+import { __DEV__, mergeWith } from "@chakra-ui/utils"
 import * as React from "react"
 
 export interface SkipNavLinkProps
@@ -42,7 +42,7 @@ export const SkipNavLink = forwardRef<SkipNavLinkProps, "a">(
     const styles = useStyleConfig("SkipLink", props)
     const { id = fallbackId, ...rest } = omitThemingProps(props)
 
-    const linkStyles = merge({}, baseStyle, styles)
+    const linkStyles = mergeWith({}, baseStyle, styles)
 
     return <chakra.a {...rest} ref={ref} href={`#${id}`} __css={linkStyles} />
   },

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -5,7 +5,7 @@ import {
   isObject,
   isResponsiveObjectLike,
   memoizedGet as get,
-  merge,
+  mergeWith,
   objectToArrayNotation,
   runIfFn,
 } from "@chakra-ui/utils"
@@ -151,7 +151,7 @@ export const css = (args: StyleObjectOrFn = {}) => (
 
     if (key === "apply") {
       const apply = css(get(theme, val))(theme)
-      computedStyles = merge({}, computedStyles, apply)
+      computedStyles = mergeWith({}, computedStyles, apply)
       continue
     }
 

--- a/packages/system/src/hooks.ts
+++ b/packages/system/src/hooks.ts
@@ -4,7 +4,7 @@ import {
   Dict,
   filterUndefined,
   memoizedGet as get,
-  merge,
+  mergeWith,
   runIfFn,
   StringOrNumber,
 } from "@chakra-ui/utils"
@@ -60,7 +60,7 @@ export function useProps(themeKey: string, props: Dict, isMultiPart?: boolean) {
 
   const stylesRef = useRef<Dict>({})
 
-  const mergedProps = merge({}, propsWithDefault, { theme, colorMode })
+  const mergedProps = mergeWith({}, propsWithDefault, { theme, colorMode })
 
   const memoizedStyles = useMemo(() => {
     if (styleConfig) {
@@ -76,7 +76,7 @@ export function useProps(themeKey: string, props: Dict, isMultiPart?: boolean) {
         mergedProps,
       )
 
-      const styles = merge(baseStyles, sizes, variants)
+      const styles = mergeWith(baseStyles, sizes, variants)
 
       if (styleConfig.parts) {
         for (const part of styleConfig.parts) {

--- a/packages/system/src/providers.tsx
+++ b/packages/system/src/providers.tsx
@@ -4,7 +4,7 @@ import {
   createContext,
   Dict,
   memoizedGet as get,
-  merge,
+  mergeWith,
   runIfFn,
 } from "@chakra-ui/utils"
 import { Global, Interpolation, ThemeContext } from "@emotion/core"
@@ -20,7 +20,7 @@ export interface ThemeProviderProps {
 export const ThemeProvider: React.FC<ThemeProviderProps> = (props) => {
   const { children, theme } = props
   const outerTheme = React.useContext(ThemeContext) as Dict
-  const mergedTheme = merge({}, outerTheme, theme)
+  const mergedTheme = mergeWith({}, outerTheme, theme)
 
   return (
     <ThemeContext.Provider value={mergedTheme}>

--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -2,7 +2,7 @@ import { SystemStyleObject } from "@chakra-ui/styled-system"
 import {
   filterUndefined,
   memoizedGet as get,
-  merge,
+  mergeWith,
   runIfFn,
   omit,
 } from "@chakra-ui/utils"
@@ -30,7 +30,7 @@ export function useStyleConfig(themeKey: any, props: any, opts: any) {
   const themeStyleConfig = get(theme, `components.${themeKey}`)
   const styleConfig = styleConfigProp || themeStyleConfig
 
-  const mergedProps = merge(
+  const mergedProps = mergeWith(
     { theme, colorMode },
     styleConfig?.defaultProps ?? {},
     filterUndefined(omit(rest, ["children"])),
@@ -56,7 +56,7 @@ export function useStyleConfig(themeKey: any, props: any, opts: any) {
         mergedProps,
       )
 
-      const styles = merge({}, baseStyles, sizes, variants)
+      const styles = mergeWith({}, baseStyles, sizes, variants)
 
       if (opts?.isMultiPart && styleConfig.parts) {
         for (const part of styleConfig.parts) {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,7 +37,6 @@
     "url": "https://github.com/chakra-ui/chakra-ui/issues"
   },
   "dependencies": {
-    "@types/lodash.merge": "4.6.6",
     "@types/lodash.mergewith": "4.6.6",
     "@types/object-assign": "4.0.30",
     "css-box-model": "1.2.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,7 +41,6 @@
     "@types/lodash.mergewith": "4.6.6",
     "@types/object-assign": "4.0.30",
     "css-box-model": "1.2.1",
-    "lodash.merge": "4.6.2",
     "lodash.mergewith": "4.6.2",
     "memoize-one": "5.1.1",
     "object-assign": "4.1.1"

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,6 +1,5 @@
 import memoizeOne from "memoize-one"
 import type { Omit, Dict } from "./types"
-export { default as merge } from "lodash.merge"
 export { default as mergeWith } from "lodash.mergewith"
 export { default as objectAssign } from "object-assign"
 

--- a/website/pages/docs/theming/advanced.mdx
+++ b/website/pages/docs/theming/advanced.mdx
@@ -35,7 +35,7 @@ based on color mode.
 ```jsx live=false
 // theme.js
 import theme from "@chakra-ui/theme"
-import { merge } from "@chakra-ui/utils"
+import { mergeWith } from "@chakra-ui/utils"
 
 const overrides = {
   components: {
@@ -54,7 +54,7 @@ const overrides = {
   },
 }
 
-export default merge(theme, overrides)
+export default mergeWith(theme, overrides)
 
 // MyBadge.js
 function MyBadge(props) {


### PR DESCRIPTION
- in favor of lodash.mergeWith, they work identical if the last argument is not a function

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

we're carrying both `lodash.merge` and `lodash.mergeWith` around, `.mergeWith` is only there for `extendTheme`. they do the same, however, unless the last argument passed is a function: https://codesandbox.io/s/condescending-mountain-m2p5v?file=/src/index.js

![image](https://user-images.githubusercontent.com/29307652/95653758-5db2cc80-0afb-11eb-9a1b-9c29f0fa1bb6.png)

This is a bundle analyzer of my site using Chakra. Except for the `src` and `i18next`, folder, almost in there should be Chakra related. As you can see, `lodash.mergeWith` and `lodash.merge` are entirely separate and not exactly small (gzip representation in bundle analyzer is active)

![image](https://user-images.githubusercontent.com/29307652/95653774-84710300-0afb-11eb-8b84-64e3d77fd6b1.png)


## What is the new behavior?

- all usage of `lodash.merge` through `/utils` has been replaced through `mergeWith`
- chose to keep the name of `mergeWith` to keep in mind to not accidentally pass a function as last argument; would be dev error anyways, but just to be explicit here

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
