### PR TITLE
fix: typescript autocomplete

### DIFF
--- a/.changeset/brown-cherries-collect.md
+++ b/.changeset/brown-cherries-collect.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": patch
+"@chakra-ui/system": patch
+---
+
+Restored TypeScript autocomplete for chakra component props in Jetbrains IDEs.

--- a/packages/modal/src/modal-transition.tsx
+++ b/packages/modal/src/modal-transition.tsx
@@ -4,8 +4,8 @@ import { HTMLMotionProps, motion } from "framer-motion"
 import * as React from "react"
 
 export interface ModalTransitionProps
-  extends Omit<HTMLMotionProps<"section">, "color">,
-    Omit<ChakraProps, "transition"> {
+  extends Omit<HTMLMotionProps<"section">, "color" | "transition">,
+    ChakraProps {
   preset: "slideInBottom" | "slideInRight" | "scale" | "none"
 }
 
@@ -31,6 +31,6 @@ export const ModalTransition = React.forwardRef(
   (props: ModalTransitionProps, ref: React.Ref<any>) => {
     const { preset, ...rest } = props
     const motionProps = transitions[preset]
-    return <Motion ref={ref} {...motionProps} {...rest} />
+    return <Motion ref={ref} {...(motionProps as ChakraProps)} {...rest} />
   },
 )

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -28,6 +28,7 @@ import {
 } from "framer-motion"
 import * as React from "react"
 import { RemoveScroll } from "react-remove-scroll"
+import { MouseEvent } from "react"
 import { ModalTransition } from "./modal-transition"
 import { useModal, UseModalProps, UseModalReturn } from "./use-modal"
 
@@ -505,7 +506,7 @@ export const ModalCloseButton = forwardRef<CloseButtonProps, "button">(
         ref={ref}
         __css={styles.closeButton}
         className={_className}
-        onClick={callAllHandlers(onClick, (event) => {
+        onClick={callAllHandlers(onClick, (event: MouseEvent) => {
           event.stopPropagation()
           onClose()
         })}

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -322,8 +322,8 @@ export function ModalFocusScope(props: ModalFocusScopeProps) {
 }
 
 export interface ModalOverlayProps
-  extends Omit<HTMLMotionProps<"div">, "color">,
-    Omit<ChakraProps, "transition"> {
+  extends Omit<HTMLMotionProps<"div">, "color" | "transition">,
+    ChakraProps {
   children?: React.ReactNode
 }
 
@@ -335,7 +335,7 @@ export interface ModalOverlayProps
  */
 export const ModalOverlay = forwardRef<ModalOverlayProps, "div">(
   (props, ref) => {
-    const { className, ...rest } = props
+    const { className, transition, ...rest } = props
     const _className = cx("chakra-modal__overlay", className)
 
     const styles = useStyles()

--- a/packages/system/src/forward-ref.tsx
+++ b/packages/system/src/forward-ref.tsx
@@ -3,43 +3,32 @@
  * the base type definitions upon which we improved on
  */
 import * as React from "react"
+import type { As } from "./system.types"
 
-type As = React.ElementType
+type OmittedProps = "transition"
 
-type PropsOf<T extends As> = React.ComponentProps<T>
+type PropsWithAs<Props = {}, Component extends As = As> = Props &
+  Omit<React.ComponentProps<Component>, "as" | keyof Props | OmittedProps> & {
+    as?: Component
+  }
 
-type AddProps<P> = React.PropsWithChildren<
-  P extends { transition?: any } ? Omit<P, "transition"> : P
->
-
-type AddTProps<T extends As> = PropsOf<T> extends { color?: any }
-  ? Omit<PropsOf<T>, "color">
-  : PropsOf<T>
-
-export interface ComponentWithAs<T extends As, P> {
-  <TT extends As>(
-    props: { as?: TT } & (PropsOf<T> extends { transition?: any }
-      ? Omit<P, "transition">
-      : P) &
-      Omit<PropsOf<TT>, keyof PropsOf<T>> &
-      Omit<AddTProps<T>, keyof P>,
+export type ComponentWithAs<Component extends As, Props> = {
+  <Component extends As>(
+    props: PropsWithAs<Props, Component> & { as?: Component },
   ): JSX.Element
+
   displayName?: string
-  propTypes?: React.WeakValidationMap<AddProps<P> & AddTProps<T>>
+  propTypes?: React.WeakValidationMap<PropsWithAs<Props, Component>>
   contextTypes?: React.ValidationMap<any>
-  defaultProps?: AddProps<P> & AddTProps<T> & { as?: As }
+  defaultProps?: Partial<PropsWithAs<Props, Component>>
   id?: string
 }
 
-export function forwardRef<P, T extends As>(
-  component: (
-    props: React.PropsWithChildren<P> &
-      Omit<PropsOf<T>, keyof P | "color" | "ref"> & { as?: As },
-    ref: React.Ref<any>,
-  ) => React.ReactElement | null,
+export function forwardRef<Props, Component extends As>(
+  component: React.ForwardRefRenderFunction<any, any>,
 ) {
-  return (React.forwardRef(component as any) as unknown) as ComponentWithAs<
-    T,
-    P
+  return (React.forwardRef(component) as unknown) as ComponentWithAs<
+    Component,
+    Props
   >
 }

--- a/packages/system/src/forward-ref.tsx
+++ b/packages/system/src/forward-ref.tsx
@@ -3,39 +3,16 @@
  * for creating the base type definitions upon which we improved on
  */
 import * as React from "react"
+import { As, ComponentWithAs, PropsOf, RightJoinProps } from "./system.types"
 
-type OmitCommonProps<
-  Target,
-  OmitAdditionalProps extends keyof any = never
-> = Omit<Target, "transition" | "as" | "color" | OmitAdditionalProps>
-
-type RightJoinProps<
-  SourceProps extends object = {},
-  OverrideProps extends object = {}
-> = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps
-
-export type ComponentWithAs<
-  Component extends React.ElementType,
-  Props extends object = {}
-> = {
-  <AliasedComponent extends React.ElementType>(
-    props: RightJoinProps<React.ComponentProps<Component>, Props> &
-      RightJoinProps<React.ComponentProps<AliasedComponent>, Props> & {
-        as?: AliasedComponent
-      },
-  ): JSX.Element
-
-  displayName?: string
-  propTypes?: React.WeakValidationMap<any>
-  contextTypes?: React.ValidationMap<any>
-  defaultProps?: Partial<any>
-  id?: string
-}
-
-export function forwardRef<
-  Props extends object,
-  Component extends React.ElementType
->(component: React.ForwardRefRenderFunction<any, any>) {
+export function forwardRef<Props extends object, Component extends As>(
+  component: React.ForwardRefRenderFunction<
+    any,
+    RightJoinProps<PropsOf<Component>, Props> & {
+      as?: As
+    }
+  >,
+) {
   return (React.forwardRef(component) as unknown) as ComponentWithAs<
     Component,
     Props

--- a/packages/system/src/forward-ref.tsx
+++ b/packages/system/src/forward-ref.tsx
@@ -1,32 +1,41 @@
 /**
- * All credit goes to Chance (Reach UI), and Haz (Reakit) for creating
- * the base type definitions upon which we improved on
+ * All credit goes to Chance (Reach UI), Haz (Reakit) and (fluentui)
+ * for creating the base type definitions upon which we improved on
  */
 import * as React from "react"
-import type { As } from "./system.types"
 
-type OmittedProps = "transition"
+type OmitCommonProps<
+  Target,
+  OmitAdditionalProps extends keyof any = never
+> = Omit<Target, "transition" | "as" | "color" | OmitAdditionalProps>
 
-type PropsWithAs<Props = {}, Component extends As = As> = Props &
-  Omit<React.ComponentProps<Component>, "as" | keyof Props | OmittedProps> & {
-    as?: Component
-  }
+type Intersection<
+  SourceProps extends object = {},
+  OverrideProps extends object = {}
+> = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps
 
-export type ComponentWithAs<Component extends As, Props> = {
-  <Component extends As>(
-    props: PropsWithAs<Props, Component> & { as?: Component },
+export type ComponentWithAs<
+  Component extends React.ElementType,
+  Props extends object = {}
+> = {
+  <AliasedComponent extends React.ElementType>(
+    props: Intersection<React.ComponentProps<Component>, Props> &
+      Intersection<React.ComponentProps<AliasedComponent>, Props> & {
+        as?: AliasedComponent
+      },
   ): JSX.Element
 
   displayName?: string
-  propTypes?: React.WeakValidationMap<PropsWithAs<Props, Component>>
+  propTypes?: React.WeakValidationMap<any>
   contextTypes?: React.ValidationMap<any>
-  defaultProps?: Partial<PropsWithAs<Props, Component>>
+  defaultProps?: Partial<any>
   id?: string
 }
 
-export function forwardRef<Props, Component extends As>(
-  component: React.ForwardRefRenderFunction<any, any>,
-) {
+export function forwardRef<
+  Props extends object,
+  Component extends React.ElementType
+>(component: React.ForwardRefRenderFunction<any, any>) {
   return (React.forwardRef(component) as unknown) as ComponentWithAs<
     Component,
     Props

--- a/packages/system/src/forward-ref.tsx
+++ b/packages/system/src/forward-ref.tsx
@@ -9,7 +9,7 @@ type OmitCommonProps<
   OmitAdditionalProps extends keyof any = never
 > = Omit<Target, "transition" | "as" | "color" | OmitAdditionalProps>
 
-type Intersection<
+type RightJoinProps<
   SourceProps extends object = {},
   OverrideProps extends object = {}
 > = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps
@@ -19,8 +19,8 @@ export type ComponentWithAs<
   Props extends object = {}
 > = {
   <AliasedComponent extends React.ElementType>(
-    props: Intersection<React.ComponentProps<Component>, Props> &
-      Intersection<React.ComponentProps<AliasedComponent>, Props> & {
+    props: RightJoinProps<React.ComponentProps<Component>, Props> &
+      RightJoinProps<React.ComponentProps<AliasedComponent>, Props> & {
         as?: AliasedComponent
       },
   ): JSX.Element

--- a/packages/system/src/system.ts
+++ b/packages/system/src/system.ts
@@ -174,6 +174,5 @@ export const chakra = (styled as unknown) as ChakraFactory &
   HTMLChakraComponents
 
 domElements.forEach((tag) => {
-  // @ts-expect-error
   chakra[tag] = chakra(tag)
 })

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -60,7 +60,7 @@ export interface ChakraProps extends SystemProps {
   css?: Interpolation<{}>
 }
 
-export type As = React.ElementType
+export type As<Props = any> = React.ElementType<Props>
 
 /**
  * Extract the props of a React element or component
@@ -70,4 +70,4 @@ export type PropsOf<T extends As> = React.ComponentPropsWithoutRef<T> & {
 }
 
 export interface ChakraComponent<T extends As, P = {}>
-  extends ComponentWithAs<T, P & ChakraProps> {}
+  extends ComponentWithAs<T, ChakraProps & P> {}

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -6,7 +6,6 @@ import {
 import { Dict } from "@chakra-ui/utils"
 import { Interpolation } from "@emotion/react"
 import * as React from "react"
-import { ComponentWithAs } from "./forward-ref"
 
 export interface ThemingProps {
   variant?: string
@@ -67,6 +66,43 @@ export type As<Props = any> = React.ElementType<Props>
  */
 export type PropsOf<T extends As> = React.ComponentPropsWithoutRef<T> & {
   as?: As
+}
+
+export type OmitCommonProps<
+  Target,
+  OmitAdditionalProps extends keyof any = never
+> = Omit<Target, "transition" | "as" | "color" | OmitAdditionalProps>
+
+export type RightJoinProps<
+  SourceProps extends object = {},
+  OverrideProps extends object = {}
+> = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps
+
+export type MergeWithAs<
+  ComponentProps extends object,
+  AsProps extends object,
+  AdditionalProps extends object = {},
+  AsComponent extends As = As
+> = RightJoinProps<ComponentProps, AdditionalProps> &
+  RightJoinProps<AsProps, AdditionalProps> & {
+    as?: AsComponent
+  }
+
+export type ComponentWithAs<Component extends As, Props extends object = {}> = {
+  <AsComponent extends As>(
+    props: MergeWithAs<
+      React.ComponentProps<Component>,
+      React.ComponentProps<AsComponent>,
+      Props,
+      AsComponent
+    >,
+  ): JSX.Element
+
+  displayName?: string
+  propTypes?: React.WeakValidationMap<any>
+  contextTypes?: React.ValidationMap<any>
+  defaultProps?: Partial<any>
+  id?: string
 }
 
 export interface ChakraComponent<T extends As, P = {}>

--- a/packages/system/tests/as-prop.test.tsx
+++ b/packages/system/tests/as-prop.test.tsx
@@ -1,0 +1,41 @@
+import * as React from "react"
+import { chakra } from ".."
+import { ChakraComponent } from "../src"
+
+/**
+ * These tests should fail
+ * if the typings for `ChakraComponent` change
+ * and create a type regression
+ */
+describe("`as` prop typings", () => {
+  const Comp = (props: {}) => null
+
+  type CompWithRequiredProps = { thisIsARequiredProp: boolean }
+  const CompWithRequired = (props: CompWithRequiredProps) => null
+
+  it("should has correct types for the chakra factory", () => {
+    const div = <chakra.div />
+    const divWithAsTag = <chakra.div as="img" src="/this-is-the-way.webp" />
+    const divWithAsComp = <chakra.div as={Comp} />
+    const divWithAsCompRequired = (
+      <chakra.div as={CompWithRequired} thisIsARequiredProp />
+    )
+
+    // make jest happy
+    expect(true).toBe(true)
+  })
+
+  it("should has correct types for the ChakraComponent", () => {
+    const Div: ChakraComponent<"div"> = (props) => <chakra.div {...props} />
+    const CustomComp: ChakraComponent<typeof Comp> = (props) => (
+      <chakra.div as={Comp} {...props} />
+    )
+    const CustomCompWithRequired = chakra(CompWithRequired)
+
+    // TODO this should fail due missing required prop
+    const renderedCustomCompWithRequired = <CustomCompWithRequired />
+
+    // make jest happy
+    expect(true).toBe(true)
+  })
+})

--- a/packages/system/tests/as-prop.test.tsx
+++ b/packages/system/tests/as-prop.test.tsx
@@ -31,8 +31,9 @@ describe("`as` prop typings", () => {
     )
     const CustomCompWithRequired = chakra(CompWithRequired)
 
-    // TODO this should fail due missing required prop
-    const renderedCustomCompWithRequired = <CustomCompWithRequired />
+    const renderedCustomCompWithRequired = (
+      <CustomCompWithRequired thisIsARequiredProp />
+    )
 
     // make jest happy
     expect(true).toBe(true)

--- a/packages/system/tests/as-prop.test.tsx
+++ b/packages/system/tests/as-prop.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { chakra, ChakraComponent } from ".."
 
 /**
- * These tests should fail
+ * These tests should fail while type checking
  * if the typings for `ChakraComponent` change
  * and create a type regression
  */
@@ -12,7 +12,7 @@ describe("`as` prop typings", () => {
   type CompWithRequiredProps = { thisIsARequiredProp: boolean }
   const CompWithRequired = (props: CompWithRequiredProps) => null
 
-  it("should has correct types for the chakra factory", () => {
+  it("should have correct types for the chakra factory", () => {
     const div = <chakra.div />
     const divWithAsTag = <chakra.div as="img" src="/this-is-the-way.webp" />
     const divWithAsComp = <chakra.div as={Comp} />
@@ -24,7 +24,7 @@ describe("`as` prop typings", () => {
     expect(true).toBe(true)
   })
 
-  it("should has correct types for the ChakraComponent", () => {
+  it("should have correct types for the ChakraComponent", () => {
     const Div: ChakraComponent<"div"> = (props) => <chakra.div {...props} />
     const CustomComp: ChakraComponent<typeof Comp> = (props) => (
       <chakra.div as={Comp} {...props} />
@@ -34,6 +34,30 @@ describe("`as` prop typings", () => {
     const renderedCustomCompWithRequired = (
       <CustomCompWithRequired thisIsARequiredProp />
     )
+
+    // make jest happy
+    expect(true).toBe(true)
+  })
+
+  it("should have correct types for the ChakraComponent with additional props", () => {
+    const AdditionalPropComp: ChakraComponent<
+      "div",
+      { additionalProp: boolean }
+    > = ({ additionalProp, ...restProps }) => <chakra.div {...restProps} />
+
+    const renderedAdditionPropComp = <AdditionalPropComp additionalProp />
+
+    // make jest happy
+    expect(true).toBe(true)
+  })
+
+  it("should have correct types for the ChakraComponent with optional additional props", () => {
+    const OptionalAdditionalPropComp: ChakraComponent<
+      "div",
+      { additionalProp?: boolean }
+    > = ({ additionalProp, ...restProps }) => <chakra.div {...restProps} />
+
+    const renderedAdditionPropComp = <OptionalAdditionalPropComp />
 
     // make jest happy
     expect(true).toBe(true)

--- a/packages/system/tests/as-prop.test.tsx
+++ b/packages/system/tests/as-prop.test.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
-import { chakra } from ".."
-import { ChakraComponent } from "../src"
+import { chakra, ChakraComponent } from ".."
 
 /**
  * These tests should fail

--- a/packages/transition/src/fade.tsx
+++ b/packages/transition/src/fade.tsx
@@ -22,7 +22,7 @@ const variants: FadeMotionVariant = {
   },
 }
 
-export const fadeConfig: HTMLMotionProps<any> = {
+export const fadeConfig: Omit<HTMLMotionProps<any>, "transition"> = {
   initial: "exit",
   animate: "enter",
   exit: "exit",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2265

## 📝 Description

Autocomplete was broken in Jetbrains IDEs with the complex `as` prop type.

## ⛳️ Current behavior (updates)

Multiple intersection types including many usages of `Omit` took too long to resolve for Jetbrains IDEs.

## 🚀 New behavior

This PR uses less intersection types and resolves fast in PhpStorm 2020.2.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
**It should not,** but this is a pretty big change in our type codebase, so I would like to be sure that it is an improvement for every editor.

## 📝 Additional Information

One explicit type annotation for a `callAllHandlers` call was needed and the `ModalTransitionProps` needed a minor change.