### PR TITLE
docs: fix next/prev links not corresponding to sidebar ordering

### DIFF
--- a/website/configs/docs-sidebar.json
+++ b/website/configs/docs-sidebar.json
@@ -116,6 +116,10 @@
               "path": "/docs/layout/grid"
             },
             {
+              "title": "Link",
+              "path": "/docs/components/link"
+            },
+            {
               "title": "SimpleGrid",
               "path": "/docs/layout/simple-grid"
             },
@@ -126,10 +130,6 @@
             {
               "title": "Wrap",
               "path": "/docs/layout/wrap"
-            },
-            {
-              "title": "Link",
-              "path": "/docs/components/link"
             }
           ]
         },
@@ -204,6 +204,10 @@
               "path": "/docs/data-display/badge"
             },
             {
+              "title": "Close Button",
+              "path": "/docs/components/close-button"
+            },
+            {
               "title": "Code",
               "path": "/docs/data-display/code"
             },
@@ -230,10 +234,6 @@
             {
               "title": "Tag",
               "path": "/docs/data-display/tag"
-            },
-            {
-              "title": "Close Button",
-              "path": "/docs/components/close-button"
             }
           ]
         },
@@ -399,16 +399,16 @@
               "path": "/docs/hooks/use-media-query"
             },
             {
+              "title": "usePrefersReducedMotion",
+              "path": "/docs/hooks/use-prefers-reduced-motion"
+            },
+            {
               "title": "useTheme",
               "path": "/docs/hooks/use-theme"
             },
             {
               "title": "useToken",
               "path": "/docs/hooks/use-token"
-            },
-            {
-              "title": "usePrefersReducedMotion",
-              "path": "/docs/hooks/use-prefers-reduced-motion"
             }
           ]
         }


### PR DESCRIPTION
## 📝 Description

This PR changes the ordering of items in the `docs-sidebar.json` to match the ordering of the sidebar. The ordering in the JSON is used to determine next/prev links in docs.

## ⛳️ Current behavior (updates)

Some items such as `Link` and `CloseButton` have invalid next/previous links due to them being at the wrong position in the JSON file.

![image](https://user-images.githubusercontent.com/25374940/103182997-fdd4f200-48af-11eb-89a0-06f34c4db2c4.png)

## 🚀 New behavior

This PR fixes the ordering so that all items in the docs have the correct siblings.

![image](https://user-images.githubusercontent.com/25374940/103183010-252bbf00-48b0-11eb-88e7-c6c3eaf7e982.png)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A
