### PR TITLE
fix(container): restore former width prop behaviour

### DIFF
--- a/packages/layout/src/container.tsx
+++ b/packages/layout/src/container.tsx
@@ -48,6 +48,7 @@ export const Container = forwardRef<ContainerProps, "div">((props, ref) => {
   } = omitThemingProps(props)
 
   const theme = useTheme()
+
   const widthProps = transform(theme, {
     maxW,
     maxWidth,

--- a/packages/layout/src/container.tsx
+++ b/packages/layout/src/container.tsx
@@ -3,8 +3,10 @@ import {
   forwardRef,
   omitThemingProps,
   ThemingProps,
+  useTheme,
   useStyleConfig,
   HTMLChakraProps,
+  SystemStyleObject,
 } from "@chakra-ui/system"
 import {
   cx,
@@ -34,17 +36,18 @@ export interface ContainerProps extends HTMLChakraProps<"div">, ThemingProps {
  */
 export const Container = forwardRef<ContainerProps, "div">((props, ref) => {
   const {
+    className,
+    centerContent,
     maxW,
     maxWidth,
     width,
     w,
     minWidth,
     minW,
-  } = props;
-  const { className, centerContent, ...rest } = omitThemingProps(props)
+    ...rest
+  } = omitThemingProps(props)
 
   const theme = useTheme()
-
   const widthProps = transform(theme, {
     maxW,
     maxWidth,
@@ -53,17 +56,15 @@ export const Container = forwardRef<ContainerProps, "div">((props, ref) => {
     minWidth,
     minW,
   })
-  
-  const styles = useStyleConfig("Container", {
-    ...props,
-    ...widthProps,
-  })
+
+  const styles = useStyleConfig("Container", props)
 
   return (
     <chakra.div
       ref={ref}
       className={cx("chakra-container", className)}
       {...rest}
+      {...widthProps}
       __css={{
         ...styles,
         ...(centerContent && {
@@ -92,4 +93,3 @@ function transform(theme: Dict, props: Dict) {
 
   return filterUndefined(result)
 }
-  

--- a/packages/layout/src/container.tsx
+++ b/packages/layout/src/container.tsx
@@ -6,7 +6,14 @@ import {
   useStyleConfig,
   HTMLChakraProps,
 } from "@chakra-ui/system"
-import { cx, __DEV__ } from "@chakra-ui/utils"
+import {
+  cx,
+  Dict,
+  filterUndefined,
+  mapResponsive,
+  memoizedGet as get,
+  __DEV__,
+} from "@chakra-ui/utils"
 import * as React from "react"
 
 export interface ContainerProps extends HTMLChakraProps<"div">, ThemingProps {
@@ -26,9 +33,31 @@ export interface ContainerProps extends HTMLChakraProps<"div">, ThemingProps {
  * It also sets a default max-width of `60ch` (60 characters).
  */
 export const Container = forwardRef<ContainerProps, "div">((props, ref) => {
+  const {
+    maxW,
+    maxWidth,
+    width,
+    w,
+    minWidth,
+    minW,
+  } = props;
   const { className, centerContent, ...rest } = omitThemingProps(props)
 
-  const styles = useStyleConfig("Container", props)
+  const theme = useTheme()
+
+  const widthProps = transform(theme, {
+    maxW,
+    maxWidth,
+    width,
+    w,
+    minWidth,
+    minW,
+  })
+  
+  const styles = useStyleConfig("Container", {
+    ...props,
+    ...widthProps,
+  })
 
   return (
     <chakra.div
@@ -50,3 +79,17 @@ export const Container = forwardRef<ContainerProps, "div">((props, ref) => {
 if (__DEV__) {
   Container.displayName = "Container"
 }
+
+function transform(theme: Dict, props: Dict) {
+  const result: SystemStyleObject = {}
+
+  Object.keys(props).forEach((prop) => {
+    const propValue = props[prop]
+    result[prop] = mapResponsive(propValue, (value) =>
+      get(theme, `sizes.container.${value}`, value),
+    )
+  })
+
+  return filterUndefined(result)
+}
+  


### PR DESCRIPTION
This branch restores the former behaviour of width props (`w`, `maxW`, `minWidth`, etc.) in the `<Container />` component. I took the approach used previously in this component from [`770466a`](https://github.com/chakra-ui/chakra-ui/blob/770466ae99443d12c214e26032a5ebc704397853/packages/layout/src/container.tsx), and combined it with the current implementation.

Fixes: #2730