### PR TITLE
chore(docs): remove redudant props in InputGroup example

### DIFF
--- a/.changeset/hip-ears-float.md
+++ b/.changeset/hip-ears-float.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Removed redudant `borderRadius` related props from `InputGroup` example.

--- a/website/pages/docs/form/input.mdx
+++ b/website/pages/docs/form/input.mdx
@@ -72,13 +72,13 @@ component. Chakra UI exports `InputGroup`, `InputLeftAddon`, and
 <Stack spacing={4}>
   <InputGroup>
     <InputLeftAddon children="+234" />
-    <Input type="tel" borderLeftRadius="0" placeholder="phone number" />
+    <Input type="tel" placeholder="phone number" />
   </InputGroup>
 
   {/* If you add the size prop to `InputGroup`, it'll pass it to all its children. */}
   <InputGroup size="sm">
     <InputLeftAddon children="https://" />
-    <Input borderRadius="0" placeholder="mysite" />
+    <Input placeholder="mysite" />
     <InputRightAddon children=".com" />
   </InputGroup>
 </Stack>


### PR DESCRIPTION
## 📝 Description

Removed redudant `borderRadius` related props from `InputGroup` example.

## 💣 Is this a breaking change (Yes/No):

No