### PR TITLE
fix(use-event-listener): restore listener fn

### DIFF
--- a/.changeset/orange-boats-pretend.md
+++ b/.changeset/orange-boats-pretend.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+Resolved an issue where event handlers for certain components were removed after
+the first event occurred.

--- a/packages/hooks/src/use-event-listener.ts
+++ b/packages/hooks/src/use-event-listener.ts
@@ -20,9 +20,14 @@ export function useEventListener<K extends keyof DocumentEventMap>(
 
   React.useEffect(() => {
     if (!env) return undefined
-    env.addEventListener(event, fn, options)
+
+    const listener = (event: any) => {
+      fn(event)
+    }
+
+    env.addEventListener(event, listener, options)
     return () => {
-      env.removeEventListener(event, fn, options)
+      env.removeEventListener(event, listener, options)
     }
   }, [event, env, options, fn])
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3040 <!-- Github issue # here -->

## 📝 Description

A recent change to `useEventListener` removed the separate `listener` function that was attached to `env` as a listener and directly attached the passed `handler`. This change resulted in listeners being removed entirely, so that something like `Slider` would no longer have a listener after the first event.

## 🚀 New behavior

Re-added the separate `listener` function that results in the `handler` remaining attached after events.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

See https://github.com/chakra-ui/chakra-ui/commit/27c8a6ce627aa18e52998b68ede6661e4c117be7#diff-28915326605476712d3e02282e5a571ea49369d7bd59eb52f2ee104cf9077bfcL24-L31 for the previous change that resulted in this issue.