### PR TITLE
docs: Update _groupHover parent role="group" attribute info - 1.0RC

### DIFF
--- a/website/pages/docs/features/style-props.mdx
+++ b/website/pages/docs/features/style-props.mdx
@@ -390,7 +390,9 @@ import { Button } from "@chakra-ui/core"
 </Button>
 
 // apply :hover over parent element
-<Box>
+<Box
+  role="group"
+>
   <Box
     _hover={{ fontWeight: 'semibold' }}
     _groupHover={{ color: 'tomato' }}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Group Hover docs in 1.0RC is missing some information details still not brought from 0.8.0 docs.

## What is the new behavior?

 I just added the role="group, as this is required for _groupHover to work

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
