### PR TITLE
fix: workaround for react concurrent mode focus and change events issue

### DIFF
--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -18,6 +18,7 @@ import React, {
   useRef,
   useState,
 } from "react"
+import ReactDOM from "react-dom"
 
 export interface UseCheckboxProps {
   /**
@@ -229,26 +230,39 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     }
   }
 
-  const getInputProps: PropGetter = (props = {}, forwardedRef = null) => ({
-    ...props,
-    ref: mergeRefs(ref, forwardedRef),
-    type: "checkbox",
-    name,
-    value,
-    id,
-    onChange: callAllHandlers(props.onChange, handleChange),
-    onBlur: callAllHandlers(props.onBlur, setFocused.off),
-    onFocus: callAllHandlers(props.onFocus, setFocused.on),
-    onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),
-    onKeyUp: callAllHandlers(props.onKeyUp, onKeyUp),
-    required: isRequired,
-    checked: isChecked,
-    disabled: trulyDisabled,
-    readOnly: isReadOnly,
-    "aria-invalid": isInvalid,
-    "aria-disabled": isDisabled,
-    style: visuallyHiddenStyle,
-  })
+  const getInputProps: PropGetter = (props = {}, forwardedRef = null) => {
+    // This is a workaround for React Concurrent Mode issue https://github.com/facebook/react/issues/18591. Remove once it's fixed.
+    const focus = () => {
+      if (typeof (ReactDOM as any).flushSync === "function") {
+        ;(ReactDOM as any).flushSync(() => {
+          setFocused.on()
+        })
+      } else {
+        setFocused.on()
+      }
+    }
+
+    return {
+      ...props,
+      ref: mergeRefs(ref, forwardedRef),
+      type: "checkbox",
+      name,
+      value,
+      id,
+      onChange: callAllHandlers(props.onChange, handleChange),
+      onBlur: callAllHandlers(props.onBlur, setFocused.off),
+      onFocus: callAllHandlers(props.onFocus, focus),
+      onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),
+      onKeyUp: callAllHandlers(props.onKeyUp, onKeyUp),
+      required: isRequired,
+      checked: isChecked,
+      disabled: trulyDisabled,
+      readOnly: isReadOnly,
+      "aria-invalid": isInvalid,
+      "aria-disabled": isDisabled,
+      style: visuallyHiddenStyle,
+    }
+  }
 
   const getLabelProps: PropGetter = (props = {}, forwardedRef = null) => ({
     ...props,

--- a/packages/radio/src/use-radio.ts
+++ b/packages/radio/src/use-radio.ts
@@ -16,6 +16,7 @@ import {
   useRef,
   useState,
 } from "react"
+import ReactDOM from "react-dom"
 import { useFormControl } from "@chakra-ui/form-control"
 
 /**
@@ -200,6 +201,17 @@ export function useRadio(props: UseRadioProps = {}) {
         "onBlur",
       ])
 
+      // This is a workaround for React Concurrent Mode issue https://github.com/facebook/react/issues/18591. Remove once it's fixed.
+      const focus = () => {
+        if (typeof (ReactDOM as any).flushSync === "function") {
+          ;(ReactDOM as any).flushSync(() => {
+            setFocused.on()
+          })
+        } else {
+          setFocused.on()
+        }
+      }
+
       const trulyDisabled = ownProps.disabled && !isFocusable
 
       return {
@@ -211,11 +223,7 @@ export function useRadio(props: UseRadioProps = {}) {
         value,
         onChange: callAllHandlers(props.onChange, handleChange),
         onBlur: callAllHandlers(ownProps.onBlur, props.onBlur, setFocused.off),
-        onFocus: callAllHandlers(
-          ownProps.onFocus,
-          props.onFocus,
-          setFocused.on,
-        ),
+        onFocus: callAllHandlers(ownProps.onFocus, props.onFocus, focus),
         onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),
         onKeyUp: callAllHandlers(props.onKeyUp, onKeyUp),
         checked: isChecked,
@@ -230,8 +238,7 @@ export function useRadio(props: UseRadioProps = {}) {
       name,
       value,
       handleChange,
-      setFocused.off,
-      setFocused.on,
+      setFocused,
       onKeyDown,
       onKeyUp,
       isChecked,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2350

## 📝 Description

Fixes checkbox and radio components in React concurrent mode by applying workaround from https://github.com/facebook/react/issues/18591#issuecomment-697999763. This can be removed after the mentioned issue is resolved in React.

## ⛳️ Current behavior (updates)

Currently in React concurrent mode checkbox and radio inputs require two clicks to update a checked state.

## 🚀 New behavior

This fix only applies the workaround for projects that use experimental React. It should not affect other projects.

## 💣 Is this a breaking change (Yes/No):

No.
