### PR TITLE
docs: notify about the `sx` prop in the useToken doc page

### DIFF
--- a/website/pages/docs/hooks/use-token.mdx
+++ b/website/pages/docs/hooks/use-token.mdx
@@ -35,3 +35,5 @@ function Example() {
   )
 }
 ```
+
+> Note that you can also use the `sx` prop to write styles freely using themes tokens.


### PR DESCRIPTION
People looking for more flexible ways of using themes token can land on the useToken page in the documentation.

## 💣 Is this a breaking change:

No