### PR TITLE
docs(aspect-ratio): remove obsolete note

### DIFF
--- a/website/pages/docs/layout/aspect-ratio.mdx
+++ b/website/pages/docs/layout/aspect-ratio.mdx
@@ -30,9 +30,6 @@ import { AspectRatio } from "@chakra-ui/core"
 To embed a video with a specific aspect ratio, use an iframe with `src` pointing
 to the link of the video.
 
-> Use `<Box as="iframe">` instead of `<iframe>` directly because we're
-> forwarding some style props behind the scene.
-
 Pass the `maxWidth` prop to `AspectRatio` to control the width of the content.
 
 ```jsx


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- ~[ ] Tests for the changes have been added (for bug fixes / features)~
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The docs conflict on whether a child of `AspectRatio` should be specified as `iframe` vs `<Box as="iframe>`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
The docs are consistent and reflect the proper usage.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

c91fdf397f5b75a315d9dff6918684b9f1e5e988 removed the need to supply a styleable child.

8990a903716f9d78b784ee5e91a3360331b2d8b5 updated the examples to reflect that change, but missed this note.
