### PR TITLE
fix: stack divider keys issue

### DIFF
--- a/.changeset/fluffy-buttons-appear.md
+++ b/.changeset/fluffy-buttons-appear.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+Fix Stack divider keys issue

--- a/packages/layout/src/stack.tsx
+++ b/packages/layout/src/stack.tsx
@@ -180,7 +180,12 @@ export const Stack = forwardRef<StackProps, "div">(function Stack(props, ref) {
         const clonedDivider = React.cloneElement(divider as any, dividerStyles)
         const _divider = isLast ? null : clonedDivider
 
-        return <React.Fragment key={index}>{[_child, _divider]}</React.Fragment>
+        return (
+          <React.Fragment key={index}>
+            {_child}
+            {_divider}
+          </React.Fragment>
+        )
       })
 
   const _className = cx("chakra-stack", className)


### PR DESCRIPTION
## Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- `StackDivider` will cause `each child in a list should have a unique "key" prop.` error.

Fixes: #2509 

## What is the new behavior?

- When using `<StackDivider>` at Stack `divider` props, There will be no errors anymore. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
None.