### PR TITLE
fix(popover): update popper position only while open

### DIFF
--- a/.changeset/slow-comics-sing.md
+++ b/.changeset/slow-comics-sing.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popover": patch
+---
+
+`Popover` now won't update its popper position while it's closed.

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -154,6 +154,7 @@ export function usePopover(props: UsePopoverProps = {}) {
   const arrowColor = useToken("colors", shadowColor, arrowShadowColor)
 
   const popper = usePopper({
+    enabled: isOpen,
     placement: placementProp,
     gutter,
     arrowSize,


### PR DESCRIPTION
## 📝 Description

The same fix as #3022, but for `Popover`.

## 💣 Is this a breaking change (Yes/No):

No