### PR TITLE
docs: typo on justify & align axis

### DIFF
--- a/website/pages/docs/layout/wrap.mdx
+++ b/website/pages/docs/layout/wrap.mdx
@@ -96,7 +96,7 @@ it wraps.
 
 ### Change the alignment
 
-Pass the `align` prop to change the alignment of the child along the main axis.
+Pass the `align` prop to change the alignment of the child along the cross axis.
 
 ```jsx
 <Wrap spacing="30px" align="center">
@@ -128,7 +128,7 @@ Pass the `align` prop to change the alignment of the child along the main axis.
 </Wrap>
 ```
 
-Pass the `justify` prop to change the alignment of the child along the cross
+Pass the `justify` prop to change the alignment of the child along the main
 axis.
 
 ```jsx


### PR DESCRIPTION
There is a typo between the justify & align should be swapped

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
