### PR TITLE
docs(progress): correct description about thickness prop

### DIFF
--- a/packages/progress/src/circular-progress.tsx
+++ b/packages/progress/src/circular-progress.tsx
@@ -51,7 +51,7 @@ interface CircularProgressOptions {
    */
   min?: number
   /**
-   * The thickness of progress indicator as a ratio of `size`. Must be between `0` and `1`
+   * This defines the stroke width of the svg circle.
    */
   thickness?: StringOrNumber
   /**

--- a/website/pages/docs/feedback/circular-progress.mdx
+++ b/website/pages/docs/feedback/circular-progress.mdx
@@ -47,7 +47,7 @@ You can add `size` prop to the progress bar to add a custom size.
 
 You can add the `thickness` prop to update the thickness of the progress ring.
 
-> The thickness has to be a ratio of the size. Value should be between 0 and 1.
+> This defines the stroke width of the svg circle.
 
 ```jsx
 <CircularProgress value={59} size="100px" thickness="4px" />


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
I noticed that the description for the `thickness` prop on CircularProgress is erroneous and may cause confusion. It says that it sets things by ratio, expecting a value between 0 and 1, but in reality all it's doing is setting stroke width by pixel.

## ⛳️ Current behavior (updates)
n/a

## 🚀 New behavior
n/a

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

