### PR TITLE
docs(use-token): replace gradient example with boxShadow example

### DIFF
--- a/.changeset/sweet-cherries-breathe.md
+++ b/.changeset/sweet-cherries-breathe.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Replace example showing how to use `useToken` to make a gradient with one that
+shows how to make a `boxShadow`.

--- a/website/pages/docs/hooks/use-token.mdx
+++ b/website/pages/docs/hooks/use-token.mdx
@@ -30,8 +30,7 @@ function Example() {
 
   return (
     <Box p={4} boxShadow={`inset 0 4px 0 ${red100}, 0 0 8px ${blue200}`}>
-      You can utilize <Code>useToken</Code> to create a <Code>boxShadow</Code>
-      with colors from your theme.
+      You can utilize <Code>useToken</Code> to create a <Code>boxShadow</Code> with colors from your theme.
     </Box>
   )
 }

--- a/website/pages/docs/hooks/use-token.mdx
+++ b/website/pages/docs/hooks/use-token.mdx
@@ -29,8 +29,9 @@ function Example() {
   )
 
   return (
-    <Box bg={`linear-gradient(${red100}, ${blue200})`}>
-      <Text color="black">wonderful gradients</Text>
+    <Box p={4} boxShadow={`inset 0 4px 0 ${red100}, 0 0 8px ${blue200}`}>
+      You can utilize <Code>useToken</Code> to create a <Code>boxShadow</Code>
+      with colors from your theme.
     </Box>
   )
 }


### PR DESCRIPTION
## 📝 Description

Since we now have gradients supported "natively" in Chakra, it might be better to not show how to use `useToken` to make one. 

## ⛳️ Current behavior

`useToken` docs show how to use it to make a background gradient.

## 🚀 New behavior

Docs show how to use it to make a `boxShadow` with colors from theme.

## 💣 Is this a breaking change (Yes/No):

No.
