### PR TITLE
fix: useColorModeValue to default to light mode first, dark only if set

### DIFF
--- a/.changeset/shaggy-seahorses-poke.md
+++ b/.changeset/shaggy-seahorses-poke.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+`useColorModeValue` defaults to light mode on first render if system color mode is used.

--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -186,5 +186,5 @@ export function useColorModeValue<TLight = unknown, TDark = unknown>(
   dark: TDark,
 ) {
   const { colorMode } = useColorMode()
-  return colorMode === "light" ? light : dark
+  return colorMode === "dark" ? dark : light
 }


### PR DESCRIPTION
Closes #3132

## 📝 Description

Fixes issue with color flashing for when using system.

## ⛳️ Current behavior (updates)

When using `useColorModeValue` there is a flash that is occurring. 

This is because useColorModeValue was checking if `useColorMode` was equal to 'light' else it defaults to whatever value is passed into 'dark'. 

This is a problem when using `initialColorMode= 'system'`, because it's passing the colorMode as 'system' and the dark value is being used.
 
So for example when using `bg={useColorModeValue('blue.500', 'red.500')}` and then disable javascript, and then set the `config.initialColorMode = system` the rendered output is showing up red, not blue. The defaults should always be set to use light, because everything else is using light.

## 🚀 New behavior

Colors and values show up properly. And the flashing is consistent with the rest of the theme.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
