### PR TITLE
chore: bump cli package to publish previous package

### DIFF
--- a/.changeset/unlucky-onions-sin.md
+++ b/.changeset/unlucky-onions-sin.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/cli": minor
+---
+
+- Package `@chakra-ui/cli@1.0.0` did already exist
+- Add minor bump for adding subcommand `tokens` to generate Theme Typings
+
+  See https://chakra-ui.com/docs/theming/advanced for more info

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -11,15 +11,11 @@
   "author": "Tim Kolberger <tim@kolberger.eu>",
   "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
   "license": "MIT",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
-  "typings": "dist/types/index.d.ts",
+  "main": "dist/index.js",
   "sideEffects": false,
   "exports": {
     ".": {
-      "require": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/website/pages/docs/theming/advanced.mdx
+++ b/website/pages/docs/theming/advanced.mdx
@@ -128,6 +128,9 @@ you don't have to think about this every time you reinstall your dependencies.
 "scripts": {
   "gen:theme-typings": "chakra-cli tokens <path/to/your/theme.(js|ts)>",
   "postinstall": "npm run gen:theme-typings"
+},
+"devDependencies": {
+  "@chakra-ui/cli": "^1.1.0"
 }
 ```
 


### PR DESCRIPTION
- Package `@chakra-ui/cli@1.0.0` [did already exist](https://www.npmjs.com/package/@chakra-ui/cli)
- Add minor bump for adding subcommand `tokens` to generate Theme Typings