### PR TITLE
docs: document the `sx` prop

### DIFF
--- a/website/configs/docs-sidebar.json
+++ b/website/configs/docs-sidebar.json
@@ -55,6 +55,10 @@
               "path": "/docs/features/text-and-layer-styles"
             },
             {
+              "title": "The `sx` Prop",
+              "path": "/docs/features/the-sx-prop"
+            },
+            {
               "title": "RTL Support",
               "path": "/docs/features/rtl-support",
               "new": true

--- a/website/pages/docs/features/the-sx-prop.mdx
+++ b/website/pages/docs/features/the-sx-prop.mdx
@@ -1,0 +1,65 @@
+---
+title: The `sx` Prop
+description:
+  The sx prop lets you style components inline, using your theme tokens.
+---
+
+The sx prop lets you style components inline, using your theme tokens.
+
+## Use cases
+
+Although the `sx` prop is considered an escape hatch, there are few cases where it is needed.
+
+### Defining Any Standard CSS Property
+
+In case you need to set a CSS property that is not listed in the [Style Props](/docs/features/style-props) list,
+you can use the `sx` prop and pass it whatever CSS property you desire.
+
+One such example is the `filter` property:
+
+```jsx
+<Image
+  src="http://placekitten.com/200/300"
+  alt="a kitten"
+  sx={{ filter: "blur(8px)" }}
+/>
+```
+
+### Defining CSS Custom Properties
+
+Custom CSS properties can be defined via the `sx` prop as well:
+
+```jsx
+<Box sx={{ "--my-color": "#53c8c4" }}>
+  <Heading color="var(--my-color)" size="lg">
+    This uses CSS Custom Properties!
+  </Heading>
+</Box>
+```
+
+### Creating Nested Selectors
+
+To create complex, nested selectors, you can use utilize the `&` operator.
+The `&` in selector will get resolved to unique `className` that is assigned the component you put `sx` on.
+
+> For simple examples like the following, you could just use the [`_groupHover` shorthand prop](/docs/features/style-props#pseudo).
+> However, that way you can't create nested groups, for example.
+
+```jsx
+<Box borderWidth={2} borderColor="purple.500" p={5} className="my-box">
+  <Heading size="lg">
+    Hover the box...
+    <Box
+      as="span"
+      color="red.500"
+      sx={{
+        ".my-box:hover &": {
+          color: "green.500"
+        }
+      }}
+    >
+      And I will turn green!
+    </Box>
+  </Heading>
+</Box>
+```

--- a/website/pages/docs/features/the-sx-prop.mdx
+++ b/website/pages/docs/features/the-sx-prop.mdx
@@ -4,16 +4,28 @@ description:
   The sx prop lets you style components inline, using your theme tokens.
 ---
 
-The sx prop lets you style components inline, using your theme tokens.
+With `sx` you can provide any valid CSS to an element and utilize tokens from
+your theme to ensure consistency and that you are utilizing constraint-based
+design principles when styling your application.
+
+This prop provides a superset of CSS (contains all CSS properties/selectors in
+addition to custom ones) that maps values directly from the theme, depending on
+the CSS property used. Also, it allows a simple way of defining responsive
+values that correspond to the breakpoints defined in the theme.
+
+To find out which properties are theme-aware, see the
+[Style Props](https://chakra-ui.com/docs/features/style-props).
 
 ## Use cases
 
-Although the `sx` prop is considered an escape hatch, there are few cases where it is needed.
+Although the `sx` prop is considered an escape hatch, there are few cases where
+it is needed.
 
 ### Defining Any Standard CSS Property
 
-In case you need to set a CSS property that is not listed in the [Style Props](/docs/features/style-props) list,
-you can use the `sx` prop and pass it whatever CSS property you desire.
+In case you need to set a CSS property that is not listed in the
+[Style Props](/docs/features/style-props) list, you can use the `sx` prop and
+pass it whatever CSS property you desire.
 
 One such example is the `filter` property:
 
@@ -39,11 +51,12 @@ Custom CSS properties can be defined via the `sx` prop as well:
 
 ### Creating Nested Selectors
 
-To create complex, nested selectors, you can use utilize the `&` operator.
-The `&` in selector will get resolved to unique `className` that is assigned the component you put `sx` on.
+To create complex, nested selectors, you can use utilize the `&` operator. The
+`&` in selector will get resolved to unique `className` that is assigned the
+component you put `sx` on.
 
-> For simple examples like the following, you could just use the [`_groupHover` shorthand prop](/docs/features/style-props#pseudo).
-> However, that way you can't create nested groups, for example.
+> For the following example you could also use the
+> [`_groupHover` shorthand prop](/docs/features/style-props#pseudo).
 
 ```jsx
 <Box borderWidth={2} borderColor="purple.500" p={5} className="my-box">
@@ -54,12 +67,26 @@ The `&` in selector will get resolved to unique `className` that is assigned the
       color="red.500"
       sx={{
         ".my-box:hover &": {
-          color: "green.500"
-        }
+          color: "green.500",
+        },
       }}
     >
       And I will turn green!
     </Box>
   </Heading>
+</Box>
+```
+
+### Custom Media queries
+
+```jsx
+<Box
+  sx={{
+    "@media print": {
+      display: "none",
+    },
+  }}
+>
+  This text won't be shown when printing this page.
 </Box>
 ```

--- a/website/src/components/page-container.tsx
+++ b/website/src/components/page-container.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from "next/router"
+import * as React from "react"
 import { Badge, Box, chakra } from "@chakra-ui/react"
 import { SkipNavContent, SkipNavLink } from "@chakra-ui/skip-nav"
 import Container from "components/container"
@@ -5,8 +7,7 @@ import EditPageLink from "components/edit-page-button"
 import Footer from "components/footer"
 import Header from "components/header"
 import SEO from "components/seo"
-import { useRouter } from "next/router"
-import * as React from "react"
+import { convertBackticksToInlineCode } from "utils/convert-backticks-to-inline-code"
 import PageTransition from "./page-transition"
 
 function useHeadingFocusOnRouteChange() {
@@ -64,7 +65,7 @@ function PageContainer(props: PageContainerProps) {
             >
               <PageTransition>
                 <chakra.h1 tabIndex={-1} outline={0} apply="mdx.h1">
-                  {title}
+                  {convertBackticksToInlineCode(title)}
                 </chakra.h1>
                 {version && (
                   <Badge colorScheme="teal" letterSpacing="wider">

--- a/website/src/components/sidebar/sidebar.tsx
+++ b/website/src/components/sidebar/sidebar.tsx
@@ -1,3 +1,7 @@
+import NextLink from "next/link"
+import { useRouter } from "next/router"
+import * as React from "react"
+import _ from "lodash"
 import {
   Badge,
   Box,
@@ -10,12 +14,10 @@ import {
   Stack,
   useColorModeValue,
 } from "@chakra-ui/react"
-import { useRouter } from "next/router"
-import * as React from "react"
 import { Routes } from "utils/get-route-context"
+import { convertBackticksToInlineCode } from "utils/convert-backticks-to-inline-code"
 import SidebarCategory from "./sidebar-category"
 import SidebarLink from "./sidebar-link"
-import NextLink from "next/link"
 import {
   BlogIcon,
   DocsIcon,
@@ -23,7 +25,6 @@ import {
   TeamIcon,
   ResourcesIcon,
 } from "./sidebar-icons"
-import _ from "lodash"
 
 export type SidebarContentProps = Routes & {
   pathname?: string
@@ -54,7 +55,7 @@ export function SidebarContent(props: SidebarContentProps) {
               if (!lvl2.routes) {
                 return (
                   <SidebarLink ml="-3" mt="2" key={lvl2.path} href={lvl2.path}>
-                    {lvl2.title}
+                    {lvl2.title} BLABLA
                   </SidebarLink>
                 )
               }
@@ -77,7 +78,7 @@ export function SidebarContent(props: SidebarContentProps) {
                   <Stack as="ul">
                     {sortedRoutes.map((lvl3) => (
                       <SidebarLink as="li" key={lvl3.path} href={lvl3.path}>
-                        <span>{lvl3.title}</span>
+                        <span>{convertBackticksToInlineCode(lvl3.title)}</span>
                         {lvl3.new && (
                           <Badge
                             ml="2"

--- a/website/src/utils/convert-backticks-to-inline-code.tsx
+++ b/website/src/utils/convert-backticks-to-inline-code.tsx
@@ -1,0 +1,19 @@
+import MDXComponents from "components/mdx-components"
+
+/**
+ * Replace the code blocks wrapped in backticks
+ * with inline code blocks.
+ */
+export function convertBackticksToInlineCode(input: string) {
+  return input
+    .split(/(`\w+`)/)
+    .map((chunk) =>
+      chunk.startsWith("`") && chunk.endsWith("`") ? (
+        <MDXComponents.inlineCode key={chunk}>
+          {chunk.slice(1, -1)}
+        </MDXComponents.inlineCode>
+      ) : (
+        chunk
+      ),
+    )
+}


### PR DESCRIPTION
## 📝 Description

Added documentation for the `sx` prop.

Open to any suggestions!

Edit:
I also whipped out a quick and dirty function to format code blocks in titles. I am not sure if I can utilize `remark` in an easy way to achieve the same. Should I commit it?
```ts
function convertBackticksToCodeBlocks(input: string) {
  return input
    .split(/(`\w+`)/)
    .map((chunk) =>
      chunk.startsWith("`") && chunk.endsWith("`") ? (
        <MDXComponents.inlineCode key={chunk}>
          {chunk.slice(1, -1)}
        </MDXComponents.inlineCode>
      ) : (
        chunk
      ),
    )
}
```
<img width="211" alt="Screenshot 2021-01-28 at 05 17 13" src="https://user-images.githubusercontent.com/14360171/106089639-a1702700-6128-11eb-8b0c-8e2a94b7f712.png">
