### PR TITLE
chore(website): add /discord invite redirect

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,4 +1,10 @@
 {
   "alias": "chakra-ui.com",
-  "scope": "chakra-ui"
+  "scope": "chakra-ui",
+  "redirects": [
+    {
+      "source": "/discord",
+      "destination": "https://discord.com/invite/dQHfcWF"
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds `/discord` as a redirect to the URL for our Discord server invite so we can direct users to https://chakra-ui.com/discord.