### PR TITLE
fix(aliased-text-props): allow override of aliased props

### DIFF
--- a/packages/layout/src/text.tsx
+++ b/packages/layout/src/text.tsx
@@ -7,7 +7,7 @@ import {
   useStyleConfig,
   HTMLChakraProps,
 } from "@chakra-ui/system"
-import { cx, __DEV__ } from "@chakra-ui/utils"
+import { cx, __DEV__, filterUndefined } from "@chakra-ui/utils"
 import * as React from "react"
 
 export interface TextProps extends HTMLChakraProps<"p">, ThemingProps {
@@ -34,21 +34,22 @@ export interface TextProps extends HTMLChakraProps<"p">, ThemingProps {
  * @see Docs https://chakra-ui.com/components/text
  */
 export const Text = forwardRef<TextProps, "p">(function Text(props, ref) {
-  const withAliasedProps = {
-    textAlign: props.align,
-    textDecoration: props.decoration,
-    textTransform: props.casing,
-    ...props,
-  }
-  const styles = useStyleConfig("Text", withAliasedProps)
+  const styles = useStyleConfig("Text", props)
   const { className, align, decoration, casing, ...rest } = omitThemingProps(
     props,
   )
+
+  const aliasedProps = filterUndefined({
+    textAlign: props.align,
+    textDecoration: props.decoration,
+    textTransform: props.casing,
+  })
 
   return (
     <chakra.p
       ref={ref}
       className={cx("chakra-text", props.className)}
+      {...aliasedProps}
       {...rest}
       __css={styles}
     />

--- a/packages/layout/src/text.tsx
+++ b/packages/layout/src/text.tsx
@@ -34,7 +34,13 @@ export interface TextProps extends HTMLChakraProps<"p">, ThemingProps {
  * @see Docs https://chakra-ui.com/components/text
  */
 export const Text = forwardRef<TextProps, "p">(function Text(props, ref) {
-  const styles = useStyleConfig("Text", props)
+  const withAliasedProps = {
+    textAlign: props.align,
+    textDecoration: props.decoration,
+    textTransform: props.casing,
+    ...props,
+  }
+  const styles = useStyleConfig("Text", withAliasedProps)
   const { className, align, decoration, casing, ...rest } = omitThemingProps(
     props,
   )
@@ -43,9 +49,6 @@ export const Text = forwardRef<TextProps, "p">(function Text(props, ref) {
     <chakra.p
       ref={ref}
       className={cx("chakra-text", props.className)}
-      textAlign={align}
-      textDecoration={decoration}
-      textTransform={casing}
       {...rest}
       __css={styles}
     />

--- a/packages/layout/stories/text.stories.tsx
+++ b/packages/layout/stories/text.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { ChakraProvider, extendTheme } from "@chakra-ui/core"
+import { Text } from "../src"
+
+export default {
+  title: "Text",
+}
+
+export const Issue2464 = () => {
+  const theme = extendTheme({
+    components: {
+      Text: {
+        variants: {
+          customCaps: {
+            textTransform: "uppercase",
+          },
+        },
+      },
+    },
+  })
+
+  return (
+    <ChakraProvider theme={theme}>
+      <Text variant="customCaps">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet,
+        sapiente.
+      </Text>
+    </ChakraProvider>
+  )
+}

--- a/packages/layout/stories/text.stories.tsx
+++ b/packages/layout/stories/text.stories.tsx
@@ -6,25 +6,32 @@ export default {
   title: "Text",
 }
 
-export const Issue2464 = () => {
-  const theme = extendTheme({
-    components: {
-      Text: {
-        variants: {
-          customCaps: {
-            textTransform: "uppercase",
-          },
+const theme = extendTheme({
+  components: {
+    Text: {
+      variants: {
+        customCaps: {
+          textTransform: "uppercase",
         },
       },
     },
-  })
+  },
+})
 
-  return (
-    <ChakraProvider theme={theme}>
-      <Text variant="customCaps">
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet,
-        sapiente.
-      </Text>
-    </ChakraProvider>
-  )
-}
+// see https://github.com/chakra-ui/chakra-ui/issues/2464
+export const withVariant = () => (
+  <ChakraProvider theme={theme}>
+    <Text variant="customCaps">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet, sapiente.
+    </Text>
+  </ChakraProvider>
+)
+
+// see https://github.com/chakra-ui/chakra-ui/issues/2464
+export const overrideVariant = () => (
+  <ChakraProvider theme={theme}>
+    <Text variant="customCaps" casing="lowercase">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet, sapiente.
+    </Text>
+  </ChakraProvider>
+)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)
- [x] new storybook story 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

A theme variant for the `Text` component should be able to override the aliased props `align`, `decoration` and
`casing`.

Fixes: #2464 

## What is the new behavior?

Props are overridden by the theme variant values. 
See storybook story Text -> Issue 2464.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
