### PR TITLE
fix(docs): align social buttons vertically

### DIFF
--- a/.changeset/spotty-ties-mix.md
+++ b/.changeset/spotty-ties-mix.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Align social buttons in the header vertically

--- a/website/src/components/header.tsx
+++ b/website/src/components/header.tsx
@@ -80,6 +80,7 @@ function HeaderContent() {
             >
               <Icon
                 as={GithubIcon}
+                display="block"
                 transition="color 0.2s"
                 w="5"
                 h="5"
@@ -89,6 +90,7 @@ function HeaderContent() {
             <Link aria-label="Go to Chakra UI Discord page" href="/discord">
               <Icon
                 as={DiscordIcon}
+                display="block"
                 transition="color 0.2s"
                 w="5"
                 h="5"


### PR DESCRIPTION
## 📝 Description

The Github and Discord buttons in the header are vertically misaligned and I cannot sleep because of that.

## ⛳️ Current behavior

Buttons are vertically slightly misaligned.

## 🚀 New behavior

Buttons are perfectly aligned.

## 💣 Is this a breaking change (Yes/No):

No