### PR TITLE
chore(eslint): enable plugin:react-hooks/recommended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
   "extends": [
     "plugin:import/recommended",
     "plugin:import/typescript",
+    "plugin:react-hooks/recommended",
     "airbnb-typescript",
     "prettier",
     "prettier/react",
@@ -64,7 +65,8 @@
     "react/require-default-props": "off",
     "react/sort-prop-types": "error",
     "react/prop-types": "off",
-    "@typescript-eslint/no-shadow": "off"
+    "@typescript-eslint/no-shadow": "off",
+    "react-hooks/exhaustive-deps": "error"
   },
   "overrides": [
     {

--- a/packages/clickable/src/use-clickable.ts
+++ b/packages/clickable/src/use-clickable.ts
@@ -99,16 +99,19 @@ export function useClickable(props: UseClickableProps = {}) {
     [isDisabled, onClick],
   )
 
-  const onDocumentKeyUp = (e: KeyboardEvent) => {
-    if (isPressed && isValidElement(e)) {
-      e.preventDefault()
-      e.stopPropagation()
+  const onDocumentKeyUp = React.useCallback(
+    (e: KeyboardEvent) => {
+      if (isPressed && isValidElement(e)) {
+        e.preventDefault()
+        e.stopPropagation()
 
-      setIsPressed(false)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      listeners.remove(document, "keyup", onDocumentKeyUp, false)
-    }
-  }
+        setIsPressed(false)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        listeners.remove(document, "keyup", onDocumentKeyUp, false)
+      }
+    },
+    [isPressed, listeners],
+  )
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
@@ -136,7 +139,15 @@ export function useClickable(props: UseClickableProps = {}) {
 
       listeners.add(document, "keyup", onDocumentKeyUp, false)
     },
-    [isDisabled, isButton, onKeyDown, clickOnEnter, clickOnSpace],
+    [
+      isDisabled,
+      isButton,
+      onKeyDown,
+      clickOnEnter,
+      clickOnSpace,
+      listeners,
+      onDocumentKeyUp,
+    ],
   )
 
   const handleKeyUp = React.useCallback(
@@ -160,11 +171,14 @@ export function useClickable(props: UseClickableProps = {}) {
     [clickOnSpace, isButton, isDisabled, onKeyUp],
   )
 
-  const onDocumentMouseUp = (event: MouseEvent) => {
-    if (event.button !== 0) return
-    setIsPressed(false)
-    listeners.remove(document, "mouseup", onDocumentMouseUp, false)
-  }
+  const onDocumentMouseUp = React.useCallback(
+    (event: MouseEvent) => {
+      if (event.button !== 0) return
+      setIsPressed(false)
+      listeners.remove(document, "mouseup", onDocumentMouseUp, false)
+    },
+    [listeners],
+  )
 
   const handleMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
@@ -187,7 +201,7 @@ export function useClickable(props: UseClickableProps = {}) {
 
       onMouseDown?.(event)
     },
-    [isDisabled, isButton, onMouseDown],
+    [isDisabled, isButton, onMouseDown, listeners, onDocumentMouseUp],
   )
 
   const handleMouseUp = React.useCallback(
@@ -223,7 +237,7 @@ export function useClickable(props: UseClickableProps = {}) {
       }
       onMouseLeave?.(event)
     },
-    [isPressed],
+    [isPressed, onMouseLeave],
   )
 
   const ref = mergeRefs(htmlRef, refCallback)

