### PR TITLE
docs: handle the display of boxes in responsive design

### DIFF
--- a/website/pages/docs/features/style-props.mdx
+++ b/website/pages/docs/features/style-props.mdx
@@ -358,7 +358,7 @@ import { Box } from "@chakra-ui/react"
 ```jsx
 <SimpleGrid
   bg="gray.50"
-  columns="4"
+  columns={{sm: 2, md: 4}}
   spacing="8"
   p="10"
   textAlign="center"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

As described in [#2986](https://github.com/chakra-ui/chakra-ui/issues/2986) the boxes are out of their wrapper in the mobile version for [#shadow](https://chakra-ui.com/docs/features/style-props#shadow) example

## ⛳️ Current behavior (updates)
`columns="4"`  for `SimpleGrid` component, which make it not responsive

## 🚀 New behavior
The boxes are now inside their wrapper in the mobile version (responsive design), by changing `columns="4"` to `columns={{sm: 2, md: 4}}`

## 💣 Is this a breaking change (Yes/No):

No, it's not a breaking change
