### PR TITLE
fix(slider): call onChangeEnd even if value doesn't change

### DIFF
--- a/.changeset/perfect-melons-serve.md
+++ b/.changeset/perfect-melons-serve.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/slider": patch
+---
+
+fix(slider): call onChangeEnd even if value doesn't change

--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -184,7 +184,6 @@ export function useSlider(props: UseSliderProps) {
    * or greater than max
    */
   const value = clampValue(computedValue, min, max)
-  const prev = useRef<number>()
 
   const reversedValue = max - value + min
   const trackValue = isReversed ? reversedValue : value
@@ -246,7 +245,6 @@ export function useSlider(props: UseSliderProps) {
     (value: number) => {
       // bail out if slider isn't interactive
       if (!isInteractive) return
-      prev.current = value
       value = parseFloat(roundValueToStep(value, min, oneStep))
       value = clampValue(value, min, max)
       setValue(value)
@@ -390,8 +388,7 @@ export function useSlider(props: UseSliderProps) {
   }, [value])
 
   useUpdateEffect(() => {
-    const shouldUpdate =
-      !isDragging && eventSource !== "keyboard" && prev.current !== value
+    const shouldUpdate = !isDragging && eventSource !== "keyboard"
 
     if (shouldUpdate) {
       onChangeEnd?.(value)
@@ -411,7 +408,6 @@ export function useSlider(props: UseSliderProps) {
     if (!isInteractive || !rootRef.current) return
 
     setDragging.on()
-    prev.current = value
     onChangeStart?.(value)
 
     const doc = getDocument(rootRef.current)
@@ -447,7 +443,6 @@ export function useSlider(props: UseSliderProps) {
     event.preventDefault()
 
     setDragging.on()
-    prev.current = value
     onChangeStart?.(value)
 
     const doc = getDocument(rootRef.current)


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2887 <!-- Github issue # here -->

## 📝 Description

`onChangeEnd` can't reliably be used to detect when dragging ends because it isn't called if the new `value` is the same as the old `value`.

## ⛳️ Current behavior (updates)

`Slider` currently has a check that prevents calling `onChangeEnd` if `value` matches the previous `value`.

## 🚀 New behavior

`onChangeEnd` is now called whether `value` matches the previous `value` or not.

## 💣 Is this a breaking change (Yes/No):

Possibly? Need to discuss. If users don't expect `onChangeEnd` to be called, it will now be called. Created as a draft so we can discuss this before merging.