--- a/packages/clickable/src/use-event-listeners.ts
+++ b/packages/clickable/src/use-event-listeners.ts
@@ -29,6 +29,7 @@ interface EventListeners {
 
 export function useEventListeners(): EventListeners {
   const listeners = React.useRef(new Map())
+  const currentListeners = listeners.current
 
   const add = React.useCallback((el, type, listener, options) => {
     listeners.current.set(listener, { type, el, options })
@@ -42,11 +43,11 @@ export function useEventListeners(): EventListeners {
 
   React.useEffect(() => {
     return () => {
-      listeners.current.forEach((value, key) => {
+      currentListeners.forEach((value, key) => {
         remove(value.el, value.type, key, value.options)
       })
     }
-  }, [remove])
+  }, [remove, currentListeners])
 
   return { add, remove }
 }

--- a/packages/counter/src/use-counter.ts
+++ b/packages/counter/src/use-counter.ts
@@ -126,7 +126,7 @@ export function useCounter(props: UseCounterProps = {}) {
       next = clamp(next as number)
       update(next)
     },
-    [clamp, props.min, stepProp, update, value],
+    [clamp, stepProp, update, value],
   )
 
   const decrement = useCallback(
@@ -143,7 +143,7 @@ export function useCounter(props: UseCounterProps = {}) {
       next = clamp(next as number)
       update(next)
     },
-    [clamp, props.min, stepProp, update, value],
+    [clamp, stepProp, update, value],
   )
 
   const reset = useCallback(() => {

--- a/packages/hooks/src/use-focus-on-show.ts
+++ b/packages/hooks/src/use-focus-on-show.ts
@@ -42,7 +42,7 @@ export function useFocusOnShow<T extends HTMLElement>(
         focus(tabbableEls[0], { preventScroll })
       }
     }
-  }, [autoFocus, preventScroll])
+  }, [autoFocus, preventScroll, element, focusRef])
 
   useUpdateEffect(() => {
     onFocus()

--- a/packages/hooks/src/use-outside-click.ts
+++ b/packages/hooks/src/use-outside-click.ts
@@ -59,7 +59,7 @@ export function useOutsideClick(props: UseOutsideClickOptions) {
       document.removeEventListener("touchstart", onPointerDown, true)
       document.removeEventListener("touchend", onTouchEnd, true)
     }
-  }, [handler, ref, state.ignoreEmulatedMouseEvents, state.isPointerDown])
+  }, [handler, ref, savedHandler, state])
 }
 
 function isValidEvent(event: any, ref: React.RefObject<HTMLElement>) {

--- a/packages/hooks/src/use-unmount-effect.ts
+++ b/packages/hooks/src/use-unmount-effect.ts
@@ -1,5 +1,9 @@
 import * as React from "react"
 
 export function useUnmountEffect(fn: () => void, deps: any[] = []) {
-  return React.useEffect(() => () => fn(), deps)
+  return React.useEffect(
+    () => () => fn(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    deps,
+  )
 }

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -23,7 +23,6 @@ import {
   getNextItemFromSearch,
   getPrevIndex,
   getValidChildren,
-  hasFocusWithin,
   isArray,
   isString,
   mergeRefs,
@@ -162,7 +161,7 @@ export function useMenu(props: UseMenuProps) {
 
     const el = domContext.descendants[focusedIndex]?.element
     el?.focus({ preventScroll: true })
-  }, [isOpen, hasFocusWithin, focusedIndex, domContext.descendants])
+  }, [isOpen, focusedIndex, domContext.descendants])
 
   return {
     openAndFocusMenu,
@@ -435,7 +434,7 @@ export function useMenuItem(
 
       setFocusedIndex(index)
     },
-    [setFocusedIndex, index, isDisabled],
+    [setFocusedIndex, index, isDisabled, onMouseEnterProp],
   )
 
   const onMouseMove = React.useCallback(
@@ -445,7 +444,7 @@ export function useMenuItem(
         onMouseEnter(event)
       }
     },
-    [onMouseEnter],
+    [onMouseEnter, onMouseMoveProp],
   )
 
   const onMouseLeave = React.useCallback(
@@ -455,7 +454,7 @@ export function useMenuItem(
 
       setFocusedIndex(-1)
     },
-    [setFocusedIndex, isDisabled],
+    [setFocusedIndex, isDisabled, onMouseLeaveProp],
   )
 
   const onClick = React.useCallback(

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -292,7 +292,7 @@ export function ModalFocusScope(props: ModalFocusScopeProps) {
     if (!isPresent && safeToRemove) {
       setTimeout(safeToRemove)
     }
-  }, [isPresent])
+  }, [isPresent, safeToRemove])
 
   return (
     <FocusLock

--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -353,7 +353,14 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
         "aria-disabled": ariaAttr(disabled),
       }
     },
