### PR TITLE
docs: update cli install instructions

### DIFF
--- a/website/pages/docs/theming/advanced.mdx
+++ b/website/pages/docs/theming/advanced.mdx
@@ -111,8 +111,22 @@ for your application theme.
 If you want to learn how to scale your custom theme you can
 [follow this guide](/docs/theming/customize-theme#scaling-out-your-project).
 
+### Install 
+
 ```bash
-npx @chakra-ui/cli tokens <path/to/your/theme.(js|ts)>
+yarn add --dev @chakra-ui/cli
+```
+
+or
+
+```bash
+npm install -D @chakra-ui/cli
+```
+
+### Usage
+
+```bash
+chakra-cli tokens <path/to/your/theme.(js|ts)>
 ```
 
 The theme entrypoint file should export the theme object either as `default`


### PR DESCRIPTION
## 📝 Description

`npx @chakra-cli tokens` is missing the project dependencies we cannot know of, like the version of @types/react etc.

```bash
$  npx @chakra-ui/cli tokens path/to/theme.ts

Chakra UI CLI  v1.1.0 by chakra UI
Generate theme typings for autocomplete
✖ An error occurred
...
Error: Cannot find module 'react'
...
```

## ⛳️ Current behavior (updates)

Usage of npx is documented

## 🚀 New behavior

Installation in project is recommended