### PR TITLE
fix: use Number instead of parseInt in isCustomBreakpoint #2789

### DIFF
--- a/.changeset/new-terms-explode.md
+++ b/.changeset/new-terms-explode.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/utils": patch
+---
+
+Resolved an issue where custom breakpoints prefixed with a number ("2xl")
+weren't detected

--- a/packages/utils/src/array.ts
+++ b/packages/utils/src/array.ts
@@ -154,4 +154,4 @@ export function getNextItemFromSearch<T>(
  * This function returns true given a custom array property.
  */
 export const isCustomBreakpoint = (maybeBreakpoint: string) =>
-  Number.isNaN(parseInt(maybeBreakpoint, 10))
+  Number.isNaN(Number(maybeBreakpoint))

--- a/packages/utils/tests/array.test.ts
+++ b/packages/utils/tests/array.test.ts
@@ -130,6 +130,7 @@ test.each([
   ["xl", true],
   ["xxl", true],
   ["custom", true],
+  ["2xl", true],
   ["0", false],
   ["1", false],
   ["2", false],


### PR DESCRIPTION
Currently, `isCustomBreakpoint` filters the breakpoint key like `2xl` as it using `parseInt` which parses string starting with number into Integer.  I think replace it with `Number()` can solve this problem. 
