### PR TITLE
Update migration documentation regarding IE11

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -35,6 +35,8 @@ one object.
 with `Box` so you can use pseudo style props, like `_hover`, `_active` in any
 Chakra components.
 
+**Dropped Support of IE11:** We've dropped support of `IE11` [reason](https://github.com/chakra-ui/chakra-ui/pull/2762)
+
 ---
 
 ## Upgrade steps


### PR DESCRIPTION
Update Migration documentation for dropping support of IE11

## 📝 Description

Chakra v0 was supporting IE11 and it will give developers unnecessary problems to figure this out to late.
See [pull request](https://github.com/chakra-ui/chakra-ui/pull/2762)