### PR TITLE
docs(button): add ButtonGroup props table

### DIFF
--- a/.changeset/chilly-emus-mate.md
+++ b/.changeset/chilly-emus-mate.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Added Props Table for the `ButtonGroup` component.

--- a/website/pages/docs/form/button.mdx
+++ b/website/pages/docs/form/button.mdx
@@ -260,7 +260,16 @@ props to style the button.
 
 ## Props
 
-Button composes the `Box` component so you can pass all props for `Box`. These
-are props specific to the Button component.
+### Button Props
+
+`Button` composes the `Box` component, so you can pass all its props.
+These are props specific to the `Button` component:
 
 <PropsTable of="Button" />
+
+### Button Group Props
+
+`ButtonGroup` composes the `Box` component, so you can pass all its props.
+These are props specific to the `ButtonGroup` component:
+
+<PropsTable of="ButtonGroup" />


### PR DESCRIPTION
## 📝 Description

Added missing props table for the `ButtonGroup` component.

## 💣 Is this a breaking change (Yes/No):

No
