### PR TITLE
chore(eslint): add tsconfig parserOptions only for ts,tsx

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 10,
-    "project": "tsconfig.json",
     "ecmaFeatures": {
       "jsx": true
     }
@@ -65,5 +64,13 @@
     "react/sort-prop-types": "error",
     "react/prop-types": "off",
     "@typescript-eslint/no-shadow": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["tsconfig.json"]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
`eslint` complains about `parserOptions.project` configuration in files
that aren't specified in `tsconfig.json` (like `babel.config.js`). This
change moves the parser configuration to an `overrides` section
specifically for `ts` and `tsx` files.