### PR TITLE
docs(theme): add missing fontWeights

### DIFF
--- a/website/pages/docs/theming/theme.mdx
+++ b/website/pages/docs/theming/theme.mdx
@@ -153,9 +153,15 @@ export default {
     "6xl": "64px",
   },
   fontWeights: {
+    hairline: 100,
+    thin: 200,
+    light: 300,
     normal: 400,
     medium: 500,
+    semibold: 600,
     bold: 700,
+    extrabold: 800,
+    black: 900,
   },
   lineHeights: {
     normal: "normal",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR adds `fontWeights` values that were missing from the "Default Theme" docs.