### PR TITLE
fix: ie11 support (#2498)

### DIFF
--- a/.changeset/angry-zoos-poke.md
+++ b/.changeset/angry-zoos-poke.md
@@ -1,0 +1,13 @@
+---
+"@chakra-ui/checkbox": minor
+"@chakra-ui/menu": minor
+"@chakra-ui/modal": minor
+"@chakra-ui/popover": minor
+"@chakra-ui/popper": minor
+"@chakra-ui/system": minor
+"@chakra-ui/toast": minor
+"@chakra-ui/tooltip": minor
+"@chakra-ui/transition": minor
+---
+
+IE11 Support

--- a/packages/checkbox/src/checkbox-icon.tsx
+++ b/packages/checkbox/src/checkbox-icon.tsx
@@ -1,8 +1,9 @@
 import { chakra, PropsOf } from "@chakra-ui/system"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, motion, createDomMotionComponent } from "framer-motion"
 import * as React from "react"
 
 const MotionSvg = motion.custom(chakra.svg)
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
 
 const CheckIcon = (props: PropsOf<typeof MotionSvg>) => (
   <MotionSvg
@@ -59,7 +60,7 @@ const IndeterminateIcon = (props: PropsOf<typeof MotionSvg>) => (
 const CheckboxTransition = ({ open, children }: any) => (
   <AnimatePresence initial={false}>
     {open && (
-      <motion.div
+      <MotionDiv
         variants={{
           unchecked: { scale: 0.5 },
           checked: { scale: 1 },
@@ -75,7 +76,7 @@ const CheckboxTransition = ({ open, children }: any) => (
         }}
       >
         {children}
-      </motion.div>
+      </MotionDiv>
     )}
   </AnimatePresence>
 )

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -12,7 +12,7 @@ import {
   useStyles,
 } from "@chakra-ui/system"
 import { cx, MaybeRenderProp, runIfFn, __DEV__ } from "@chakra-ui/utils"
-import { motion, Variants } from "framer-motion"
+import { createDomMotionComponent, Variants } from "framer-motion"
 import * as React from "react"
 import {
   MenuProvider,
@@ -144,7 +144,7 @@ const motionVariants: Variants = {
   },
 }
 
-const Motion = chakra(motion.div)
+const Motion = chakra(createDomMotionComponent("div"))
 
 export const MenuList = forwardRef<MenuListProps, "div">((props, ref) => {
   const { isOpen, onTransitionEnd } = useMenuContext()

--- a/packages/modal/src/modal-transition.tsx
+++ b/packages/modal/src/modal-transition.tsx
@@ -1,6 +1,6 @@
 import { chakra, ChakraProps } from "@chakra-ui/system"
 import { scaleFadeConfig, slideFadeConfig } from "@chakra-ui/transition"
-import { HTMLMotionProps, motion } from "framer-motion"
+import { createDomMotionComponent, HTMLMotionProps } from "framer-motion"
 import * as React from "react"
 
 export interface ModalTransitionProps
@@ -24,7 +24,7 @@ const transitions = {
   },
 }
 
-const Motion = chakra(motion.section)
+const Motion = chakra(createDomMotionComponent("section"))
 
 export const ModalTransition = React.forwardRef(
   (props: ModalTransitionProps, ref: React.Ref<any>) => {

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -23,8 +23,8 @@ import {
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
   usePresence,
+  createDomMotionComponent,
 } from "framer-motion"
 import * as React from "react"
 import { RemoveScroll } from "react-remove-scroll"
@@ -204,7 +204,7 @@ export interface ModalContentProps extends HTMLChakraProps<"section"> {
   containerProps?: HTMLChakraProps<"div">
 }
 
-const Motion = chakra(motion.div)
+const Motion = chakra(createDomMotionComponent("div"))
 
 /**
  * ModalContent is used to group modal's content. It has all the

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -17,7 +17,7 @@ import {
   runIfFn,
   __DEV__,
 } from "@chakra-ui/utils"
-import { motion, Variants } from "framer-motion"
+import { createDomMotionComponent, Variants } from "framer-motion"
 import * as React from "react"
 import { usePopover, UsePopoverProps, UsePopoverReturn } from "./use-popover"
 
@@ -108,7 +108,7 @@ if (__DEV__) {
 
 export interface PopoverContentProps extends HTMLChakraProps<"section"> {}
 
-const Motion = chakra(motion.section)
+const Motion = chakra(createDomMotionComponent("section"))
 
 export const PopoverContent = forwardRef<PopoverContentProps, "section">(
   (props, ref) => {

--- a/packages/popper/stories/popper.stories.tsx
+++ b/packages/popper/stories/popper.stories.tsx
@@ -1,7 +1,9 @@
 import { useDisclosure } from "@chakra-ui/hooks"
-import { AnimatePresence, motion, Variants } from "framer-motion"
+import { AnimatePresence, motion, Variants, createDomMotionComponent } from "framer-motion"
 import * as React from "react"
 import { usePopper } from "../src"
+
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
 
 export default {
   title: "Popper",
@@ -86,7 +88,7 @@ export const WithTransition = () => {
       <div {...getPopperProps()}>
         <AnimatePresence>
           {isOpen && (
-            <motion.div
+            <MotionDiv
               transition={{
                 duration: 0.15,
                 easings: "easeInOut",
@@ -106,7 +108,7 @@ export const WithTransition = () => {
               <div {...getArrowWrapperProps()}>
                 <div {...getArrowProps({ style: { background: bg } })} />
               </div>
-            </motion.div>
+            </MotionDiv>
           )}
         </AnimatePresence>
       </div>

--- a/packages/system/migration.md
+++ b/packages/system/migration.md
@@ -74,7 +74,7 @@ const theme = {
   afterwards. Here's what I mean
 
 ```jsx
-const Motion = chakra(motion.div)
+const Motion = chakra(createDomMotionComponent("div"))
 
 // you can't use the `as` prop in the `Motion` component.
 // If you do, it won't work.

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -1,7 +1,7 @@
 import { useTimeout, useUpdateEffect } from "@chakra-ui/hooks"
 import { isFunction, __DEV__ } from "@chakra-ui/utils"
 import ReachAlert from "@reach/alert"
-import { motion, useIsPresent, Variants } from "framer-motion"
+import { createDomMotionComponent, motion, useIsPresent, Variants } from "framer-motion"
 import * as React from "react"
 import { ToastOptions } from "./toast.types"
 import { getToastStyle } from "./toast.utils"
@@ -101,8 +101,10 @@ export const Toast: React.FC<ToastProps> = (props) => {
 
   const style = React.useMemo(() => getToastStyle(position), [position])
 
+  const MotionLi = createDomMotionComponent("li") as typeof motion.li
+
   return (
-    <motion.li
+    <MotionLi
       layout
       className="chakra-toast"
       variants={toastMotionVariants}
@@ -125,7 +127,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
       >
         {isFunction(message) ? message({ id, onClose: close }) : message}
       </ReachAlert>
-    </motion.li>
+    </MotionLi>
   )
 }
 

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -9,7 +9,7 @@ import {
 } from "@chakra-ui/system"
 import { isString, omit, pick, __DEV__ } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
-import { AnimatePresence, motion, Variants } from "framer-motion"
+import { AnimatePresence, createDomMotionComponent, Variants } from "framer-motion"
 import * as React from "react"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
 
@@ -45,7 +45,7 @@ export interface TooltipProps
   hasArrow?: boolean
 }
 
-const StyledTooltip = chakra(motion.div)
+const StyledTooltip = chakra(createDomMotionComponent("div"))
 
 const scaleVariants: Variants = {
   exit: {

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { Modal, ModalContent, ModalOverlay } from "@chakra-ui/modal"
 import { Portal } from "@chakra-ui/portal"
 import { chakra } from "@chakra-ui/system"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, createDomMotionComponent, motion } from "framer-motion"
 import * as React from "react"
 import { Tooltip, useTooltip } from "../src"
 
@@ -55,6 +55,8 @@ const HookTooltip = ({ children }: any) => {
   )
 }
 
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
+
 export const Basic = () => <HookTooltip>This is me</HookTooltip>
 
 export const MultipleTooltips = () => (
@@ -84,13 +86,13 @@ export const WithTransition = () => {
         {isOpen && (
           <Portal>
             <div {...getTooltipPositionerProps()}>
-              <motion.div
+              <MotionDiv
                 initial="exit"
                 animate="enter"
                 exit="exit"
                 {...(getTooltipProps() as any)}
               >
-                <motion.div
+                <MotionDiv
                   transition={{
                     duration: 0.12,
                     ease: [0.4, 0, 0.2, 1],
@@ -114,8 +116,8 @@ export const WithTransition = () => {
                       {...getArrowProps({ style: { background: "tomato" } })}
                     />
                   </div>
-                </motion.div>
-              </motion.div>
+                </MotionDiv>
+              </MotionDiv>
             </div>
           </Portal>
         )}

--- a/packages/transition/src/collapse.tsx
+++ b/packages/transition/src/collapse.tsx
@@ -1,10 +1,12 @@
 import { useUpdateEffect } from "@chakra-ui/hooks"
 import { cx, warn, __DEV__ } from "@chakra-ui/utils"
-import { AnimatePresence, HTMLMotionProps, motion } from "framer-motion"
+import { AnimatePresence, createDomMotionComponent, HTMLMotionProps, motion } from "framer-motion"
 import * as React from "react"
 import { EASINGS, MotionVariants } from "./__utils"
 
 type CollapseVariants = MotionVariants<"enter" | "exit">
+
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
 
 const hasHeightValue = (value?: string | number) =>
   value != null && parseInt(value.toString(), 10) > 0
@@ -143,7 +145,7 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
       return (
         <AnimatePresence initial={false} custom={custom}>
           {isOpen && (
-            <motion.div
+            <MotionDiv
               {...ownProps}
               initial="exit"
               animate="enter"
@@ -155,7 +157,7 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
     }
 
     return (
-      <motion.div
+      <MotionDiv
         {...ownProps}
         style={{ ...ownProps.style, display }}
         initial={false}

--- a/packages/transition/src/fade.tsx
+++ b/packages/transition/src/fade.tsx
@@ -1,9 +1,11 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
-import { AnimatePresence, HTMLMotionProps, motion } from "framer-motion"
+import { AnimatePresence, createDomMotionComponent, HTMLMotionProps, motion } from "framer-motion"
 import * as React from "react"
 import { EASINGS, MotionVariants } from "./__utils"
 
 type FadeMotionVariant = MotionVariants<"enter" | "exit">
+
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
 
 const variants: FadeMotionVariant = {
   exit: {
@@ -48,7 +50,7 @@ export const Fade = React.forwardRef<HTMLDivElement, FadeProps>(
     return (
       <AnimatePresence>
         {shouldExpand && (
-          <motion.div
+          <MotionDiv
             ref={ref}
             className={cx("chakra-fade", className)}
             {...fadeConfig}

--- a/packages/transition/src/scale-fade.tsx
+++ b/packages/transition/src/scale-fade.tsx
@@ -1,9 +1,11 @@
 import { cx, mergeWith, __DEV__ } from "@chakra-ui/utils"
-import { AnimatePresence, HTMLMotionProps, motion } from "framer-motion"
+import { AnimatePresence, createDomMotionComponent, HTMLMotionProps, motion } from "framer-motion"
 import * as React from "react"
 import { EASINGS, MotionVariants } from "./__utils"
 
 type ScaleFadeVariants = MotionVariants<"enter" | "exit">
+
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
 
 const variants: ScaleFadeVariants = {
   exit: (props) => ({
@@ -75,7 +77,7 @@ export const ScaleFade = React.forwardRef<HTMLDivElement, ScaleFadeProps>(
     return (
       <AnimatePresence custom={custom}>
         {show && (
-          <motion.div
+          <MotionDiv
             ref={ref}
             className={cx("chakra-offset-slide", className)}
             {...motionProps}

--- a/packages/transition/src/slide-fade.tsx
+++ b/packages/transition/src/slide-fade.tsx
@@ -1,9 +1,11 @@
 import { cx, mergeWith, __DEV__ } from "@chakra-ui/utils"
-import { AnimatePresence, HTMLMotionProps, motion } from "framer-motion"
+import { AnimatePresence, createDomMotionComponent, HTMLMotionProps, motion } from "framer-motion"
 import * as React from "react"
 import { EASINGS, MotionVariants } from "./__utils"
 
 type SlideFadeVariant = MotionVariants<"initial" | "enter" | "exit">
+
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
 
 const transitions = {
   enter: {
@@ -102,7 +104,7 @@ export const SlideFade = React.forwardRef<HTMLDivElement, SlideFadeProps>(
     return (
       <AnimatePresence custom={custom}>
         {shouldExpand && (
-          <motion.div
+          <MotionDiv
             ref={ref}
             className={cx("chakra-offset-slide", className)}
             {...motionProps}

--- a/packages/transition/src/slide.tsx
+++ b/packages/transition/src/slide.tsx
@@ -1,9 +1,11 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
-import { AnimatePresence, HTMLMotionProps, motion } from "framer-motion"
+import { AnimatePresence, createDomMotionComponent, HTMLMotionProps, motion } from "framer-motion"
 import * as React from "react"
 import { EASINGS, MotionVariants } from "./__utils"
 
 export type SlideDirection = keyof typeof directions
+
+const MotionDiv = createDomMotionComponent("div") as typeof motion.div
 
 const directions = {
   bottom: {
@@ -106,7 +108,7 @@ export const Slide = React.forwardRef<HTMLDivElement, SlideProps>(
     return (
       <AnimatePresence custom={direction}>
         {shouldExpand && (
-          <motion.div
+          <MotionDiv
             ref={ref}
             initial="exit"
             className={cx("chakra-slide", className)}


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

#2498 

IE 11 does not support Proxy, so framer-motion used by chakra-ui did not work well. Fortunately, framer-motion has an alternative API without Proxy. I changed to use it.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
