### PR TITLE
docs(tooltip): remove shouldWrapChildren prop from examples

### DIFF
--- a/website/pages/docs/overlay/tooltip.mdx
+++ b/website/pages/docs/overlay/tooltip.mdx
@@ -89,71 +89,71 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 ```jsx
 <VStack spacing={6}>
   <HStack spacing={6}>
-    <Tooltip shouldWrapChildren label="Auto start" placement="auto-start">
+    <Tooltip label="Auto start" placement="auto-start">
       <Button>Auto-Start</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Auto" placement="auto">
+    <Tooltip label="Auto" placement="auto">
       <Button>Auto</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Auto end" placement="auto-end">
+    <Tooltip label="Auto end" placement="auto-end">
       <Button>Auto-End</Button>
     </Tooltip>
   </HStack>
 
   <HStack spacing={6}>
-    <Tooltip shouldWrapChildren label="Top start" placement="top-start">
+    <Tooltip label="Top start" placement="top-start">
       <Button>Top-Start</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Top" placement="top">
+    <Tooltip label="Top" placement="top">
       <Button>Top</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Top end" placement="top-end">
+    <Tooltip label="Top end" placement="top-end">
       <Button>Top-End</Button>
     </Tooltip>
   </HStack>
 
   <HStack spacing={6}>
-    <Tooltip shouldWrapChildren label="Right start" placement="right-start">
+    <Tooltip label="Right start" placement="right-start">
       <Button>Right-Start</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Right" placement="right">
+    <Tooltip label="Right" placement="right">
       <Button>Right</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Right end" placement="right-end">
+    <Tooltip label="Right end" placement="right-end">
       <Button>Right-End</Button>
     </Tooltip>
   </HStack>
 
   <HStack spacing={6}>
-    <Tooltip shouldWrapChildren label="Bottom start" placement="bottom-start">
+    <Tooltip label="Bottom start" placement="bottom-start">
       <Button>Bottom Start</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Bottom" placement="bottom">
+    <Tooltip label="Bottom" placement="bottom">
       <Button>Bottom</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Bottom end" placement="bottom-end">
+    <Tooltip label="Bottom end" placement="bottom-end">
       <Button>Bottom End</Button>
     </Tooltip>
   </HStack>
 
   <HStack spacing={6}>
-    <Tooltip shouldWrapChildren label="Left start" placement="left-start">
+    <Tooltip label="Left start" placement="left-start">
       <Button>Left-Start</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Left" placement="left">
+    <Tooltip label="Left" placement="left">
       <Button>Left</Button>
     </Tooltip>
 
-    <Tooltip shouldWrapChildren label="Left end" placement="left-end">
+    <Tooltip label="Left end" placement="left-end">
       <Button>Left-End</Button>
     </Tooltip>
   </HStack>
@@ -165,57 +165,43 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 ```jsx
 <Wrap spacing={6}>
   <WrapItem>
-    <Tooltip shouldWrapChildren label="I close on click">
+    <Tooltip label="I close on click">
       <Button>Close on Click - true(default)</Button>
     </Tooltip>
   </WrapItem>
 
   <WrapItem>
-    <Tooltip
-      shouldWrapChildren
-      label="I don't close on click"
-      closeOnClick={false}
-    >
+    <Tooltip label="I don't close on click" closeOnClick={false}>
       <Button>Close on Click - false</Button>
     </Tooltip>
   </WrapItem>
 
   <WrapItem>
-    <Tooltip shouldWrapChildren label="I am always open" placement="top" isOpen>
+    <Tooltip label="I am always open" placement="top" isOpen>
       <Button>Always Open</Button>
     </Tooltip>
   </WrapItem>
 
   <WrapItem>
-    <Tooltip
-      shouldWrapChildren
-      label="I am open by default"
-      placement="left"
-      defaultIsOpen
-    >
+    <Tooltip label="I am open by default" placement="left" defaultIsOpen>
       <Button>Open on startup</Button>
     </Tooltip>
   </WrapItem>
 
   <WrapItem>
-    <Tooltip shouldWrapChildren label="Opened after 500ms" openDelay={500}>
+    <Tooltip label="Opened after 500ms" openDelay={500}>
       <Button>Delay Open - 500ms</Button>
     </Tooltip>
   </WrapItem>
 
   <WrapItem>
-    <Tooltip shouldWrapChildren label="Closed after 500ms" closeDelay={500}>
+    <Tooltip label="Closed after 500ms" closeDelay={500}>
       <Button>Delay Close - 500ms</Button>
     </Tooltip>
   </WrapItem>
 
   <WrapItem>
-    <Tooltip
-      shouldWrapChildren
-      label="I have 15px arrow"
-      hasArrow
-      arrowSize={15}
-    >
+    <Tooltip label="I have 15px arrow" hasArrow arrowSize={15}>
       <Button>Arrow size - 15px</Button>
     </Tooltip>
   </WrapItem>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Discovered in #3223 <!-- Github issue # here -->

## 📝 Description

This PR removes the `shouldWrapChildren` prop from `Tooltip` examples. The presence of that prop causes `children` to be wrapped in a `span` with `tabIndex={0}`. Since `children` are already buttons, this causes them to have two focusable wrappers, requiring a double-tab to move to the next element.
