### PR TITLE
feat: add support for text and layer style in component theme

### DIFF
--- a/.changeset/eighty-ties-melt.md
+++ b/.changeset/eighty-ties-melt.md
@@ -1,0 +1,28 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+- Add support for `textStyle` and `layerStyle` in styled-system package. This
+  makes it possible to use them in the component theme, `css` function, and `sx`
+  prop as well.
+
+  ```jsx
+  const theme = {
+    textStyles: {
+      caps: {
+        fontWeight: "bold",
+        fontSize: "24px",
+      },
+    },
+  }
+
+  const styles = css({ textStyle: "caps" })(theme)
+  ```
+
+  This also works for component theme as well.
+
+  > `layerStyle`, `textStyle` and `apply` can now take responsive values as
+  > well.
+
+- Refactored `apply` prop handling to use the style config pattern instead of
+  add it imperatively.

--- a/.changeset/fast-dragons-retire.md
+++ b/.changeset/fast-dragons-retire.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/system": minor
+---
+
+- Add support for responsive values when using `apply`, `textStyle` and
+  `layerStyle`.

--- a/.changeset/moody-mice-knock.md
+++ b/.changeset/moody-mice-knock.md
@@ -1,0 +1,10 @@
+---
+"@chakra-ui/utils": patch
+---
+
+Removed `objectAssign` function in favor of using native `Object.assign` method.
+It is
+[now supported in most browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#browser_compatibility)
+
+This function is only used once in the `system` package as well. This PR simply
+removes it to cut bundle size of utils. Less is more 😃.

--- a/.eslintrc
+++ b/.eslintrc
@@ -68,7 +68,8 @@
     "react/prop-types": "off",
     "@typescript-eslint/no-shadow": "off",
     "react-hooks/exhaustive-deps": "error",
-    "import/no-named-as-default": "off"
+    "import/no-named-as-default": "off",
+    "prefer-object-spread": "off"
   },
   "overrides": [
     {

--- a/packages/styled-system/src/config/others.ts
+++ b/packages/styled-system/src/config/others.ts
@@ -1,7 +1,8 @@
+import { memoizedGet as get } from "@chakra-ui/utils"
 import * as CSS from "csstype"
 import { Config, createParser, PropConfig, system } from "../core"
-import { getIsRtl } from "../utils/directionality"
 import { Length, ResponsiveValue } from "../utils"
+import { getIsRtl } from "../utils/directionality"
 
 const floatTransform: PropConfig["transform"] = (value, _, props = {}) => {
   const map = { left: "right", right: "left" }
@@ -55,6 +56,21 @@ const config: Config = {
       if (value === "focusable") return srFocusable
       return {}
     },
+  },
+  layerStyle: {
+    processResult: true,
+    property: "&",
+    transform: (value, _, theme) => get(theme, `layerStyles.${value}`, {}),
+  },
+  textStyle: {
+    processResult: true,
+    property: "&",
+    transform: (value, _, theme) => get(theme, `textStyles.${value}`, {}),
+  },
+  apply: {
+    processResult: true,
+    property: "&",
+    transform: (value, _, theme) => get(theme, value, {}),
   },
 }
 
@@ -120,6 +136,20 @@ export interface OtherProps {
    * It creates a clipping region that sets what part of an element should be shown.
    */
   clipPath?: ResponsiveValue<CSS.Property.ClipPath>
+  /**
+   * The layer style object to apply.
+   * Note: Styles must be located in `theme.layerStyles`
+   */
+  layerStyle?: ResponsiveValue<string>
+  /**
+   * The text style object to apply.
+   * Note: Styles must be located in `theme.textStyles`
+   */
+  textStyle?: ResponsiveValue<string>
+  /**
+   * Apply theme-aware style objects in `theme`
+   */
+  apply?: ResponsiveValue<string>
 }
 
 export const others = system(config)

--- a/packages/styled-system/src/core/types.ts
+++ b/packages/styled-system/src/core/types.ts
@@ -30,6 +30,7 @@ export interface PropConfig {
   scale?: string
   defaultScale?: Scale
   transform?(value: any, scale: any, props: Props): any
+  processResult?: boolean
 }
 
 export interface Config {

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -151,16 +151,7 @@ export const css = (styleOrFn: StyleObjectOrFn = {}) => (
 
     if (config === true) {
       // shortcut definition
-      config = {
-        property: key,
-        scale: key,
-      }
-    }
-
-    if (key === "apply") {
-      const apply = css(get(theme, val))(theme)
-      computedStyles = mergeWith({}, computedStyles, apply)
-      continue
+      config = { property: key, scale: key }
     }
 
     if (isObject(val)) {
@@ -169,7 +160,12 @@ export const css = (styleOrFn: StyleObjectOrFn = {}) => (
     }
 
     const scale = get(theme, config?.scale, {})
-    const value = config?.transform?.(val, scale, props) ?? get(scale, val, val)
+    let value = config?.transform?.(val, scale, props) ?? get(scale, val, val)
+    /**
+     * Useful for `layerStyle`, and `textStyle` to transform the returned
+     * result since it might use theme tokens
+     */
+    value = config?.processResult ? css(value)(theme) : value
 
     if (config?.properties) {
       for (const property of config.properties) {

--- a/packages/styled-system/src/types.ts
+++ b/packages/styled-system/src/types.ts
@@ -21,17 +21,9 @@ export interface StyleProps
     System.OutlineProps,
     System.OtherProps {}
 
-export interface ApplyPropStyles {
-  /**
-   * Apply theme-aware style objects in `theme`
-   */
-  apply?: ResponsiveValue<string>
-}
-
 export interface SystemCSSProperties
   extends CSS.Properties,
-    Omit<StyleProps, keyof CSS.Properties>,
-    ApplyPropStyles {}
+    Omit<StyleProps, keyof CSS.Properties> {}
 
 export type ThemeThunk<T> = T | ((theme: Dict) => T)
 

--- a/packages/styled-system/tests/css.test.ts
+++ b/packages/styled-system/tests/css.test.ts
@@ -493,3 +493,61 @@ test("pseudo selectors are transformed", () => {
     },
   })
 })
+
+test("should expand textStyle and layerStyle", () => {
+  const theme = {
+    colors: { red: { 300: "#red" } },
+    breakpoints: createBreakpoints({
+      sm: "400px",
+      md: "768px",
+      lg: "1200px",
+      xl: "1800px",
+    }),
+    layerStyles: {
+      v1: {
+        color: "red.300",
+        bg: "tomato",
+      },
+    },
+    textStyles: {
+      caps: {
+        textTransform: "uppercase",
+        letterSpacing: "wide",
+        fontSize: "lg",
+      },
+      lower: {
+        textTransform: "lowercase",
+        letterSpacing: "0.2px",
+        fontSize: "sm",
+      },
+    },
+  }
+
+  expect(css({ layerStyle: "v1" })(theme)).toMatchInlineSnapshot(`
+    Object {
+      "background": "tomato",
+      "color": "#red",
+    }
+  `)
+
+  expect(css({ textStyle: "caps" })(theme)).toMatchInlineSnapshot(`
+    Object {
+      "fontSize": "lg",
+      "letterSpacing": "wide",
+      "textTransform": "uppercase",
+    }
+  `)
+
+  expect(css({ textStyle: ["caps", "lower"] })(theme)).toMatchInlineSnapshot(`
+    Object {
+      "@media screen and (min-width: 400px)": Object {
+        "fontSize": "sm",
+        "letterSpacing": "0.2px",
+        "textTransform": "lowercase",
+      },
+      "fontSize": "lg",
+      "letterSpacing": "wide",
+      "textTransform": "uppercase",
+    }
+  `)
+})

--- a/packages/system/src/system.ts
+++ b/packages/system/src/system.ts
@@ -2,17 +2,10 @@ import {
   css,
   propNames,
   ResponsiveValue,
-  SystemProps,
-  SystemStyleObject,
   StyleProps,
+  SystemStyleObject,
 } from "@chakra-ui/styled-system"
-import {
-  memoizedGet as get,
-  objectFilter,
-  objectAssign,
-  Dict,
-  isFunction,
-} from "@chakra-ui/utils"
+import { Dict, isFunction, objectFilter } from "@chakra-ui/utils"
 import _styled, {
   CSSObject,
   FunctionInterpolation,
@@ -25,26 +18,25 @@ import { domElements, DOMElements } from "./system.utils"
 /**
  * Convert propNames array to object to faster lookup perf
  */
-const stylePropNames = propNames.reduce((keymirror, key) => {
-  if (typeof key !== "object" && typeof key !== "function") keymirror[key] = key
-  return keymirror
+const stylePropNames = propNames.reduce((acc, key) => {
+  if (typeof key !== "object" && typeof key !== "function") acc[key] = key
+  return acc
 }, {})
 
-interface StyleResolverProps extends SystemProps {
+type StyleResolverProps = SystemStyleObject & {
   __css?: SystemStyleObject
   sx?: SystemStyleObject
   theme: Dict
   css?: CSSObject
   noOfLines?: ResponsiveValue<number>
   isTruncated?: boolean
-  layerStyle?: string
-  textStyle?: string
-  apply?: ResponsiveValue<string>
 }
 
-type GetStyleObject = (options: {
-  baseStyle?: SystemStyleObject
-}) => FunctionInterpolation<StyleResolverProps>
+interface GetStyleObject {
+  (options: {
+    baseStyle?: SystemStyleObject
+  }): FunctionInterpolation<StyleResolverProps>
+}
 
 /**
  * Style resolver function that manages how style props are merged
@@ -62,9 +54,6 @@ type GetStyleObject = (options: {
 export const getStyleObject: GetStyleObject = ({ baseStyle }) => (props) => {
   const {
     theme,
-    layerStyle,
-    textStyle,
-    apply,
     noOfLines,
     isTruncated,
     css: cssProp,
@@ -72,9 +61,6 @@ export const getStyleObject: GetStyleObject = ({ baseStyle }) => (props) => {
     sx,
     ...rest
   } = props
-
-  const _layerStyle = get(theme, `layerStyles.${layerStyle}`, {})
-  const _textStyle = get(theme, `textStyles.${textStyle}`, {})
 
   // filter out props that aren't style props
   const styleProps = objectFilter(rest, (_, prop) => prop in stylePropNames)
@@ -101,13 +87,10 @@ export const getStyleObject: GetStyleObject = ({ baseStyle }) => (props) => {
    * The computed, theme-aware style object. The other of the properties
    * within `objectAssign` determines how styles are overriden.
    */
-  const finalStyles = objectAssign(
+  const finalStyles = Object.assign(
     {},
     __css,
     baseStyle,
-    { apply },
-    _layerStyle,
-    _textStyle,
     truncateStyle,
     styleProps,
     sx,
@@ -117,7 +100,7 @@ export const getStyleObject: GetStyleObject = ({ baseStyle }) => (props) => {
   const computedCSS = css(finalStyles)(props.theme)
 
   // Merge the computed css object with styles in css prop
-  const cssObject: Interpolation<StyleResolverProps> = objectAssign(
+  const cssObject: Interpolation<StyleResolverProps> = Object.assign(
     computedCSS,
     isFunction(cssProp) ? cssProp(theme) : cssProp,
   )

--- a/packages/system/stories/system.stories.tsx
+++ b/packages/system/stories/system.stories.tsx
@@ -115,3 +115,26 @@ export const WithRgbGradient = () => (
     />
   </>
 )
+
+export const WithLayerStyle = () => (
+  <ThemeProvider
+    theme={{
+      layerStyles: {
+        base: {
+          bg: "pink",
+          color: "red",
+        },
+      },
+      textStyles: {
+        caps: {
+          textTransform: "uppercase",
+          fontWeight: "bold",
+        },
+      },
+    }}
+  >
+    <chakra.div layerStyle="base" textStyle="caps" color="white" px="2">
+      Welcome
+    </chakra.div>
+  </ThemeProvider>
+)

--- a/packages/system/stories/system.stories.tsx
+++ b/packages/system/stories/system.stories.tsx
@@ -1,7 +1,14 @@
 import React from "react"
 import theme from "@chakra-ui/theme"
 import { motion } from "framer-motion"
-import { chakra, PropsOf, ThemeProvider, ThemingProps, useProps } from "../src"
+import {
+  chakra,
+  PropsOf,
+  ThemeProvider,
+  ThemingProps,
+  useProps,
+  useStyleConfig,
+} from "../src"
 
 export default {
   title: "System",
@@ -136,5 +143,33 @@ export const WithLayerStyle = () => (
     <chakra.div layerStyle="base" textStyle="caps" color="white" px="2">
       Welcome
     </chakra.div>
+  </ThemeProvider>
+)
+
+const Div: React.FC = ({ children }) => {
+  const styles = useStyleConfig("Div")
+  return <chakra.div sx={styles}>{children}</chakra.div>
+}
+
+export const WithLayerStyleInComponentTheme = () => (
+  <ThemeProvider
+    theme={{
+      textStyles: {
+        caps: {
+          textTransform: "uppercase",
+          fontWeight: "bold",
+        },
+      },
+      components: {
+        Div: {
+          baseStyle: {
+            textStyle: "caps",
+            bg: "red",
+          },
+        },
+      },
+    }}
+  >
+    <Div>Welcome</Div>
   </ThemeProvider>
 )

--- a/packages/system/tests/style-resolver.test.ts
+++ b/packages/system/tests/style-resolver.test.ts
@@ -78,7 +78,7 @@ test("should resolve styles correctly", () => {
       "WebkitLineClamp": 3,
       "background": "tomato",
       "backgroundPosition": "top left",
-      "color": "#F687B3",
+      "color": "#FC8181",
       "display": "-webkit-box",
       "fontSize": 10,
       "letterSpacing": "2px",
@@ -86,7 +86,7 @@ test("should resolve styles correctly", () => {
       "paddingLeft": 40,
       "paddingRight": "1.25rem",
       "textOverflow": "ellipsis",
-      "textTransform": "capitalize",
+      "textTransform": "uppercase",
     }
   `)
 })

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -46,8 +46,7 @@
     "@types/lodash.mergewith": "4.6.6",
     "@types/object-assign": "4.0.30",
     "css-box-model": "1.2.1",
-    "lodash.mergewith": "4.6.2",
-    "object-assign": "4.1.1"
+    "lodash.mergewith": "4.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.6"

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,7 +1,6 @@
 import type { Dict, Omit } from "./types"
 
 export { default as mergeWith } from "lodash.mergewith"
-export { default as objectAssign } from "object-assign"
 
 export function omit<T extends Dict, K extends keyof T>(object: T, keys: K[]) {
   const result: Dict = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19003,7 +19003,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.1.1, object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=


### PR DESCRIPTION
## 📝 Description

This PR adds support for using `layerStyle` and `textStyle` in component theme.

- Extracted the layer and text style code to chakra's styled-system package
- Extracted the apply style to the styled-system package config

## ⛳️ Current behavior (updates)

 It's not possible to use layer and text styles

## 💣 Is this a breaking change (Yes/No):

No