### PR TITLE
docs(slider): add discrete slider example

### DIFF
--- a/website/pages/docs/form/slider.mdx
+++ b/website/pages/docs/form/slider.mdx
@@ -94,6 +94,21 @@ customize its styles.
 </Slider>
 ```
 
+### Discrete Sliders
+
+Discrete sliders allow you to snap to predefined sets of values. This can be
+accomplished using the `step` prop.
+
+```jsx
+<Slider defaultValue={60} min={0} max={300} step={30}>
+  <SliderTrack bg="red.100">
+    <Box position="relative" right={10} />
+    <SliderFilledTrack bg="tomato" />
+  </SliderTrack>
+  <SliderThumb boxSize={6} />
+</Slider>
+```
+
 ### Getting the final value when dragging the slider
 
 Dragging the slider can trigger lots of updates and the user might only be


### PR DESCRIPTION
Closes #3183

## 📝 Description

As pointed out in #3183, add an example for discrete sliders in documentation.

## ⛳️ Current behavior (updates)

As described,

## 🚀 New behavior

As described.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
