### PR TITLE
fix: vertical align property not used with display: block in css-reset

### DIFF
--- a/packages/css-reset/src/css-reset.tsx
+++ b/packages/css-reset/src/css-reset.tsx
@@ -9,9 +9,9 @@ export const CSSReset = () => (
         -webkit-text-size-adjust: 100%;
         font-family: system-ui, sans-serif;
         -webkit-font-smoothing: antialiased;
-        text-rendering: optimizeLegibility;      
-        -moz-osx-font-smoothing: grayscale; 
-        touch-action: manipulation; 
+        text-rendering: optimizeLegibility;
+        -moz-osx-font-smoothing: grayscale;
+        touch-action: manipulation;
       }
 
       body {
@@ -263,7 +263,6 @@ export const CSSReset = () => (
       embed,
       object {
         display: block;
-        vertical-align: middle;
       }
 
       img,


### PR DESCRIPTION
## 📝 Description

> vertical-align only applies to inline, inline-block and table-cell elements: you can't use it to vertically align block-level elements. from [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)

## 💣 Is this a breaking change (Yes/No):

No.