### PR TITLE
fix(checkbox): call group.onChange only once

### DIFF
--- a/.changeset/slimy-birds-melt.md
+++ b/.changeset/slimy-birds-melt.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+Resolved an issue where `Checkbox` used inside `CheckboxGroup` would call the
+group's `onChange` handler twice

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -96,7 +96,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">((props, ref) => {
   const mergedProps = { ...group, ...props } as CheckboxProps
   const styles = useMultiStyleConfig("Checkbox", mergedProps)
 
-  const ownProps = omitThemingProps(mergedProps)
+  const ownProps = omitThemingProps(props)
 
   const {
     spacing = "0.5rem",

--- a/packages/checkbox/tests/checkbox.test.tsx
+++ b/packages/checkbox/tests/checkbox.test.tsx
@@ -6,6 +6,7 @@ import {
   renderHook,
   screen,
   testA11y,
+  userEvent,
 } from "@chakra-ui/test-utils"
 import * as React from "react"
 import {
@@ -186,8 +187,24 @@ test("Controlled CheckboxGroup", () => {
   // change props
   rerender(<Component value={checked} onChange={onChange} />)
 
-  expect(onChange).toHaveBeenCalled()
+  expect(onChange).toHaveBeenCalledTimes(1)
   expect(checked).toEqual(["one", "two", "three"])
+})
+
+test("uncontrolled CheckboxGroup handles change", () => {
+  const onChange = jest.fn()
+  render(
+    <CheckboxGroup defaultValue={["A", "C"]} onChange={onChange}>
+      <Checkbox value="A">A</Checkbox>
+      <Checkbox value="B">B</Checkbox>
+      <Checkbox value="C">C</Checkbox>
+    </CheckboxGroup>,
+  )
+
+  userEvent.click(screen.getByLabelText("B"))
+
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(onChange).toHaveBeenCalledWith(["A", "C", "B"])
 })
 
 test("accepts custom icon", () => {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3177 <!-- Github issue # here -->

## 📝 Description

This PR resolves an issue where `Checkbox` used inside `CheckboxGroup` was calling `group.onChange` twice per event.

## 🚀 New behavior

Within `Checkbox`, `ownProps` is now derived only from `props` rather than `mergedProps` which already contains `group.onChange` if `props.onChange` does not exist.

## 💣 Is this a breaking change (Yes/No):

No