### PR TITLE
docs(use-controllable): fix typo

### DIFF
--- a/website/pages/docs/hooks/use-controllable.mdx
+++ b/website/pages/docs/hooks/use-controllable.mdx
@@ -25,7 +25,7 @@ determine whether a component is controlled or uncontrolled, and also returns
 the computed value.
 
 - It returns the prop value if the component is controlled
-- It returns the state value if the component if uncontrolled
+- It returns the state value if the component is uncontrolled
 
 ### Usage
 


### PR DESCRIPTION
## 📝 Description

Hi! I just notice this little typo in the [hooks/use-controllable](https://github.com/chakra-ui/chakra-ui/blob/main/website/pages/docs/hooks/use-controllable.mdx) docs, is fixed now! 😉
