### PR TITLE
fix(extend-theme): move escape hatch typings

### DIFF
--- a/.changeset/rotten-doors-smash.md
+++ b/.changeset/rotten-doors-smash.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix too narrow TypeScript type for theme override

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -17,9 +17,9 @@ type DeepThemeExtension<ThemeObject, TypeHints> = {
     | (ThemeObject[Key] extends (...args: any[]) => any
         ? Partial<ReturnType<ThemeObject[Key]>>
         : Partial<ThemeObject[Key]>) // allow function or object
-    | Record<string, any> // escape hatch
 } &
-  Partial<TypeHints>
+  Partial<TypeHints> &
+  Record<string, any> // escape hatch
 
 export type ThemeOverride = DeepThemeExtension<Theme, ThemeExtensionTypeHints>
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

Throws TypeScript error with some overrides.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- moved type escape hatch to an higher level to allow every override

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Tested with this _not so pretty_ theme override:

```ts
const customTheme = extendTheme({
  shadows: {
    outline: "0 0 0 3px rgb(0, 255, 0)",
  },
  colors: {
    gray: {
      "300": "red",
    },
    myCustomColor: {
      "50": "papayawhip",
    },
  },
  textStyles: {
    dl: {
      lineHeight: "tall",
      "dd + dt": {
        marginTop: "4",
      },
    },
    dt: {
      color: "gray.600",
      fontSize: "sm",
      fontWeight: "bold",
    },
    dd: {
      color: "gray.800",
    },
  },
  config: {
    useSystemColorMode: false,
    initialColorMode: "dark",
  },
  styles: {
    global: {
      body: {
        color: "green.500",
      },
    },
  },
  components: {
    Button: {
      variants: {
        ghost: {
          fontFamily: "mono",
          _active: {
            bg: "red",
          },
        },
      },
    },
    Input: {
      baseStyle: {
        field: {
          outline: "1px solid black",
        },
      },
      variants: {
        outline: (props) => ({
          field: {
            bg: "green.500",
          },
        }),
        myCustomVariant: {
          field: {
            bg: "red.500",
          },
        },
      },
    },
  },
})
```

