### PR TITLE
fix: match media on useBreakpoint when no default value

### DIFF
--- a/.changeset/unlucky-peas-yawn.md
+++ b/.changeset/unlucky-peas-yawn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+fix: match media on useBreakpoint when no default value

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -31,9 +31,10 @@ export function useBreakpoint(defaultBreakpoint?: string) {
   )
 
   const [currentBreakpoint, setCurrentBreakpoint] = React.useState(() => {
-    if (!defaultBreakpoint) return undefined
-    const mediaQuery = mediaQueries.find(
-      (query) => query.breakpoint === defaultBreakpoint,
+    const mediaQuery = mediaQueries.find(({ query, breakpoint }) =>
+      defaultBreakpoint
+        ? breakpoint === defaultBreakpoint
+        : window.matchMedia(query).matches,
     )
 
     if (mediaQuery) {

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -1,4 +1,5 @@
 import { useTheme } from "@chakra-ui/system"
+import { isBrowser } from "@chakra-ui/utils"
 import React from "react"
 import createMediaQueries from "./create-media-query"
 
@@ -31,11 +32,11 @@ export function useBreakpoint(defaultBreakpoint?: string) {
   )
 
   const [currentBreakpoint, setCurrentBreakpoint] = React.useState(() => {
-    const mediaQuery = mediaQueries.find(({ query, breakpoint }) =>
-      defaultBreakpoint
-        ? breakpoint === defaultBreakpoint
-        : window.matchMedia(query).matches,
-    )
+    const mediaQuery = mediaQueries.find(({ query, breakpoint }) => {
+      if (defaultBreakpoint) return breakpoint === defaultBreakpoint
+      if (isBrowser) return window.matchMedia(query).matches
+      return undefined
+    })
 
     if (mediaQuery) {
       const { query, ...breakpoint } = mediaQuery


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`useBreakpoint` uses `undefined` for its current breakpoint if no default value is passed, causing its effect to trigger a re-render when the current breakpoint gets updated to its correct value

## What is the new behavior?

`useBreakpoint` matches media on first render

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information