### PR TITLE
fix(extend-theme): allow string properties besides ColorHue

### DIFF
--- a/.changeset/young-trainers-invite.md
+++ b/.changeset/young-trainers-invite.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+fix(extend-theme): allow string properties besides ColorHue in colors

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -3,7 +3,7 @@ import { isFunction, mergeWith } from "@chakra-ui/utils"
 import { ColorHues } from "@chakra-ui/theme/dist/types/foundations/colors"
 
 type ThemeExtensionTypeHints = {
-  colors: Record<string, Partial<ColorHues> | string> // typehints for color definitions
+  colors: Record<string, Partial<ColorHues> | Record<string, string> | string> // typehints for color definitions
 }
 
 /**

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -66,4 +66,112 @@ describe("extendTheme", () => {
     // should have more properties from the default theme
     expect(Object.keys(solidStyles).length).toBeGreaterThan(1)
   })
+
+  it("should pass typescript lint with random custom theme", () => {
+    const override = {
+      shadows: {
+        outline: "0 0 0 3px rgb(0, 255, 0)",
+      },
+      colors: {
+        gray: {
+          "300": "red",
+        },
+        myCustomColor: {
+          "50": "papayawhip",
+        },
+      },
+      textStyles: {
+        dl: {
+          lineHeight: "tall",
+          "dd + dt": {
+            marginTop: "4",
+          },
+        },
+        dt: {
+          color: "gray.600",
+          fontSize: "sm",
+          fontWeight: "bold",
+        },
+        dd: {
+          color: "gray.800",
+        },
+      },
+      config: {
+        useSystemColorMode: false,
+        initialColorMode: "dark",
+      },
+      styles: {
+        global: {
+          body: {
+            color: "green.500",
+          },
+        },
+      },
+      components: {
+        Button: {
+          variants: {
+            ghost: {
+              fontFamily: "mono",
+              _active: {
+                bg: "red",
+              },
+            },
+          },
+        },
+        Input: {
+          baseStyle: {
+            field: {
+              outline: "1px solid black",
+            },
+          },
+          variants: {
+            outline: () => ({
+              field: {
+                bg: "green.500",
+              },
+            }),
+            myCustomVariant: {
+              field: {
+                bg: "red.500",
+              },
+            },
+          },
+        },
+      },
+    }
+
+    extendTheme(override)
+  })
+
+  it("should pass typescript lint with non colorhue properties", () => {
+    const override = {
+      colors: {
+        grey: {
+          100: "#e3e3e3",
+          200: "#edf2f7",
+          300: "#e2e8f0",
+          400: "#cbd5e0",
+          light: "#D4D4D4",
+          medium: "#929292",
+          dark: "#1D1D1B",
+          navSubMenu: "#9F9F9F",
+        },
+        white: "#fff",
+        black: {
+          25: "rgba(0, 0, 0, 0.25)",
+          50: "rgba(0, 0, 0, 0.5)",
+          100: "#000",
+          150: "#1D1D1B",
+        },
+        pink: {
+          dark: "#FF8FA2",
+          base: "#f6ced6",
+          light: "#FAA4B3",
+          lighter: "#F6CED6",
+        },
+      },
+    }
+
+    extendTheme(override)
+  })
 })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2757

## 📝 Description

`extendTheme`  override type could not handle nested property names other than from the `ColorHues` type at `colors`.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Extended the override type to allow `Record<string, string>` values in the `colors` section.

## 🚀 New behavior

Extended the ThemeExtensionTypeHints type and added two TypeScript tests.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
