### PR TITLE
fix(progress): allow overriding borderRadius in theme

### DIFF
--- a/.changeset/brave-ties-flow.md
+++ b/.changeset/brave-ties-flow.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/progress": patch
+---
+
+You can now override linear progress component's border radius in the theme.

--- a/packages/progress/src/progress.tsx
+++ b/packages/progress/src/progress.tsx
@@ -132,12 +132,16 @@ export const Progress: React.FC<ProgressProps> = (props) => {
     hasStripe,
     isAnimated,
     children,
-    borderRadius,
+    borderRadius: propBorderRadius,
     isIndeterminate,
     ...rest
   } = omitThemingProps(props)
 
   const styles = useMultiStyleConfig("Progress", props)
+
+  const borderRadius =
+    propBorderRadius ??
+    (styles.track?.borderRadius as string | number | undefined)
 
   const stripAnimation = { animation: `${stripe} 1s linear infinite` }
 

--- a/packages/progress/stories/progress.stories.tsx
+++ b/packages/progress/stories/progress.stories.tsx
@@ -1,4 +1,5 @@
 import { chakra } from "@chakra-ui/system"
+import { extendTheme, useTheme, ThemeProvider } from "@chakra-ui/react"
 import * as React from "react"
 import { Progress, ProgressLabel } from "../src"
 
@@ -48,3 +49,27 @@ export const withAnimation = () => (
 export const withCustomBorderRadius = () => (
   <Progress value={20} borderRadius="4px" />
 )
+
+export const withThemeBorderRadiusOverride = () => {
+  const theme = useTheme()
+  const extendedTheme = extendTheme(
+    {
+      components: {
+        Progress: {
+          baseStyle: {
+            track: {
+              borderRadius: "md",
+            },
+          },
+        },
+      },
+    },
+    theme,
+  )
+
+  return (
+    <ThemeProvider theme={extendedTheme}>
+      <Progress value={50} />
+    </ThemeProvider>
+  )
+}


### PR DESCRIPTION
Closes #2921

## ⛳️ Current behavior (updates)

`borderRadius` for the linear progress component can't be set in the theme.

## 🚀 New behavior

You can set `borderRadius` in the `baseStyle` of the `track` part and it will take effect on both `track` and `filledTrack`.
Prop `borderRadius` can still be used to override it.

## 💣 Is this a breaking change (Yes/No):

No
