### PR TITLE
Docs/menu auto select

### DIFF
--- a/.changeset/famous-foxes-move.md
+++ b/.changeset/famous-foxes-move.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Update Menu docs for the autoSelect property to specify focus over "selected".

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -55,7 +55,7 @@ export interface UseMenuProps extends UsePopperProps, UseDisclosureProps {
    */
   closeOnBlur?: boolean
   /**
-   * If `true`, the first enabled menu item will receive focus
+   * If `true`, the first enabled menu item will receive focus and be selected
    * when the menu opens.
    *
    * @default true

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -55,7 +55,7 @@ export interface UseMenuProps extends UsePopperProps, UseDisclosureProps {
    */
   closeOnBlur?: boolean
   /**
-   * If `true`, the first enabled menu item will be selected
+   * If `true`, the first enabled menu item will receive focus
    * when the menu opens.
    *
    * @default true


### PR DESCRIPTION
## 📝 Description

Hello! 👋🏼 

I missed this property for a couple days because I was searching on the docs page for the keyword `focus`. While I should have read each prop carefully, I think clarifying that the opened menu applies focus is more accurate compared to actually making a selection. Is there a reason the prop isn't `autoFocus`? I realize that would be a breaking change, so I figured a docs update is the next best thing.

## 💣 Is this a breaking change (Yes/No):

No

