### PR TITLE
Import should be @chakra-ui/core not /react

### DIFF
--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -24,7 +24,7 @@ time.
 ## Import
 
 ```js
-import { useToast } from "@chakra-ui/react"
+import { useToast } from "@chakra-ui/core"
 ```
 
 ## Usage


### PR DESCRIPTION
@chakra-ui/react import doesn't render any stylesheets. @chakra-ui/core works as expected.

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Import statement is inaccurate, confuses new users of the framework as there is no error. CSS is missing with wrong import.

## ⛳️ Current behavior (updates)

> Missing CSS

## 🚀 New behavior

> CSS as expected

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
