### PR TITLE
fix(form-control): remove obsolete props

### DIFF
--- a/.changeset/nasty-bottles-run.md
+++ b/.changeset/nasty-bottles-run.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/form-control": major
+"@chakra-ui/form-control": patch
 ---
 
 Remove nonfunctional props `errorText` and `helperText` from FormControl props

--- a/.changeset/nasty-bottles-run.md
+++ b/.changeset/nasty-bottles-run.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/form-control": major
+---
+
+Remove nonfunctional props `errorText` and `helperText` from FormControl props
+type definition

--- a/packages/form-control/src/form-control.tsx
+++ b/packages/form-control/src/form-control.tsx
@@ -48,14 +48,6 @@ interface FormControlContext extends FormControlOptions {
    */
   label?: string
   /**
-   * The error message to be displayed when `isInvalid` is set to `true`
-   */
-  errorText?: string
-  /**
-   * The assistive text to be displayed that provides additional guidance to users
-   */
-  helperText?: string
-  /**
    * The custom `id` to use for the form control. This is passed directly to the form element (e.g, Input).
    * - The form element (e.g Input) gets the `id`
    * - The form label id: `form-label-${id}`
@@ -70,9 +62,10 @@ type ControlContext = Omit<
   "htmlProps"
 >
 
-const [FormControlProvider, useFormControlContext] = createContext<
-  ControlContext
->({
+const [
+  FormControlProvider,
+  useFormControlContext,
+] = createContext<ControlContext>({
   strict: false,
   name: "FormControlContext",
 })


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Nonfunctional props `helperText` and `errorText` are present

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

removed the props

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

The removal of the prop definition is imo a breaking change. It do not think it will have an impact on the userland usage, because they do nothing. 

## Other information

Should we major bump form-control for this or go with a patch?
