### PR TITLE
docs(doc-mistake): Corrected jsdoc for lineSpacing typography prop

### DIFF
--- a/packages/styled-system/src/config/typography.ts
+++ b/packages/styled-system/src/config/typography.ts
@@ -47,7 +47,7 @@ export interface TypographyProps {
    */
   lineHeight?: ResponsiveValue<CSS.Property.LineHeight<Length>>
   /**
-   * The CSS `line-height` property
+   * The CSS `letter-spacing` property
    */
   letterSpacing?: ResponsiveValue<CSS.Property.LetterSpacing<Length>>
   /**


### PR DESCRIPTION
lineSpacing prop had jsdoc referring to 'line-height' css property before.
Now, it correctly refers to 'line-spacing' css property.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: [ISSUE NUMBER]

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
