### PR TITLE
fix(menu): update popper position only while open

### DIFF
--- a/.changeset/twenty-trees-stare.md
+++ b/.changeset/twenty-trees-stare.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/popper": minor
+"@chakra-ui/menu": patch
+---
+
+Added `enabled` property to `usePopper`. Popper won't be updated while it is set
+to `false`.
+
+`Menu` now uses this option to not update its position while it's closed.

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -109,7 +109,11 @@ export function useMenu(props: UseMenuProps) {
   /**
    * Add some popper.js for dynamic positioning
    */
-  const popper = usePopper({ placement, ...props })
+  const popper = usePopper({
+    placement,
+    ...props,
+    enabled: isOpen,
+  })
 
   const [focusedIndex, setFocusedIndex] = React.useState(-1)
 

--- a/packages/popper/src/react-popper.ts
+++ b/packages/popper/src/react-popper.ts
@@ -11,6 +11,7 @@ import { dequal } from "dequal"
 import * as React from "react"
 
 type Options = Partial<PopperOptions> & {
+  enabled?: boolean
   createPopper?: typeof defaultCreatePopper
 }
 
@@ -44,6 +45,8 @@ export function usePopper(
   popperElement: HTMLElement,
   options: Options = {},
 ) {
+  const { enabled = true } = options
+
   const prevOptions = React.useRef<any>(null)
 
   const optionsWithDefaults = {
@@ -66,16 +69,17 @@ export function usePopper(
   const updateStateModifier: Modifier<"updateState", any> = React.useMemo(
     () => ({
       name: "updateState",
-      enabled: true,
+      enabled,
       phase: "write",
       fn: ({ state }) => {
         const elements = Object.keys(state.elements)
+
         setStyles(resolve(state.styles, elements))
         setAttrs(resolve(state.attributes, elements))
       },
       requires: ["computeStyles"],
     }),
-    [],
+    [enabled],
   )
 
   const popperOptions = React.useMemo(() => {

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -7,6 +7,7 @@ import { usePopper as useBasePopper } from "./react-popper"
 export type { Placement }
 
 export interface UsePopperProps {
+  enabled?: boolean
   gutter?: number
   placement?: Placement
   offset?: [number, number]
@@ -26,6 +27,7 @@ export interface UsePopperProps {
 
 export function usePopper(props: UsePopperProps = {}) {
   const {
+    enabled,
     placement = "bottom",
     preventOverflow = true,
     fixed = false,
@@ -127,6 +129,7 @@ export function usePopper(props: UsePopperProps = {}) {
   ])
 
   const popperJS = useBasePopper(referenceNode as any, popperNode as any, {
+    enabled,
     placement,
     strategy: fixed ? "fixed" : "absolute",
     modifiers: customModifiers.concat(modifiers),


### PR DESCRIPTION
Closes #2531

## 📝 Description

I added a `enabled` option to `usePopper`. While this option is `false`, the attrs and styles won't be updated.
`Menu` uses this option, so its position won't update while it is not open.