### PR TITLE
fix: loosen colorScheme type

### DIFF
--- a/.changeset/slow-chicken-shave.md
+++ b/.changeset/slow-chicken-shave.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/system": patch
+---
+
+Allow string values for ThemingProps['colorScheme']

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -15,7 +15,7 @@ export interface ThemingProps<ThemeComponent extends string = string> {
   size?: ThemeComponent extends keyof ThemeTypings["components"]
     ? ThemeTypings["components"][ThemeComponent]["sizes"] | (string & {})
     : string
-  colorScheme?: ThemeTypings["colorSchemes"]
+  colorScheme?: ThemeTypings["colorSchemes"] | (string & {})
   orientation?: "vertical" | "horizontal"
   styleConfig?: Dict
 }


### PR DESCRIPTION
## 📝 Description

Theme Typings introduced a too narrow type for `ThemeTypings['colorScheme']`

## ⛳️ Current behavior (updates)

TS error: 

```
Type 'string' is not assignable to type '"whiteAlpha" | "blackAlpha" | "gray" | "red" | "orange" | "yellow" | "green" | "teal" | "blue" | "cyan" | "purple" | "pink" | "linkedin" | "facebook" | "messenger" | "whatsapp" | "twitter" | "telegram" | undefined'.

249             colorScheme={buttonColorScheme}
```
## 🚀 New behavior

No TS error in userland project

## 💣 Is this a breaking change (Yes/No):

No

## Additional Info

Let's get this fix published asap 🚀 😅 