### PR TITLE
fix(skeleton-text): fix SkeletonText dimensions when isLoaded

### DIFF
--- a/.changeset/little-rocks-battle.md
+++ b/.changeset/little-rocks-battle.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/skeleton": patch
+---
+
+Fixed a bug where `SkeletonText` kept its fixed dimensions when `isLoaded` is true.

--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -172,17 +172,23 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
           return null
         }
 
+        const sizeProps = isLoaded
+          ? null
+          : {
+              mb: number === numbers.length ? "0" : spacing,
+              width: getWidth(number),
+              height: skeletonHeight,
+            }
+
         return (
           <Skeleton
             key={numbers.length.toString() + number}
-            mb={number === numbers.length ? "0" : spacing}
-            width={getWidth(number)}
-            height={skeletonHeight}
             startColor={startColor}
             endColor={endColor}
             isLoaded={isLoaded}
             fadeDuration={fadeDuration}
             speed={speed}
+            {...sizeProps}
           >
             {
               // allows animating the children


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2956

## 📝 Description

`SkeletonText` kept its fixed height and width when `isLoaded === true`.

## ⛳️ Current behavior (updates)

size props where not dependent on `isLoaded`

## 🚀 New behavior

`mb`, `width` and `height` are set according to `isLoaded`.

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
