### PR TITLE
docs: update the zIndex value for the navbar

### DIFF
--- a/website/src/components/header.tsx
+++ b/website/src/components/header.tsx
@@ -139,7 +139,7 @@ function Header(props) {
       transition="box-shadow 0.2s"
       pos="fixed"
       top="0"
-      zIndex="1"
+      zIndex="3"
       bg={bg}
       left="0"
       right="0"


### PR DESCRIPTION
Closes #3068 

## 📝 Description

Fix issue with the Input icon overlap on navbar by updating the `zIndex` value for the navbar.

## ⛳️ Current behavior (updates)

The icons for Inputs with `InputLeftElement` or `InputRightElement` overlap the navbar on scroll.

<img width="689" alt="Screen Shot 2021-01-15 at 3 58 36 PM" src="https://user-images.githubusercontent.com/31396350/104783076-eb313880-574a-11eb-9eae-be18600207e0.png">

## 🚀 New behavior

The icons for Inputs with `InputLeftElement` or `InputRightElement` do not 
overlap the navbar on scroll.

<img width="1280" alt="Screenshot 2021-01-16 at 04 44 53" src="https://user-images.githubusercontent.com/11310046/104796399-06855d80-57b6-11eb-911f-81f82e9c7780.png">

## 💣 Is this a breaking change (Yes/No):

No
