### PR TITLE
docs: Update props table to display valid size and variant props values

### DIFF
--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -17,7 +17,7 @@ import {
   EventKeyMap,
   focus,
   getBox,
-  getDocument,
+  getOwnerDocument,
   isRightClick,
   mergeRefs,
   normalizeEventKey,
@@ -414,7 +414,7 @@ export function useSlider(props: UseSliderProps) {
     prev.current = value
     onChangeStart?.(value)
 
-    const doc = getDocument(rootRef.current)
+    const doc = getOwnerDocument(rootRef.current)
 
     const run = (event: MouseEvent) => {
       const nextValue = getValueFromPointer(event)
@@ -450,7 +450,7 @@ export function useSlider(props: UseSliderProps) {
     prev.current = value
     onChangeStart?.(value)
 
-    const doc = getDocument(rootRef.current)
+    const doc = getOwnerDocument(rootRef.current)
 
     const run = (event: TouchEvent) => {
       const nextValue = getValueFromPointer(event)

--- a/website/src/components/omni-search.tsx
+++ b/website/src/components/omni-search.tsx
@@ -132,7 +132,7 @@ function OmniSearch() {
   useEventListener("keydown", (event) => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform)
     const hotkey = isMac ? "metaKey" : "ctrlKey"
-    if (event.key.toLowerCase() === "k" && event[hotkey]) {
+    if (event?.key?.toLowerCase() === "k" && event[hotkey]) {
       event.preventDefault()
       modal.onOpen()
     }

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as ComponentProps from "@chakra-ui/props-docs"
 import MDXComponents from "./mdx-components"
+import { theme } from "@chakra-ui/react"
 
 export type PropsTableProps = {
   /**
@@ -35,6 +36,27 @@ const PropsTable = ({
     return null
   }
 
+  const themeComponent = theme.components[of]
+  const sizeValues = themeComponent?.sizes && Object.keys(themeComponent.sizes)
+  const variantValues =
+    themeComponent?.variants && Object.keys(themeComponent.variants)
+
+  /**
+   * If component has size prop, override the rendered values
+   * for `size` prop with  the component's size values
+   */
+  if (info.props.size && sizeValues) {
+    info.props.size.type.name = sizeValues
+  }
+
+  /**
+   * If component has variant prop, override the rendered value
+   * for `variant` prop with the component's variant values
+   */
+  if (info.props.variant && variantValues) {
+    info.props.variant.type.name = variantValues
+  }
+
   const entries = React.useMemo(
     () =>
       Object.entries(info.props)
@@ -64,6 +86,18 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
     )
   }
 
+  const renderPropType = (type: string | string[]) => {
+    if (Array.isArray(type)) {
+      return type.map((item, index) => {
+        if (index === type.length - 1) {
+          return `${item}`
+        }
+        return `${item}, `
+      })
+    }
+    return type
+  }
+
   return (
     <MDXComponents.table>
       <thead>
@@ -85,7 +119,7 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
                 d="inline-block"
                 lineHeight="tall"
               >
-                {values.type?.name}
+                {renderPropType(values.type?.name)}
               </MDXComponents.inlineCode>
             </MDXComponents.td>
             <MDXComponents.td>{values.description}</MDXComponents.td>

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -46,7 +46,7 @@ const PropsTable = ({
    * for `size` prop with  the component's size values
    */
   if (info.props.size && sizeValues) {
-    info.props.size.type.name = sizeValues
+    info.props.size.type.name = sizeValues.join(", ")
   }
 
   /**
@@ -54,7 +54,7 @@ const PropsTable = ({
    * for `variant` prop with the component's variant values
    */
   if (info.props.variant && variantValues) {
-    info.props.variant.type.name = variantValues
+    info.props.variant.type.name = variantValues.join(", ")
   }
 
   const entries = React.useMemo(
@@ -86,18 +86,6 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
     )
   }
 
-  const renderPropType = (type: string | string[]) => {
-    if (Array.isArray(type)) {
-      return type.map((item, index) => {
-        if (index === type.length - 1) {
-          return `${item}`
-        }
-        return `${item}, `
-      })
-    }
-    return type
-  }
-
   return (
     <MDXComponents.table>
       <thead>
@@ -119,7 +107,7 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
                 d="inline-block"
                 lineHeight="tall"
               >
-                {renderPropType(values.type?.name)}
+                {values.type?.name}
               </MDXComponents.inlineCode>
             </MDXComponents.td>
             <MDXComponents.td>{values.description}</MDXComponents.td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,14 +3956,6 @@
     prop-types "^15.7.2"
     tslib "^2.0.0"
 
-"@reach/portal@^0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.12.1.tgz#995858a6e758d9446870937b60b8707a2efa11cb"
-  integrity sha512-Lhmtd2Qw1DzNZ2m0GHNzCu+2TYUf6kBREPSQJf44AP6kThRs02p1clntbJcmW/rrpYFYgFNbgf5Lso7NyW9ZXg==
-  dependencies:
-    "@reach/utils" "0.12.1"
-    tslib "^2.0.0"
-
 "@reach/router@^1.2.1", "@reach/router@^1.3.3", "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -3978,15 +3970,6 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.11.0.tgz#09ad5e1f42b498253df8a6a4c99ccd0ab2d85464"
   integrity sha512-A7Ofr1Biq4vUeTBYhbZ/YiLq1B/lEObbEoR2UiuQqCO1r093N95hZNcKqfFwpkRScjD87uob3wSYYGxvq9y/+w==
-  dependencies:
-    "@types/warning" "^3.0.0"
-    tslib "^2.0.0"
-    warning "^4.0.3"
-
-"@reach/utils@0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.12.1.tgz#02b9c15ba5cddf23e16f2d2ca77aef98a9702607"
-  integrity sha512-5uH4OgO+GupAzZuf3b6Wv/9uC6NdMBlxS6FSKD6YqSxP4QJ0vjD34RVon6N/RMRORacCLyD/aaZIA7283YgeOg==
   dependencies:
     "@types/warning" "^3.0.0"
     tslib "^2.0.0"


### PR DESCRIPTION
Closes #2984 

## 📝 Description

Updated the `PropsTable` component to display valid values for the `size` and `variant` props for each component on the docs.

## ⛳️ Current behavior (updates)

All valid values for the `size` and `variant` props are not being displayed in the props table for each component.

![image](https://user-images.githubusercontent.com/16899513/103955622-05658800-5147-11eb-8884-bff1aa78dba9.png)

## 🚀 New behavior

Display all valid values for the `size` and `variant` props in the props table for each component.

<img width="583" alt="Screenshot 2021-01-09 at 15 29 51" src="https://user-images.githubusercontent.com/11310046/104094178-892a8c00-528f-11eb-88d3-f0cacfc30922.png">

## 💣 Is this a breaking change (Yes/No):

No

