### PR TITLE
fix(docs): format size and variant values as TS types

### DIFF
--- a/.changeset/tasty-singers-design.md
+++ b/.changeset/tasty-singers-design.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Format `size` and `variant` prop values as TS types.

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -42,19 +42,23 @@ const PropsTable = ({
     themeComponent?.variants && Object.keys(themeComponent.variants)
 
   /**
-   * If component has size prop, override the rendered values
-   * for `size` prop with  the component's size values
+   * If component has size prop, override the rendered value
+   * for `size` prop with the component's size values formatted as TS type.
    */
   if (info.props.size && sizeValues) {
-    info.props.size.type.name = sizeValues.join(", ")
+    info.props.size.type.name = sizeValues
+      .map((size) => `"${size}"`)
+      .join(" | ")
   }
 
   /**
    * If component has variant prop, override the rendered value
-   * for `variant` prop with the component's variant values
+   * for `variant` prop with the component's variant values formatted as TS type.
    */
   if (info.props.variant && variantValues) {
-    info.props.variant.type.name = variantValues.join(", ")
+    info.props.variant.type.name = variantValues
+      .map((variant) => `"${variant}"`)
+      .join(" | ")
   }
 
   const entries = React.useMemo(


### PR DESCRIPTION
## 📝 Description

Currently some props are formatted as TS types and some as loose human-readable strings. 
I updated the `size` and `variant` values formatting to be a valid TS string literal union type (same as `orientation` for example). 

For example, before:
`ghost, outline, solid, link, unstyled`

After:
`"ghost" | "outline" | "solid" | "link" | "unstyled"`

## 💣 Is this a breaking change (Yes/No):

No.
