### PR TITLE
fix(system): set default useStyleConfig arguments

### DIFF
--- a/.changeset/nice-tools-jump.md
+++ b/.changeset/nice-tools-jump.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/system": patch
+---
+
+Added default empty object argument values for the `props` and `opts` arguments
+of `useStyleConfig`.

--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -23,7 +23,7 @@ export function useStyleConfig(
   opts?: { isMultiPart?: boolean },
 ): SystemStyleObject
 
-export function useStyleConfig(themeKey: any, props: any, opts: any) {
+export function useStyleConfig(themeKey: any, props: any = {}, opts: any = {}) {
   const { styleConfig: styleConfigProp, ...rest } = props
 
   const { theme, colorMode } = useChakra()


### PR DESCRIPTION
Fixes #2705

`useStyleConfig` is typed for the `props` argument to be optional, but
we then destructure `props` within the function. This change resolves
the issue by setting a default empty object value for the `props` and
`opts` arguments.