### PR TITLE
feat(number-input): uses props of wrapping form-control

### DIFF
--- a/.changeset/beige-snails-burn.md
+++ b/.changeset/beige-snails-burn.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/number-input": patch
+"@chakra-ui/docs": patch
+---
+
+feat(number-input): uses props of wrapping form-control
+
+This change enables `NumberInput` to automatically derive various values from a surrounding `FormControl` if found, similar to `Input` and `Select`.

--- a/packages/number-input/package.json
+++ b/packages/number-input/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@chakra-ui/counter": "1.0.1",
+    "@chakra-ui/form-control": "1.0.1",
     "@chakra-ui/hooks": "1.0.1",
     "@chakra-ui/icon": "1.0.1",
     "@chakra-ui/utils": "1.0.1"

--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -1,5 +1,6 @@
 import { useCounter, UseCounterProps } from "@chakra-ui/counter"
 import { useBoolean, useEventListener } from "@chakra-ui/hooks"
+import { useFormControl } from "@chakra-ui/form-control"
 import {
   ariaAttr,
   callAllHandlers,
@@ -373,6 +374,14 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
     [pointerDown, counter.isAtMin, keepWithinRange, spinDown, spinner.stop],
   )
 
+  const {
+    "aria-invalid": formControlInvalid,
+    "aria-required": formControlRequired,
+    "aria-readonly": formControlReadOnly,
+    "aria-describedby": formControlDescribedBy,
+    disabled: formControlDisabled,
+  } = useFormControl<HTMLInputElement>({})
+
   const getInputProps: PropGetter = useCallback(
     (props = {}, ref = null) => ({
       ...props,
@@ -385,14 +394,16 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
       pattern,
       "aria-valuemin": min,
       "aria-valuemax": max,
-      "aria-disabled": isDisabled,
+      "aria-disabled": isDisabled || formControlDisabled,
       "aria-valuenow": Number.isNaN(counter.valueAsNumber)
         ? undefined
         : counter.valueAsNumber,
-      "aria-invalid": isInvalid || counter.isOutOfRange,
+      "aria-invalid": isInvalid || counter.isOutOfRange || formControlInvalid,
       "aria-valuetext": ariaValueText,
-      readOnly: isReadOnly,
-      disabled: isDisabled,
+      "aria-describedby": formControlDescribedBy,
+      readOnly: isReadOnly || formControlReadOnly,
+      disabled: isDisabled || formControlDisabled,
+      required: formControlRequired,
       autoComplete: "off",
       autoCorrect: "off",
       onChange: callAllHandlers(props.onChange, onChange),
@@ -401,22 +412,27 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
       onBlur: callAllHandlers(props.onBlur, onBlur),
     }),
     [
-      inputMode,
-      pattern,
-      ariaValueText,
-      counter.isOutOfRange,
+      id,
       counter.value,
       counter.valueAsNumber,
-      id,
-      isDisabled,
-      isInvalid,
-      isReadOnly,
-      max,
+      counter.isOutOfRange,
+      inputMode,
+      pattern,
       min,
-      onBlur,
+      max,
+      isDisabled,
+      formControlDisabled,
+      isInvalid,
+      formControlInvalid,
+      ariaValueText,
+      formControlDescribedBy,
+      isReadOnly,
+      formControlReadOnly,
+      formControlRequired,
       onChange,
       onKeyDown,
       setFocused.on,
+      onBlur,
     ],
   )
 

--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -395,7 +395,6 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
       return {
         ...props,
         ...ownProps,
-        id,
         ref: mergeRefs(inputRef, ref),
         value: counter.value,
         role: "spinbutton",

--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -12,6 +12,7 @@ import {
   mergeRefs,
   minSafeInteger,
   normalizeEventKey,
+  pick,
   PropGetter,
   StringOrNumber,
 } from "@chakra-ui/utils"
@@ -374,45 +375,54 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
     [pointerDown, counter.isAtMin, keepWithinRange, spinDown, spinner.stop],
   )
 
