### PR TITLE
feat: update and refactor pin input

### DIFF
--- a/.changeset/curly-squids-chew.md
+++ b/.changeset/curly-squids-chew.md
@@ -1,0 +1,17 @@
+---
+"@chakra-ui/pin-input": minor
+---
+
+- Move input props logic to parent hook and expose prop-getter `getInputProps`.
+  This helps to co-locate the state logic for easier debugging
+- Added support for alpha-numeric and secret values.
+- Added `type` prop which can be either `alphanumeric` or `number`
+- Added `mask` prop to hide input value similar to `<input type='password' />`
+
+```jsx
+<PinInput type="alphanumeric" mask>
+  <PinInputField />
+  <PinInputField />
+  <PinInputField />
+</PinInput>
+```

--- a/packages/pin-input/src/pin-input.tsx
+++ b/packages/pin-input/src/pin-input.tsx
@@ -60,7 +60,7 @@ if (__DEV__) {
 export interface PinInputFieldProps extends HTMLChakraProps<"input"> {}
 
 export const PinInputField = forwardRef<PinInputFieldProps, "input">(
-  function PinInputField(props, ref) {
+  (props, ref) => {
     const inputProps = usePinInputField(props, ref)
     return (
       <chakra.input

--- a/packages/pin-input/src/pin-input.tsx
+++ b/packages/pin-input/src/pin-input.tsx
@@ -60,8 +60,8 @@ if (__DEV__) {
 export interface PinInputFieldProps extends HTMLChakraProps<"input"> {}
 
 export const PinInputField = forwardRef<PinInputFieldProps, "input">(
-  (props, ref) => {
-    const inputProps = usePinInputField({ ref, ...props })
+  function PinInputField(props, ref) {
+    const inputProps = usePinInputField(props, ref)
     return (
       <chakra.input
         {...inputProps}

--- a/packages/pin-input/src/use-pin-input.ts
+++ b/packages/pin-input/src/use-pin-input.ts
@@ -8,7 +8,10 @@ import {
 } from "@chakra-ui/utils"
 import * as React from "react"
 
-type InputProps = React.ComponentPropsWithRef<"input">
+type InputProps = Omit<
+  React.ComponentPropsWithRef<"input">,
+  "color" | "height" | "width"
+>
 
 export type PinInputContext = UsePinInputReturn & {
   /**
@@ -318,9 +321,10 @@ export interface UsePinInputFieldProps extends InputProps {
   ref?: React.Ref<HTMLInputElement>
 }
 
-export function usePinInputField(props: UsePinInputFieldProps = {}) {
-  const { ref: forwardedRef, ...rest } = props
-
+export function usePinInputField(
+  props: UsePinInputFieldProps = {},
+  forwardedRef: React.Ref<any>,
+) {
   const ref = React.useRef<HTMLInputElement>(null)
 
   const { domContext, getInputProps } = usePinInputContext()
@@ -331,7 +335,7 @@ export function usePinInputField(props: UsePinInputFieldProps = {}) {
   })
 
   return getInputProps({
-    ...rest,
+    ...props,
     ref: mergeRefs(ref, forwardedRef),
     index,
   })

--- a/packages/pin-input/src/use-pin-input.ts
+++ b/packages/pin-input/src/use-pin-input.ts
@@ -323,7 +323,7 @@ export interface UsePinInputFieldProps extends InputProps {
 
 export function usePinInputField(
   props: UsePinInputFieldProps = {},
-  forwardedRef: React.Ref<any>,
+  forwardedRef: React.Ref<any> = null,
 ) {
   const ref = React.useRef<HTMLInputElement>(null)
 

--- a/packages/pin-input/src/use-pin-input.ts
+++ b/packages/pin-input/src/use-pin-input.ts
@@ -1,24 +1,14 @@
-import { useDescendants, useDescendant } from "@chakra-ui/descendant"
+import { useDescendant, useDescendants } from "@chakra-ui/descendant"
 import { useControllableState, useId } from "@chakra-ui/hooks"
 import {
-  mergeRefs,
+  ariaAttr,
   callAllHandlers,
   createContext,
-  ariaAttr,
+  mergeRefs,
 } from "@chakra-ui/utils"
-import {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  ChangeEvent,
-  ChangeEventHandler,
-  KeyboardEventHandler,
-  KeyboardEvent,
-  InputHTMLAttributes,
-  FocusEventHandler,
-  Ref,
-} from "react"
+import * as React from "react"
+
+type InputProps = React.ComponentPropsWithRef<"input">
 
 export type PinInputContext = UsePinInputReturn & {
   /**
@@ -71,8 +61,8 @@ export interface UsePinInputProps {
    */
   manageFocus?: boolean
   /**
-   * The base id string that will be applied to the input fields.
-   * The index of the input will be appended to this base id.
+   * The top-level id string that will be applied to the input fields.
+   * The index of the input will be appended to this top-level id.
    *
    * @example
    * if id="foo", the first input will have `foo-0`
@@ -86,13 +76,20 @@ export interface UsePinInputProps {
    * If `true`, the pin input component is put in the invalid state
    */
   isInvalid?: boolean
+  /**
+   * The type of values the pin-input should allow
+   */
+  type?: "string" | "number"
 }
 
 function toArray(value?: string) {
-  if (typeof value === "string") {
-    return value.split("")
-  }
-  return undefined
+  return typeof value === "string" ? value.split("") : undefined
+}
+
+function checkValueRegex(value: string, type: "string" | "number") {
+  const NUMERIC_REGEX = /^[0-9]+$/
+  const ALPHA_NUMERIC_REGEX = /^[a-z0-9]+$/i
+  return value.match(type === "string" ? ALPHA_NUMERIC_REGEX : NUMERIC_REGEX)
 }
 
 export function usePinInput(props: UsePinInputProps = {}) {
@@ -107,6 +104,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
     id: idProp,
     isDisabled,
     isInvalid,
+    type = "number",
   } = props
 
   const uuid = useId()
@@ -115,7 +113,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
   const domContext = useDescendants<HTMLInputElement, {}>()
   const { descendants } = domContext
 
-  const [moveFocus, setMoveFocus] = useState(true)
+  const [moveFocus, setMoveFocus] = React.useState(true)
 
   const [values, setValues] = useControllableState<string[]>({
     defaultValue: toArray(defaultValue) || [],
@@ -123,14 +121,16 @@ export function usePinInput(props: UsePinInputProps = {}) {
     onChange: (values) => onChange?.(values.join("")),
   })
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (autoFocus) {
       const firstInput = descendants[0]
       firstInput?.element?.focus()
     }
-  }, [descendants, autoFocus])
+    // We don't want to listen for updates to `autoFocus` since it only runs initially
+    // eslint-disable-next-line
+  }, [descendants])
 
-  const focusNext = useCallback(
+  const focusNext = React.useCallback(
     (index: number) => {
       if (!moveFocus || !manageFocus) return
 
@@ -140,7 +140,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
     [descendants, moveFocus, manageFocus],
   )
 
-  const setValue = useCallback(
+  const setValue = React.useCallback(
     (value: string, index: number) => {
       const nextValues = [...values]
       nextValues[index] = value
@@ -156,15 +156,140 @@ export function usePinInput(props: UsePinInputProps = {}) {
     [values, setValues, focusNext, onComplete, descendants.length],
   )
 
-  const clear = useCallback(() => {
+  const clear = React.useCallback(() => {
     const values: string[] = Array(descendants.length).fill("")
     setValues(values)
     const firstInput = descendants[0]
     firstInput.element?.focus()
   }, [descendants, setValues])
 
+  const getNextValue = React.useCallback(
+    (value: string, eventValue: string) => {
+      let nextValue = eventValue
+      if (value?.length > 0) {
+        const [firstValue, secondValue] = eventValue
+        if (value[0] === firstValue) {
+          nextValue = secondValue
+        } else if (value[0] === secondValue) {
+          nextValue = firstValue
+        }
+      }
+      return nextValue
+    },
+    [],
+  )
+
+  const [focusedIndex, setFocusedIndex] = React.useState(-1)
+
+  const getInputProps = React.useCallback(
+    (props: InputProps & { index: number }) => {
+      const { index, ...rest } = props
+
+      /**
+       * Improved from: https://github.com/uber/baseweb/blob/master/src/pin-code/pin-code.js
+       */
+      const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const eventValue = event.target.value
+        const currentValue = values[index]
+        const nextValue = getNextValue(currentValue, eventValue)
+
+        // if the value was removed using backspace
+        if (nextValue === "") {
+          setValue("", index)
+          return
+        }
+
+        // in the case of an autocomplete or copy and paste
+        if (eventValue.length > 2) {
+          // see if we can use the string to fill out our values
+          if (checkValueRegex(eventValue, type)) {
+            // Ensure the value matches the number of inputs
+            const nextValue = eventValue
+              .split("")
+              .filter((_, index) => index < descendants.length)
+
+            setValues(nextValue)
+
+            // if pasting fills the entire input fields, trigger `onComplete`
+            if (nextValue.length === descendants.length) {
+              onComplete?.(nextValue.join(""))
+            }
+          } else {
+            return
+          }
+        }
+
+        // only set if the new value is a number
+        if (checkValueRegex(nextValue, type)) {
+          setValue(nextValue, index)
+        }
+
+        setMoveFocus(true)
+      }
+
+      const onKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === "Backspace" && manageFocus) {
+          if ((event.target as HTMLInputElement).value === "") {
+            const prevInput = descendants[index - 1]
+            if (prevInput) {
+              setValue("", index - 1)
+              prevInput.element?.focus()
+              setMoveFocus(true)
+            }
+          } else {
+            setMoveFocus(false)
+          }
+        }
+      }
+
+      const onFocus = () => {
+        setFocusedIndex(index)
+      }
+
+      const onBlur = () => {
+        setFocusedIndex(-1)
+      }
+
+      const hasFocus = focusedIndex === index
+
+      return {
+        "aria-label": "Please enter your pin code",
+        inputMode: "numeric" as React.InputHTMLAttributes<any>["inputMode"],
+        ...rest,
+        id: `${id}-${index}`,
+        disabled: isDisabled,
+        "aria-invalid": ariaAttr(isInvalid),
+        onChange: callAllHandlers(rest.onChange, onChange),
+        onKeyDown: callAllHandlers(rest.onKeyDown, onKeyDown),
+        onFocus: callAllHandlers(rest.onFocus, onFocus),
+        onBlur: callAllHandlers(rest.onBlur, onBlur),
+        value: values[index] || "",
+        autoComplete: "not-allowed",
+        placeholder: hasFocus ? "" : placeholder,
+      }
+    },
+    [
+      descendants,
+      focusedIndex,
+      getNextValue,
+      id,
+      isDisabled,
+      isInvalid,
+      manageFocus,
+      onComplete,
+      placeholder,
+      setValue,
+      setValues,
+      type,
+      values,
+    ],
+  )
+
   return {
+    getInputProps,
+    type,
     id,
+    getNextValue,
     domContext,
     setValue,
     values,
@@ -181,141 +306,25 @@ export function usePinInput(props: UsePinInputProps = {}) {
 
 export type UsePinInputReturn = ReturnType<typeof usePinInput>
 
-export interface UsePinInputFieldProps {
-  ref?: Ref<HTMLInputElement>
-  onChange?: ChangeEventHandler
-  onKeyDown?: KeyboardEventHandler
-  onFocus?: FocusEventHandler
-  onBlur?: FocusEventHandler
+export interface UsePinInputFieldProps extends InputProps {
+  ref?: React.Ref<HTMLInputElement>
 }
 
 export function usePinInputField(props: UsePinInputFieldProps = {}) {
   const { ref: forwardedRef, ...rest } = props
 
-  const ref = useRef<HTMLInputElement>(null)
+  const ref = React.useRef<HTMLInputElement>(null)
 
-  const {
-    id,
-    isDisabled,
-    isInvalid,
-    setValue,
-    values,
-    setMoveFocus,
-    setValues,
-    domContext,
-    placeholder,
-    manageFocus,
-  } = usePinInputContext()
-
-  const { descendants } = domContext
+  const { domContext, getInputProps } = usePinInputContext()
 
   const index = useDescendant({
     context: domContext,
     element: ref.current,
   })
 
-  const getNextValue = useCallback(
-    (currentValue: string, eventValue: string) => {
-      let nextValue = eventValue
-      if (currentValue && currentValue.length > 0) {
-        const [firstValue, secondValue] = eventValue
-        if (currentValue[0] === firstValue) {
-          nextValue = secondValue
-        } else if (currentValue[0] === secondValue) {
-          nextValue = firstValue
-        }
-      }
-      return nextValue
-    },
-    [],
-  )
-
-  // Improved from: https://github.com/uber/baseweb/blob/master/src/pin-code/pin-code.js
-  const onChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const eventValue = event.target.value
-      const currentValue = values[index]
-      const nextValue = getNextValue(currentValue, eventValue)
-
-      // if the value was removed using backspace
-      if (nextValue === "") {
-        setValue("", index)
-        return
-      }
-
-      // in the case of an autocomplete or copy and paste
-      if (eventValue.length > 2) {
-        // see if we can use the string to fill out our values
-        if (eventValue.match(/^[0-9]+$/)) {
-          // ensure the value matches the number of inputs
-          const nextValue = eventValue
-            .split("")
-            .filter((_, i) => i < descendants.length)
-          setValues(nextValue)
-        }
-        return
-      }
-
-      // only set if the new value is a number
-      if (nextValue.match(/^[0-9]$/)) {
-        setValue(nextValue, index)
-      }
-
-      setMoveFocus(true)
-    },
-    [
-      values,
-      index,
-      getNextValue,
-      setMoveFocus,
-      setValue,
-      descendants.length,
-      setValues,
-    ],
-  )
-
-  const onKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === "Backspace" && manageFocus) {
-        if ((event.target as HTMLInputElement).value === "") {
-          const prevInput = descendants[index - 1]
-          if (prevInput) {
-            setValue("", index - 1)
-            prevInput.element?.focus()
-            setMoveFocus(true)
-          }
-        } else {
-          setMoveFocus(false)
-        }
-      }
-    },
-    [descendants, index, setValue, setMoveFocus, manageFocus],
-  )
-
-  const [hasFocus, setHasFocus] = useState(false)
-
-  const onFocus = useCallback(() => {
-    setHasFocus(true)
-  }, [])
-
-  const onBlur = useCallback(() => {
-    setHasFocus(false)
-  }, [])
-
-  return {
+  return getInputProps({
     ...rest,
-    id: `${id}-${index}`,
-    disabled: isDisabled,
-    "aria-invalid": ariaAttr(isInvalid),
     ref: mergeRefs(ref, forwardedRef),
-    onChange: callAllHandlers(rest.onChange, onChange),
-    onKeyDown: callAllHandlers(rest.onKeyDown, onKeyDown),
-    onFocus: callAllHandlers(rest.onFocus, onFocus),
-    onBlur: callAllHandlers(rest.onBlur, onBlur),
-    value: values[index] || "",
-    inputMode: "numeric" as InputHTMLAttributes<any>["inputMode"],
-    "aria-label": rest["aria-label"] || "Please enter your pin code",
-    autoComplete: "not-allowed",
-    placeholder: hasFocus ? "" : placeholder,
-  }
+    index,
+  })
 }

--- a/packages/pin-input/stories/pin-input.stories.tsx
+++ b/packages/pin-input/stories/pin-input.stories.tsx
@@ -25,7 +25,12 @@ function Input(props: any) {
 }
 
 export function HookExample() {
-  const context = usePinInput({ autoFocus: true, onComplete: console.log })
+  const context = usePinInput({
+    autoFocus: true,
+    mask: true,
+    onComplete: alert,
+    type: "number",
+  })
   return (
     <PinInputProvider value={context}>
       <Input style={style} />

--- a/packages/pin-input/stories/pin-input.stories.tsx
+++ b/packages/pin-input/stories/pin-input.stories.tsx
@@ -25,7 +25,7 @@ function Input(props: any) {
 }
 
 export function HookExample() {
-  const context = usePinInput({ autoFocus: true })
+  const context = usePinInput({ autoFocus: true, onComplete: console.log })
   return (
     <PinInputProvider value={context}>
       <Input style={style} />

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -13,10 +13,7 @@ import { cx } from "@chakra-ui/utils"
 
 export interface TableProps extends HTMLChakraProps<"table">, ThemingProps {}
 
-export const Table = forwardRef<TableProps, "table">(function Table(
-  props,
-  ref,
-) {
+export const Table = forwardRef<TableProps, "table">((props, ref) => {
   const styles = useMultiStyleConfig("Table", props)
   const { className, ...tableProps } = omitThemingProps(props)
 
@@ -42,7 +39,7 @@ export interface TableCaptionProps extends HTMLChakraProps<"caption"> {
 }
 
 export const TableCaption = forwardRef<TableCaptionProps, "caption">(
-  function TableCaption(props, ref) {
+  (props, ref) => {
     const { placement = "bottom", ...rest } = props
     const styles = useStyles()
     return (


### PR DESCRIPTION
Closes #2679

## 📝 Description

- Move input props logic to parent hook and expose prop-getter `getInputProps`.
  This helps to co-locate the state logic for easier debugging
- Added support for alpha-numeric and secret values.
- Added `type` prop which can be either `alphanumeric` or `number`
- Added `mask` prop to hide input value similar to `<input type='password' />`

```jsx
<PinInput type="alphanumeric" mask>
  <PinInputField />
  <PinInputField />
  <PinInputField />
</PinInput>
```
