### PR TITLE
fix(extend-theme): merge fn overrides with objects

### DIFF
--- a/.changeset/funny-monkeys-build.md
+++ b/.changeset/funny-monkeys-build.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fixed issue in `extendTheme` where overrides defined as function replaced all
+base styles defined as plain object.

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -41,11 +41,11 @@ export function extendTheme<
     object: any,
   ) {
     if (
-      isFunction(source) &&
+      (isFunction(source) || isFunction(override)) &&
       Object.prototype.hasOwnProperty.call(object, key)
     ) {
       return (...args: unknown[]) => {
-        const sourceValue = source(...args)
+        const sourceValue = isFunction(source) ? source(...args) : source
 
         const overrideValue = isFunction(override)
           ? override(...args)

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { extendTheme, ThemeOverride } from "../src/extend-theme"
 import { createBreakpoints } from "@chakra-ui/theme-tools"
 
@@ -41,6 +40,29 @@ describe("extendTheme", () => {
 
     // should have more properties from the default theme
     expect(Object.keys(solidStyles).length).toBeGreaterThan(1)
+  })
+
+  it("should merge component baseStyle object with a function result", () => {
+    const testColor = "papayawhip"
+    const override = {
+      components: {
+        Button: {
+          baseStyle: () => ({
+            bg: testColor,
+          }),
+        },
+      },
+    }
+
+    const customTheme = extendTheme(override)
+
+    const { baseStyle, defaultProps } = customTheme.components.Button
+    const baseStyles = baseStyle(defaultProps)
+
+    expect(baseStyles.bg).toBe(testColor)
+
+    // should have more properties from the default theme
+    expect(Object.keys(baseStyles).length).toBeGreaterThan(1)
   })
 
   it("should override component variant with an object", () => {

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -57,7 +57,7 @@ describe("extendTheme", () => {
     const customTheme = extendTheme(override)
 
     const { baseStyle, defaultProps } = customTheme.components.Button
-    const baseStyles = baseStyle(defaultProps)
+    const baseStyles = baseStyle()
 
     expect(baseStyles.bg).toBe(testColor)
 


### PR DESCRIPTION
## 📝 Description

Fixed issue in `extendTheme` where overrides defined as function replaced all base styles defined as plain object.

## ⛳️ Current behavior

If styles (`baseStyles`, an variant, or an size) are defined in a plain object in the base theme and user provides a function as override, all base theme styles will be dropped.

## 🚀 New behavior

Styles returned from user's override function will be merged to base theme styles.

## 💣 Is this a breaking change (Yes/No):

Hopefully no?