### PR TITLE
feat(chakra-theme): introduce type ChakraTheme

### DIFF
--- a/.changeset/old-sheep-melt.md
+++ b/.changeset/old-sheep-melt.md
@@ -1,0 +1,35 @@
+---
+"@chakra-ui/react": minor
+"@chakra-ui/styled-system": patch
+"@chakra-ui/theme": minor
+---
+
+Introducing a generic TypeScript type `ChakraTheme` to improve the `extendTheme`
+function even further.
+
+```ts
+import { extendTheme } from "@chakra-ui/react"
+
+export const customTheme = extendTheme({
+  // here you get autocomplete for
+  //   - existing definitions from the default theme
+  //   - new components (Single and MultiStyle)
+  //   - CSS definitions
+  //   - color hues
+  //   - etc.
+})
+
+export type MyCustomTheme = typeof customTheme
+```
+
+You can get typesafe access to your custom theme like this:
+
+```ts
+import { useTheme } from "@chakra-ui/react"
+import { MyCustomTheme } from "./my-custom-theme"
+
+const MyComponent = () => {
+  const customTheme = useTheme<MyCustomTheme>()
+  //...
+}
+```

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -1,42 +1,39 @@
-import defaultTheme, { Theme } from "@chakra-ui/theme"
+import defaultTheme, { ChakraTheme, DefaultChakraTheme } from "@chakra-ui/theme"
 import { isFunction, mergeWith } from "@chakra-ui/utils"
-import { ColorHues } from "@chakra-ui/theme/dist/types/foundations/colors"
 
-// recursive color object type
-type ThemeColors = string | ColorObject | Record<string, ColorHues>
-interface ColorObject {
-  [property: string]: ThemeColors
-}
+type CloneKey<Target, Key> = Key extends keyof Target ? Target[Key] : unknown
 
-type ThemeExtensionTypeHints = {
-  colors: ThemeColors // typehints for color definitions
-}
 /**
  * Represents a loose but specific type for the theme override.
  * It provides autocomplete hints for extending the theme, but leaves room
  * for adding properties.
  */
-type DeepThemeExtension<ThemeObject, TypeHints> = {
-  [Key in keyof ThemeObject]?:
-    | Omit<DeepThemeExtension<ThemeObject[Key], TypeHints>, keyof TypeHints> // recursive type clone
-    | (ThemeObject[Key] extends (...args: any[]) => any
-        ? Partial<ReturnType<ThemeObject[Key]>>
-        : Partial<ThemeObject[Key]>) // allow function or object
-} &
-  Partial<TypeHints> &
-  Record<string, any> // escape hatch
+type DeepThemeExtension<BaseTheme, ThemeType> = {
+  [Key in keyof BaseTheme]?: BaseTheme[Key] extends (...args: any[]) => any
+    ? DeepThemeExtension<
+        Partial<ReturnType<BaseTheme[Key]>>,
+        CloneKey<ThemeType, Key>
+      >
+    : BaseTheme[Key] extends object
+    ? DeepThemeExtension<Partial<BaseTheme[Key]>, CloneKey<ThemeType, Key>>
+    : CloneKey<ThemeType, Key>
+}
 
-export type ThemeOverride = DeepThemeExtension<Theme, ThemeExtensionTypeHints>
+export type ThemeOverride = Partial<ChakraTheme> &
+  DeepThemeExtension<DefaultChakraTheme, ChakraTheme>
 
 /**
  * Function to override or customize the Chakra UI theme conveniently
  * @param overrides - Your custom theme object overrides
  * @param baseTheme - theme to customize
  */
