### PR TITLE
fix(pin-input): use valid autocomplete value

### DIFF
--- a/.changeset/sharp-comics-tease.md
+++ b/.changeset/sharp-comics-tease.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/pin-input": patch
+---
+
+Resolved an issue where `PinInputField` rendered an input with
+`autocomplete="not-allowed"` instead of `autocomplete="off"`

--- a/packages/pin-input/src/use-pin-input.ts
+++ b/packages/pin-input/src/use-pin-input.ts
@@ -274,7 +274,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
         onFocus: callAllHandlers(rest.onFocus, onFocus),
         onBlur: callAllHandlers(rest.onBlur, onBlur),
         value: values[index] || "",
-        autoComplete: "not-allowed",
+        autoComplete: "off",
         placeholder: hasFocus ? "" : placeholder,
       }
     },


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2879 <!-- Github issue # here -->

## 📝 Description

This PR resolves an issue where `PinInputField` renders an `input` with invalid attribute `autocomplete="not-allowed".

## ⛳️ Current behavior (updates)

`input` rendered by `PinInputField` contains `autocomplete="not-allowed"` attribute.

## 🚀 New behavior

`input` rendered by `PinInputField` contains `autocomplete="off"` attribute.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
