### PR TITLE
docs(icon): fix typos and inconsistent word capitalization

### DIFF
--- a/.changeset/warm-shrimps-tease.md
+++ b/.changeset/warm-shrimps-tease.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Fix typos and inconsistent word capitalization in the `Icon` docs.

--- a/website/pages/docs/components/icon.mdx
+++ b/website/pages/docs/components/icon.mdx
@@ -22,8 +22,8 @@ Chakra provides multiple ways to use icons in your project:
 
 ## Using Chakra UI icons
 
-Chakra provides a set of commonly used interfact icons you can use in your
-project. To these icons, install `@chakra-ui/icons`, import the icon you need
+Chakra provides a set of commonly used interface icons you can use in your
+project. To use these icons, install `@chakra-ui/icons`, import the icons you need
 and style them.
 
 ### Installation
@@ -49,7 +49,7 @@ import { PhoneIcon, AddIcon, WarningIcon } from '@chakra-ui/icons'
 <WarningIcon w={8} h={8} color="red.500" />
 ```
 
-### All Icons
+### All icons
 
 Below is a list of all of the icons in the library, along with the corresponding
 component names:
@@ -77,7 +77,7 @@ function Example() {
 }
 ```
 
-### Some Examples
+### Some examples
 
 ```jsx
 <HStack>
@@ -172,7 +172,6 @@ export const UpDownIcon = createIcon({
 })
 
 // OR using the `d` value of a path (the path definition) directly
-
 export const UpDownIcon = createIcon({
   displayName: "UpDownIcon",
   viewBox: "0 0 200 200",


### PR DESCRIPTION
## 📝 Description

A few cosmetic changes / typo fixes.