### PR TITLE
fix(radio-group): fix issue with uncontrolled radio group

### DIFF
--- a/.changeset/lazy-poets-cheat.md
+++ b/.changeset/lazy-poets-cheat.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+Fixed issue where using an uncontrolled RadioGroup without a defaultValue causes multiple radio options can be selected.
+
+This was caused by the `useControllableProp` hook that uses `useRef` to check if a value is controlled or uncontrolled.

--- a/packages/accordion/src/use-accordion.ts
+++ b/packages/accordion/src/use-accordion.ts
@@ -99,11 +99,6 @@ export function useAccordion(props: UseAccordionProps) {
       return defaultIndex ?? -1
     },
     onChange,
-    propsMap: {
-      value: "index",
-      defaultValue: "defaultIndex",
-      onChange: "onChange",
-    },
   })
 
   /**
@@ -151,9 +146,10 @@ interface AccordionContext extends Omit<UseAccordionReturn, "htmlProps"> {
   reduceMotion: boolean
 }
 
-const [AccordionProvider, useAccordionContext] = createContext<
-  AccordionContext
->({
+const [
+  AccordionProvider,
+  useAccordionContext,
+] = createContext<AccordionContext>({
   name: "AccordionContext",
   errorMessage:
     "useAccordionContext: `context` is undefined. Seems you forgot to wrap the accordion components in `<Accordion />`",

--- a/packages/radio/src/use-radio-group.ts
+++ b/packages/radio/src/use-radio-group.ts
@@ -5,15 +5,9 @@ import {
   PropGetter,
   StringOrNumber,
 } from "@chakra-ui/utils"
-import {
-  ChangeEvent,
-  useCallback,
-  useRef,
-  useState,
-  InputHTMLAttributes,
-} from "react"
+import * as React from "react"
 
-type EventOrValue = ChangeEvent<HTMLInputElement> | StringOrNumber
+type EventOrValue = React.ChangeEvent<HTMLInputElement> | StringOrNumber
 
 export interface UseRadioGroupProps {
   /**
@@ -44,6 +38,14 @@ export interface UseRadioGroupProps {
   isNative?: boolean
 }
 
+type RadioPropGetter = PropGetter<
+  HTMLInputElement,
+  { onChange?: (e: EventOrValue) => void; value?: StringOrNumber } & Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "onChange" | "size" | "value"
+  >
+>
+
 /**
  * React hook to manage a group of radio inputs
  */
@@ -57,13 +59,14 @@ export function useRadioGroup(props: UseRadioGroupProps = {}) {
     ...htmlProps
   } = props
 
-  const [valueState, setValue] = useState<StringOrNumber>(defaultValue || "")
-
+  const [valueState, setValue] = React.useState<StringOrNumber>(
+    defaultValue || "",
+  )
   const [isControlled, value] = useControllableProp(valueProp, valueState)
 
-  const ref = useRef<any>(null)
+  const ref = React.useRef<any>(null)
 
-  const focus = useCallback(() => {
+  const focus = React.useCallback(() => {
     const rootNode = ref.current
     if (!rootNode) return
 
@@ -90,7 +93,7 @@ export function useRadioGroup(props: UseRadioGroupProps = {}) {
   const fallbackName = useId(undefined, `radio`)
   const name = nameProp || fallbackName
 
-  const onChange = useCallback(
+  const onChange = React.useCallback(
     (eventOrValue: EventOrValue) => {
       const nextValue = isInputEvent(eventOrValue)
         ? eventOrValue.target.value
@@ -105,30 +108,28 @@ export function useRadioGroup(props: UseRadioGroupProps = {}) {
     [onChangeProp, isControlled],
   )
 
-  const getRootProps: PropGetter = (props = {}, forwardedRef = null) => ({
-    ...props,
-    ref: mergeRefs(forwardedRef, ref),
-    role: "radiogroup",
-  })
-
-  type RadioPropGetter = PropGetter<
-    HTMLInputElement,
-    { onChange?: (e: EventOrValue) => void; value?: StringOrNumber } & Omit<
-      InputHTMLAttributes<HTMLInputElement>,
-      "onChange" | "size" | "value"
-    >
-  >
-
-  const getRadioProps: RadioPropGetter = (props = {}, ref = null) => {
-    const checkedKey = isNative ? "checked" : "isChecked"
-    return {
+  const getRootProps: PropGetter = React.useCallback(
+    (props = {}, forwardedRef = null) => ({
       ...props,
-      ref,
-      name,
-      [checkedKey]: props.value === value,
-      onChange,
-    }
-  }
+      ref: mergeRefs(forwardedRef, ref),
+      role: "radiogroup",
+    }),
+    [],
+  )
+
+  const getRadioProps: RadioPropGetter = React.useCallback(
+    (props = {}, ref = null) => {
+      const checkedKey = isNative ? "checked" : "isChecked"
+      return {
+        ...props,
+        ref,
+        name,
+        [checkedKey]: value ? props.value === value : "",
+        onChange,
+      }
+    },
+    [isNative, name, onChange, value],
+  )
 
   return {
     getRootProps,

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -92,11 +92,6 @@ export function useTabs(props: UseTabsProps) {
     defaultValue: defaultIndex ?? 0,
     value: index,
     onChange,
-    propsMap: {
-      value: "index",
-      defaultValue: "defaultIndex",
-      onChange: "onChange",
-    },
   })
 
   /**


### PR DESCRIPTION
Closes #3112

## 📝 Description

Fixed issue where using an uncontrolled RadioGroup without a defaultValue causes multiple radio options can be selected.


## ⛳️ Current behavior (updates)

Multiple Radios are Selected when there's no defaultValue

## 🚀 New behavior

Works as expected. only one radio can be active at a time.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
