### PR TITLE
feat(docs): show default value for variant and size in props table

### DIFF
--- a/.changeset/pretty-actors-float.md
+++ b/.changeset/pretty-actors-float.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Props table for each component now displays default `size` and `variant` values
+where possible.

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -61,6 +61,21 @@ const PropsTable = ({
       .join(" | ")
   }
 
+  const defaultSize = themeComponent?.defaultProps?.size
+  const defaultVariant = themeComponent?.defaultProps?.variant
+
+  if (defaultSize != null) {
+    info.props.size.defaultValue = {
+      value: defaultSize,
+    }
+  }
+
+  if (defaultVariant != null) {
+    info.props.variant.defaultValue = {
+      value: defaultVariant,
+    }
+  }
+
   const entries = React.useMemo(
     () =>
       Object.entries(info.props)


### PR DESCRIPTION
## 📝 Description

Currently, default value for `size` and `variant` is always displayed as `-` in the props table.
I added a check that sets it to `defaultProps.size` and  `defaultProps.variant` from the theme where possible.

## 💣 Is this a breaking change (Yes/No):

No

Example before:
<img width="745" alt="Screenshot 2021-01-12 at 22 09 30" src="https://user-images.githubusercontent.com/14360171/104374946-e9852c00-5522-11eb-839d-3e2d3d2e4752.png">

After:
<img width="759" alt="Screenshot 2021-01-12 at 22 05 29" src="https://user-images.githubusercontent.com/14360171/104374959-ec801c80-5522-11eb-9064-83d543cb11e8.png">
