### PR TITLE
docs: update docs regarding breakpoints

### DIFF
--- a/website/pages/docs/features/responsive-styles.mdx
+++ b/website/pages/docs/features/responsive-styles.mdx
@@ -14,12 +14,15 @@ Responsive syntax relies on the breakpoints defined in the theme object. Chakra
 UI provides default breakpoints, here's what it looks like:
 
 ```js
-const breakpoints = {
+import { createBreakpoints } from "@chakra-ui/theme-tools"
+
+const breakpoints = createBreakpoints({
   sm: "30em",
   md: "48em",
   lg: "62em",
   xl: "80em",
-}
+  "2xl": "96em",
+})
 ```
 
 To make styles responsive, you can use either the array or object syntax.
@@ -51,11 +54,19 @@ To interpret array responsive values, Chakra UI converts the values defined in
 values defined in the array to the breakpoints
 
 ```js
+import { createBreakpoints } from "@chakra-ui/theme-tools"
+
 // This is the default breakpoint
-const breakpoints = { sm: "30em", md: "48em", lg: "62em", xl: "80em" }
+const breakpoints = createBreakpoints({
+  sm: "30em",
+  md: "48em",
+  lg: "62em",
+  xl: "80em",
+  "2xl": "96em",
+})
 
 // Internally, we transform to this
-const breakpoints = ["0em", "30em", "48em", "62em", "80em"]
+const breakpoints = ["0em", "30em", "48em", "62em", "80em", "96em"]
 ```
 
 Here's how to interpret this syntax:

--- a/website/pages/docs/theming/theme.mdx
+++ b/website/pages/docs/theming/theme.mdx
@@ -185,19 +185,21 @@ export default {
 
 ## Breakpoints
 
-To configure the default breakpoints used in responsive array values, add a
-breakpoints array to your theme. These values will be used to generate
-mobile-first (i.e. min-width) media queries, which can then be used to apply
-responsive styles.
+Chakra UI comes with a predefined set of commonly used breakpoints.
 
-> For example, you can write `<Box fontSize={["14px", "16px"]}/>` to make the
-> fontSize responsive.
+> Learn more about [Responsive Styles and Customizing Breakpoints](/docs/features/responsive-styles).
 
 ```js
 // theme.js
-export default {
-  breakpoints: ["30em", "48em", "62em", "80em"],
-}
+import { createBreakpoints } from "@chakra-ui/theme-tools"
+
+export default createBreakpoints({
+  sm: "30em",
+  md: "48em",
+  lg: "62em",
+  xl: "80em",
+  "2xl": "96em",
+})
 ```
 
 ## Spacing
@@ -364,9 +366,3 @@ export default {
   },
 }
 ```
-
-## Configuration reference
-
-Except for breakpoints, colors, and spacing, all the keys in the theme object
-map to one of Chakra's core theme. All of these keys can be replaced or
-extended.


### PR DESCRIPTION
## 📝 Description

- updated the breakpoints
- use the `createBreakpoints` function
- remove some redudant sentences in `Default Theme` and instead link to `Responsive Styles` section.