### PR TITLE
fix: #2644 skeleton fading on mounting

### DIFF
--- a/.changeset/rude-ravens-smell.md
+++ b/.changeset/rude-ravens-smell.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/skeleton": minor
+---
+
+## 🐛 Bug Fix
+
+Prevent content from fading-in on initial render when isLoaded is already true (#2644)
+
+For example, the content would appear without the fade-in animation in this case:
+```jsx
+<Skeleton isLoaded={true}>
+  <h1>My Content</h1>
+</Skeleton>
+```

--- a/.changeset/rude-ravens-smell.md
+++ b/.changeset/rude-ravens-smell.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/skeleton": minor
+"@chakra-ui/skeleton": patch
 ---
 
 ## 🐛 Bug Fix

--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -67,14 +67,13 @@ const fade = keyframes({
 
 const useIsFirstRender = () => {
   const isFirstRender = React.useRef(true)
-  
+
   React.useEffect(() => {
     isFirstRender.current = false
   }, [])
-  
+
   return isFirstRender.current
 }
-
 
 export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
   const styles = useStyleConfig("Skeleton", props)
@@ -93,7 +92,7 @@ export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
   const _className = cx("chakra-skeleton", className)
 
   if (isLoaded) {
-    const animation = isFirstRender ? null : `${fade} ${fadeDuration}s`
+    const animation = isFirstRender ? "none" : `${fade} ${fadeDuration}s`
 
     return (
       <chakra.div

--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -65,8 +65,20 @@ const fade = keyframes({
   to: { opacity: 1 },
 })
 
+const useIsFirstRender = () => {
+  const isFirstRender = React.useRef(true)
+  
+  React.useEffect(() => {
+    isFirstRender.current = false
+  }, [])
+  
+  return isFirstRender.current
+}
+
+
 export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
   const styles = useStyleConfig("Skeleton", props)
+  const isFirstRender = useIsFirstRender()
 
   const {
     startColor,
@@ -81,11 +93,13 @@ export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
   const _className = cx("chakra-skeleton", className)
 
   if (isLoaded) {
+    const animation = isFirstRender ? null : `${fade} ${fadeDuration}s`
+
     return (
       <chakra.div
         ref={ref}
         className={_className}
-        __css={{ animation: `${fade} ${fadeDuration}s` }}
+        __css={{ animation }}
         {...rest}
       />
     )

--- a/packages/skeleton/stories/skeleton.stories.tsx
+++ b/packages/skeleton/stories/skeleton.stories.tsx
@@ -48,6 +48,14 @@ export const WithFade = () => {
   )
 }
 
+export const WithFadeAlreadyLoaded = () => {
+  return (
+    <Skeleton isLoaded={true}>
+      <span>This should not fade in</span>
+    </Skeleton>
+  )
+}
+
 export const WithNoFade = () => {
   const [hasLoaded, setHasLoaded] = React.useState(false)
 


### PR DESCRIPTION
Closes #2644

## 📝 Description

As described in #2644 there are cases where during the render of a skeleton component we might want to statically set isLoaded to true OR cases where the loading is already completed and therefore we want to avoid using the skeleton for a better UX (less page flickering).

#2644 did mention that a solution could be to add a flag to control this behavior. But I think that we should be opinionated about this and always prevent the use of the skeleton if the isLoaded property is already true on the first load. This will make the skeleton component simpler (by avoiding excessive flags) and nudge the developer towards better UX (less noise).

## ⛳️ Current behavior (updates)

If **isLoaded** is true on the first render the fade-in animation is included

## 🚀 New behavior

If **isLoaded** is true on the first render that fade-in animation is avoided

## 💣 Is this a breaking change (Yes/No):

No, if we consider the current behavior a bug.

## 📝 Additional Information

I didn't include unit tests because they would need to be _implementation_ tests. We would need to check the CSS animation property directly to determine any difference. 

Also, I'm not sure if we have a way to check CSS properties in our tests?

If anyone has a way to write unit tests or thinks we should go down the _implementation_ testing route, let me know. Thanks!
