### PR TITLE
feat(docs): display "not implemented" note for size and variant where appropriate

### DIFF
--- a/.changeset/friendly-parents-guess.md
+++ b/.changeset/friendly-parents-guess.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Components that don't implement `size` or `variant` in the default theme will
+show note regarding that in their props table.

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import Link from "next/link"
 import * as ComponentProps from "@chakra-ui/props-docs"
 import MDXComponents from "./mdx-components"
 import { theme } from "@chakra-ui/react"
@@ -41,24 +42,51 @@ const PropsTable = ({
   const variantValues =
     themeComponent?.variants && Object.keys(themeComponent.variants)
 
+  const extendThemeLink = (
+    <Link
+      href="/docs/theming/customize-theme#customizing-component-styles"
+      passHref
+    >
+      <MDXComponents.a>extend the theme</MDXComponents.a>
+    </Link>
+  )
+
   /**
    * If component has size prop, override the rendered value
    * for `size` prop with the component's size values formatted as TS type.
    */
-  if (info.props.size && sizeValues) {
-    info.props.size.type.name = sizeValues
-      .map((size) => `"${size}"`)
-      .join(" | ")
+  if (info.props.size) {
+    if (sizeValues) {
+      info.props.size.type.name = sizeValues
+        .map((size) => `"${size}"`)
+        .join(" | ")
+    } else {
+      info.props.size.description = (
+        <>
+          Sizes for {of} are not implemented in the default theme, but you can{" "}
+          {extendThemeLink} to implement them.
+        </>
+      )
+    }
   }
 
   /**
    * If component has variant prop, override the rendered value
    * for `variant` prop with the component's variant values formatted as TS type.
    */
-  if (info.props.variant && variantValues) {
-    info.props.variant.type.name = variantValues
-      .map((variant) => `"${variant}"`)
-      .join(" | ")
+  if (info.props.variant) {
+    if (variantValues) {
+      info.props.variant.type.name = variantValues
+        .map((variant) => `"${variant}"`)
+        .join(" | ")
+    } else {
+      info.props.variant.description = (
+        <>
+          Variants for {of} are not implemented in the default theme, but you
+          can {extendThemeLink} to implement them.
+        </>
+      )
+    }
   }
 
   const entries = React.useMemo(


### PR DESCRIPTION
## 📝 Description

Currently, the `size` and `variant` props are listed for all components, although it does not do anything with chakra's default theme in many of them.
I added the description that will warn you where component does not implement these.

Example before:
<img width="751" alt="Screenshot 2021-01-13 at 00 11 49" src="https://user-images.githubusercontent.com/14360171/104385683-f5c5b500-5533-11eb-90fb-589e972f6b39.png">

After:
<img width="737" alt="Screenshot 2021-01-14 at 19 11 59" src="https://user-images.githubusercontent.com/14360171/104631371-71db0c80-569c-11eb-9e3c-ccf30958b3f5.png">


The description can/should be improved upon time. Ideally with a link to example on how to do that for that specific component.

## 💣 Is this a breaking change (Yes/No):

No
