### PR TITLE
chore(stalebot): make only "not stale" and high priority issues exempt

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,26 +5,19 @@ daysUntilClose: 5
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "not stale"
-  - "good first issue 👍"
-  - "good for beginners 😃"
-  - "help wanted 🆘"
   - "Priority: High 🚨"
-  - "Showcase 💖"
-  - "Topic: Reviews ⭐️💖"
-  - "Status: Assigned ➡"
-  - "Status: Work in Progress 🛠"
-  - "Type: Bug 🐛"
-  - "Type: Documentation 📚"
-  - "Type: Feature 🚀"
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   Hi!
 
-  This issue hasn't seen any activity recently. We close inactive issues after 20 days to manage the volume of issues we receive.
+  This issue hasn't seen any activity recently. We close inactive issues after
+  20 days to manage the volume of issues we receive.
 
-  If we missed this issue or you want to keep it open, please reply here. That will reset the timer and allow more time for this issue to be addressed before it is closed.
+  If we missed this issue or you want to keep it open, please reply here. That
+  will reset the timer and allow more time for this issue to be addressed before
+  it is closed.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
 unmarkComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 15
+daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 5
 # Issues with these labels will never be considered stale
@@ -13,7 +13,7 @@ markComment: >
   Hi!
 
   This issue hasn't seen any activity recently. We close inactive issues after
-  20 days to manage the volume of issues we receive.
+  35 days to manage the volume of issues we receive.
 
   If we missed this issue or you want to keep it open, please reply here. That
   will reset the timer and allow more time for this issue to be addressed before


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2634 <!-- Github issue # here -->

## 📝 Description

This PR makes `stalebot` useful again by removing almost all of the label exemptions while increasing the number of days of inactivity on an issue before it's marked as "stale" to 30.

## ⛳️ Current behavior (updates)

`stalebot` does nothing because almost every label we use was added to `exemptLabels`.

## 🚀 New behavior

- Removed all labels except for "not stale" and "Priority: High 🚨" from `exemptLabels`, which means everything except high priority issues and those we specifically mark as "not stale" will now be handled by the `stalebot` workflow.
- Since we're a small team and it can take us awhile to address things, I increased the number of days of inactivity on an issue before an issue is marked as "stale" to 30. This gives us a whole month on inactivity to decide whether to label an issue as "not stale" or not.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

cc @chakra-ui/triage @chakra-ui/react-team: This means that unless we mark an issue as "high priority" or "not stale", `stalebot` will mark issues as "stale" after 30 days, and then close then 5 days after that if the issue receives no reply. So if you'd like an issue to be exempt from this workflow (because it's high priority or something we definitely plan to implement eventually), add the "not stale" or "Priority: High 🚨" label to the issue.

Another thing to note: Once this PR is merged, we'll likely see a LOT of issues suddenly marked as "stale". That's fine imo, and gives us and the community a chance to label these issues/reply to keep them open, or otherwise have them automatically be closed after 5 days.