### PR TITLE
fix(theme): align link button to baseline

### DIFF
--- a/.changeset/tidy-berries-promise.md
+++ b/.changeset/tidy-berries-promise.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/theme": patch
+---
+
+A `Button` with `variant="link"` has now `verticalAlign` set to `baseline`, instead of
+`middle`.

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -128,6 +128,7 @@ function variantLink(props: Dict) {
     padding: 0,
     height: "auto",
     lineHeight: "normal",
+    verticalAlign: "baseline",
     color: mode(`${c}.500`, `${c}.200`)(props),
     _hover: {
       textDecoration: "underline",


### PR DESCRIPTION
Closes #3147

## 📝 Description

`<Button variant="link">chakra</Button>` should have `vertical-align="baseline"` instead of `"middle"`

Before:
<img width="754" alt="Screenshot 2021-01-29 at 04 02 42" src="https://user-images.githubusercontent.com/14360171/106226164-e22e7580-61e6-11eb-874b-7b27de0d1378.png">


After:
<img width="755" alt="Screenshot 2021-01-29 at 04 02 51" src="https://user-images.githubusercontent.com/14360171/106226169-e5c1fc80-61e6-11eb-97d6-49d494b4f996.png">



## 💣 Is this a breaking change (Yes/No):

Hopefully no