### PR TITLE
fix(number-input): always cast counter.value

### DIFF
--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -295,9 +295,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
      * - sanitize the value by using parseFloat and some Regex
      * - used to round value to computed precision or decimal points
      */
-    if (counter.value !== next) {
-      counter.cast(next)
-    }
+    counter.cast(next)
   }, [counter, max, min])
 
   const onBlur = React.useCallback(() => {

--- a/packages/number-input/tests/number-input.test.tsx
+++ b/packages/number-input/tests/number-input.test.tsx
@@ -128,7 +128,7 @@ test("should increase/decrease by 0.1*step on ctrl+Arrow", () => {
   expect(input).toHaveValue("0.00")
 })
 
-it("should behave properly precision value", () => {
+it("should behave properly with precision value", () => {
   const { getByTestId } = renderComponent({
     defaultValue: 0,
     step: 0.65,
@@ -147,6 +147,12 @@ it("should behave properly precision value", () => {
   userEvent.click(incBtn)
   expect(input).toHaveValue("1.95")
   userEvent.click(decBtn)
+  expect(input).toHaveValue("1.30")
+
+  // on blur, value is clamped using precision
+  userEvent.type(input, "1234")
+  expect(input).toHaveValue("1.301234")
+  fireEvent.blur(input)
   expect(input).toHaveValue("1.30")
 })
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3178 <!-- Github issue # here -->

## 📝 Description

This PR resolves an issue where clamping to a `precision` prop value doesn't occur on blur.

## ⛳️ Current behavior (updates)

Blurring the `input` when `precision` prop is present doesn't clamp the value to the `precision` value.

## 🚀 New behavior

Blurring the `input` clamps the value using the `precision` prop.

## 💣 Is this a breaking change (Yes/No):

No
