### PR TITLE
fix: close tooltip when leaving wrapped disabled trigger

### DIFF
--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -145,10 +145,24 @@ export function useTooltip(props: UseTooltipProps = {}) {
     }
   }, [])
 
+  /**
+   * This allows for catching mouseleave events when the tooltip
+   * trigger is disabled. There's currently a known issue in
+   * React regarding the onMouseLeave polyfill.
+   * @see https://github.com/facebook/react/issues/11972
+   */
+  useEffect(() => {
+    if (ref.current) {
+      const tooltipElement = ref.current
+      tooltipElement.addEventListener("mouseleave", closeWithDelay)
+      return () =>
+        tooltipElement.removeEventListener("mouseleave", closeWithDelay)
+    }
+  }, [closeWithDelay])
+
   const getTriggerProps: PropGetter = (props = {}, _ref = null) => {
     const triggerProps = {
       ...props,
-      onMouseLeave: callAllHandlers(props.onMouseLeave, closeWithDelay),
       onMouseEnter: callAllHandlers(props.onMouseEnter, openWithDelay),
       onClick: callAllHandlers(props.onClick, onClick),
       onMouseDown: callAllHandlers(props.onMouseDown, onMouseDown),

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -214,6 +214,14 @@ export const withDisabledButton = () => (
   </Tooltip>
 )
 
+export const withWrappedDisabledButton = () => (
+  <Tooltip label="Hello world" shouldWrapChildren>
+    <button style={{ fontSize: 25, pointerEvents: "all" }} disabled>
+      Hover me
+    </button>
+  </Tooltip>
+)
+
 export const withIsOpenProp = () => (
   <Tooltip label="Hello world" isOpen={true} hasArrow>
     <button style={{ fontSize: 25, pointerEvents: "all" }} disabled>

--- a/packages/tooltip/tests/tooltip.test.tsx
+++ b/packages/tooltip/tests/tooltip.test.tsx
@@ -13,11 +13,16 @@ import { Tooltip } from "../src"
 const buttonLabel = "Hover me"
 const tooltipLabel = "tooltip label"
 
-const DummyComponent = (props: Omit<TooltipProps, "children">) => (
-  <Tooltip label={tooltipLabel} {...props}>
-    <button>{buttonLabel}</button>
-  </Tooltip>
-)
+const DummyComponent = (
+  props: Omit<TooltipProps & { isButtonDisabled?: boolean }, "children">,
+) => {
+  const { isButtonDisabled, ...tooltipProps } = props
+  return (
+    <Tooltip label={tooltipLabel} {...tooltipProps}>
+      <button disabled={isButtonDisabled || false}>{buttonLabel}</button>
+    </Tooltip>
+  )
+}
 
 test("passes a11y test when hovered", async () => {
   render(<DummyComponent />)
@@ -29,7 +34,7 @@ test("passes a11y test when hovered", async () => {
   await testA11y(tooltip)
 })
 
-test("shows on mouseover and closes on mouseout", async () => {
+test("shows on mouseover and closes on mouseleave", async () => {
   render(<DummyComponent />)
 
   act(() => {
@@ -42,7 +47,7 @@ test("shows on mouseover and closes on mouseout", async () => {
   expect(screen.getByRole("tooltip")).toBeInTheDocument()
 
   act(() => {
-    fireEvent.mouseOut(screen.getByText(buttonLabel))
+    fireEvent.mouseLeave(screen.getByText(buttonLabel))
   })
 
   await waitForElementToBeRemoved(() => screen.getByText(tooltipLabel))
@@ -73,4 +78,23 @@ test("should show on mouseover if isDisabled has a falsy value", async () => {
   await screen.findByRole("tooltip")
 
   expect(screen.getByText(buttonLabel)).toBeInTheDocument()
+})
+
+test("should close on mouseleave if shouldWrapChildren is true and child is a disabled element", async () => {
+  render(<DummyComponent shouldWrapChildren isButtonDisabled={true} />)
+
+  act(() => {
+    fireEvent.mouseEnter(screen.getByText(buttonLabel))
+  })
+
+  await screen.findByRole("tooltip")
+
+  const wrapper = screen.getByText(buttonLabel).parentElement
+  expect(wrapper).not.toBeNull()
+
+  act(() => {
+    fireEvent.mouseLeave(wrapper!)
+  })
+
+  await waitForElementToBeRemoved(() => screen.getByText(tooltipLabel))
 })


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: https://github.com/chakra-ui/chakra-ui/issues/500

Events are not dispatched by default on disabled buttons. However, for tooltips, when `shouldWrapChildren` is set to true, we can still expect to see the tooltip, since it's placed on the `span` parent. There seemed to be an issue with the tooltip never being closed in such cases. My guess is that it's related to the following React issue: https://github.com/facebook/react/issues/11972.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The tooltip is closed when an `onMouseLeave` event is launched from a "wrapped trigger" that has a disabled element as a child

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is my first contribution! Please let me know if I'm missing something. 🙂