### PR TITLE
fix: gatsby-plugin had wrong filename to override theme

### DIFF
--- a/tooling/gatsby-plugin/README.md
+++ b/tooling/gatsby-plugin/README.md
@@ -100,7 +100,7 @@ module.exports = {
 ## Customizing the theme
 
 To use customize the theme in your Gatsby site, you can shadow the plugin's
-`src/@chakra-ui/gatsby-plugin/index.js` file with your own theme:
+`src/@chakra-ui/gatsby-plugin/theme.js` file with your own theme:
 
 ```js
 // src/@chakra-ui/gatsby-plugin/theme.js


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Gatsby plugin docs say to override theme in `src/@chakra-ui/gatsby-plugin/index.js`

Fixes: [ISSUE NUMBER]

## What is the new behavior?

Theme needs to be placed at `src/@chakra-ui/gatsby-plugin/theme.js`

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
