### PR TITLE
fix: portal manager z-index issue

### DIFF
--- a/.changeset/small-trainers-deliver.md
+++ b/.changeset/small-trainers-deliver.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/portal": patch
+---
+
+Fixed issue where adding `portalZIndex` to `ChakraProvider` makes app unusable

--- a/packages/portal/src/portal.tsx
+++ b/packages/portal/src/portal.tsx
@@ -20,14 +20,7 @@ const Container: React.FC<{ zIndex?: number }> = (props) => {
   return (
     <div
       className="chakra-portal-zIndex"
-      style={{
-        position: "absolute",
-        zIndex,
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-      }}
+      style={{ display: "inline-block", position: "absolute", zIndex }}
     >
       {children}
     </div>
@@ -100,7 +93,7 @@ export function Portal(props: PortalProps) {
   }, [])
 
   const childrenToRender = manager?.zIndex ? (
-    <Container>{props.children}</Container>
+    <Container zIndex={manager.zIndex}>{props.children}</Container>
   ) : (
     props.children
   )

--- a/packages/portal/stories/portal.stories.tsx
+++ b/packages/portal/stories/portal.stories.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@chakra-ui/button"
+import { Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/menu"
 import * as React from "react"
 import Frame from "react-frame-component"
 import { Portal, PortalManager } from "../src"
@@ -60,20 +62,34 @@ function Wrapper(props: any) {
   )
 }
 
-export const NestedPortals = () => {
-  return (
+export const NestedPortals = () => (
+  <Portal>
+    <Wrapper color="red">Welcome</Wrapper>
     <Portal>
-      <Wrapper color="red">Welcome</Wrapper>
+      <Wrapper offset="40%" color="green">
+        Welcome
+      </Wrapper>
       <Portal>
-        <Wrapper offset="40%" color="green">
+        <Wrapper offset="30%" color="tomato">
           Welcome
         </Wrapper>
-        <Portal>
-          <Wrapper offset="30%" color="tomato">
-            Welcome
-          </Wrapper>
-        </Portal>
       </Portal>
     </Portal>
-  )
-}
+  </Portal>
+)
+
+export const WithZIndex = () => (
+  <PortalManager zIndex={5}>
+    <Menu>
+      <MenuButton as={Button} variant="outline">
+        Hola
+      </MenuButton>
+      <Portal>
+        <MenuList>
+          <MenuItem>item1</MenuItem>
+          <MenuItem>item2</MenuItem>
+        </MenuList>
+      </Portal>
+    </Menu>
+  </PortalManager>
+)


### PR DESCRIPTION
Closes #3026

## 📝 Description

Fix issue where adding portalZIndex makes portaled content unusable.

This happened because we added `inset:0` styles to the portal z-index container and that makes the container occupy the full screen, making it hard to interact with content inside the portal.