### PR TITLE
docs: add example of how to use custom colorScheme

### DIFF
--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -48,6 +48,11 @@ function Usage() {
 }
 ```
 
+You can also use the color for the `colorScheme` prop like this:
+```jsx live=false
+<Button colorScheme="brand">Click me</Button>
+```
+
 > If you're curious as to what theme styles you can override, please reference
 > the
 > [default theme foundation style files](https://github.com/chakra-ui/chakra-ui/tree/master/packages/theme/src/foundations).


### PR DESCRIPTION
I think it would be nice to also show how you can use a custom theme color for the `colorScheme` prop 😄 