-export function extendTheme<T extends ThemeOverride>(
-  overrides: T,
-  baseTheme: any = defaultTheme,
-) {
+export function extendTheme<
+  BaseTheme extends ChakraTheme = DefaultChakraTheme,
+  Overrides extends ThemeOverride = ThemeOverride
+>(
+  overrides: Overrides,
+  baseTheme: BaseTheme = defaultTheme as BaseTheme,
+): BaseTheme & Overrides {
   function customizer(
     source: unknown,
     override: unknown,

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { extendTheme, ThemeOverride } from "../src/extend-theme"
+import { createBreakpoints } from "@chakra-ui/theme-tools"
 
 describe("extendTheme", () => {
   it("should override a color", () => {
@@ -98,7 +99,7 @@ describe("extendTheme", () => {
       },
       config: {
         useSystemColorMode: false,
-        initialColorMode: "dark",
+        initialColorMode: "dark" as const,
       },
       styles: {
         global: {
@@ -186,13 +187,18 @@ describe("extendTheme", () => {
     Array.prototype["customFunction"] = () => {}
 
     const override = {
-      breakpoints: [],
+      breakpoints: createBreakpoints({
+        sm: "1",
+        md: "1",
+        lg: "1",
+        xl: "1",
+      }),
     }
 
     const customTheme = extendTheme(override)
 
     delete Array.prototype["customFunction"]
 
-    expect(customTheme.breakpoints.customFunction).toBeUndefined()
+    expect((customTheme.breakpoints as any).customFunction).toBeUndefined()
   })
 })

--- a/packages/styled-system/src/types.ts
+++ b/packages/styled-system/src/types.ts
@@ -33,7 +33,7 @@ export interface SystemCSSProperties
     Omit<StyleProps, keyof CSS.Properties>,
     ApplyPropStyles {}
 
-type ThemeThunk<T> = T | ((theme: Dict) => T)
+export type ThemeThunk<T> = T | ((theme: Dict) => T)
 
 type PropertyValue<K extends keyof SystemCSSProperties> = ThemeThunk<
   ResponsiveValue<boolean | number | string | SystemCSSProperties[K]>

--- a/packages/theme/src/foundations/colors.ts
+++ b/packages/theme/src/foundations/colors.ts
@@ -1,18 +1,3 @@
-export interface ColorHues {
-  50: string
-  100: string
-  200: string
-  300: string
-  400: string
-  500: string
-  600: string
-  700: string
-  800: string
-  900: string
-}
-
-export type Colors = typeof colors
-
 const colors = {
   transparent: "transparent",
   current: "currentColor",

--- a/packages/theme/src/foundations/colors.ts
+++ b/packages/theme/src/foundations/colors.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated
+ * You can derive the Colors type from the DefaultChakraTheme:
+ *
+ * type Colors = DefaultChakraTheme["colors"]
+ */
+export type Colors = typeof colors
+
 const colors = {
   transparent: "transparent",
   current: "currentColor",

--- a/packages/theme/src/foundations/index.ts
+++ b/packages/theme/src/foundations/index.ts
@@ -22,4 +22,30 @@ const foundations = {
   transition,
 }
 
+type FoundationsType = typeof foundations
+
+/**
+ * @deprecated
+ * You can derive the Foundations type from the DefaultChakraTheme
+ *
+ * type Foundations = Pick<
+ *   DefaultChakraTheme,
+ *   | "breakpoints"
+ *   | "zIndices"
+ *   | "radii"
+ *   | "colors"
+ *   | "letterSpacings"
+ *   | "lineHeights"
+ *   | "fontWeights"
+ *   | "fonts"
+ *   | "fontSizes"
+ *   | "sizes"
+ *   | "shadows"
+ *   | "space"
+ *   | "borders"
+ *   | "transition"
+ *  >
+ */
+export interface Foundations extends FoundationsType {}
+
 export default foundations

--- a/packages/theme/src/foundations/index.ts
+++ b/packages/theme/src/foundations/index.ts
@@ -22,7 +22,4 @@ const foundations = {
   transition,
 }
 
-type FoundationsType = typeof foundations
-export interface Foundations extends FoundationsType {}
-
 export default foundations

--- a/packages/theme/src/foundations/radius.ts
+++ b/packages/theme/src/foundations/radius.ts
@@ -10,6 +10,4 @@ const radii = {
   full: "9999px",
 }
 
-export type Radii = typeof radii
-
 export default radii

--- a/packages/theme/src/foundations/radius.ts
+++ b/packages/theme/src/foundations/radius.ts
@@ -10,4 +10,12 @@ const radii = {
   full: "9999px",
 }
 
+/**
+ * @deprecated
+ * You can derive the Radii type from the DefaultChakraTheme
+ *
+ * type Radii = DefaultChakraTheme['radii']
+ */
+export type Radii = typeof radii
+
 export default radii

--- a/packages/theme/src/foundations/shadows.ts
+++ b/packages/theme/src/foundations/shadows.ts
@@ -14,4 +14,12 @@ const shadows = {
     "rgba(0, 0, 0, 0.1) 0px 0px 0px 1px, rgba(0, 0, 0, 0.2) 0px 5px 10px, rgba(0, 0, 0, 0.4) 0px 15px 40px",
 }
 
+/**
+ * @deprecated
+ * You can derive the Shadows type from the DefaultChakraTheme
+ *
+ * type Shadows = DefaultChakraTheme['shadows']
+ */
+export type Shadows = typeof shadows
+
 export default shadows

--- a/packages/theme/src/foundations/shadows.ts
+++ b/packages/theme/src/foundations/shadows.ts
@@ -14,6 +14,4 @@ const shadows = {
     "rgba(0, 0, 0, 0.1) 0px 0px 0px 1px, rgba(0, 0, 0, 0.2) 0px 5px 10px, rgba(0, 0, 0, 0.4) 0px 15px 40px",
 }
 
-export type Shadows = typeof shadows
-
 export default shadows

--- a/packages/theme/src/foundations/sizes.ts
+++ b/packages/theme/src/foundations/sizes.ts
@@ -33,4 +33,13 @@ const sizes = {
   container,
 }
 
+/**
+ * @deprecated
+ * You can derive the Sizes type from the DefaultChakraTheme
+ *
+ * type Sizes = DefaultChakraTheme['sizes']
+ */
+export type Sizes = typeof spacing &
+  typeof largeSizes & { container: typeof container }
+
 export default sizes

--- a/packages/theme/src/foundations/sizes.ts
+++ b/packages/theme/src/foundations/sizes.ts
@@ -33,7 +33,4 @@ const sizes = {
   container,
 }
 
-export type Sizes = typeof spacing &
-  typeof largeSizes & { container: typeof container }
-
 export default sizes

--- a/packages/theme/src/foundations/spacing.ts
+++ b/packages/theme/src/foundations/spacing.ts
@@ -30,5 +30,3 @@ export const spacing = {
   80: "20rem",
   96: "24rem",
 }
-
-export type Spacing = typeof spacing

--- a/packages/theme/src/foundations/spacing.ts
+++ b/packages/theme/src/foundations/spacing.ts
@@ -30,3 +30,9 @@ export const spacing = {
   80: "20rem",
   96: "24rem",
 }
+
+/**
+ * @deprecated
+ * Spacing tokens are a part of DefaultChakraTheme['sizes']
+ */
+export type Spacing = typeof spacing

--- a/packages/theme/src/foundations/typography.ts
+++ b/packages/theme/src/foundations/typography.ts
@@ -61,4 +61,19 @@ const typography = {
   },
 }
 
+/**
+ * @deprecated
+ * You can derive the Typography type from the DefaultChakraTheme
+ *
+ * type Typography = Pick<
+ *   DefaultChakraTheme,
+ *   | "letterSpacings"
+ *   | "lineHeights"
+ *   | "fontWeights"
+ *   | "fonts"
+ *   | "fontSizes"
+ *  >
+ */
+export type Typography = typeof typography
+
 export default typography

--- a/packages/theme/src/foundations/typography.ts
+++ b/packages/theme/src/foundations/typography.ts
@@ -61,6 +61,4 @@ const typography = {
   },
 }
 
-export type Typography = typeof typography
-
 export default typography

--- a/packages/theme/src/foundations/z-index.ts
+++ b/packages/theme/src/foundations/z-index.ts
@@ -14,6 +14,4 @@ const zIndices = {
   tooltip: 1800,
 }
 
-export type ZIndices = typeof zIndices
-
 export default zIndices

--- a/packages/theme/src/foundations/z-index.ts
+++ b/packages/theme/src/foundations/z-index.ts
@@ -14,4 +14,12 @@ const zIndices = {
   tooltip: 1800,
 }
 
+/**
+ * @deprecated
+ * You can derive the ZIndices type from the DefaultChakraTheme
+ *
+ * type ZIndices = DefaultChakraTheme['zIndices']
+ */
+export type ZIndices = typeof zIndices
+
 export default zIndices

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,11 +1,8 @@
-import { ColorModeOptions } from "@chakra-ui/system"
 import components from "./components"
-import foundations, { Foundations } from "./foundations"
+import foundations from "./foundations"
 import styles from "./styles"
+import { ChakraTheme, ThemeConfig, ThemeDirection } from "./theme.types"
 
-export interface ThemeConfig extends ColorModeOptions {}
-
-export type ThemeDirection = "ltr" | "rtl"
 const direction: ThemeDirection = "ltr"
 
 const config: ThemeConfig = {
@@ -13,7 +10,7 @@ const config: ThemeConfig = {
   initialColorMode: "light",
 }
 
-export const theme = {
+const defaultTheme = {
   direction,
   ...foundations,
   components,
@@ -21,11 +18,10 @@ export const theme = {
   config,
 }
 
-export interface Theme extends Foundations {
-  direction: ThemeDirection
-  components: typeof components
-  styles: typeof styles
-  config: ThemeConfig
-}
+export const theme: ChakraTheme = defaultTheme
+
+export type DefaultChakraTheme = typeof defaultTheme
+
+export * from "./theme.types"
 
 export default theme

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -33,26 +33,6 @@ export interface ColorHues {
 
 export type ThemeDirection = "ltr" | "rtl"
 
-export interface Typography {
-  fonts: RecursiveObject<string>
-  fontSizes: RecursiveObject
-  fontWeights: RecursiveObject
-  letterSpacings: RecursiveObject
-  lineHeights: RecursiveObject
-}
-
-export interface Foundations extends Typography {
-  borders: RecursiveObject
-  breakpoints: Breakpoints<Dict>
-  colors: RecursiveObject<Record<string, Partial<ColorHues>> | string>
-  radii: RecursiveObject
-  shadows: RecursiveObject<string>
-  sizes: RecursiveObject
-  space: RecursiveObject
-  transition: ThemeTransitions
-  zIndices: RecursiveObject
-}
-
 interface ComponentDefaultProps {
   size?: string
   variant?: string
@@ -84,6 +64,26 @@ export type ComponentStyleConfig =
 
 export interface ThemeComponents {
   [componentName: string]: ComponentStyleConfig
+}
+
+interface Typography {
+  fonts: RecursiveObject<string>
+  fontSizes: RecursiveObject
+  fontWeights: RecursiveObject
+  letterSpacings: RecursiveObject
+  lineHeights: RecursiveObject
+}
+
+interface Foundations extends Typography {
+  borders: RecursiveObject
+  breakpoints: Breakpoints<Dict>
+  colors: RecursiveObject<Record<string, Partial<ColorHues>> | string>
+  radii: RecursiveObject
+  shadows: RecursiveObject<string>
+  sizes: RecursiveObject
+  space: RecursiveObject
+  transition: ThemeTransitions
+  zIndices: RecursiveObject
 }
 
 export interface ChakraTheme extends Foundations {

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -1,0 +1,96 @@
+import { ColorModeOptions } from "@chakra-ui/system"
+import { Breakpoints, Styles } from "@chakra-ui/theme-tools"
+import { Dict } from "@chakra-ui/utils"
+import { StyleObjectOrFn, ThemeThunk } from "@chakra-ui/styled-system"
+
+export type RecursiveProperty<Nested = string | number> =
+  | RecursiveObject<Nested>
+  | Nested
+
+export interface RecursiveObject<Nested = string | number> {
+  [property: string]: RecursiveProperty<Nested>
+}
+
+export interface ThemeConfig extends ColorModeOptions {}
+export type ThemeTransitions = RecursiveObject & {
+  property: RecursiveObject
+  easing: RecursiveObject
+  duration: RecursiveObject
+}
+
+export interface ColorHues {
+  50: string
+  100: string
+  200: string
+  300: string
+  400: string
+  500: string
+  600: string
+  700: string
+  800: string
+  900: string
+}
+
+export type ThemeDirection = "ltr" | "rtl"
+
+export interface Typography {
+  fonts: RecursiveObject<string>
+  fontSizes: RecursiveObject
+  fontWeights: RecursiveObject
+  letterSpacings: RecursiveObject
+  lineHeights: RecursiveObject
+}
+
+export interface Foundations extends Typography {
+  borders: RecursiveObject
+  breakpoints: Breakpoints<Dict>
+  colors: RecursiveObject<Record<string, Partial<ColorHues>> | string>
+  radii: RecursiveObject
+  shadows: RecursiveObject<string>
+  sizes: RecursiveObject
+  space: RecursiveObject
+  transition: ThemeTransitions
+  zIndices: RecursiveObject
+}
+
+interface ComponentDefaultProps {
+  size?: string
+  variant?: string
+  colorScheme?: string
+}
+
+interface SystemStyleObjectRecord {
+  [key: string]: StyleObjectOrFn
+}
+
+export interface ComponentSingleStyleConfig {
+  baseStyle?: StyleObjectOrFn
+  sizes?: SystemStyleObjectRecord
+  variants?: SystemStyleObjectRecord
+  defaultProps?: ComponentDefaultProps
+}
+
+export interface ComponentMultiStyleConfig {
+  parts: string[]
+  baseStyle?: ThemeThunk<SystemStyleObjectRecord>
+  sizes?: SystemStyleObjectRecord
+  variants?: SystemStyleObjectRecord
+  defaultProps?: ComponentDefaultProps
+}
+
+export type ComponentStyleConfig =
+  | ComponentSingleStyleConfig
+  | ComponentMultiStyleConfig
+
+export interface ThemeComponents {
+  [componentName: string]: ComponentStyleConfig
+}
+
+export interface ChakraTheme extends Foundations {
+  components: ThemeComponents
+  config: ThemeConfig
+  direction: ThemeDirection
+  styles: Styles
+  layerStyles?: SystemStyleObjectRecord
+  textStyles?: SystemStyleObjectRecord
+}


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3101 

## 📝 Description

Adding an arbitrary baseTheme as second parameter to the `extendTheme` function lead to the return type any.
This PR adds a new type for a chakra ui theme `ChakraTheme`, which defined how the generic theme object looks like.

With this new type the `extendTheme` function can now provide better autocomplete and typesafety for theme overrides.

## ⛳️ Current behavior (updates)

Introducing a generic TypeScript type `ChakraTheme` to improve the `extendTheme` function even further.

## 🚀 New behavior

```ts
import { extendTheme } from "@chakra-ui/react"

export const customTheme = extendTheme({
  // here you get autocomplete for
  //   - existing definitions from the default theme
  //   - new components (Single and MultiStyle)
  //   - CSS definitions
  //   - color hues
  //   - etc.
})

export type MyCustomTheme = typeof customTheme
```

You can get typesafe access to your custom theme like this:

```ts
import { useTheme } from "@chakra-ui/react"
import { MyCustomTheme } from "./my-custom-theme"

const MyComponent = () => {
  const customTheme = useTheme<MyCustomTheme>()
  //...
}
```

## 💣 Is this a breaking change (Yes/No):

I removed a few derived types from the theme package, like `Colors` and `Sizes` because they can be statically derived by TS. Those types were meant to be used only in our codebase. If a userland project did use them nevertheless, it can be replaced by `DefaultChakraTheme['colors']`, `DefaultChakraTheme['sizes']`.

~~I do not classify this as a breaking change.~~ They are now only marked as deprecated