### PR TITLE
fix: set default type as "button" for AccordionButton

### DIFF
--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -169,11 +169,13 @@ export const AccordionButton = forwardRef<AccordionButtonProps, "button">(
       ...styles.button,
     }
 
+    // Set the default type to "button" to prevent form submit when accordion is within a form
     return (
       <chakra.button
-        {...buttonProps}
+        type="button"
         className={cx("chakra-accordion__button", props.className)}
         __css={buttonStyles}
+        {...buttonProps}
       />
     )
   },

--- a/packages/accordion/tests/accordion.test.tsx
+++ b/packages/accordion/tests/accordion.test.tsx
@@ -297,3 +297,19 @@ test("panel has role=region and aria-labelledby", () => {
   expect(panel).toHaveAttribute("aria-labelledby")
   expect(panel).toHaveAttribute("role", "region")
 })
+
+// test that accordion button should have default type="button"
+test('accordion button should have default type="button"', () => {
+  render(
+    <Accordion>
+      <AccordionItem>
+        <AccordionButton>First section</AccordionButton>
+        <AccordionPanel>Panel 1</AccordionPanel>
+      </AccordionItem>
+    </Accordion>,
+  )
+
+  const firstAccordion = screen.getByText("First section")
+
+  expect(firstAccordion).toHaveAttribute("type", "button")
+})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #2267 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Default type attribute on AccordionButton is now "button"
- Clicking AccordionButton within a form should not submit the form.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
