### PR TITLE
fix(extend-theme): allow nested theme colors

### DIFF
--- a/.changeset/weak-wombats-shake.md
+++ b/.changeset/weak-wombats-shake.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Improve TypeScript type for `extendTheme` to allow deeply nested color objects

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -2,10 +2,15 @@ import defaultTheme, { Theme } from "@chakra-ui/theme"
 import { isFunction, mergeWith } from "@chakra-ui/utils"
 import { ColorHues } from "@chakra-ui/theme/dist/types/foundations/colors"
 
-type ThemeExtensionTypeHints = {
-  colors: Record<string, Partial<ColorHues> | Record<string, string> | string> // typehints for color definitions
+// recursive color object type
+type ThemeColors = string | ColorObject | Record<string, ColorHues>
+interface ColorObject {
+  [property: string]: ThemeColors
 }
 
+type ThemeExtensionTypeHints = {
+  colors: ThemeColors // typehints for color definitions
+}
 /**
  * Represents a loose but specific type for the theme override.
  * It provides autocomplete hints for extending the theme, but leaves room

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { extendTheme } from "../src/extend-theme"
+import { extendTheme, ThemeOverride } from "../src/extend-theme"
 
 describe("extendTheme", () => {
   it("should override a color", () => {
@@ -144,7 +144,7 @@ describe("extendTheme", () => {
   })
 
   it("should pass typescript lint with non colorhue properties", () => {
-    const override = {
+    const override: ThemeOverride = {
       colors: {
         grey: {
           100: "#e3e3e3",
@@ -155,6 +155,13 @@ describe("extendTheme", () => {
           medium: "#929292",
           dark: "#1D1D1B",
           navSubMenu: "#9F9F9F",
+          special: {
+            nestedColor: "#111",
+            verySpecial: {
+              50: "#fff",
+              deepNestedColor: "#111",
+            },
+          },
         },
         white: "#fff",
         black: {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3085

## 📝 Description

Add recursive TS type to allow deeply nested color objects in `extendTheme`

## ⛳️ Current behavior (updates)

Did not allow nested color objects.

## 🚀 New behavior

Now you can nest them as deep as it gets.

## 💣 Is this a breaking change (Yes/No):

No
