### PR TITLE
feat(extend-theme): allow passing a base theme to customize

### DIFF
--- a/.changeset/clean-balloons-pull.md
+++ b/.changeset/clean-balloons-pull.md
@@ -2,4 +2,15 @@
 "@chakra-ui/react": minor
 ---
 
-extendTheme: allow passing a base theme to customize
+extendTheme: added an optional second argument `baseTheme` to customize:
+
+```jsx
+const theme = extendTheme({
+  // theme overrides
+  colors: { red: { 500: "#ff0000" } },
+  // the base theme to customize with the above overrides
+  yourTheme,
+})
+```
+
+If no `baseTheme` is provided, defaults to the Chakra theme.

--- a/.changeset/clean-balloons-pull.md
+++ b/.changeset/clean-balloons-pull.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+extendTheme: allow passing a base theme to customize

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -26,8 +26,12 @@ export type ThemeOverride = DeepThemeExtension<Theme, ThemeExtensionTypeHints>
 /**
  * Function to override or customize the Chakra UI theme conveniently
  * @param overrides - Your custom theme object overrides
+ * @param baseTheme - theme to customize
  */
-export function extendTheme<T extends ThemeOverride>(overrides: T) {
+export function extendTheme<T extends ThemeOverride>(
+  overrides: T,
+  baseTheme: any = defaultTheme,
+) {
   function customizer(source: unknown, override: unknown) {
     if (isFunction(source)) {
       return (...args: unknown[]) => {
@@ -45,5 +49,5 @@ export function extendTheme<T extends ThemeOverride>(overrides: T) {
     return undefined
   }
 
-  return mergeWith({}, defaultTheme, overrides, customizer)
+  return mergeWith({}, baseTheme, overrides, customizer)
 }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2769

## 📝 Description

```diff
- extendTheme(overrides)
+ extendTheme(overrides, baseTheme = defaultTheme)
```

Allows extending an already extended theme. This is helps maintaining inherited design system.

## ⛳️ Current behavior (updates)

Not possible without a copy of the extendTheme function.

## 🚀 New behavior

```ts
const theme1 = extendTheme(overrides)
const theme2 = extendTheme(overrides, theme1)
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