-    [pointerDown, counter.isAtMax, keepWithinRange, spinUp, spinner.stop],
+    [
+      pointerDown,
+      counter.isAtMax,
+      keepWithinRange,
+      spinUp,
+      spinner.stop,
+      isDisabled,
+    ],
   )
 
   const getDecrementButtonProps: PropGetter = useCallback(
@@ -372,7 +379,14 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
         "aria-disabled": ariaAttr(disabled),
       }
     },
-    [pointerDown, counter.isAtMin, keepWithinRange, spinDown, spinner.stop],
+    [
+      pointerDown,
+      counter.isAtMin,
+      keepWithinRange,
+      spinDown,
+      spinner.stop,
+      isDisabled,
+    ],
   )
 
   const inputProps = useFormControl<HTMLInputElement>(props)
@@ -420,7 +434,6 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
       }
     },
     [
-      id,
       inputProps,
       counter.value,
       counter.valueAsNumber,

--- a/packages/pin-input/src/use-pin-input.ts
+++ b/packages/pin-input/src/use-pin-input.ts
@@ -247,9 +247,10 @@ export function usePinInputField(props: UsePinInputFieldProps = {}) {
       if (eventValue.length > 2) {
         // see if we can use the string to fill out our values
         if (eventValue.match(/^[0-9]+$/)) {
-          const { length } = descendants
           // ensure the value matches the number of inputs
-          const nextValue = eventValue.split("").filter((_, i) => i < length)
+          const nextValue = eventValue
+            .split("")
+            .filter((_, i) => i < descendants.length)
           setValues(nextValue)
         }
         return

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -245,6 +245,7 @@ export function usePopover(props: UsePopoverProps = {}) {
       closeOnEsc,
       onClose,
       closeDelay,
+      closeOnBlur,
     ],
   )
 

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -47,15 +47,16 @@ export function usePopper(props: UsePopperProps = {}) {
     null,
   )
   const [arrowNode, setArrowNode] = React.useState<HTMLDivElement | null>(null)
-  const offset = offsetProp ?? [0, gutter]
 
   /**
    * recommended via popper docs
    * @see https://popper.js.org/react-popper/v2/faq/#why-i-get-render-loop-whenever-i-put-a-function-inside-the-popper-configuration
    */
   type Modifiers = Partial<Modifier<any, unknown>>[]
-  const customModifiers = React.useMemo<Modifiers>(
-    () => [
+  const customModifiers = React.useMemo<Modifiers>(() => {
+    const offset = offsetProp ?? [0, gutter]
+
+    return [
       // @see https://popper.js.org/docs/v2/modifiers/offset/
       {
         name: "offset",
@@ -114,17 +115,16 @@ export function usePopper(props: UsePopperProps = {}) {
           }
         },
       },
-    ],
-    [
-      arrowNode,
-      arrowPadding,
-      flip,
-      preventOverflow,
-      offset,
-      gutter,
-      matchWidth,
-    ],
-  )
+    ]
+  }, [
+    arrowNode,
+    arrowPadding,
+    flip,
+    preventOverflow,
+    offsetProp,
+    gutter,
+    matchWidth,
+  ])
 
   const popperJS = useBasePopper(referenceNode as any, popperNode as any, {
     placement,

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -95,7 +95,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
     if (isPresent && requestClose) {
       onRequestRemove()
     }
-  }, [isPresent, requestClose])
+  }, [isPresent, requestClose, onRequestRemove])
 
   useTimeout(close, delay)
 

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -173,8 +173,8 @@ export function useTooltip(props: UseTooltipProps = {}) {
       onMouseDown,
       isOpen,
       tooltipId,
-      popper.getReferenceProps,
       onClick,
+      popper,
     ],
   )
 
@@ -204,7 +204,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
       }
       return popper.getPopperProps(positionerProps, _ref)
     },
-    [popper.getPopperProps, popper.transformOrigin],
+    [popper],
   )
 
   return {


### PR DESCRIPTION
This PR enables `plugin:react-hooks/recommended` rules, which gives us the `react-hooks/exhaustive-deps` rule. I've bumped that rule to `error` level and resolved this error throughout the project. This should have been enabled awhile ago but didn't notice it was missing until now.