### PR TITLE
fix(docs): correct capitalization of rightIcon

### DIFF
--- a/.changeset/wild-pandas-suffer.md
+++ b/.changeset/wild-pandas-suffer.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Correct capitalization of `rightIcon` prop

--- a/website/pages/docs/form/button.mdx
+++ b/website/pages/docs/form/button.mdx
@@ -81,7 +81,7 @@ value to `solid`, `ghost`, `outline`, or `link`.
 ### Button with icon
 
 You can add left and right icons to the Button component using the `leftIcon`
-and `RightIcon` props respectively.
+and `rightIcon` props respectively.
 
 > Note: The `leftIcon` and `rightIcon` prop values should be react elements NOT
 > strings.


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3153 

## 📝 Description

I corrected the capitalization of `rightIcon`.

## ⛳️ Current behavior (updates)

The docs use `rightIcon` instead of `RightIcon`.

## 💣 Is this a breaking change (Yes/No):

Absolutely not.