### PR TITLE
docs: add colorModeValue to MainNavLink

### DIFF
--- a/website/src/components/sidebar/sidebar.tsx
+++ b/website/src/components/sidebar/sidebar.tsx
@@ -97,8 +97,10 @@ const MainNavLink = ({ href, icon, children }) => {
         fontWeight="semibold"
         transitionProperty="colors"
         transitionDuration="200ms"
-        color={active ? "gray.900" : "gray.500"}
-        _hover={{ color: "gray.900" }}
+        color={
+          active ? useColorModeValue("gray.900", "whiteAlpha.900") : "gray.500"
+        }
+        _hover={{ color: useColorModeValue("gray.900", "whiteAlpha.900") }}
       >
         <Center w="6" h="6" bg="teal.400" rounded="base" mr="3">
           {icon}

--- a/website/src/components/sidebar/sidebar.tsx
+++ b/website/src/components/sidebar/sidebar.tsx
@@ -87,6 +87,7 @@ const MainNavLink = ({ href, icon, children }) => {
   const { pathname } = useRouter()
   const [, group] = href.split("/")
   const active = pathname.includes(group)
+  const linkColor = useColorModeValue("gray.900", "whiteAlpha.900")
 
   return (
     <NextLink href={href} passHref>
@@ -97,10 +98,8 @@ const MainNavLink = ({ href, icon, children }) => {
         fontWeight="semibold"
         transitionProperty="colors"
         transitionDuration="200ms"
-        color={
-          active ? useColorModeValue("gray.900", "whiteAlpha.900") : "gray.500"
-        }
-        _hover={{ color: useColorModeValue("gray.900", "whiteAlpha.900") }}
+        color={active ? linkColor : "gray.500"}
+        _hover={{ color: linkColor }}
       >
         <Center w="6" h="6" bg="teal.400" rounded="base" mr="3">
           {icon}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/chakra-ui/chakra-ui/blob/develop/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes
      /start features)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
- The MainNavLink color in sidebar.tsx is hard to see in dark mode.

![image](https://user-images.githubusercontent.com/5641734/101262002-26722d80-36f0-11eb-8d8c-842028e0219b.png)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #2714

## What is the new behavior?
I added `useColorModeValue` to change the color to display them better in active/hover link mode.

![image](https://user-images.githubusercontent.com/5641734/101262017-3ab62a80-36f0-11eb-9ef6-a499cad4bc66.png)

<!-- Please describe the behavior or changes that are being added by this PR. -->

```js
useColorModeValue("gray.900", "whiteAlpha.900")
```

- The above was the default for the other links in the sidebar so I used the same.
- This changes is for `active` (if it's the current path) and `:hover`
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
