### PR TITLE
chore(docs): split installation codeblocks to allow easier copying

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -5,13 +5,12 @@ description: How to install and set up Chakra UI in your project
 
 ## Installation
 
-Inside your React project directory, install Chakra UI by running the following:
+Inside your React project directory, install Chakra UI by running either of the following:
 
 ```bash
 npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion
-
-# or
-
+```
+```bash
 yarn add @chakra-ui/react @emotion/react @emotion/styled framer-motion
 ```
 


### PR DESCRIPTION
## 📝 Description

When I wanted to copy the commands, I might try to use the copy button but if I do it won't work :/

This PR slightly reworks that section to enable this flow

## 💣 Is this a breaking change (Yes/No):

No

