### PR TITLE
Remove inaccessible box example from documentation

### DIFF
--- a/website/pages/docs/layout/box.mdx
+++ b/website/pages/docs/layout/box.mdx
@@ -114,13 +114,3 @@ function AirbnbExample() {
 }
 ```
 
-### as prop
-
-You can use the `as` prop to change the element render, just like
-styled-components.
-
-```jsx
-<Box as="button" borderRadius="md" bg="tomato" color="white" px={4} h={8}>
-  Button
-</Box>
-```


### PR DESCRIPTION


<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

If the Box component defaults to a Div, adding a role of a button makes it seem like a button but this is not semantic. I propose removing that bit from the example, the existing example is already a good fit.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Remove as prop example from box component 

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

I think the card example provided is sufficent 

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
