### PR TITLE
fix: tab indicator in relative container #2040

### DIFF
--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -37,7 +37,7 @@ interface TabsOptions {
 }
 
 export interface TabsProps
-  extends Omit<UseTabsProps, "rootRef">,
+  extends Omit<UseTabsProps, "rootTabsElement">,
     ThemingProps,
     Omit<HTMLChakraProps<"div">, "onChange">,
     TabsOptions {

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -10,7 +10,7 @@ import {
   HTMLChakraProps,
   ChakraProps,
 } from "@chakra-ui/system"
-import { cx, omit, __DEV__ } from "@chakra-ui/utils"
+import { cx, mergeRefs, omit, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import {
   TabsProvider,
@@ -37,7 +37,7 @@ interface TabsOptions {
 }
 
 export interface TabsProps
-  extends UseTabsProps,
+  extends Omit<UseTabsProps, "rootRef">,
     ThemingProps,
     Omit<HTMLChakraProps<"div">, "onChange">,
     TabsOptions {
@@ -51,10 +51,12 @@ export interface TabsProps
  * any DOM node.
  */
 export const Tabs = forwardRef<TabsProps, "div">((props, ref) => {
+  const [rootTabsElement, setRootTabsElement] = React.useState()
+
   const styles = useMultiStyleConfig("Tabs", props)
   const { children, className, ...rest } = omitThemingProps(props)
 
-  const { htmlProps, ...ctx } = useTabs(rest)
+  const { htmlProps, ...ctx } = useTabs({ ...rest, rootTabsElement })
   const context = React.useMemo(() => ctx, [ctx])
 
   const rootProps = omit(htmlProps as any, ["isFitted"])
@@ -64,12 +66,18 @@ export const Tabs = forwardRef<TabsProps, "div">((props, ref) => {
     ...styles.root,
   }
 
+  const captureElement = React.useCallback((node) => {
+    if (node !== null) {
+      setRootTabsElement(node)
+    }
+  }, [])
+
   return (
     <TabsProvider value={context}>
       <StylesProvider value={styles}>
         <chakra.div
           className={cx("chakra-tabs", className)}
-          ref={ref}
+          ref={mergeRefs(ref, captureElement)}
           {...rootProps}
           __css={rootStyles}
         >

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -37,7 +37,7 @@ interface TabsOptions {
 }
 
 export interface TabsProps
-  extends Omit<UseTabsProps, "rootTabsElement">,
+  extends UseTabsProps,
     ThemingProps,
     Omit<HTMLChakraProps<"div">, "onChange">,
     TabsOptions {
@@ -51,12 +51,10 @@ export interface TabsProps
  * any DOM node.
  */
 export const Tabs = forwardRef<TabsProps, "div">((props, ref) => {
-  const [rootTabsElement, setRootTabsElement] = React.useState()
-
   const styles = useMultiStyleConfig("Tabs", props)
   const { children, className, ...rest } = omitThemingProps(props)
 
-  const { htmlProps, ...ctx } = useTabs({ ...rest, rootTabsElement })
+  const { htmlProps, ...ctx } = useTabs(rest)
   const context = React.useMemo(() => ctx, [ctx])
 
   const rootProps = omit(htmlProps as any, ["isFitted"])
@@ -66,18 +64,12 @@ export const Tabs = forwardRef<TabsProps, "div">((props, ref) => {
     ...styles.root,
   }
 
-  const captureElement = React.useCallback((node) => {
-    if (node !== null) {
-      setRootTabsElement(node)
-    }
-  }, [])
-
   return (
     <TabsProvider value={context}>
       <StylesProvider value={styles}>
         <chakra.div
           className={cx("chakra-tabs", className)}
-          ref={mergeRefs(ref, captureElement)}
+          ref={ref}
           {...rootProps}
           __css={rootStyles}
         >

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -8,6 +8,7 @@ import {
   useMultiStyleConfig,
   useStyles,
   HTMLChakraProps,
+  ChakraProps,
 } from "@chakra-ui/system"
 import { cx, omit, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -58,6 +59,11 @@ export const Tabs = forwardRef<TabsProps, "div">((props, ref) => {
 
   const rootProps = omit(htmlProps as any, ["isFitted"])
 
+  const rootStyles: ChakraProps["__css"] = {
+    position: "relative",
+    ...styles.root,
+  }
+
   return (
     <TabsProvider value={context}>
       <StylesProvider value={styles}>
@@ -65,7 +71,7 @@ export const Tabs = forwardRef<TabsProps, "div">((props, ref) => {
           className={cx("chakra-tabs", className)}
           ref={ref}
           {...rootProps}
-          __css={styles.root}
+          __css={rootStyles}
         >
           {children}
         </chakra.div>

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -10,7 +10,7 @@ import {
   HTMLChakraProps,
   ChakraProps,
 } from "@chakra-ui/system"
-import { cx, mergeRefs, omit, __DEV__ } from "@chakra-ui/utils"
+import { cx, omit, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import {
   TabsProvider,

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -427,14 +427,26 @@ export function useTabIndicator(): React.CSSProperties {
 
     // Horizontal Tab: Calculate width and left distance
     if (isHorizontal && tabRect) {
-      const { left, width } = tabRect
-      setRect({ left, width })
+      const { width } = tabRect
+      setRect({
+        left: makeHorizontalLeft({
+          descendants: domContext.descendants,
+          selectedIndex,
+        }),
+        width,
+      })
     }
 
     // Vertical Tab: Calculate height and top distance
     if (isVertical && tabRect) {
-      const { top, height } = tabRect
-      setRect({ top, height })
+      const { height } = tabRect
+      setRect({
+        top: makeVerticalTop({
+          descendants: domContext.descendants,
+          selectedIndex,
+        }),
+        height,
+      })
     }
 
     // Prevent unwanted transition from 0 to measured rect
@@ -463,4 +475,31 @@ function makeTabId(id: string, index: number) {
 
 function makeTabPanelId(id: string, index: number) {
   return `${id}--tabpanel-${index}`
+}
+
+interface MakePositionProps {
+  descendants: ReturnType<typeof useTabsContext>["domContext"]["descendants"]
+  selectedIndex: number
+}
+
+function makeHorizontalLeft({ descendants, selectedIndex }: MakePositionProps) {
+  const previousTabs = descendants.slice(0, selectedIndex)
+  return previousTabs.reduce((left, previousTab) => {
+    const rect = previousTab?.element?.getBoundingClientRect()
+    if (rect?.width) {
+      return left + rect.width
+    }
+    return left
+  }, 0)
+}
+
+function makeVerticalTop({ descendants, selectedIndex }: MakePositionProps) {
+  const previousTabs = descendants.slice(0, selectedIndex)
+  return previousTabs.reduce((top, previousTab) => {
+    const rect = previousTab?.element?.getBoundingClientRect()
+    if (rect?.height) {
+      return top + rect.height
+    }
+    return top
+  }, 0)
 }

--- a/packages/tabs/stories/tabs.stories.tsx
+++ b/packages/tabs/stories/tabs.stories.tsx
@@ -89,7 +89,7 @@ export const withIndicator = () => (
 )
 export const withIndicatorWithinRelative = () => (
   <div style={{ position: "relative" }}>
-    <Tabs variant="unstyled" isManual>
+    <Tabs variant="unstyled" css={{ padding: "24px" }} isManual>
       <TabList>
         <Tab>Settings</Tab>
         <Tab _disabled={{ color: "gray.400" }} isDisabled>
@@ -130,7 +130,7 @@ export const withVerticalTabs = () => (
 
 export const withVerticalIndicatorWithinRelative = () => (
   <div style={{ position: "relative" }}>
-    <Tabs variant="unstyled" orientation="vertical">
+    <Tabs variant="unstyled" css={{ padding: "24px" }} orientation="vertical">
       <TabList>
         <Tab>Settings</Tab>
         <Tab>Billings</Tab>

--- a/packages/tabs/stories/tabs.stories.tsx
+++ b/packages/tabs/stories/tabs.stories.tsx
@@ -77,7 +77,7 @@ export const withIndicator = () => (
       <Tab>Shut Down</Tab>
     </TabList>
 
-    <TabIndicator mt="-36px" zIndex={-1} height="34px" bg="green.200" />
+    <TabIndicator mt="-40px" zIndex={-1} height="40px" bg="green.200" />
 
     <TabPanels>
       <TabPanel>Settings</TabPanel>
@@ -86,6 +86,29 @@ export const withIndicator = () => (
       <TabPanel>Shut Down</TabPanel>
     </TabPanels>
   </Tabs>
+)
+export const withIndicatorWithinRelative = () => (
+  <div style={{ position: "relative" }}>
+    <Tabs variant="unstyled" isManual>
+      <TabList>
+        <Tab>Settings</Tab>
+        <Tab _disabled={{ color: "gray.400" }} isDisabled>
+          Billings
+        </Tab>
+        <Tab>Preferences</Tab>
+        <Tab>Shut Down</Tab>
+      </TabList>
+
+      <TabIndicator mt="-40px" zIndex={-1} height="40px" bg="green.200" />
+
+      <TabPanels>
+        <TabPanel>Settings</TabPanel>
+        <TabPanel>Billings</TabPanel>
+        <TabPanel>Preferences</TabPanel>
+        <TabPanel>Shut Down</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </div>
 )
 
 export const withVerticalTabs = () => (
@@ -103,4 +126,26 @@ export const withVerticalTabs = () => (
       <TabPanel>Shut Down</TabPanel>
     </TabPanels>
   </Tabs>
+)
+
+export const withVerticalIndicatorWithinRelative = () => (
+  <div style={{ position: "relative" }}>
+    <Tabs variant="unstyled" orientation="vertical">
+      <TabList>
+        <Tab>Settings</Tab>
+        <Tab>Billings</Tab>
+        <Tab isDisabled>Preferences</Tab>
+        <Tab>Shut Down</Tab>
+      </TabList>
+
+      <TabIndicator zIndex={-1} width="160px" bg="green.200" />
+
+      <TabPanels bg="red.200">
+        <TabPanel>Settings</TabPanel>
+        <TabPanel>Billings</TabPanel>
+        <TabPanel>Preferences</TabPanel>
+        <TabPanel>Shut Down</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </div>
 )


### PR DESCRIPTION
Closes #2040

## 📝 Description

As described in #2040 the tab indicator becomes misaligned when inside a position relative or fixed container. 

## ⛳️ Current behavior (updates)

The tab indicators position is calculated relative to the viewport

## 🚀 New behavior

The tab container is now calculated with the assumption that the tabs root element is position relative.

## 💣 Is this a breaking change (Yes/No):

No, I don't think so. But if you can think of one let me know.

## 📝 Additional Information

This fix got awfully complex, especially when having to account for potential padding in the tabs container. I'm very open to any feedback on this one and would welcome a much simpler solution. 

I haven't include testing-library tests because testing positioning logic is hard without a lot of mocking. The added storybook stories would serve the purpose of testing this functionality.