### PR TITLE
feat(toast): useToast can accept default options

### DIFF
--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -113,6 +113,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
       onHoverEnd={onMouseLeave}
       custom={{ position }}
       style={style}
+      data-testid="toast"
     >
       <ReachAlert
         className="chakra-toast__inner"

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -117,7 +117,7 @@ const defaults = {
 export type CreateStandAloneToastParam = Partial<
   {
     setColorMode: (value: ColorMode) => void
-  } & ReturnType<typeof useChakra>
+  } & ReturnType<typeof useChakra> & { defaultOptions: UseToastOptions }
 >
 
 export const defaultStandaloneParam: Required<CreateStandAloneToastParam> = {
@@ -125,6 +125,7 @@ export const defaultStandaloneParam: Required<CreateStandAloneToastParam> = {
   colorMode: "light",
   toggleColorMode: noop,
   setColorMode: noop,
+  defaultOptions: defaults,
 }
 /**
  * Create a toast from outside of React Components
@@ -134,6 +135,7 @@ export function createStandaloneToast({
   colorMode = defaultStandaloneParam.colorMode,
   toggleColorMode = defaultStandaloneParam.toggleColorMode,
   setColorMode = defaultStandaloneParam.setColorMode,
+  defaultOptions = defaultStandaloneParam.defaultOptions,
 }: CreateStandAloneToastParam = defaultStandaloneParam) {
   const renderWithProviders = (
     props: React.PropsWithChildren<RenderProps>,
@@ -152,8 +154,8 @@ export function createStandaloneToast({
     </ThemeProvider>
   )
 
-  const toastImpl = (options: UseToastOptions) => {
-    const opts = { ...defaults, ...options }
+  const toastImpl = (options?: UseToastOptions) => {
+    const opts = { ...defaultOptions, ...options }
 
     const Message: React.FC<RenderProps> = (props) =>
       renderWithProviders(props, opts)
@@ -187,7 +189,7 @@ export function createStandaloneToast({
  * React hook used to create a function that can be used
  * to show toasts in an application.
  */
-export function useToast() {
+export function useToast(options?: UseToastOptions) {
   const { theme, setColorMode, toggleColorMode, colorMode } = useChakra()
   return React.useMemo(
     () =>
@@ -196,8 +198,9 @@ export function useToast() {
         colorMode,
         setColorMode,
         toggleColorMode,
+        defaultOptions: options,
       }),
-    [theme, setColorMode, toggleColorMode, colorMode],
+    [theme, setColorMode, toggleColorMode, colorMode, options],
   )
 }
 

--- a/packages/toast/test/use-toast.test.tsx
+++ b/packages/toast/test/use-toast.test.tsx
@@ -1,0 +1,63 @@
+import {
+  invoke,
+  renderHook,
+  screen,
+  waitForElementToBeRemoved,
+} from "@chakra-ui/test-utils"
+import { toast, useToast } from "../src"
+
+beforeEach(async () => {
+  // close all toasts before each tests and wait for them to be removed
+  toast.closeAll()
+
+  const toasts = screen.queryAllByTestId("toast")
+
+  await Promise.all(toasts.map((toasts) => waitForElementToBeRemoved(toasts)))
+})
+
+test("can accept default options", async () => {
+  const title = "Yay!"
+  const description = "Something awesome happened"
+
+  const { result } = renderHook(() =>
+    useToast({
+      title,
+      description,
+    }),
+  )
+
+  invoke(() => {
+    result.current()
+  })
+
+  const allByTitle = await screen.findAllByText(title)
+  const allByDescription = await screen.findAllByText(description)
+
+  expect(allByTitle).toHaveLength(1)
+  expect(allByDescription).toHaveLength(1)
+})
+
+test("can override default options", async () => {
+  const defaultTitle = "Yay!"
+  const defaultDescription = "Something awesome happened"
+
+  const { result } = renderHook(() =>
+    useToast({
+      title: defaultTitle,
+      description: defaultDescription,
+    }),
+  )
+
+  const title = "Hooray!"
+  const description = "Something splendid happened"
+
+  invoke(() => {
+    result.current({ title, description })
+  })
+
+  const allByTitle = await screen.findAllByText(title)
+  const allByDescription = await screen.findAllByText(description)
+
+  expect(allByTitle).toHaveLength(1)
+  expect(allByDescription).toHaveLength(1)
+})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `useToast` hook cannot accept default options for subsequent `toast(...)` calls.

Fixes: #2316 

## What is the new behavior?

The `useToast` hook cannot accept default options for subsequent `toast(...)` calls.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
