### PR TITLE
docs(chakra-factory): Fix typo in filter example

### DIFF
--- a/website/pages/docs/features/chakra-factory.mdx
+++ b/website/pages/docs/features/chakra-factory.mdx
@@ -128,7 +128,7 @@ To filter non-HTML attributes, you can leverage
 package.
 
 ```jsx live=false
-import isValidHMTLProp from "@emotion/is-prop-valid"
+import isValidHTMLProp from "@emotion/is-prop-valid"
 import { shouldForwardProp } from "@chakra-ui/react"
 
 const Div = chakra("div", {


### PR DESCRIPTION
## 📝 Description

Fix a typo in the code example of how to filter non-HTML attributes.

## ⛳️ Current behavior (updates)

Little typo in the documentation.

## 🚀 New behavior

Typo fixed.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
