### PR TITLE
docs: omit og:image in docs pages

### DIFF
--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -1,18 +1,24 @@
 import { trackPageview } from "analytics/track-event"
 import { DefaultSeo } from "next-seo"
 import Head from "next/head"
-import Router from "next/router"
+import Router, { useRouter } from "next/router"
 import React from "react"
-import siteConfig from "configs/site-config"
 import { ChakraProvider } from "@chakra-ui/react"
 import theme from "theme"
 import FontFace from "components/font-face"
+import { getSeo } from "utils/seo"
 
 Router.events.on("routeChangeComplete", (url) => {
   trackPageview(url)
 })
 
 const App = ({ Component, pageProps }) => {
+  // Omit og:image in Docs pages.
+  // It currently doesn't add any value and clutters discussions.
+  const { pathname } = useRouter()
+  const isDocsPage = pathname.startsWith("/docs/")
+  const seo = getSeo({ omitOpenGraphImage: isDocsPage })
+
   return (
     <>
       <Head>
@@ -23,7 +29,7 @@ const App = ({ Component, pageProps }) => {
         <link rel="preconnect" href="https://static.cloudflareinsights.com" />
         <meta name="theme-color" content="#319795" />
       </Head>
-      <DefaultSeo {...siteConfig.seo} />
+      <DefaultSeo {...seo} />
       <ChakraProvider theme={theme}>
         <Component {...pageProps} />
       </ChakraProvider>

--- a/website/src/utils/seo.ts
+++ b/website/src/utils/seo.ts
@@ -1,0 +1,18 @@
+import siteConfig from "configs/site-config"
+
+export function getSeo({
+  omitOpenGraphImage,
+}: {
+  omitOpenGraphImage: boolean
+}) {
+  const { seo } = siteConfig
+  const { images, ...openGraph } = seo.openGraph
+
+  return {
+    ...seo,
+    openGraph: {
+      ...openGraph,
+      images: omitOpenGraphImage ? undefined : images,
+    },
+  }
+}


### PR DESCRIPTION
## 📝 Description

Omit `og:image` tags on all Docs pages (pages where path starts with `/docs/`).
The image currently provides no additional value, as it is just Chakra UI logo, and it clutters up discussions on Discord, for example.

Not the most straightforward solution, but [`next-seo` doesn't allow to unset `og:image`](https://github.com/garmeeh/next-seo/blob/master/src/meta/buildTags.tsx#L469) once it's set in `DefaultSeo`, so we could it override on page-level.

## ⛳️ Current behavior

<img width="440" alt="Screenshot 2021-01-30 at 02 46 20" src="https://user-images.githubusercontent.com/14360171/106343569-5aa83b80-62a6-11eb-87c3-6d50478fc5ef.png">

## 🚀 New behavior

<img width="533" alt="Screenshot 2021-01-30 at 02 53 20" src="https://user-images.githubusercontent.com/14360171/106343576-5d0a9580-62a6-11eb-93eb-5031ccece7a9.png">

Observation: For some reason Discord makes the preview wider when there is no image, so it takes even less space vertically.

## 💣 Is this a breaking change (Yes/No):

No
