### PR TITLE
fix(docs): make select custom icon example live

### DIFF
--- a/.changeset/dry-wolves-kick.md
+++ b/.changeset/dry-wolves-kick.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+The `Changing the icon in the Select` example is now editable.

--- a/website/pages/docs/form/select.mdx
+++ b/website/pages/docs/form/select.mdx
@@ -72,7 +72,7 @@ select. Simply pass the `icon` prop.
 In case the custom icon size doesn't look right, you can pass the `iconSize`
 prop to change it.
 
-```jsx live=true
+```jsx
 <Select icon={<MdArrowDropDown />} placeholder="Woohoo! A new icon" />
 ```
 


### PR DESCRIPTION
## 📝 Description

The `Changing the icon in the Select` example is not live / editable.
In the source code there was `jsx live=true`, which apparently does the same as `jsx live=false`. 
To enable editable example, the `live` directive has to be omitted altogether.