### PR TITLE
chore(scripts): use lerna run for lint:types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "lerna run build --ignore @chakra-ui/test-utils --no-private --stream",
     "test": "lerna run test --no-private --stream",
     "lint": "lerna run lint --no-private --stream",
-    "lint:types": "lerna exec --parallel \"tsc --noEmit\"",
+    "lint:types": "lerna run lint:types --no-private --stream",
     "storybook": "start-storybook -p 6006 --no-dll",
     "clean": "lerna clean --yes && rm -rf node_modules",
     "bootstrap": "lerna bootstrap --use-workspaces",


### PR DESCRIPTION
This PR updates the `lint:types` command to use `lerna run lint:types`, causing the command to only be run in packages where it exists. The previous script would run `tsc --noEmit` in packages where it shouldn't be run (like `examples` packages) causing local failures. This script is now useful for checking types locally.