### PR TITLE
docs(migration): fix the framer-motion version

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -61,7 +61,7 @@ Rename the `@chakra-ui/core` package to `@chakra-ui/react`.
 "dependencies": {
 - "@chakra-ui/core": "^0.8.0",
 + "@chakra-ui/react": "^1.0.0",
-  "framer-motion": "^2.9.5",
+  "framer-motion": "^2.9.4",
 - "@emotion/core": "^10.0.10",
 + "@emotion/react": "^11.0.0",
   "@emotion/styled": "^11.0.0",


### PR DESCRIPTION
The last version of framer-motion is still 2.9.4

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Following the migration steps by manually update the package.json file give the following message with yarn :
```
Couldn't find any versions for "framer-motion" that matches "^2.9.5"
? Please choose a version of "framer-motion" from this list: (Use arrow keys)
❯ 3.0.0-rc.16 
  3.0.0-rc.14 
  3.0.0-rc.13 
  3.0.0-rc.12 
  3.0.0-rc.11 
  3.0.0-rc.10 
  3.0.0-rc.9 
  3.0.0-rc.8 
  3.0.0-rc.7 
  3.0.0-rc.6 
  3.0.0-rc.5 
  3.0.0-rc.4 
  3.0.0-rc.3 
  3.0.0-rc.2
```

The documented version of framer-motion is wrong.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
