### PR TITLE
fix(use-callback): allow onChange prop to update updateValue callback

### DIFF
--- a/packages/hooks/src/use-controllable.ts
+++ b/packages/hooks/src/use-controllable.ts
@@ -92,11 +92,14 @@ export function useControllableState<T>(props: UseControllableStateProps<T>) {
 
   const value = isControlled ? (valueProp as T) : valueState
 
-  const updateValue = React.useCallback((next: React.SetStateAction<T>) => {
-    const nextValue = runIfFn(next, value)
-    if (!isControlled) setValue(nextValue)
-    onChange?.(nextValue)
-  }, [])
+  const updateValue = React.useCallback(
+    (next: React.SetStateAction<T>) => {
+      const nextValue = runIfFn(next, value)
+      if (!isControlled) setValue(nextValue)
+      onChange?.(nextValue)
+    },
+    [onChange],
+  )
 
   return [value, updateValue] as [T, React.Dispatch<React.SetStateAction<T>>]
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `updateValue` callback inside `useControllableState` has an empty dependencies array, so it's impossible to update the `onChange` callback.

Fixes #2384

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added `onChange` callback to `updateValue` dependencies array, so that when `onChange` changes, the correct callback is called.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I think this change makes sense, but I'd like to get some feedback to make sure.