### PR TITLE
fix(slide): iOS Safari overlays DrawerFooter

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prestart": "yarn && yarn bootstrap",
     "boot": "yarn prestart && yarn build",
     "start": "yarn build && yarn storybook",
-    "start:all": "yarn build && concurrently \"yarn docs develop\"  \"yarn storybook\" ",
+    "start:all": "yarn build && concurrently \"yarn docs dev\"  \"yarn storybook\" ",
     "prebuild": "yarn pkg babel-plugin build",
     "build": "lerna run build --ignore @chakra-ui/test-utils --no-private --stream",
     "test": "lerna run test --no-private --stream",

--- a/packages/transition/src/slide.tsx
+++ b/packages/transition/src/slide.tsx
@@ -28,9 +28,9 @@ const directions = {
     motion: { x: "-100%" },
     baseStyle: {
       width: "100%",
-      height: "100vh",
       left: 0,
       top: 0,
+      bottom: 0,
     },
   },
   right: {
@@ -39,7 +39,7 @@ const directions = {
       width: "100%",
       right: 0,
       top: 0,
-      height: "100vh",
+      bottom: 0,
     },
   },
 }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2468

## 📝 Description

The Drawer currently uses a height of `100vh` (introduced in e7cbdeb762c38767268cf5fd3fafb649e0f6691e) which is the whole viewport. Unfortunately, depending on the scrolling direction, Safari overlays the page content with a bottom bar (to share the URL or switch tabs). So, if a user scrolls up and opens a Drawer, parts of it might be hidden by the bottom bar.

The drawer is already `position: fixed`. It is therefore easy to replace the explicit hight by an implicit one by setting `top: 0; bottom: 0` as this relates to the currently available space (i.e. takes the bottom bar into account). (There' no need to re-calculate in case the bar appears / disappears, as there's a scroll-lock in place when the Drawer opens and the bar can't change.)

## ⛳️ Current behavior (updates)

| without Safaris UI | with Safaris UI |
| --- | --- |
| ![with-1](https://user-images.githubusercontent.com/236774/104503556-81e1e600-55e1-11eb-9462-2c6422818339.jpeg) | ![without-1](https://user-images.githubusercontent.com/236774/104503616-9625e300-55e1-11eb-898a-7ab3b871fdd5.jpeg) |

## 🚀 New behavior

| without Safaris UI | with Safaris UI |
| --- | --- |
| ![with-2](https://user-images.githubusercontent.com/236774/104503684-ab9b0d00-55e1-11eb-807d-c14574043123.jpeg) | ![without-2](https://user-images.githubusercontent.com/236774/104503726-b786cf00-55e1-11eb-8aac-7fa6210185ea.jpeg) |

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I like this project a lot. But it was kinda time consuming to find this bug as code is often spread (which makes it hard to trace the source of a property) and code is distributed over different packages (and they are not compiled on changes, so code might be stale – but recompiling everything takes some time.) It would be great to have a general watcher service that recompiles a package on changes.
