### PR TITLE
refactor: deprecate defaultIsChecked props

### DIFF
--- a/.changeset/late-colts-change.md
+++ b/.changeset/late-colts-change.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/checkbox": minor
+"@chakra-ui/radio": minor
+---
+
+Deprecated the `defaultIsChecked` prop on `Radio` and `Checkbox` in favor of
+`defaultChecked`, which mirrors the default React prop name for this
+functionality. `defaultIsChecked` will continue to work, but may be removed in
+future versions.

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -8,6 +8,7 @@ import {
   dataAttr,
   mergeRefs,
   PropGetter,
+  warn,
 } from "@chakra-ui/utils"
 import { visuallyHiddenStyle } from "@chakra-ui/visually-hidden"
 import React, {
@@ -55,8 +56,14 @@ export interface UseCheckboxProps {
   isRequired?: boolean
   /**
    * If `true`, the checkbox will be initially checked.
+   * @deprecated Please use the `defaultChecked` prop, which mirrors default
+   * React checkbox behavior.
    */
   defaultIsChecked?: boolean
+  /**
+   * If `true`, the checkbox will be initially checked.
+   */
+  defaultChecked?: boolean
   /**
    * The callback invoked when the checked state of the `Checkbox` changes..
    */
@@ -86,6 +93,7 @@ export interface UseCheckboxProps {
 export function useCheckbox(props: UseCheckboxProps = {}) {
   const {
     defaultIsChecked,
+    defaultChecked = defaultIsChecked,
     isChecked: checkedProp,
     isFocusable,
     isDisabled,
@@ -106,12 +114,19 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
 
   const ref = useRef<HTMLInputElement>(null)
 
-  const [checkedState, setCheckedState] = useState(!!defaultIsChecked)
+  const [checkedState, setCheckedState] = useState(!!defaultChecked)
 
   const [isControlled, isChecked] = useControllableProp(
     checkedProp,
     checkedState,
   )
+
+  warn({
+    condition: !!defaultIsChecked,
+    message:
+      'The "defaultIsChecked" prop has been deprecated and will be removed in a future version. ' +
+      'Please use the "defaultChecked" prop instead, which mirrors default React checkbox behavior.',
+  })
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/radio/src/use-radio.ts
+++ b/packages/radio/src/use-radio.ts
@@ -6,6 +6,7 @@ import {
   mergeRefs,
   pick,
   PropGetter,
+  warn,
 } from "@chakra-ui/utils"
 import { visuallyHiddenStyle } from "@chakra-ui/visually-hidden"
 import {
@@ -43,8 +44,15 @@ export interface UseRadioProps {
   isChecked?: boolean
   /**
    * If `true`, the radio will be initially checked.
+   *
+   * @deprecated Please use `defaultChecked` which mirrors the default prop
+   * name for radio elements.
    */
   defaultIsChecked?: boolean
+  /**
+   * If `true`, the radio will be initially checked.
+   */
+  defaultChecked?: boolean
   /**
    * If `true`, the radio will be disabled
    */
@@ -75,6 +83,7 @@ export interface UseRadioProps {
 export function useRadio(props: UseRadioProps = {}) {
   const {
     defaultIsChecked,
+    defaultChecked = defaultIsChecked,
     isChecked: isCheckedProp,
     isFocusable,
     isDisabled,
@@ -94,12 +103,19 @@ export function useRadio(props: UseRadioProps = {}) {
 
   const ref = useRef<HTMLInputElement>(null)
 
-  const [isCheckedState, setChecked] = useState(Boolean(defaultIsChecked))
+  const [isCheckedState, setChecked] = useState(Boolean(defaultChecked))
 
   const [isControlled, isChecked] = useControllableProp(
     isCheckedProp,
     isCheckedState,
   )
+
+  warn({
+    condition: !!defaultIsChecked,
+    message:
+      'The "defaultIsChecked" prop has been deprecated and will be removed in a future version. ' +
+      'Please use the "defaultChecked" prop instead, which mirrors default React checkbox behavior.',
+  })
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR deprecates the `defaultIsChecked` prop in favor of a new `defaultChecked` prop. I think `defaultChecked` makes more sense as it mirrors the default prop name that React uses for `radio` and `checkbox` elements, which will make this easier to pick up. It's also confusing because `Radio` and `Checkbox` have both `defaultChecked` and `defaultIsChecked` as part of their types due to reliance on the underlying `HTMLInputElement` type, so removing this extra prop will make that even more clear.

## ⛳️ Current behavior (updates)

Uncontrolled `Radio` and `Checkbox` components use `defaultIsChecked` for setting the default checked element.

## 🚀 New behavior

`Radio` and `Checkbox` now use the `defaultChecked` prop to set the default checked element. 

## 💣 Is this a breaking change (Yes/No):

No. This is not a breaking change because `defaultChecked` defaults to the value of `defaultIsChecked` if not provided, meaning that `defaultIsChecked` will still work for both components. We should remove this in a future `major` bump.

## 📝 Additional Information
