### PR TITLE
feat: sr-only prop

### DIFF
--- a/.changeset/loud-teachers-shop.md
+++ b/.changeset/loud-teachers-shop.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Move `srOnly` prop to styled system props. This will deprecate the need for the
+visually hidden package. Less is more!
+
+```jsx
+// If `true`, hide an element visually without hiding it from screen readers.
+<Box srOnly>Visually hidden</Box>
+
+// If `focusable`, the sr-only styles will be undone, making the element visible to sighted users as well as screen readers.
+<Box srOnly _active={{ srOnly: "focusable" }}>Visually hidden but shown on focus</Box>
+```

--- a/packages/styled-system/src/config/others.ts
+++ b/packages/styled-system/src/config/others.ts
@@ -8,6 +8,29 @@ const floatTransform: PropConfig["transform"] = (value, _, props = {}) => {
   return getIsRtl(props) ? map[value] : value
 }
 
+const srOnly = {
+  border: "0px",
+  clip: "rect(0, 0, 0, 0)",
+  width: "1px",
+  height: "1px",
+  margin: "-1px",
+  padding: "0px",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+  position: "absolute",
+}
+
+const srFocusable = {
+  position: "static",
+  width: "auto",
+  height: "auto",
+  clip: "auto",
+  padding: "0",
+  margin: "0",
+  overflow: "visible",
+  whiteSpace: "normal",
+}
+
 const config: Config = {
   animation: true,
   appearance: true,
@@ -24,6 +47,14 @@ const config: Config = {
   },
   willChange: true,
   filter: true,
+  srOnly: {
+    property: "&",
+    transform(value) {
+      if (value === true) return srOnly
+      if (value === "focusable") return srFocusable
+      return {}
+    },
+  },
 }
 
 export interface OtherProps {
@@ -75,6 +106,13 @@ export interface OtherProps {
    * The CSS `filter` property
    */
   filter?: ResponsiveValue<CSS.Property.Filter>
+  /**
+   * If `true`, hide an element visually without hiding it from screen readers.
+   *
+   * If `focusable`, the sr-only styles will be undone, making the element visible
+   * to sighted users as well as screen readers.
+   */
+  srOnly?: true | "focusable"
 }
 
 export const others = system(config)

--- a/packages/styled-system/tests/sr-only.test.tsx
+++ b/packages/styled-system/tests/sr-only.test.tsx
@@ -1,0 +1,35 @@
+import { css } from "../src"
+import { createTheme } from "./theme"
+
+test("should process sr-only", () => {
+  const result = css({
+    srOnly: true,
+    _active: {
+      srOnly: "focusable",
+    },
+  })(createTheme("ltr"))
+
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "&:active, &[data-active]": Object {
+        "clip": "auto",
+        "height": "auto",
+        "margin": "0",
+        "overflow": "visible",
+        "padding": "0",
+        "position": "static",
+        "whiteSpace": "normal",
+        "width": "auto",
+      },
+      "border": "0px",
+      "clip": "rect(0, 0, 0, 0)",
+      "height": "1px",
+      "margin": "-1px",
+      "overflow": "hidden",
+      "padding": "0px",
+      "position": "absolute",
+      "whiteSpace": "nowrap",
+      "width": "1px",
+    }
+  `)
+})


### PR DESCRIPTION
Move `srOnly` prop to styled system props. This will deprecate the need for the `visually-hidden` package. Less is more!

```jsx
// If `true`, hide an element visually without hiding it from screen readers.
<Box srOnly>Visually hidden</Box>

// If `focusable`, the sr-only styles will be undone, making the element visible to sighted users as well as screen readers.
<Box srOnly _active={{ srOnly: "focusable" }}>Visually hidden but shown on focus</Box>
```