### PR TITLE
RFC: Use WrapItem in favour of cloning children in Wrap

### DIFF
--- a/packages/layout/src/wrap.tsx
+++ b/packages/layout/src/wrap.tsx
@@ -3,11 +3,13 @@ import {
   css,
   forwardRef,
   PropsOf,
+  StylesProvider,
   SystemProps,
   SystemStyleObject,
   useTheme,
+  useStyles,
 } from "@chakra-ui/system"
-import { getValidChildren, mapResponsive, __DEV__ } from "@chakra-ui/utils"
+import { mapResponsive, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
 export interface WrapProps extends PropsOf<typeof chakra.div> {
@@ -61,15 +63,7 @@ export const Wrap = forwardRef<WrapProps, "div">(function Wrap(props, ref) {
     return `calc(${margin} / 2 * -1)`
   })
 
-  const validChildren = getValidChildren(children)
-
-  const clones = validChildren.map((child, index) => (
-    <chakra.li key={index} margin={itemSpacing}>
-      {child}
-    </chakra.li>
-  ))
-
-  const styles: SystemStyleObject = {
+  const groupStyles: SystemStyleObject = {
     display: "flex",
     flexWrap: "wrap",
     justifyContent: justify,
@@ -80,13 +74,31 @@ export const Wrap = forwardRef<WrapProps, "div">(function Wrap(props, ref) {
     margin: groupSpacing,
   }
 
+  const itemStyles: SystemStyleObject = {
+    margin: itemSpacing,
+  }
+
   return (
-    <chakra.div ref={ref} {...rest}>
-      <chakra.ul __css={styles}>{clones}</chakra.ul>
-    </chakra.div>
+    <StylesProvider value={{ item: itemStyles }}>
+      <chakra.div ref={ref} {...rest}>
+        <chakra.ul __css={groupStyles}>{children}</chakra.ul>
+      </chakra.div>
+    </StylesProvider>
   )
+})
+
+export interface WrapItemProps extends PropsOf<typeof chakra.li> {}
+
+export const WrapItem = forwardRef<WrapItemProps, "li">(function WrapItem(
+  props,
+  ref,
+) {
+  const styles = useStyles()
+
+  return <chakra.li ref={ref} __css={styles.item} {...props} />
 })
 
 if (__DEV__) {
   Wrap.displayName = "Wrap"
+  WrapItem.displayName = "WrapItem"
 }

--- a/packages/layout/stories/wrap.stories.tsx
+++ b/packages/layout/stories/wrap.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Badge, Wrap } from "../src"
+import { Badge, Wrap, WrapItem } from "../src"
 
 export default {
   title: "Wrap",
@@ -8,18 +8,28 @@ export default {
 export const basic = () => {
   return (
     <Wrap spacing="40px">
-      <Badge>Badge 1</Badge>
-      <Badge>Badge 2</Badge>
-      <Badge>Badge 3</Badge>
-      <Badge>Badge 4</Badge>
+      <WrapItem>
+        <Badge>Badge 1</Badge>
+      </WrapItem>
+      <WrapItem>
+        <Badge>Badge 2</Badge>
+      </WrapItem>
+      <WrapItem>
+        <Badge>Badge 3</Badge>
+      </WrapItem>
+      <WrapItem>
+        <Badge>Badge 4</Badge>
+      </WrapItem>
     </Wrap>
   )
 }
 const Placeholder = (props: any) => (
-  <div
-    style={{ height: 48, width: props.width || 48, background: "red" }}
-    {...props}
-  />
+  <WrapItem>
+    <div
+      style={{ height: 48, width: props.width || 48, background: "red" }}
+      {...props}
+    />
+  </WrapItem>
 )
 
 export const placeholder = () => {

--- a/website/pages/docs/layout/wrap.mdx
+++ b/website/pages/docs/layout/wrap.mdx
@@ -31,18 +31,26 @@ In the example, you see that the last `Box` wrapped to the next line.
 
 ```jsx
 <Wrap>
-  <Center w="180px" h="80px" bg="red.200">
-    Box 1
-  </Center>
-  <Center w="180px" h="80px" bg="green.200">
-    Box 2
-  </Center>
-  <Center w="180px" h="80px" bg="tomato">
-    Box 3
-  </Center>
-  <Center w="180px" h="80px" bg="blue.200">
-    Box 4
-  </Center>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="red.200">
+      Box 1
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="green.200">
+      Box 2
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="tomato">
+      Box 3
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="blue.200">
+      Box 4
+    </Center>
+  </WrapItem>
 </Wrap>
 ```
 
@@ -55,21 +63,31 @@ it wraps.
 
 ```jsx
 <Wrap spacing="30px">
-  <Center w="180px" h="80px" bg="red.200">
-    Box 1
-  </Center>
-  <Center w="180px" h="80px" bg="green.200">
-    Box 2
-  </Center>
-  <Center w="180px" h="80px" bg="tomato">
-    Box 3
-  </Center>
-  <Center w="180px" h="80px" bg="blue.200">
-    Box 4
-  </Center>
-  <Center w="180px" h="80px" bg="blackAlpha.500">
-    Box 5
-  </Center>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="red.200">
+      Box 1
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="green.200">
+      Box 2
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="tomato">
+      Box 3
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="blue.200">
+      Box 4
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="blackAlpha.500">
+      Box 5
+    </Center>
+  </WrapItem>
 </Wrap>
 ```
 
@@ -79,21 +97,31 @@ Pass the `align` prop to change the alignment of the child along the main axis.
 
 ```jsx
 <Wrap spacing="30px" align="center">
-  <Center w="180px" h="80px" bg="red.200">
-    Box 1
-  </Center>
-  <Center w="180px" h="40px" bg="green.200">
-    Box 2
-  </Center>
-  <Center w="120px" h="80px" bg="tomato">
-    Box 3
-  </Center>
-  <Center w="180px" h="40px" bg="blue.200">
-    Box 4
-  </Center>
-  <Center w="180px" h="80px" bg="whiteAlpha.500">
-    Box 5
-  </Center>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="red.200">
+      Box 1
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="40px" bg="green.200">
+      Box 2
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="120px" h="80px" bg="tomato">
+      Box 3
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="40px" bg="blue.200">
+      Box 4
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="blackAlpha.500">
+      Box 5
+    </Center>
+  </WrapItem>
 </Wrap>
 ```
 
@@ -102,25 +130,37 @@ axis.
 
 ```jsx
 <Wrap spacing="30px" justify="center">
-  <Center w="180px" h="80px" bg="red.200">
-    Box 1
-  </Center>
-  <Center w="180px" h="80px" bg="green.200">
-    Box 2
-  </Center>
-  <Center w="120px" h="80px" bg="tomato">
-    Box 3
-  </Center>
-  <Center w="180px" h="80px" bg="blue.200">
-    Box 4
-  </Center>
-  <Center w="180px" h="80px" bg="whiteAlpha.500">
-    Box 5
-  </Center>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="red.200">
+      Box 1
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="green.200">
+      Box 2
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="120px" h="80px" bg="tomato">
+      Box 3
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="blue.200">
+      Box 4
+    </Center>
+  </WrapItem>
+  <WrapItem>
+    <Center w="180px" h="80px" bg="blackAlpha.500">
+      Box 5
+    </Center>
+  </WrapItem>
 </Wrap>
 ```
 
 ## Props
+
+### Wrap Props
 
 Wrap extends `Box`, so you can pass all `BoxProps` in addition to these:
 
@@ -130,3 +170,7 @@ Wrap extends `Box`, so you can pass all `BoxProps` in addition to these:
 | justify   | `FlexProps['justifyContent']`  |          | The `justify-content` value (for cross axis alignment) |
 | align     | `FlexProps['alignItems']`      |          | The `align-items` value (for main axis alignment)      |
 | direction | `FlexProps['flexDirection']`   |          | The `flex-direction` value                             |
+
+### WrapItem Props
+
+WrapItem composes the Box component.


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, `Wrap` clones all children and "wraps" each child with item styles. Although I may have something to do with influencing this in the initial version of [`raam`](raam.joebell.co.uk/), I no longer believe this is the right way forward.

I recently hit a snag in a custom component which involved adding/removing items to `Wrap`, with the last element being an `Input` (enhanced by Downshift). Unfortunately, every time an item was added/removed, the re-render of children caused Downshift to behave unexpectedly (https://github.com/downshift-js/downshift/issues/1187#issuecomment-713641908).

With the current implementation it's also difficult to customise the flex behaviour of individual items. For example, for my use-case to adjust the flex-grow, my workaround was as follows:

```jsx
<Wrap
  sx={{
    "> ul > li:last-of-type": {
      flexGrow: 2,
    },
  }}
>
```

Whilst this works _fine_, `Wrap's` DOM structure isn't immediately obvious (that it's wrapped in a `div`) and it's not exactly intuitive given the unreliable nature of Emotion's pseudo selectors (https://github.com/emotion-js/emotion/issues/1178)

## What is the new behavior?

Introduce `WrapItem` (like `ListItem`), which should be manually implemented around each child.

This would give more flexibility to add `flex` styles and avoid re-render issues. If a consumer wants to map through children and add the component to each item, they still have the option to do so on their own terms.

In an ideal world, we could style Wrap Items using an `> *` selector, but Emotion doesn't make that easy for us (https://github.com/emotion-js/emotion/issues/1178). This gives us two potential options:
1. Style items on the `groupStyles` with a basic class (e.g. `> .chakra-wrap__item`)
2. Use `StyleProvider` and `useStyles` to get item styles.

> I'd prefer to go down the option of a `.class` but I know that's not very Chakra

In this case it didn't make sense to use `useMultiStyleConfig()` because we don't need themed styles, but I'm open to any alternative ideas to make the dev experience better.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Alert users in the migration guide that `Wrap` will require children to be wrapped individually (which file should I do this in?)

I think it's also worth considering this approach for other "mapping" components such as `Stack` too.

-----

FYI: I'm more than happy to jump on a call to pair on any requested changes 🙂 
