### PR TITLE
fix(guides): unsued box import

### DIFF
--- a/website/pages/guides/integrations/with-framer.mdx
+++ b/website/pages/guides/integrations/with-framer.mdx
@@ -9,7 +9,7 @@ If you'd like to add some interesting motion interaction or animation to your
 Chakra UI websites or apps, here's a quick tip:
 
 ```jsx live=false
-import { Box } from "@chakra-ui/react"
+import { Box, forwardRef } from "@chakra-ui/react"
 import { motion, isValidMotionProp } from "framer-motion"
 
 // 1. Create a custom motion component from Box
@@ -19,7 +19,7 @@ const MotionBox = motion.custom(
       // do not pass framer props to DOM element
       Object.entries(props).filter(([key]) => !isValidMotionProp(key)),
     )
-    return <chakra.div ref={ref} {...chakraProps} />
+    return <Box ref={ref} {...chakraProps} />
   }),
 )
 


### PR DESCRIPTION
## 📝 Description

- Used the imported `Box` instead of `chakra.div`
- added `forwardRef` import

## ⛳️ Current behavior (updates)

The framer example is not using the imported `Box`

## 🚀 New behavior

Easier to understand the framer example.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
