### PR TITLE
feat(pin-input): add otp flag to PinInput

### DIFF
--- a/.changeset/four-ways-visit.md
+++ b/.changeset/four-ways-visit.md
@@ -1,0 +1,15 @@
+---
+"@chakra-ui/pin-input": minor
+---
+
+Added an `otp` flag to `PinInput` that sets the `autoComplete` value of
+`PinInputField` to `"one-time-code"`.
+
+```jsx
+<PinInput otp>
+  <PinInputField />
+  <PinInputField />
+  <PinInputField />
+  <PinInputField />
+</PinInput>
+```

--- a/packages/pin-input/src/use-pin-input.ts
+++ b/packages/pin-input/src/use-pin-input.ts
@@ -64,6 +64,11 @@ export interface UsePinInputProps {
    */
   manageFocus?: boolean
   /**
+   * If `true`, the pin input component signals to its fields that they should
+   * use `autocomplete="one-time-code"`.
+   */
+  otp?: boolean
+  /**
    * The top-level id string that will be applied to the input fields.
    * The index of the input will be appended to this top-level id.
    *
@@ -107,6 +112,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
     onComplete,
     placeholder = "○",
     manageFocus = true,
+    otp = false,
     id: idProp,
     isDisabled,
     isInvalid,
@@ -274,7 +280,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
         onFocus: callAllHandlers(rest.onFocus, onFocus),
         onBlur: callAllHandlers(rest.onBlur, onBlur),
         value: values[index] || "",
-        autoComplete: "off",
+        autoComplete: otp ? "one-time-code" : "off",
         placeholder: hasFocus ? "" : placeholder,
       }
     },
@@ -288,6 +294,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
       isInvalid,
       manageFocus,
       onComplete,
+      otp,
       placeholder,
       setValue,
       setValues,

--- a/packages/pin-input/tests/pin-input.test.tsx
+++ b/packages/pin-input/tests/pin-input.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { render, userEvent, fireEvent } from "@chakra-ui/test-utils"
+import { render, userEvent, fireEvent, screen } from "@chakra-ui/test-utils"
 import {
   usePinInput,
   usePinInputField,
@@ -99,4 +99,21 @@ test("can clear all input", () => {
   // verify that input values are blank
   expect(utils.getByTestId("1")).toHaveValue("")
   expect(utils.getByTestId("2")).toHaveValue("")
+})
+
+test('otp flag enables "one-time-code" autocomplete on fields', () => {
+  render(<Component otp />)
+
+  expect(screen.getByTestId("1")).toHaveAttribute(
+    "autocomplete",
+    "one-time-code",
+  )
+  expect(screen.getByTestId("2")).toHaveAttribute(
+    "autocomplete",
+    "one-time-code",
+  )
+  expect(screen.getByTestId("3")).toHaveAttribute(
+    "autocomplete",
+    "one-time-code",
+  )
 })

--- a/website/pages/docs/form/pin-input.mdx
+++ b/website/pages/docs/form/pin-input.mdx
@@ -63,6 +63,20 @@ alphanumeric values, pass the `type` prop and set its value to either
 </HStack>
 ```
 
+### Using fields as a one time password (OTP)
+
+Use the `otp` prop on `PinInput` to set `autocomplete="one-time-code"` for all
+children `PinInputField` components.
+
+```jsx
+<PinInput otp>
+  <PinInputField />
+  <PinInputField />
+  <PinInputField />
+  <PinInputField />
+</PinInput>
+```
+
 ### Masking the pin input's value
 
 When collecting private or sensitive information using the pin input, you might


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR adds an `otp` prop to `PinInput` which causes `PinInputField` children to render with `autocomplete="one-time-code"`.

```jsx
<PinInput otp>
  <PinInputField />
  <PinInputField />
  <PinInputField />
  <PinInputField />
</PinInput>
```

## ⛳️ Current behavior (updates)

`PinInputField` always renders with `autocomplete="off"`.

## 🚀 New behavior

When `PinInput` has the `otp` prop enabled, each `PinInputField` renders with `autocomplete="one-time-code"`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
