### PR TITLE
chore(radio): omit invalid "defaultChecked" prop from RadioGroupProps

### DIFF
--- a/packages/radio/src/radio-group.tsx
+++ b/packages/radio/src/radio-group.tsx
@@ -26,7 +26,12 @@ const [
 
 export { useRadioGroupContext }
 
-type Omitted = "onChange" | "value" | "defaultValue" | "children"
+type Omitted =
+  | "onChange"
+  | "value"
+  | "defaultValue"
+  | "defaultChecked"
+  | "children"
 export interface RadioGroupProps
   extends UseRadioGroupProps,
     Omit<HTMLChakraProps<"div">, Omitted>,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

The type for `RadioGroupProps` was a little too wide and allow `defaultChecked` to be passed to `RadioGroup` even though that has no effect. Could be potentially confusing.

## 🚀 New behavior

Added `defaultChecked` to the `Omitted` type for `RadioGroupProps`.

## 💣 Is this a breaking change (Yes/No):

No