### PR TITLE
fix(alert): respect the colorScheme prop

### DIFF
--- a/.changeset/plenty-experts-explain.md
+++ b/.changeset/plenty-experts-explain.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/alert": patch
+---
+
+`Alert` now respects the `colorScheme` property. You can set it to override the
+color scheme that is by default determined by the `status` property.

--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -50,7 +50,7 @@ export interface AlertProps
  */
 export const Alert = forwardRef<AlertProps, "div">((props, ref) => {
   const { status = "info", ...rest } = omitThemingProps(props)
-  const { colorScheme } = STATUSES[status]
+  const colorScheme = props.colorScheme ?? STATUSES[status].colorScheme
 
   const styles = useMultiStyleConfig("Alert", { ...props, colorScheme })
 


### PR DESCRIPTION
## Pull request type

Bugfix

## What is the current behavior?

Fixes: #2696

## What is the new behavior?

`Alert` now respects the `colorScheme` property.
You can set it to override the color scheme that is by default determined by the `status` property.

## Does this introduce a breaking change?

No
