### PR TITLE
docs(theme-links): add links to default theme implementation

### DIFF
--- a/.changeset/giant-rats-enjoy.md
+++ b/.changeset/giant-rats-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Add links to the default theme implementation on all themable component pages.

--- a/website/pages/docs/components/accordion.mdx
+++ b/website/pages/docs/components/accordion.mdx
@@ -11,6 +11,7 @@ Accordions display a list of high-level options that can expand/collapse to
 reveal more information.
 
 <ComponentLinks
+  theme={{ componentName: "accordion" }}
   github={{ package: "accordion" }}
   npm={{ package: "@chakra-ui/accordion" }}
 />

--- a/website/pages/docs/components/breadcrumb.mdx
+++ b/website/pages/docs/components/breadcrumb.mdx
@@ -13,6 +13,7 @@ previous page levels of a website, especially if that website has many pages or
 products.
 
 <ComponentLinks
+  theme={{ componentName: "breadcrumb" }}
   github={{ package: "breadcrumb" }}
   npm={{ package: "@chakra-ui/breadcrumb" }}
 />
@@ -41,8 +42,8 @@ import {
 ## Usage
 
 Add `isCurrentPage` prop to the `BreadcrumbItem` that matches the current path.
-When this prop is present, the `BreadcrumbLink` renders
-a `span` with `aria-current` set to `page` instead of an anchor element.
+When this prop is present, the `BreadcrumbLink` renders a `span` with
+`aria-current` set to `page` instead of an anchor element.
 
 ```jsx
 <Breadcrumb>

--- a/website/pages/docs/components/close-button.mdx
+++ b/website/pages/docs/components/close-button.mdx
@@ -14,6 +14,7 @@ close functionality in feedback and overlay components like
 [Drawers](/docs/overlay/drawer) and [Modals](/docs/overlay/modal).
 
 <ComponentLinks
+  theme={{ componentName: "close-button" }}
   github={{ package: "close-button" }}
   npm={{ package: "@chakra-ui/close-button" }}
 />

--- a/website/pages/docs/components/icon.mdx
+++ b/website/pages/docs/components/icon.mdx
@@ -14,6 +14,7 @@ Chakra provides multiple ways to use icons in your project:
 > clickable icon, use the [IconButton](/docs/form/icon-button) instead.
 
 <ComponentLinks
+  theme={{ componentName: "icon" }}
   github={{ package: "icon" }}
   npm={{ package: "@chakra-ui/icon" }}
 />

--- a/website/pages/docs/components/link.mdx
+++ b/website/pages/docs/components/link.mdx
@@ -9,6 +9,7 @@ Links are accessible elements used primarily for navigation. This component is
 styled to resemble a hyperlink and semantically renders an `<a>`.
 
 <ComponentLinks
+  theme={{ componentName: "link" }}
   github={{ package: "layout" }}
   npm={{ package: "@chakra-ui/layout" }}
 />

--- a/website/pages/docs/components/tabs.mdx
+++ b/website/pages/docs/components/tabs.mdx
@@ -13,6 +13,7 @@ attributes described in the
 [WAI-ARIA Tabs Design Pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel).
 
 <ComponentLinks
+  theme={{ componentName: "tabs" }}
   github={{ package: "tabs" }}
   npm={{ package: "@chakra-ui/tabs" }}
 />
@@ -493,17 +494,17 @@ function Example() {
 
 ### ARIA roles
 
-| Component | Aria               | Usage                                                                       |
-| --------- | ------------------ | --------------------------------------------------------------------------- |
-| Tab       | `role="tab"`       | Indicates that it is a tab                                                  |
+| Component | Aria               | Usage                                                                      |
+| --------- | ------------------ | -------------------------------------------------------------------------- |
+| Tab       | `role="tab"`       | Indicates that it is a tab                                                 |
 |           | `aria-selected`    | Set to `true` a tab is selected and all other Tabs have it set to `false`  |
-|           | `aria-controls`    | Set to the `id` of its associated `TabPanel`                                |
-|           |                    |                                                                             |
-| TabList   | `id`               | The `id` of the `TabPanel` that's referenced by its associated `Tab`        |
+|           | `aria-controls`    | Set to the `id` of its associated `TabPanel`                               |
+|           |                    |                                                                            |
+| TabList   | `id`               | The `id` of the `TabPanel` that's referenced by its associated `Tab`       |
 |           | `aria-orientation` | Set to vertical or horizontal based on the value of the `orientation` prop |
-|           | `role="tablist"`   | Indicates that it is a tablist                                              |
-|           |                    |                                                                             |
-| TabPanel  | `role="tabpanel"`  | Indicates that it is a tabpanel                                   |
+|           | `role="tablist"`   | Indicates that it is a tablist                                             |
+|           |                    |                                                                            |
+| TabPanel  | `role="tabpanel"`  | Indicates that it is a tabpanel                                            |
 |           | `aria-labelledby`  | Set to the `id` of the `Tab` that labels the `TabPanel`                    |
 
 ## Props

--- a/website/pages/docs/components/transitions.mdx
+++ b/website/pages/docs/components/transitions.mdx
@@ -11,6 +11,7 @@ Chakra exports four components `Fade`, `ScaleFade`, `Slide`, and `SlideFade` to
 provide simple transitions.
 
 <ComponentLinks
+  theme={{ componentName: "transition" }}
   github={{ package: "transition" }}
   npm={{ package: "@chakra-ui/transition" }}
 />

--- a/website/pages/docs/data-display/avatar.mdx
+++ b/website/pages/docs/data-display/avatar.mdx
@@ -11,6 +11,7 @@ The `Avatar` component is used to represent a user, and displays the profile
 picture, initials or fallback icon.
 
 <ComponentLinks
+  theme={{ componentName: "avatar" }}
   github={{ package: "avatar" }}
   npm={{ package: "@chakra-ui/avatar" }}
 />

--- a/website/pages/docs/data-display/badge.mdx
+++ b/website/pages/docs/data-display/badge.mdx
@@ -9,6 +9,7 @@ description:
 Badges are used to highlight an item's status for quick recognition.
 
 <ComponentLinks
+  theme={{ componentName: "badge" }}
   github={{ package: "layout" }}
   npm={{ package: "@chakra-ui/layout" }}
 />

--- a/website/pages/docs/data-display/code.mdx
+++ b/website/pages/docs/data-display/code.mdx
@@ -12,6 +12,7 @@ description:
 code.
 
 <ComponentLinks
+  theme={{ componentName: "code" }}
   github={{ package: "layout" }}
   npm={{ package: "@chakra-ui/layout" }}
 />

--- a/website/pages/docs/data-display/divider.mdx
+++ b/website/pages/docs/data-display/divider.mdx
@@ -8,6 +8,7 @@ description: Dividers are used to visually separate content in a list or group.
 Dividers are used to visually separate content in a list or group.
 
 <ComponentLinks
+  theme={{ componentName: "divider" }}
   github={{ package: "divider" }}
   npm={{ package: "@chakra-ui/layout" }}
 />

--- a/website/pages/docs/data-display/kbd.mdx
+++ b/website/pages/docs/data-display/kbd.mdx
@@ -11,6 +11,7 @@ The action itself should be further explained in accompanying content. It
 renders a `<kbd>` element.
 
 <ComponentLinks
+  theme={{ componentName: "kbd" }}
   github={{ package: "layout" }}
   npm={{ package: "@chakra-ui/input" }}
 />

--- a/website/pages/docs/data-display/list.mdx
+++ b/website/pages/docs/data-display/list.mdx
@@ -10,6 +10,7 @@ description:
 default.
 
 <ComponentLinks
+  theme={{ componentName: "list" }}
   github={{ package: "layout" }}
   npm={{ package: "@chakra-ui/layout" }}
 />

--- a/website/pages/docs/data-display/stat.mdx
+++ b/website/pages/docs/data-display/stat.mdx
@@ -9,6 +9,7 @@ description:
 As the name implies, the `Stat` component is used to display some statistics.
 
 <ComponentLinks
+  theme={{ componentName: "stat" }}
   github={{ package: "stat" }}
   npm={{ package: "@chakra-ui/stat" }}
 />

--- a/website/pages/docs/data-display/table.mdx
+++ b/website/pages/docs/data-display/table.mdx
@@ -11,6 +11,7 @@ Tables are used to organize and display data efficiently. It renders a `<table>`
 element by default.
 
 <ComponentLinks
+  theme={{ componentName: "table" }}
   github={{ package: "table" }}
   npm={{ package: "@chakra-ui/table" }}
 />

--- a/website/pages/docs/data-display/tag.mdx
+++ b/website/pages/docs/data-display/tag.mdx
@@ -9,6 +9,7 @@ description: Tag component is used for items that need to be labeled
 organized using keywords that describe them.
 
 <ComponentLinks
+  theme={{ componentName: "tag" }}
   github={{ package: "tag" }}
   npm={{ package: "@chakra-ui/tag" }}
 />

--- a/website/pages/docs/feedback/alert.mdx
+++ b/website/pages/docs/feedback/alert.mdx
@@ -9,6 +9,7 @@ description:
 Alerts are used to communicate a state that affects a system, feature or page.
 
 <ComponentLinks
+  theme={{ componentName: "alert" }}
   github={{ package: "alert" }}
   npm={{ package: "@chakra-ui/alert" }}
 />

--- a/website/pages/docs/feedback/circular-progress.mdx
+++ b/website/pages/docs/feedback/circular-progress.mdx
@@ -11,6 +11,7 @@ The CircularProgress component is used to indicate the progress for determinate
 and indeterminate processes.
 
 <ComponentLinks
+  theme={{ componentName: "progress" }}
   github={{ package: "progress" }}
   npm={{ package: "@chakra-ui/progress" }}
 />

--- a/website/pages/docs/feedback/progress.mdx
+++ b/website/pages/docs/feedback/progress.mdx
@@ -11,6 +11,7 @@ description:
 time or consists of several steps.
 
 <ComponentLinks
+  theme={{ componentName: "progress" }}
   github={{ package: "progress" }}
   npm={{ package: "@chakra-ui/progress" }}
 />

--- a/website/pages/docs/feedback/skeleton.mdx
+++ b/website/pages/docs/feedback/skeleton.mdx
@@ -7,6 +7,7 @@ package: "@chakra-ui/skeleton"
 `Skeleton` is used to display the loading state of some components.
 
 <ComponentLinks
+  theme={{ componentName: "skeleton" }}
   github={{ package: "skeleton" }}
   npm={{ package: "@chakra-ui/skeleton" }}
 />

--- a/website/pages/docs/feedback/spinner.mdx
+++ b/website/pages/docs/feedback/spinner.mdx
@@ -11,6 +11,7 @@ Spinners provide a visual cue that an action is either processing, awaiting a
 course of change or a result.
 
 <ComponentLinks
+  theme={{ componentName: "spinner" }}
   github={{ package: "spinner" }}
   npm={{ package: "@chakra-ui/spinner" }}
 />

--- a/website/pages/docs/form/button.mdx
+++ b/website/pages/docs/form/button.mdx
@@ -11,6 +11,7 @@ The Button component is used to trigger an action or event, such as submitting a
 form, opening a dialog, canceling an action, or performing a delete operation.
 
 <ComponentLinks
+  theme={{ componentName: "button" }}
   github={{ package: "button" }}
   npm={{ package: "@chakra-ui/button" }}
 />

--- a/website/pages/docs/form/checkbox.mdx
+++ b/website/pages/docs/form/checkbox.mdx
@@ -11,6 +11,7 @@ The `Checkbox` component is used in forms when a user needs to select multiple
 values from several options.
 
 <ComponentLinks
+  theme={{ componentName: "checkbox" }}
   github={{ package: "checkbox" }}
   npm={{ package: "@chakra-ui/checkbox" }}
 />

--- a/website/pages/docs/form/editable.mdx
+++ b/website/pages/docs/form/editable.mdx
@@ -13,6 +13,7 @@ text but transforms into a text input field when the user clicks on or focuses
 it.
 
 <ComponentLinks
+  theme={{ componentName: "editable" }}
   github={{ package: "editable" }}
   npm={{ package: "@chakra-ui/editable" }}
 />

--- a/website/pages/docs/form/form-control.mdx
+++ b/website/pages/docs/form/form-control.mdx
@@ -13,6 +13,7 @@ It follows the [WAI specifications](https://www.w3.org/WAI/tutorials/forms/) for
 forms.
 
 <ComponentLinks
+  theme={{ componentName: "form" }}
   github={{ package: "form-control" }}
   npm={{ package: "@chakra-ui/form-control" }}
 />

--- a/website/pages/docs/form/input.mdx
+++ b/website/pages/docs/form/input.mdx
@@ -10,6 +10,7 @@ The `Input` component is a component that is used to get user input in a text
 field.
 
 <ComponentLinks
+  theme={{ componentName: "input" }}
   github={{ package: "input" }}
   npm={{ package: "@chakra-ui/input" }}
 />

--- a/website/pages/docs/form/number-input.mdx
+++ b/website/pages/docs/form/number-input.mdx
@@ -11,6 +11,7 @@ The `NumberInput` component is similar to the [Input](/docs/form/input)
 component, but it has controls for incrementing or decrementing numeric values.
 
 <ComponentLinks
+  theme={{ componentName: "number-input" }}
   github={{ package: "number-input" }}
   npm={{ package: "@chakra-ui/number-input" }}
 />

--- a/website/pages/docs/form/pin-input.mdx
+++ b/website/pages/docs/form/pin-input.mdx
@@ -13,6 +13,7 @@ but it is optimized for entering sequences of digits.
 The most common application is for entering OTP or security codes.
 
 <ComponentLinks
+  theme={{ componentName: "pin-input" }}
   github={{ package: "pin-input" }}
   npm={{ package: "@chakra-ui/pin-input" }}
 />

--- a/website/pages/docs/form/radio.mdx
+++ b/website/pages/docs/form/radio.mdx
@@ -9,6 +9,7 @@ description:
 Radios are used when only one choice may be selected in a series of options.
 
 <ComponentLinks
+  theme={{ componentName: "radio" }}
   github={{ package: "radio" }}
   npm={{ package: "@chakra-ui/radio" }}
 />

--- a/website/pages/docs/form/select.mdx
+++ b/website/pages/docs/form/select.mdx
@@ -11,6 +11,12 @@ description:
 options. Ideally, it should be used when there are more than 5 options,
 otherwise you might consider using a radio group instead.
 
+<ComponentLinks
+  theme={{ componentName: "select" }}
+  github={{ package: "select" }}
+  npm={{ package: "@chakra-ui/select" }}
+/>
+
 <carbon-ad></carbon-ad>
 
 ## Import

--- a/website/pages/docs/form/slider.mdx
+++ b/website/pages/docs/form/slider.mdx
@@ -7,6 +7,7 @@ image: "components/slider.svg"
 The `Slider` is used to allow users to make selections from a range of values.
 
 <ComponentLinks
+  theme={{ componentName: "slider" }}
   github={{ package: "slider" }}
   npm={{ package: "@chakra-ui/slider" }}
 />

--- a/website/pages/docs/form/switch.mdx
+++ b/website/pages/docs/form/switch.mdx
@@ -9,6 +9,7 @@ The `Switch` component is used as an alternative for the
 disabled states.
 
 <ComponentLinks
+  theme={{ componentName: "switch" }}
   github={{ package: "switch" }}
   npm={{ package: "@chakra-ui/switch" }}
 />

--- a/website/pages/docs/form/textarea.mdx
+++ b/website/pages/docs/form/textarea.mdx
@@ -7,6 +7,7 @@ image: "components/textarea.svg"
 The `Textarea` component allows you to easily create multi-line text inputs.
 
 <ComponentLinks
+  theme={{ componentName: "textarea" }}
   github={{ package: "textarea" }}
   npm={{ package: "@chakra-ui/textarea" }}
 />

--- a/website/pages/docs/overlay/drawer.mdx
+++ b/website/pages/docs/overlay/drawer.mdx
@@ -13,6 +13,7 @@ It can be useful when you need users to complete a task or view some details
 without leaving the current page.
 
 <ComponentLinks
+  theme={{ componentName: "drawer" }}
   github={{ package: "drawer" }}
   npm={{ package: "@chakra-ui/drawer" }}
 />

--- a/website/pages/docs/overlay/menu.mdx
+++ b/website/pages/docs/overlay/menu.mdx
@@ -11,6 +11,7 @@ An accessible dropdown menu for the common dropdown menu button design pattern.
 `Menu` uses roving `tabIndex` for focus management.
 
 <ComponentLinks
+  theme={{ componentName: "menu" }}
   github={{ package: "menu" }}
   npm={{ package: "@chakra-ui/menu" }}
 />
@@ -85,20 +86,19 @@ To access the internal state of the `Menu`, use a function as `children`
 </Menu>
 ```
 
-### Customising the button 
+### Customising the button
 
-The default `MenuButton` can be styled using the usual styled-system props, but it
-starts off plainly styled.
+The default `MenuButton` can be styled using the usual styled-system props, but
+it starts off plainly styled.
 
-Using the `as` prop of the `MenuButton`, you can render a custom component instead
-of the default `MenuButton`. For instance, you can use Chakra's `Button` component,
-or your own custom component.
+Using the `as` prop of the `MenuButton`, you can render a custom component
+instead of the default `MenuButton`. For instance, you can use Chakra's `Button`
+component, or your own custom component.
 
-> Custom components must take a `ref` prop which is assigned to the React component
-that triggers the menu opening. This is so that the `MenuList` popover can be
-positioned correctly. Without this, the `MenuList` will render in an undefined
-position.
-
+> Custom components must take a `ref` prop which is assigned to the React
+> component that triggers the menu opening. This is so that the `MenuList`
+> popover can be positioned correctly. Without this, the `MenuList` will render
+> in an undefined position.
 
 ### Letter Navigation
 

--- a/website/pages/docs/overlay/modal.mdx
+++ b/website/pages/docs/overlay/modal.mdx
@@ -12,6 +12,7 @@ window. Content behind a modal dialog is **inert**, meaning that users cannot
 interact with it.
 
 <ComponentLinks
+  theme={{ componentName: "modal" }}
   github={{ package: "modal" }}
   npm={{ package: "@chakra-ui/modal" }}
 />

--- a/website/pages/docs/overlay/popover.mdx
+++ b/website/pages/docs/overlay/popover.mdx
@@ -10,6 +10,7 @@ display contextual information to the user, and should be paired with a
 clickable trigger element.
 
 <ComponentLinks
+  theme={{ componentName: "popover" }}
   github={{ package: "popover" }}
   npm={{ package: "@chakra-ui/popover" }}
 />

--- a/website/pages/docs/overlay/tooltip.mdx
+++ b/website/pages/docs/overlay/tooltip.mdx
@@ -12,6 +12,7 @@ with an element. Tooltips are usually initiated in one of two ways: through a
 mouse-hover gesture or through a keyboard-hover gesture.
 
 <ComponentLinks
+  theme={{ componentName: "tooltip" }}
   github={{ package: "tooltip" }}
   npm={{ package: "@chakra-ui/tooltip" }}
 />

--- a/website/pages/docs/typography/heading.mdx
+++ b/website/pages/docs/typography/heading.mdx
@@ -13,6 +13,7 @@ Headings are used for rendering headlines.
 styles as well. It renders an `<h2>` tag by default.
 
 <ComponentLinks
+  theme={{ componentName: "heading" }}
   github={{ package: "layout" }}
   npm={{ package: "@chakra-ui/layout" }}
 />

--- a/website/src/components/component-links.tsx
+++ b/website/src/components/component-links.tsx
@@ -9,7 +9,8 @@ import {
   LinkProps,
   WrapItem,
 } from "@chakra-ui/react"
-import { FaNpm, FaGithub, FaWrench } from "react-icons/fa"
+import { FaNpm, FaGithub } from "react-icons/fa"
+import { WiStars } from "react-icons/wi"
 import StorybookIcon from "./storybook-icon"
 
 type ComponentLinkProps = LinkProps & {
@@ -106,11 +107,11 @@ function ComponentLinks(props: ComponentLinksProps) {
     <WrapItem>
       <ComponentLink
         url={`${githubRepoUrl}/tree/master/packages/theme/src/components/${theme.componentName}.ts`}
-        icon={FaWrench}
-        iconSize="1rem"
+        icon={WiStars}
+        iconSize="1.25rem"
         iconColor="blue.500"
       >
-        View default theme
+        View theme source
       </ComponentLink>
     </WrapItem>
   )
@@ -118,9 +119,9 @@ function ComponentLinks(props: ComponentLinksProps) {
   return (
     <Wrap mt="2rem" spacing="4" {...rest}>
       {githubLink}
+      {themeComponentLink}
       {npmLink}
       {storybookLink}
-      {themeComponentLink}
     </Wrap>
   )
 }

--- a/website/src/components/component-links.tsx
+++ b/website/src/components/component-links.tsx
@@ -10,7 +10,6 @@ import {
   WrapItem,
 } from "@chakra-ui/react"
 import { FaNpm, FaGithub } from "react-icons/fa"
-import { WiStars } from "react-icons/wi"
 import StorybookIcon from "./storybook-icon"
 
 type ComponentLinkProps = LinkProps & {
@@ -107,9 +106,8 @@ function ComponentLinks(props: ComponentLinksProps) {
     <WrapItem>
       <ComponentLink
         url={`${githubRepoUrl}/tree/master/packages/theme/src/components/${theme.componentName}.ts`}
-        icon={WiStars}
-        iconSize="1.25rem"
-        iconColor="blue.500"
+        icon={FaGithub}
+        iconSize="1rem"
       >
         View theme source
       </ComponentLink>

--- a/website/src/components/component-links.tsx
+++ b/website/src/components/component-links.tsx
@@ -107,6 +107,7 @@ function ComponentLinks(props: ComponentLinksProps) {
       <ComponentLink
         url={`${githubRepoUrl}/tree/master/packages/theme/src/components/${theme.componentName}.ts`}
         icon={FaGithub}
+        iconColor={useColorModeValue("gray.600", "inherit")}
         iconSize="1rem"
       >
         View theme source

--- a/website/src/components/component-links.tsx
+++ b/website/src/components/component-links.tsx
@@ -9,7 +9,7 @@ import {
   LinkProps,
   WrapItem,
 } from "@chakra-ui/react"
-import { FaNpm, FaGithub } from "react-icons/fa"
+import { FaNpm, FaGithub, FaWrench } from "react-icons/fa"
 import StorybookIcon from "./storybook-icon"
 
 type ComponentLinkProps = LinkProps & {
@@ -50,19 +50,22 @@ function ComponentLink(props: ComponentLinkProps) {
 }
 
 export type ComponentLinksProps = {
+  theme?: { componentName: string }
   github?: { url?: string; package?: string }
   npm?: { package: string }
   storybook?: { url: string }
 }
 function ComponentLinks(props: ComponentLinksProps) {
-  const { github, npm, storybook, ...rest } = props
+  const { theme, github, npm, storybook, ...rest } = props
+
+  const githubRepoUrl = "https://github.com/chakra-ui/chakra-ui"
 
   const githubLink = (github?.url || github?.package) && (
     <WrapItem>
       <ComponentLink
         url={
           github.url ||
-          `https://github.com/chakra-ui/chakra-ui/tree/master/packages/${github.package}`
+          `${githubRepoUrl}/tree/master/packages/${github.package}`
         }
         icon={FaGithub}
         iconColor={useColorModeValue("gray.600", "inherit")}
@@ -99,11 +102,25 @@ function ComponentLinks(props: ComponentLinksProps) {
     </WrapItem>
   )
 
+  const themeComponentLink = theme && (
+    <WrapItem>
+      <ComponentLink
+        url={`${githubRepoUrl}/tree/master/packages/theme/src/components/${theme.componentName}.ts`}
+        icon={FaWrench}
+        iconSize="1rem"
+        iconColor="blue.500"
+      >
+        View default theme
+      </ComponentLink>
+    </WrapItem>
+  )
+
   return (
     <Wrap mt="2rem" spacing="4" {...rest}>
       {githubLink}
       {npmLink}
       {storybookLink}
+      {themeComponentLink}
     </Wrap>
   )
 }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Currently we have to manually search for the default theme in the chakra source code.
This PR adds a link to the default theme implementation on all themable component pages.
