### PR TITLE
fix(gradient-rgb): handle rgb values in gradients

### DIFF
--- a/.changeset/spicy-eels-fold.md
+++ b/.changeset/spicy-eels-fold.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Fixed a bug where rgb values in bgGradient did not work correctly

--- a/packages/styled-system/src/utils/parse-gradient.ts
+++ b/packages/styled-system/src/utils/parse-gradient.ts
@@ -28,7 +28,7 @@ const trimSpace = (str: string) => str.trim()
 export function parseGradient(value: string | null | undefined, theme: Dict) {
   if (value == null || globals.includes(value)) return value
 
-  const regex = /(?<type>^[a-z-A-Z]+)\((?<values>(.*?))\)/g
+  const regex = /(?<type>^[a-z-A-Z]+)\((?<values>(.*))\)/g
 
   const { type, values } = regex.exec(value)?.groups ?? {}
 

--- a/packages/styled-system/tests/parse-gradient.test.ts
+++ b/packages/styled-system/tests/parse-gradient.test.ts
@@ -69,6 +69,23 @@ describe("linear gradient", () => {
       parseGradient("radial(to-b, #bbb 15%, pink.dark 15%)", theme),
     ).toEqual("radial-gradient(to bottom, #bbb 15%, #FF1493 15%)")
   })
+
+  test("should parse colors in rgb", () => {
+    expect(
+      parseGradient("linear(to-l, rgb(0,0,0), rgb(255,255,255))", theme),
+    ).toEqual("linear-gradient(to left, rgb(0, 0, 0), rgb(255, 255, 255))")
+  })
+
+  test("should parse colors in rgb with percentage", () => {
+    expect(
+      parseGradient(
+        "linear(to-l, rgb(0,0,0) 15%, rgb(255,255,255) 15%)",
+        theme,
+      ),
+    ).toEqual(
+      "linear-gradient(to left, rgb(0, 0, 0) 15%, rgb(255, 255, 255) 15%)",
+    )
+  })
 })
 
 describe("conic gradient", () => {

--- a/packages/system/stories/system.stories.tsx
+++ b/packages/system/stories/system.stories.tsx
@@ -105,3 +105,13 @@ export const WithGradient = () => (
     </chakra.span>
   </>
 )
+
+export const WithRgbGradient = () => (
+  <>
+    <chakra.div
+      bgGradient="linear(to-r, rgb(0,0,0), rgb(230,230,230))"
+      w="500px"
+      h="64px"
+    />
+  </>
+)


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2981

## 📝 Description

`bgGradient="linear(to-l, rgb(0,0,0) 15%, rgb(255,255,255) 15%)"`  did create an invalid css value.

## ⛳️ Current behavior (updates)

Modified the regex to extract values between the first `(` to the last `)` in the gradient string by removing the lookahead operator.

## 🚀 New behavior

Creates correct CSS gradient values for rgb values. A test ensures this.

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

