### PR TITLE
fix(radio): allow useRadio to detect uncontrolled Radio

### DIFF
--- a/.changeset/light-geckos-divide.md
+++ b/.changeset/light-geckos-divide.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Resolved an issue where uncontrolled `Radio` components used outside of
+`RadioGroup` were not working

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -52,7 +52,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
     ...rest
   } = omitThemingProps(props)
 
-  let isChecked = props.isChecked || false
+  let isChecked = props.isChecked
   if (group?.value && valueProp) {
     isChecked = group.value === valueProp
   }

--- a/packages/radio/tests/behavior.test.tsx
+++ b/packages/radio/tests/behavior.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from "@chakra-ui/test-utils"
+import * as React from "react"
+import { RadioGroup, Radio } from "../src"
+
+const runTest = () => {
+  const one = screen.getByLabelText("One")
+  const two = screen.getByLabelText("Two")
+  const three = screen.getByLabelText("Three")
+
+  expect(one).toBeChecked()
+  expect(two).not.toBeChecked()
+  expect(three).not.toBeChecked()
+
+  fireEvent.click(two)
+
+  expect(one).not.toBeChecked()
+  expect(two).toBeChecked()
+  expect(three).not.toBeChecked()
+}
+
+describe("RadioGroup", () => {
+  test("uncontrolled", () => {
+    const onChange = jest.fn()
+    render(
+      <RadioGroup name="radio" defaultValue="1" onChange={onChange}>
+        <Radio value="1">One</Radio>
+        <Radio value="2">Two</Radio>
+        <Radio value="3">Three</Radio>
+      </RadioGroup>,
+    )
+    runTest()
+    expect(onChange).toHaveBeenCalledWith("2")
+  })
+
+  test("controlled", () => {
+    const Component = () => {
+      const [value, setValue] = React.useState("1")
+      const onChange = (value: string) => setValue(value)
+
+      return (
+        <RadioGroup name="radio" value={value} onChange={onChange}>
+          <Radio value="1">One</Radio>
+          <Radio value="2">Two</Radio>
+          <Radio value="3">Three</Radio>
+        </RadioGroup>
+      )
+    }
+    render(<Component />)
+    runTest()
+  })
+})
+
+describe("Radio", () => {
+  test("uncontrolled", () => {
+    render(
+      <>
+        <Radio name="radio" value="1" defaultIsChecked>
+          One
+        </Radio>
+        <Radio name="radio" value="2">
+          Two
+        </Radio>
+        <Radio name="radio" value="3">
+          Three
+        </Radio>
+      </>,
+    )
+    runTest()
+  })
+
+  test("controlled", () => {
+    const Component = () => {
+      const [value, setValue] = React.useState("1")
+      const onChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+        setValue(event.target.value)
+
+      return (
+        <>
+          <Radio
+            name="radio"
+            value="1"
+            isChecked={value === "1"}
+            onChange={onChange}
+          >
+            One
+          </Radio>
+          <Radio
+            name="radio"
+            value="2"
+            isChecked={value === "2"}
+            onChange={onChange}
+          >
+            Two
+          </Radio>
+          <Radio
+            name="radio"
+            value="3"
+            isChecked={value === "3"}
+            onChange={onChange}
+          >
+            Three
+          </Radio>
+        </>
+      )
+    }
+    render(<Component />)
+    runTest()
+  })
+})


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2842 <!-- Github issue # here -->

## 📝 Description

This PR resolves an issue where `Radio` components used outside of `RadioGroup` were not working correctly when uncontrolled. I also added a suite of tests around controlled/uncontrolled behavior for both `Radio` and `RadioGroup` to help prevent these issues in the future.

## ⛳️ Current behavior (updates)

When used outside of `RadioGroup`, `Radio` components don't work when uncontrolled.

## 🚀 New behavior

`Radio` can be used independently of `RadioGroup` without issues.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
