### PR TITLE
docs: descriptive title and description in OG tags

### DIFF
--- a/.changeset/witty-pets-visit.md
+++ b/.changeset/witty-pets-visit.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+The `og:title` and `og:description` meta tags now describe specific URLs.

--- a/website/src/components/seo.tsx
+++ b/website/src/components/seo.tsx
@@ -1,11 +1,14 @@
 import React from "react"
-import { NextSeo } from "next-seo"
+import { NextSeo, NextSeoProps } from "next-seo"
 import siteConfig from "configs/site-config"
 
-const SEO = ({ title, description }) => (
+export interface SEOProps extends Pick<NextSeoProps, "title" | "description"> {}
+
+const SEO = ({ title, description }: SEOProps) => (
   <NextSeo
     title={title}
     description={description}
+    openGraph={{ title, description }}
     titleTemplate={siteConfig.seo.titleTemplate}
   />
 )


### PR DESCRIPTION
Closes #3047

## 📝 Description

Added the same description and title to OpenGraph tags that is used for meta `title` and `description`.

Before:
<img width="447" alt="Screenshot 2021-01-16 at 00 11 56" src="https://user-images.githubusercontent.com/14360171/104787307-79c7a900-578f-11eb-88e5-7d0d5b23bad7.png">


After:

<img width="447" alt="Screenshot 2021-01-16 at 00 11 07" src="https://user-images.githubusercontent.com/14360171/104787267-66b4d900-578f-11eb-92a0-7aeac51de3d6.png">

## 💣 Is this a breaking change (Yes/No):

No