### PR TITLE
chore: readme was updated but never published

### DIFF
--- a/.changeset/early-poems-fly.md
+++ b/.changeset/early-poems-fly.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/gatsby-plugin": patch
+---
+
+The readme was updated but never published.


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

The `@chakra-ui/gatsby-plugin` readme was updated but never published. I generated a changeset just so we can get this published.

## ⛳️ Current behavior (updates)

The docs are outdated and dont match whats in the repo: https://www.npmjs.com/package/@chakra-ui/gatsby-plugin

## 🚀 New behavior

Docs are current

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
