### PR TITLE
fix: use the lobotomized owl selector for spacing list children

### DIFF
--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -36,6 +36,8 @@ export const List = forwardRef<ListProps, "ul">(function List(props, ref) {
 
   const validChildren = getValidChildren(children)
 
+  const selector = "& > *:not(style) ~ *:not(style)"
+
   return (
     <chakra.ul
       ref={ref}
@@ -46,13 +48,10 @@ export const List = forwardRef<ListProps, "ul">(function List(props, ref) {
        * @see https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
        */
       role="list"
+      __css={spacing ? { [selector]: { mt: spacing } } : {}}
       {...rest}
     >
-      {validChildren.map((child, index) => {
-        const isLast = index + 1 === validChildren.length
-        if (isLast) return child
-        return spacing ? React.cloneElement(child, { mb: spacing }) : child
-      })}
+      {validChildren}
     </chakra.ul>
   )
 })

--- a/packages/layout/stories/list.stories.tsx
+++ b/packages/layout/stories/list.stories.tsx
@@ -68,3 +68,24 @@ export const unstyledWithIcon = () => (
     </List>
   </Box>
 )
+
+export const withFragment = () => (
+  <Box mb={6}>
+    <List spacing={3}>
+      <ListItem>
+        <ListIcon as={FaCheck} color="green.500" />
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit
+      </ListItem>
+      <>
+        <ListItem>
+          <ListIcon as={FaPhone} color="green.500" />
+          Assumenda, quia temporibus eveniet a libero incidunt suscipit
+        </ListItem>
+      </>
+      <ListItem>
+        <ListIcon as={FaAccessibleIcon} color="green.500" />
+        Quidem, ipsam illum quis sed voluptatum quae eum fugit earum
+      </ListItem>
+    </List>
+  </Box>
+)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`List` handles the spacing prop by injecting `mb` directly into children. This causes `List` spacing to fail when children are wrapped in `React.Fragment`.

Fixes: #2233 

## What is the new behavior?

`List` now handles the spacing prop by using the lobotomized owl selector. This causes `List` spacing to work correctly even when children are wrapped in `React.Fragment`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No