### PR TITLE
fix(collapse): show children if initial in prop is true

### DIFF
--- a/.changeset/sixty-lizards-provide.md
+++ b/.changeset/sixty-lizards-provide.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/transition": patch
+---
+
+Fixed a bug where children of `<Collapse />` where not rendered if prop `in` was
+true on first render

--- a/packages/transition/src/collapse.tsx
+++ b/packages/transition/src/collapse.tsx
@@ -99,7 +99,7 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
     const [display, setDisplay] = React.useState<Display>(() => {
       if (!fromZeroHeight) return "block"
       const hidden = getInitialHidden()
-      return hidden ? "block" : "none"
+      return hidden ? "none" : "block"
     })
 
     useUpdateEffect(() => {

--- a/packages/transition/stories/collapse.stories.tsx
+++ b/packages/transition/stories/collapse.stories.tsx
@@ -43,3 +43,19 @@ export const WithUnmount = () => <CollapseExample unmountOnExit />
 export const WithoutOpacityTransition = () => (
   <CollapseExample animateOpacity={false} />
 )
+
+export const WithInitialIn = () => (
+  <Collapse in>
+    <div>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+      Lorem Ipsum has been the industry's standard dummy text ever since the
+      1500s, when an unknown printer took a galley of type and scrambled it to
+      make a type specimen book. It has survived not only five centuries, but
+      also the leap into electronic typesetting, remaining essentially
+      unchanged. It was popularised in the 1960s with the release of Letraset
+      sheets containing Lorem Ipsum passages, and more recently with desktop
+      publishing software like Aldus PageMaker including versions of Lorem
+      Ipsum.
+    </div>
+  </Collapse>
+)

--- a/packages/transition/tests/collapse.test.tsx
+++ b/packages/transition/tests/collapse.test.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { Collapse } from "../src"
+import { render, screen } from "@chakra-ui/test-utils"
+
+describe("<Collapse />", () => {
+  it("should hide its children", async () => {
+    render(
+      <Collapse>
+        <div data-testid="collapse-children">Test</div>
+      </Collapse>,
+    )
+    expect(await screen.findByTestId("collapse-children")).not.toBeVisible()
+  })
+
+  it("should render its children on initial in", async () => {
+    render(
+      <Collapse in>
+        <div data-testid="collapse-children">Test</div>
+      </Collapse>,
+    )
+    expect(await screen.findByTestId("collapse-children")).toBeVisible()
+  })
+})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Collapse with in prop set to true on first render did not show its children

Fixes: #2534 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now it renders its children

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
