### PR TITLE
fix(tooltip): className typo on arrow

### DIFF
--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -174,7 +174,7 @@ export const Tooltip = forwardRef<TooltipProps, "div">(function Tooltip(
                     {...tooltip.getArrowWrapperProps()}
                   >
                     <chakra.div
-                      className="chakra-toolip__arrow"
+                      className="chakra-tooltip__arrow"
                       {...tooltip.getArrowProps()}
                       __css={{ bg: styles.bg }}
                     />


### PR DESCRIPTION
Fixes a className type on the arrow element.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current arrow component of `Tooltip` has a the className of `chakra-toolip_arrow`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Set the className to `chakra-tooltip_arrow`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
