### PR TITLE
feat(menu): add commandSpacing prop to MenuItem

### DIFF
--- a/.changeset/hungry-donkeys-unite.md
+++ b/.changeset/hungry-donkeys-unite.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/menu": minor
+---
+
+The `MenuItem` now accepts a `commandSpacing` prop that can be used to adjust
+the space between the command and label.

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -221,7 +221,7 @@ interface MenuItemOptions
    */
   icon?: React.ReactElement
   /**
-   * The spacing between the icon and menu item's label
+   * The spacing between the icon and menu item's label.
    * @type SystemProps["mr"]
    */
   iconSpacing?: SystemProps["mr"]
@@ -229,6 +229,11 @@ interface MenuItemOptions
    * Right-aligned label text content, useful for displaying hotkeys.
    */
   command?: string
+  /**
+   * The spacing between the command and menu item's label.
+   * @type SystemProps["ml"]
+   */
+  commandSpacing?: SystemProps["ml"]
 }
 
 export interface MenuItemProps
@@ -236,7 +241,14 @@ export interface MenuItemProps
     MenuItemOptions {}
 
 export const MenuItem = forwardRef<MenuItemProps, "button">((props, ref) => {
-  const { icon, iconSpacing = "0.75rem", command, children, ...rest } = props
+  const {
+    icon,
+    iconSpacing = "0.75rem",
+    command,
+    commandSpacing = "0.75rem",
+    children,
+    ...rest
+  } = props
 
   const menuItemProps = useMenuItem(rest, ref) as MenuItemProps
 
@@ -261,7 +273,9 @@ export const MenuItem = forwardRef<MenuItemProps, "button">((props, ref) => {
         </MenuIcon>
       )}
       {_children}
-      {command && <MenuCommand>{command}</MenuCommand>}
+      {command && (
+        <MenuCommand marginStart={commandSpacing}>{command}</MenuCommand>
+      )}
     </StyledMenuItem>
   )
 })

--- a/website/pages/docs/overlay/menu.mdx
+++ b/website/pages/docs/overlay/menu.mdx
@@ -86,7 +86,7 @@ To access the internal state of the `Menu`, use a function as `children`
 </Menu>
 ```
 
-### Customising the button
+### Customizing the button
 
 The default `MenuButton` can be styled using the usual styled-system props, but
 it starts off plainly styled.
@@ -116,9 +116,9 @@ the letter you typed.
     transition="all 0.2s"
     borderRadius="md"
     borderWidth="1px"
-    _hover={{ bg: "gray.100" }}
-    _expanded={{ bg: "red.200" }}
-    _focus={{ outline: 0, boxShadow: "outline" }}
+    _hover={{ bg: "gray.400" }}
+    _expanded={{ bg: "blue.400" }}
+    _focus={{ boxShadow: "outline" }}
   >
     File <ChevronDownIcon />
   </MenuButton>
@@ -166,7 +166,7 @@ the letter you typed.
 
 ### Adding icons and commands
 
-You can add icon to the left side of each `MenuItem` by passing the `icon` prop.
+You can add icon to each `MenuItem` by passing the `icon` prop.
 To add a commands (or hotkeys) to menu items, you can use the `command` prop.
 
 ```jsx


### PR DESCRIPTION
## 📝 Description

I noticed the MenuItem's command currently does not have a margin.
I added the `commandSpacing` prop similar to `iconSpacing` that can be used to customize the default margin of `0.75rem`.

## 💣 Is this a breaking change (Yes/No):

No.

Before:
<img width="244" alt="Screenshot 2021-01-24 at 17 36 01" src="https://user-images.githubusercontent.com/14360171/105637335-4fe84380-5e6d-11eb-8db9-b862f90681d0.png">

After:
<img width="253" alt="Screenshot 2021-01-24 at 17 35 29" src="https://user-images.githubusercontent.com/14360171/105637338-54146100-5e6d-11eb-8294-acd3f5b6a1f1.png">