-  const {
-    "aria-invalid": formControlInvalid,
-    "aria-required": formControlRequired,
-    "aria-readonly": formControlReadOnly,
-    "aria-describedby": formControlDescribedBy,
-    disabled: formControlDisabled,
-  } = useFormControl<HTMLInputElement>({})
+  const inputProps = useFormControl<HTMLInputElement>(props)
 
   const getInputProps: PropGetter = useCallback(
-    (props = {}, ref = null) => ({
-      ...props,
-      id,
-      ref: mergeRefs(inputRef, ref),
-      value: counter.value,
-      role: "spinbutton",
-      type: "text",
-      inputMode: props["inputMode"] ?? inputMode,
-      pattern,
-      "aria-valuemin": min,
-      "aria-valuemax": max,
-      "aria-disabled": isDisabled || formControlDisabled,
-      "aria-valuenow": Number.isNaN(counter.valueAsNumber)
-        ? undefined
-        : counter.valueAsNumber,
-      "aria-invalid": isInvalid || counter.isOutOfRange || formControlInvalid,
-      "aria-valuetext": ariaValueText,
-      "aria-describedby": formControlDescribedBy,
-      readOnly: isReadOnly || formControlReadOnly,
-      disabled: isDisabled || formControlDisabled,
-      required: formControlRequired,
-      autoComplete: "off",
-      autoCorrect: "off",
-      onChange: callAllHandlers(props.onChange, onChange),
-      onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),
-      onFocus: callAllHandlers(props.onFocus, setFocused.on),
-      onBlur: callAllHandlers(props.onBlur, onBlur),
-    }),
+    (props = {}, ref = null) => {
+      const ownProps = pick(inputProps, [
+        "id",
+        "disabled",
+        "readOnly",
+        "required",
+        "aria-invalid",
+        "aria-required",
+        "aria-readonly",
+        "aria-describedby",
+        "onFocus",
+        "onBlur",
+      ])
+
+      return {
+        ...props,
+        ...ownProps,
+        id,
+        ref: mergeRefs(inputRef, ref),
+        value: counter.value,
+        role: "spinbutton",
+        type: "text",
+        inputMode: props.inputMode ?? inputMode,
+        pattern,
+        "aria-valuemin": min,
+        "aria-valuemax": max,
+        "aria-disabled": ownProps.disabled,
+        "aria-valuenow": Number.isNaN(counter.valueAsNumber)
+          ? undefined
+          : counter.valueAsNumber,
+        "aria-invalid": ariaAttr(
+          ownProps["aria-invalid"] || counter.isOutOfRange,
+        ),
+        "aria-valuetext": ariaValueText,
+        autoComplete: "off",
+        autoCorrect: "off",
+        onChange: callAllHandlers(props.onChange, onChange),
+        onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),
+        onFocus: callAllHandlers(ownProps.onFocus, setFocused.on),
+        onBlur: callAllHandlers(ownProps.onBlur, onBlur),
+      }
+    },
     [
       id,
+      inputProps,
       counter.value,
       counter.valueAsNumber,
       counter.isOutOfRange,
@@ -420,15 +430,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
       pattern,
       min,
       max,
-      isDisabled,
-      formControlDisabled,
-      isInvalid,
-      formControlInvalid,
       ariaValueText,
-      formControlDescribedBy,
-      isReadOnly,
-      formControlReadOnly,
-      formControlRequired,
       onChange,
       onKeyDown,
       setFocused.on,

--- a/packages/number-input/stories/number-input.stories.tsx
+++ b/packages/number-input/stories/number-input.stories.tsx
@@ -1,9 +1,15 @@
-import { Button } from "@chakra-ui/button"
-import { Input } from "@chakra-ui/input"
-import { Stack } from "@chakra-ui/layout"
 import { chakra } from "@chakra-ui/system"
 import * as React from "react"
 import Lorem from "react-lorem-component"
+import { Button } from "@chakra-ui/button"
+import { Input } from "@chakra-ui/input"
+import { Stack } from "@chakra-ui/layout"
+import {
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+} from "@chakra-ui/form-control"
 import {
   NumberDecrementStepper,
   NumberIncrementStepper,
@@ -186,5 +192,45 @@ export const BugFix2242 = () => {
       </NumberInput>
       <input min={-999} max={999} type="number" />
     </chakra.div>
+  )
+}
+
+function FormError(props: any) {
+  return (
+    <FormErrorMessage
+      mt="0"
+      bg="red.500"
+      color="white"
+      px="1"
+      lineHeight="1em"
+      borderRadius="sm"
+      {...props}
+    />
+  )
+}
+
+export const WithFormControl = () => {
+  const [isError, setIsError] = React.useState(false)
+
+  return (
+    <Stack align="start">
+      <FormControl id="first-name" isRequired isInvalid={isError}>
+        <chakra.div display="flex" mb="2">
+          <FormLabel mb="0" lineHeight="1em">
+            Amount
+          </FormLabel>
+          <FormError>is invalid!</FormError>
+        </chakra.div>
+        <NumberInput max={50} min={10}>
+          <NumberInputField />
+          <NumberInputStepper>
+            <NumberIncrementStepper />
+            <NumberDecrementStepper />
+          </NumberInputStepper>
+        </NumberInput>
+        <FormHelperText>Keep it very short and sweet!</FormHelperText>
+      </FormControl>
+      <Button onClick={() => setIsError((s) => !s)}>Toggle Invalid</Button>
+    </Stack>
   )
 }

--- a/packages/number-input/tests/__snapshots__/number-input.test.tsx.snap
+++ b/packages/number-input/tests/__snapshots__/number-input.test.tsx.snap
@@ -153,7 +153,6 @@ exports[`should render correctly 1`] = `
     data-testid="root"
   >
     <input
-      aria-invalid="false"
       aria-valuemax="9007199254740991"
       aria-valuemin="-9007199254740991"
       autocomplete="off"

--- a/packages/number-input/tests/number-input.test.tsx
+++ b/packages/number-input/tests/number-input.test.tsx
@@ -1,3 +1,4 @@
+import { FormControl, FormHelperText, FormLabel } from "@chakra-ui/form-control"
 import {
   testA11y,
   fireEvent,
@@ -5,6 +6,7 @@ import {
   renderHook,
   userEvent,
   press,
+  screen,
 } from "@chakra-ui/test-utils"
 import * as React from "react"
 import {
@@ -191,4 +193,46 @@ test("should focus input on spin", () => {
 
   // for some reason, .toHaveFocus assertion doesn't work
   // expect(tools.getByTestId("input")).toEqual(document.activeElement)
+})
+
+test("should derive values from surrounding FormControl", () => {
+  const onFocus = jest.fn()
+  const onBlur = jest.fn()
+
+  render(
+    <FormControl
+      id="input"
+      isRequired
+      isInvalid
+      isDisabled
+      isReadOnly
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
+      <FormLabel>Number</FormLabel>
+      <NumberInput data-testid="root">
+        <NumberInputField data-testid="input" />
+        <NumberInputStepper data-testid="group">
+          <NumberIncrementStepper children="+" data-testid="up-btn" />
+          <NumberDecrementStepper children="-" data-testid="down-btn" />
+        </NumberInputStepper>
+      </NumberInput>
+      <FormHelperText>Select a number</FormHelperText>
+    </FormControl>,
+  )
+
+  const input = screen.getByTestId("input")
+
+  expect(input).toHaveAttribute("id", "input")
+  expect(input).toHaveAttribute("aria-invalid", "true")
+  expect(input).toHaveAttribute("aria-required", "true")
+  expect(input).toHaveAttribute("aria-readonly", "true")
+  expect(input).toHaveAttribute("aria-invalid", "true")
+  expect(input).toHaveAttribute("aria-describedby")
+
+  fireEvent.focus(input)
+  expect(onFocus).toHaveBeenCalled()
+
+  fireEvent.blur(input)
+  expect(onBlur).toHaveBeenCalled()
 })

--- a/website/pages/docs/form/form-control.mdx
+++ b/website/pages/docs/form/form-control.mdx
@@ -81,6 +81,21 @@ By passing the `isRequired` props, the `Input` field has `aria-required` set to
 </FormControl>
 ```
 
+### Number Input Example
+
+```jsx
+<FormControl id="amount">
+  <FormLabel>Amount</FormLabel>
+  <NumberInput max={50} min={10}>
+    <NumberInputField />
+    <NumberInputStepper>
+      <NumberIncrementStepper />
+      <NumberDecrementStepper />
+    </NumberInputStepper>
+  </NumberInput>
+</FormControl>
+```
+
 ### Usage with Form Libraries
 
 Form Libraries like [Formik](https://jaredpalmer.com/formik/) make it soooo easy


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #804 
## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

`FormControl` propagates props down to `NumberInput` children.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I couldn't find any tests between FormControl and Select. So do i have to test the composition between FormControl and NumberInput?
