### PR TITLE
fix(portal-manager): portal z-index wrapper squashing portaled elements 

### DIFF
--- a/.changeset/smooth-tomatoes-hope.md
+++ b/.changeset/smooth-tomatoes-hope.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/portal": patch
+---
+
+fix(portal-manager): portal z-index wrapper squashing portaled elements 

--- a/packages/portal/src/portal.tsx
+++ b/packages/portal/src/portal.tsx
@@ -20,7 +20,7 @@ const Container: React.FC<{ zIndex?: number }> = (props) => {
   return (
     <div
       className="chakra-portal-zIndex"
-      style={{ display: "inline-block", position: "absolute", zIndex }}
+      style={{ position: "relative", zIndex }}
     >
       {children}
     </div>
@@ -73,10 +73,16 @@ export function Portal(props: PortalProps) {
     if (!tempNode.current) return
 
     const doc = tempNode.current!.ownerDocument
+    const host = getContainer() ?? parentPortal ?? doc.body
+
+    /**
+     * host may be `null` when a hot-loader
+     * replaces components on the page
+     */
+    if (!host) return
+
     portal.current = doc.createElement("div")
     portal.current.className = Portal.className
-
-    const host = getContainer() ?? parentPortal ?? doc.body
 
     host.appendChild(portal.current)
     forceUpdate()

--- a/packages/portal/stories/portal.stories.tsx
+++ b/packages/portal/stories/portal.stories.tsx
@@ -1,5 +1,12 @@
 import { Button } from "@chakra-ui/button"
 import { Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/menu"
+import {
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+} from "@chakra-ui/popover"
+import { Tooltip } from "@chakra-ui/tooltip"
 import * as React from "react"
 import Frame from "react-frame-component"
 import { Portal, PortalManager } from "../src"
@@ -91,5 +98,28 @@ export const WithZIndex = () => (
         </MenuList>
       </Portal>
     </Menu>
+  </PortalManager>
+)
+
+export const WithZIndexPopover = () => (
+  <PortalManager zIndex={20}>
+    <Popover isOpen>
+      <PopoverTrigger>
+        <p>Popover</p>
+      </PopoverTrigger>
+      <Portal>
+        <PopoverContent>
+          <PopoverBody>I am a popover</PopoverBody>
+        </PopoverContent>
+      </Portal>
+    </Popover>
+  </PortalManager>
+)
+
+export const WithZIndexTooltip = () => (
+  <PortalManager zIndex={20}>
+    <Tooltip isOpen label="I am a tooltip">
+      Tooltip
+    </Tooltip>
   </PortalManager>
 )


### PR DESCRIPTION
Closes #3088

## 📝 Description

Fixed issue where using portalZIndex causes Tooltips and Popovers to not render correctly.