### PR TITLE
fix(utils): properly filter undefined object values

### DIFF
--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -97,7 +97,7 @@ export function objectFilter<T extends Dict>(object: T, fn: FilterFn<T>) {
 }
 
 export const filterUndefined = (object: Dict) =>
-  objectFilter(object, (val) => val !== null)
+  objectFilter(object, (val) => val !== null && val !== undefined)
 
 export const objectKeys = <T extends Dict>(obj: T) =>
   (Object.keys(obj) as unknown) as (keyof T)[]

--- a/packages/utils/tests/object.test.ts
+++ b/packages/utils/tests/object.test.ts
@@ -24,6 +24,10 @@ test("should get value of specified path in object or return path as default if 
 })
 
 test("should filter undefined values in object", () => {
-  const result = filterUndefined({ variant: undefined, colorScheme: "red" })
-  expect(result).toMatchObject({ colorScheme: "red" })
+  const result = filterUndefined({
+    size: null,
+    variant: undefined,
+    colorScheme: "red",
+  })
+  expect(result).toStrictEqual({ colorScheme: "red" })
 })


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `filteredUndefined` method in `@chakra-ui/utils` does not properly filter undefined. The unit test for this was a false positive due to the use of `.toMatchObject()`, which will pass on partial matches.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixed `filterUndefined()` to also remove `undefined`, along with `null`.
- Fixed the associated unit test to use `.toStrictEqual()`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
