### PR TITLE
fix(input): make focus outline take precedence over isInvalid outline

### DIFF
--- a/.changeset/sour-cherries-unite.md
+++ b/.changeset/sour-cherries-unite.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Focus outline now takes precedence over "isInvalid" outline. This change affects
+all components that extend from `Input`'s theme, such as `Select`, `PinInput`,
+`Textarea` or `NumberInput`.

--- a/packages/input/tests/__snapshots__/input.test.tsx.snap
+++ b/packages/input/tests/__snapshots__/input.test.tsx.snap
@@ -83,17 +83,17 @@ exports[`Elements inside input render correctly 1`] = `
   cursor: not-allowed;
 }
 
+.emotion-2[aria-invalid=true],
+.emotion-2[data-invalid] {
+  border-color: #E53E3E;
+  box-shadow: 0 0 0 1px #E53E3E;
+}
+
 .emotion-2:focus,
 .emotion-2[data-focus] {
   z-index: 1;
   border-color: #3182ce;
   box-shadow: 0 0 0 1px #3182ce;
-}
-
-.emotion-2[aria-invalid=true],
-.emotion-2[data-invalid] {
-  border-color: #E53E3E;
-  box-shadow: 0 0 0 1px #E53E3E;
 }
 
 .emotion-3 {
@@ -235,17 +235,17 @@ exports[`addons render correctly 1`] = `
   cursor: not-allowed;
 }
 
+.emotion-2[aria-invalid=true],
+.emotion-2[data-invalid] {
+  border-color: #E53E3E;
+  box-shadow: 0 0 0 1px #E53E3E;
+}
+
 .emotion-2:focus,
 .emotion-2[data-focus] {
   z-index: 1;
   border-color: #3182ce;
   box-shadow: 0 0 0 1px #3182ce;
-}
-
-.emotion-2[aria-invalid=true],
-.emotion-2[data-invalid] {
-  border-color: #E53E3E;
-  box-shadow: 0 0 0 1px #E53E3E;
 }
 
 .emotion-3 {
@@ -346,17 +346,17 @@ exports[`renders correctly 1`] = `
   cursor: not-allowed;
 }
 
+.emotion-0[aria-invalid=true],
+.emotion-0[data-invalid] {
+  border-color: #E53E3E;
+  box-shadow: 0 0 0 1px #E53E3E;
+}
+
 .emotion-0:focus,
 .emotion-0[data-focus] {
   z-index: 1;
   border-color: #3182ce;
   box-shadow: 0 0 0 1px #3182ce;
-}
-
-.emotion-0[aria-invalid=true],
-.emotion-0[data-invalid] {
-  border-color: #E53E3E;
-  box-shadow: 0 0 0 1px #E53E3E;
 }
 
 <input

--- a/packages/number-input/tests/__snapshots__/number-input.test.tsx.snap
+++ b/packages/number-input/tests/__snapshots__/number-input.test.tsx.snap
@@ -60,17 +60,17 @@ exports[`should render correctly 1`] = `
   cursor: not-allowed;
 }
 
+.emotion-1[aria-invalid=true],
+.emotion-1[data-invalid] {
+  border-color: #E53E3E;
+  box-shadow: 0 0 0 1px #E53E3E;
+}
+
 .emotion-1:focus,
 .emotion-1[data-focus] {
   z-index: 1;
   border-color: #3182ce;
   box-shadow: 0 0 0 1px #3182ce;
-}
-
-.emotion-1[aria-invalid=true],
-.emotion-1[data-invalid] {
-  border-color: #E53E3E;
-  box-shadow: 0 0 0 1px #E53E3E;
 }
 
 .emotion-2 {

--- a/packages/select/tests/__snapshots__/select.test.tsx.snap
+++ b/packages/select/tests/__snapshots__/select.test.tsx.snap
@@ -64,17 +64,17 @@ exports[`Select renders correctly 1`] = `
   cursor: not-allowed;
 }
 
+.emotion-1[aria-invalid=true],
+.emotion-1[data-invalid] {
+  border-color: #E53E3E;
+  box-shadow: 0 0 0 1px #E53E3E;
+}
+
 .emotion-1:focus,
 .emotion-1[data-focus] {
   z-index: unset;
   border-color: #3182ce;
   box-shadow: 0 0 0 1px #3182ce;
-}
-
-.emotion-1[aria-invalid=true],
-.emotion-1[data-invalid] {
-  border-color: #E53E3E;
-  box-shadow: 0 0 0 1px #E53E3E;
 }
 
 .emotion-2 {

--- a/packages/textarea/tests/__snapshots__/text-area.test.tsx.snap
+++ b/packages/textarea/tests/__snapshots__/text-area.test.tsx.snap
@@ -54,17 +54,17 @@ exports[`Textarea renders correctly 1`] = `
   cursor: not-allowed;
 }
 
+.emotion-0[aria-invalid=true],
+.emotion-0[data-invalid] {
+  border-color: #E53E3E;
+  box-shadow: 0 0 0 1px #E53E3E;
+}
+
 .emotion-0:focus,
 .emotion-0[data-focus] {
   z-index: 1;
   border-color: #3182ce;
   box-shadow: 0 0 0 1px #3182ce;
-}
-
-.emotion-0[aria-invalid=true],
-.emotion-0[data-invalid] {
-  border-color: #E53E3E;
-  box-shadow: 0 0 0 1px #E53E3E;
 }
 
 <textarea

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -81,14 +81,14 @@ function variantOutline(props: Record<string, any>) {
         opacity: 0.4,
         cursor: "not-allowed",
       },
+      _invalid: {
+        borderColor: getColor(theme, ec),
+        boxShadow: `0 0 0 1px ${getColor(theme, ec)}`,
+      },
       _focus: {
         zIndex: 1,
         borderColor: getColor(theme, fc),
         boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
-      },
-      _invalid: {
-        borderColor: getColor(theme, ec),
-        boxShadow: `0 0 0 1px ${getColor(theme, ec)}`,
       },
     },
     addon: {
@@ -119,12 +119,12 @@ function variantFilled(props: Record<string, any>) {
         opacity: 0.4,
         cursor: "not-allowed",
       },
+      _invalid: {
+        borderColor: getColor(theme, ec),
+      },
       _focus: {
         bg: "transparent",
         borderColor: getColor(theme, fc),
-      },
-      _invalid: {
-        borderColor: getColor(theme, ec),
       },
     },
     addon: {
@@ -151,13 +151,13 @@ function variantFlushed(props: Record<string, any>) {
         boxShadow: "none !important",
         userSelect: "all",
       },
-      _focus: {
-        borderColor: getColor(theme, fc),
-        boxShadow: `0px 1px 0px 0px ${getColor(theme, fc)}`,
-      },
       _invalid: {
         borderColor: getColor(theme, ec),
         boxShadow: `0 0 0 1px ${getColor(theme, ec)}`,
+      },
+      _focus: {
+        borderColor: getColor(theme, fc),
+        boxShadow: `0px 1px 0px 0px ${getColor(theme, fc)}`,
       },
     },
     addon: {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2703 

## ⛳️ Current behavior

The Select component uses border for both focus state and invalid state, and the invalid state takes precedence. This means that, when a Select component has the isInvalid prop applied, it becomes impossible to visually determine whether the element has focus.

(Input has a similar style conflict, but it at least has the blinking cursor—but that might not be enough feedback for disabled users who expect a stronger visual signal.)

## 🚀 New behavior

Focus outline now takes precedence over "isInvalid" outline.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
This change just moves lines around to change their css priority.
Should we leave a comment in the code to make the intent explicit?