### PR TITLE
fix(skeleton-text): accept animation props

### DIFF
--- a/.changeset/late-schools-wash.md
+++ b/.changeset/late-schools-wash.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/skeleton": patch
+---
+
+SkeletonText accepts fadeDuration and speed prop and animates children

--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -143,6 +143,8 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
     startColor,
     endColor,
     isLoaded,
+    fadeDuration,
+    speed,
     children,
     ...rest
   } = props
@@ -164,19 +166,31 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
 
   return (
     <chakra.div className={_className} {...rest}>
-      {isLoaded
-        ? children
-        : numbers.map((number) => (
-            <Skeleton
-              key={numbers.length.toString() + number}
-              height={skeletonHeight}
-              mb={number === numbers.length ? "0" : spacing}
-              width={getWidth(number)}
-              startColor={startColor}
-              endColor={endColor}
-              isLoaded={isLoaded}
-            />
-          ))}
+      {numbers.map((number, index) => {
+        if (isLoaded && index > 0) {
+          // skip other lines
+          return null
+        }
+
+        return (
+          <Skeleton
+            key={numbers.length.toString() + number}
+            mb={number === numbers.length ? "0" : spacing}
+            width={getWidth(number)}
+            height={skeletonHeight}
+            startColor={startColor}
+            endColor={endColor}
+            isLoaded={isLoaded}
+            fadeDuration={fadeDuration}
+            speed={speed}
+          >
+            {
+              // allows animating the children
+              index === 0 ? children : undefined
+            }
+          </Skeleton>
+        )
+      })}
     </chakra.div>
   )
 }

--- a/packages/skeleton/stories/skeleton.stories.tsx
+++ b/packages/skeleton/stories/skeleton.stories.tsx
@@ -48,6 +48,20 @@ export const WithFade = () => {
   )
 }
 
+export const WithFadeText = () => {
+  const [hasLoaded, setHasLoaded] = React.useState(false)
+
+  React.useEffect(() => {
+    setTimeout(() => setHasLoaded(true), 1000)
+  }, [])
+
+  return (
+    <SkeletonText isLoaded={hasLoaded}>
+      <span>Chakra ui is cool</span>
+    </SkeletonText>
+  )
+}
+
 export const WithFadeAlreadyLoaded = () => {
   return (
     <Skeleton isLoaded={true}>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2800 

## 📝 Description

SkeletonText does not

* fade in when isLoaded toggles (so fadeDuration property does nothing on top of that)
* obey speed property

## ⛳️ Current behavior (updates)

* Appling the component children to the first Skeleton in the noOfLines map function allows the animation to kick in.
* Passed the missing props through

## 🚀 New behavior

> Please describe the behavior or changes this PR adds
SkeletonText accepts fadeDuration and speed prop and animates children

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
