### PR TITLE
fix(extend-theme): extend theme should not include polyfill function

### DIFF
--- a/.changeset/flat-files-provide.md
+++ b/.changeset/flat-files-provide.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+fix: Extend theme should not include polyfill function

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -32,8 +32,16 @@ export function extendTheme<T extends ThemeOverride>(
   overrides: T,
   baseTheme: any = defaultTheme,
 ) {
-  function customizer(source: unknown, override: unknown) {
-    if (isFunction(source)) {
+  function customizer(
+    source: unknown,
+    override: unknown,
+    key: string,
+    object: any,
+  ) {
+    if (
+      isFunction(source) &&
+      Object.prototype.hasOwnProperty.call(object, key)
+    ) {
       return (...args: unknown[]) => {
         const sourceValue = source(...args)
 

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -174,4 +174,18 @@ describe("extendTheme", () => {
 
     extendTheme(override)
   })
+
+  it("should not extend with function that is inherited", () => {
+    Array.prototype["customFunction"] = () => {}
+
+    const override = {
+      breakpoints: [],
+    }
+
+    const customTheme = extendTheme(override)
+
+    delete Array.prototype["customFunction"]
+
+    expect(customTheme.breakpoints.customFunction).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/2615

## 📝 Description

> When we have polyfill for `Array` or `Object`, calling useBreakpoint will throw error `Object doesn't support property or method 'endsWith'`. This is because extendTheme are also extending the polyfill functions of Array and Object

## ⛳️ Current behavior (updates)

> When we have polyfill like `Array.prototype.each = () => {}` in our code, `extendTheme` will treat `each` as a props in theme 

## 🚀 New behavior

> When we have polyfill like `Array.prototype.each = () => {}` in our code, `extendTheme` should not include `each` as a props in theme

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Sometimes we don't have control over which polyfill to load. For my case, I am building an embeddable widget to be included in another website, but the website are loading `prototype.js` which includes bunch of polyfills

Here's what happen:

<img width="548" alt="Screenshot 2021-01-26 at 4 44 13 PM" src="https://user-images.githubusercontent.com/4277951/105821834-40e0cd00-5ff6-11eb-880b-8a846eadcb2b.png">

<img width="421" alt="Screenshot 2021-01-26 at 4 47 33 PM" src="https://user-images.githubusercontent.com/4277951/105821819-3c1c1900-5ff6-11eb-9c9c-b1504b5278c5.png">
