### PR TITLE
docs(style props): add note regarding the order of border style props

### DIFF
--- a/website/pages/docs/features/style-props.mdx
+++ b/website/pages/docs/features/style-props.mdx
@@ -274,6 +274,9 @@ import { Box } from "@chakra-ui/react"
 </Box>
 ```
 
+> **Note**: The order of properties matter. So while the above example works,
+> `<Box borderColor="gray.200" border="1px">` does not.
+
 | Prop                | CSS Property                   | Theme Field    |
 | ------------------- | ------------------------------ | -------------- |
 | `border`            | `border`                       | `borders`      |


### PR DESCRIPTION
## 📝 Description

I had a bug due to the order of (border) style props and it took me some time to find it. So I thought this note might help others to not repeat the mistake.

## ⛳️ Current behaviour (updates)

Having border style props in different orders produces different visual results, which might be unintended.

## 🚀 New behaviour

Added a note to inform users about this behaviour.

## 💣 Is this a breaking change (Yes/No):

No
