### PR TITLE
fix(deprecation): deprecate isFullWidth on Input, NumberInput, Radio,…

### DIFF
--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -25,6 +25,10 @@ interface InputOptions {
   errorBorderColor?: string
   /**
    * If `true`, the input element will span the full width of its parent
+   *
+   * @deprecated
+   * This component defaults to 100% width,
+   *  please use the props `maxWidth` or `width` to configure
    */
   isFullWidth?: boolean
 }

--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -46,6 +46,10 @@ interface InputOptions {
   errorBorderColor?: string
   /**
    * If `true`, the input element will span the full width of its parent
+   *
+   * @deprecated
+   * This component defaults to 100% width,
+   * please use the props `maxWidth` or `width` to configure
    */
   isFullWidth?: boolean
 }

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -29,6 +29,10 @@ export interface RadioProps
   spacing?: SystemProps["marginLeft"]
   /**
    * If `true`, the radio will occupy the full width of its parent container
+   *
+   * @deprecated
+   * This component defaults to 100% width,
+   * please use the props `maxWidth` or `width` to configure
    */
   isFullWidth?: boolean
 }

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -60,6 +60,10 @@ interface SelectOptions extends FormControlOptions {
   errorBorderColor?: string
   /**
    * If `true`, the select element will span the full width of its parent
+   *
+   * @deprecated
+   * This component defaults to 100% width,
+   * please use the props `maxWidth` or `width` to configure
    */
   isFullWidth?: boolean
   /**
@@ -113,6 +117,7 @@ export const Select = forwardRef<SelectProps, "select">((props, ref) => {
     minHeight,
     iconColor,
     iconSize,
+    isFullWidth,
     ...rest
   } = omitThemingProps(props)
 

--- a/packages/textarea/src/textarea.tsx
+++ b/packages/textarea/src/textarea.tsx
@@ -26,6 +26,10 @@ interface TextareaOptions {
   errorBorderColor?: string
   /**
    * If `true`, the textarea element will span the full width of its parent
+   *
+   * @deprecated
+   * This component defaults to 100% width,
+   * please use the props `maxWidth` or `width` to configure
    */
   isFullWidth?: boolean
 }


### PR DESCRIPTION
… Select and Textarea

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2865 

## 📝 Description

`isFullWidth` is present in the type definitions of Input, NumberInput, Radio, Select and Textarea - but unused as they are all defaulting to a 100% width.

I marked this prop as deprecated and we can remove them with the next major release.

## ⛳️ Current behavior (updates)

Select passes `isFullWidth` to the DOM element.

## 🚀 New behavior

Select no longer passes `isFullWidth` to the DOM - and is marked as deprecated, because it has no effect.

## 💣 Is this a breaking change (Yes/No):

No, but we should remove `isFullWidth` on those mentioned components with the next major version.
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
