### PR TITLE
docs: explain `ref` needed for MenuButton `as` Component

### DIFF
--- a/website/pages/docs/overlay/menu.mdx
+++ b/website/pages/docs/overlay/menu.mdx
@@ -85,6 +85,21 @@ To access the internal state of the `Menu`, use a function as `children`
 </Menu>
 ```
 
+### Customising the button 
+
+The default `MenuButton` can be styled using the usual styled-system props, but it
+starts off plainly styled.
+
+Using the `as` prop of the `MenuButton`, you can render a custom component instead
+of the default `MenuButton`. For instance, you can use Chakra's `Button` component,
+or your own custom component.
+
+> Custom components must take a `ref` prop which is assigned to the React component
+that triggers the menu opening. This is so that the `MenuList` popover can be
+positioned correctly. Without this, the `MenuList` will render in an undefined
+position.
+
+
 ### Letter Navigation
 
 When focus is on the `MenuButton` or within the `MenuList` and you type a letter


### PR DESCRIPTION
This just cost me half an hour!

Could be explained more succinctly, and maybe in a better place in the document.

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Document requirement to have a `ref`-accepting component for the `as` prop of `MenuButton`

## ⛳️ Current behavior (updates)

Not described.

## 🚀 New behavior

Describe requirement in docs.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
