### PR TITLE
fix(modal): disable the ModalOverlay animation if motionPreset="none"

### DIFF
--- a/.changeset/eighty-teachers-brush.md
+++ b/.changeset/eighty-teachers-brush.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Disable the `ModalOverlay` animation as well as the `ModalContent` animation, if
+`motionPreset="none"`

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -347,9 +347,12 @@ export const ModalOverlay = forwardRef<ModalOverlayProps, "div">(
       ...styles.overlay,
     }
 
+    const { motionPreset } = useModalContext()
+    const motionProps = motionPreset === "none" ? {} : fadeConfig
+
     return (
       <Motion
-        {...fadeConfig}
+        {...motionProps}
         __css={overlayStyle}
         ref={ref}
         className={_className}


### PR DESCRIPTION

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2519

## 📝 Description

`motionPreset="none"` introduced in #2888 disables the `ModalContent` animation, but the `ModalOverlay` is still animated. This PR fixes it.

## ⛳️ Current behavior (updates)

`ModalOverlay` component fades in/out even if `motionPreset="none"`.

https://user-images.githubusercontent.com/6268183/103666173-9e659900-4fb7-11eb-8ee7-9e58df94fe98.mp4

## 🚀 New behavior

No animations for `ModalOverlay` component with `motionPreset="none"`.

https://user-images.githubusercontent.com/6268183/103665970-62323880-4fb7-11eb-9e44-d9474383d905.mp4

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
