### PR TITLE
docs: Mention mandatory version update explicitly

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -57,6 +57,8 @@ fix it.
 
 - Rename the `@chakra-ui/core` package to `@chakra-ui/react`.
 
+- Update the `@emotion/styled` package to v11.
+
 ```diff
 "dependencies": {
 - "@chakra-ui/core": "^0.8.0",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [-] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

### Short status quo
The bullet points contain all changes depicted in the diff, except for one: `"@emotion/styled": "^11.0.0"`

### Full context
I recently migrated to chakra-ui v1 using the migration guide. Unfortunately I overlooked that it is mandatory to update the `@emotion/styled` package since I followed only the steps in the bullet points, assuming that the diff below reflects the exact steps from the bullet points.
As a result, I was still using v10.0.27 which resulted in theme tokens not being resolved at all without any runtime error or warning.

## What is the new behavior?

Add a bullet point explicitly mentioning that `@emotion/styled` needs to be updated.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

