### PR TITLE
docs(accordion): fix typo in README

### DIFF
--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -29,7 +29,7 @@ import {
 
 ## Component:
 
-- `Accordion`: manages the global state of all opened accordionitems via
+- `Accordion`: manages the global state of all opened accordion items via
   context.
 - `AccordionItem`: manages the state for a single accordion item.
 - `AccordionButton`: the trigger to open/close an accordion item.


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
--> docs

Closes # <!-- Github issue # here -->

## 📝 Description

> There is no spacing between 'accordion' and 'items'. And, it is not good for readability.

## ⛳️ Current behavior (updates)

> I added spacing between 'accordion' and 'items'.

## 🚀 New behavior

> This improves readability.

## 💣 Is this a breaking change (Yes/No): No.

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
