### PR TITLE
refactor: add index, setIndex to AccordionContext

### DIFF
--- a/packages/accordion/src/use-accordion.ts
+++ b/packages/accordion/src/use-accordion.ts
@@ -129,6 +129,8 @@ export function useAccordion(props: UseAccordionProps) {
   }
 
   return {
+    index,
+    setIndex,
     htmlProps,
     getItemProps,
     focusedIndex,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Expanded `useAccordionContext` API

## What is the current behavior?

`AccordionContext` provides access to the data required by Chakra's `Accordion`-related components, but doesn't provide access to the actual `index` value, or the `setValue` function for modifying that value.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `index` and `setIndex` are attached to `AccordionContext`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is the result of a conversion on Discord surrounding the ability to create a "toggle all" button for toggling all accordion items open or closed. That's possible with the existing API but would require directly passing `index` and `setIndex` to the button. This change allows the button to directly access and set the `index` value just by using context.