### PR TITLE
fix(select): allow Select.icon component theme color to be applied

### DIFF
--- a/.changeset/odd-cobras-fix.md
+++ b/.changeset/odd-cobras-fix.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/select": patch
+---
+
+Fixed an issue where component theme `color` style for `Select.icon` wasn't
+applied.

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -155,7 +155,7 @@ export const Select = forwardRef<SelectProps, "select">((props, ref) => {
 
       <SelectIcon
         data-disabled={props.isDisabled}
-        color={iconColor || color}
+        {...((iconColor || color) && { color: iconColor || color })}
         __css={styles.icon}
         {...(iconSize && { fontSize: iconSize })}
       >


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2951 <!-- Github issue # here -->

## 📝 Description

Allow theme-derived `color` style from `Select.icon` to be applied.

## ⛳️ Current behavior (updates)

`SelectIcon` never receives the `color` style from the `Select.icon` theme because `Select` always passed a `color` prop to it, even if the value was `undefined`.

## 🚀 New behavior

`Select` only passes the `color` prop if `iconColor` or `color` have a value.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
