### PR TITLE
docs: fix typo in color mode instructions for Create React App

### DIFF
--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -91,7 +91,7 @@ export default App
 
 #### For Create React App
 
-For Next.js, you need to add the script the the `index.js` file.
+For Create React App, you need to add the script the the `index.js` file.
 
 ```jsx live=false ln={10}
 // index.js


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I just changed the name "Next.js" to "Create React App" in the instructions for setting color mode in CRA

## ⛳️ Current behavior (updates)

It says "Next.js" in the instructions for CRA

## 🚀 New behavior

The name "Next.js" was changed to "Create React App"

## 💣 Is this a breaking change (Yes/No):

No