### PR TITLE
Fix/utils: stop memory leak in object.ts

### DIFF
--- a/.changeset/sharp-trains-fly.md
+++ b/.changeset/sharp-trains-fly.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/utils": patch
+---
+
+fix memory leak in utils/objects.ts

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -88,15 +88,14 @@ const memoize = (fn: Handler) => {
     }
 
     const map = cache.get(obj)
-    const key = typeof path === "string" ? path.split(".") : [path]
 
-    if (map.has(key)) {
-      return map.get(key)
+    if (map.has(path)) {
+      return map.get(path)
     }
 
     const value = fn(obj, path, fallback, index)
 
-    map.set(key, value)
+    map.set(path, value)
 
     return value
   }

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -74,7 +74,7 @@ type Handler = (
   index?: number,
 ) => any
 
-const memoize = (fn: Handler) => {
+export const memoize = (fn: Handler) => {
   const cache = new WeakMap()
 
   const memoizedFn: Handler = (

--- a/packages/utils/tests/object.test.ts
+++ b/packages/utils/tests/object.test.ts
@@ -1,4 +1,12 @@
-import { omit, pick, split, get, getWithDefault, filterUndefined } from "../src"
+import {
+  omit,
+  pick,
+  split,
+  get,
+  memoize,
+  getWithDefault,
+  filterUndefined,
+} from "../src/object"
 
 const object = { a: 1, b: 2, c: { d: 3 } }
 
@@ -30,4 +38,15 @@ test("should filter undefined values in object", () => {
     colorScheme: "red",
   })
   expect(result).toStrictEqual({ colorScheme: "red" })
+})
+
+test("should get memoized value on successive calls", () => {
+  const mockGet = jest.fn(() => true)
+  const memoizedMockGet = memoize(mockGet)
+
+  // run the memoized get twice
+  expect(memoizedMockGet(object, "path")).toStrictEqual(true)
+  expect(memoizedMockGet(object, "path")).toStrictEqual(true)
+  // make sure get was only called once
+  expect(mockGet).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
## Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The cache for memoized get function in the object util is using newly created arrays for it's keys, this causes cache misses on every call and leads to a memory leak. 

## What is the new behavior?

The cache now uses the provided path as it's keys, this fixes the cache misses and by extension the memory leak.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

We are now exporting 'memoize' from object.ts to make testing it easier/possible.