### PR TITLE
fix(flex-shrink-shorthand): adds missing shrink style prop shorthand for Flex

### DIFF
--- a/packages/layout/src/flex.tsx
+++ b/packages/layout/src/flex.tsx
@@ -49,7 +49,16 @@ export interface FlexProps extends HTMLChakraProps<"div">, FlexOptions {}
  * @see Docs https://chakra-ui.com/components/flex
  */
 export const Flex = forwardRef<FlexProps, "div">(function Flex(props, ref) {
-  const { direction, align, justify, wrap, basis, grow, ...rest } = props
+  const {
+    direction,
+    align,
+    justify,
+    wrap,
+    basis,
+    grow,
+    shrink,
+    ...rest
+  } = props
 
   const styles = {
     display: "flex",
@@ -59,6 +68,7 @@ export const Flex = forwardRef<FlexProps, "div">(function Flex(props, ref) {
     flexWrap: wrap,
     flexBasis: basis,
     flexGrow: grow,
+    flexShrink: shrink,
   }
 
   return <chakra.div ref={ref} __css={styles} {...rest} />

--- a/packages/layout/tests/__snapshots__/layout.test.tsx.snap
+++ b/packages/layout/tests/__snapshots__/layout.test.tsx.snap
@@ -68,3 +68,42 @@ exports[`<Box /> renders box correctly 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`<Flex /> renders all the allowed shorthand style props 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+<div
+    class="emotion-0"
+  />
+</DocumentFragment>
+`;

--- a/packages/layout/tests/layout.test.tsx
+++ b/packages/layout/tests/layout.test.tsx
@@ -1,6 +1,6 @@
 import { render, testA11y } from "@chakra-ui/test-utils"
 import * as React from "react"
-import { Box, Badge } from "../src"
+import { Box, Badge, Flex } from "../src"
 
 describe("<Box />", () => {
   test("renders box correctly", () => {
@@ -38,6 +38,24 @@ describe("<Badge />", () => {
         Badge
       </Badge>,
     )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})
+
+describe("<Flex />", () => {
+  test("renders all the allowed shorthand style props", () => {
+    const { asFragment } = render(
+      <Flex
+        align="stretch"
+        justify="start"
+        wrap="nowrap"
+        direction="row"
+        basis="auto"
+        grow={1}
+        shrink={0}
+      />,
+    )
+
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/website/pages/docs/layout/flex.mdx
+++ b/website/pages/docs/layout/flex.mdx
@@ -33,6 +33,9 @@ Using the Flex components, here are some helpful shorthand props:
 
 - `flexDirection` is `direction`
 - `flexWrap` is `wrap`
+- `flexBasis` is `basis`
+- `flexGrow` is `grow`
+- `flexShrink` is `shrink`
 - `alignItems` is `align`
 - `justifyContent` is `justify`
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #2373 

The Flex component accepts the `shrink` prop but does not map to `flexShrink`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The Flex component now correctly maps `shrink` prop to `flexShrink` style prop.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
