### PR TITLE
perf: update descendants for pin-input

### DIFF
--- a/packages/pin-input/package.json
+++ b/packages/pin-input/package.json
@@ -53,9 +53,9 @@
     "lint:types": "tsc --noEmit"
   },
   "dependencies": {
-    "@chakra-ui/descendant": "1.0.6",
     "@chakra-ui/hooks": "1.1.3",
-    "@chakra-ui/utils": "1.1.0"
+    "@chakra-ui/utils": "1.1.0",
+    "@descendants/react": "^1.1.1"
   },
   "devDependencies": {
     "@chakra-ui/system": "1.2.1",

--- a/packages/pin-input/src/pin-input.tsx
+++ b/packages/pin-input/src/pin-input.tsx
@@ -1,10 +1,10 @@
 import {
   chakra,
-  forwardRef,
+  ChakraComponent,
+  HTMLChakraProps,
   omitThemingProps,
   ThemingProps,
   useStyleConfig,
-  HTMLChakraProps,
 } from "@chakra-ui/system"
 import { cx, getValidChildren, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -59,17 +59,19 @@ if (__DEV__) {
 
 export interface PinInputFieldProps extends HTMLChakraProps<"input"> {}
 
-export const PinInputField = forwardRef<PinInputFieldProps, "input">(
-  (props, ref) => {
-    const inputProps = usePinInputField(props, ref)
-    return (
-      <chakra.input
-        {...inputProps}
-        className={cx("chakra-pin-input", props.className)}
-      />
-    )
-  },
-)
+export const PinInputField = React.memo(
+  React.forwardRef(
+    (props: PinInputFieldProps, ref: React.Ref<HTMLInputElement>) => {
+      const inputProps = usePinInputField(props, ref)
+      return (
+        <chakra.input
+          {...inputProps}
+          className={cx("chakra-pin-input", props.className)}
+        />
+      )
+    },
+  ),
+) as ChakraComponent<"a">
 
 if (__DEV__) {
   PinInputField.displayName = "PinInputField"

--- a/packages/pin-input/src/use-pin-input.tsx
+++ b/packages/pin-input/src/use-pin-input.tsx
@@ -162,8 +162,10 @@ export function usePinInput(props: UsePinInputProps = {}) {
     if (autoFocus) {
       const firstInput = nodes.first()
       firstInput?.node?.focus()
+      setFocusedIndex(0)
     }
-  }, [autoFocus, nodes])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodes])
 
   const focusNext = React.useCallback(
     (index: number) => {

--- a/packages/pin-input/stories/pin-input.stories.tsx
+++ b/packages/pin-input/stories/pin-input.stories.tsx
@@ -1,3 +1,4 @@
+import { DescendantsContext } from "@descendants/react"
 import * as React from "react"
 import {
   PinInput,
@@ -33,10 +34,12 @@ export function HookExample() {
   })
   return (
     <PinInputProvider value={context}>
-      <Input style={style} />
-      <Input style={style} />
-      <Input style={style} />
-      <Input style={style} />
+      <DescendantsContext.Provider value={context.descendants}>
+        <Input style={style} />
+        <Input style={style} />
+        <Input style={style} />
+        <Input style={style} />
+      </DescendantsContext.Provider>
     </PinInputProvider>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,6 +1805,18 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@descendants/core@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@descendants/core/-/core-1.1.1.tgz#1b00fb7c81d07a0849f48f4a66edd02a91702f39"
+  integrity sha512-Sd/WSCIfsmtuvi4+8nMMelio3eLsJDRGoYKDHe1X9a4nqbnqc/psE9P+EPJLAsurOD8S2PUKCEHgWhKVgrB2WQ==
+
+"@descendants/react@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@descendants/react/-/react-1.1.1.tgz#0247cf68914a11befe8ce56d1e01926b1fbf8cb8"
+  integrity sha512-8CwsklXMvtZm+xku2KbOsrtv+pTn0mHHGVerSzMZ81D8v02jU6rm9TzYB6wvx0MCiL+FgJ2sSlG84xVUYwngsg==
+  dependencies:
+    "@descendants/core" "^1.1.1"
+
 "@docsearch/css@^1.0.0-alpha.28":
   version "1.0.0-alpha.28"
   resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-1.0.0-alpha.28.tgz#c8a2cd8c1bb3a6855c51892e9dbdab5d42fe6e23"


### PR DESCRIPTION
## 📝 Description

The current implementation of descendant management in Chakra provides a pretty good way to keep track of index of child specific components.

I've updated the implementation to be 2.8x faster and published it under `@descendants/react` as a way to share with the broader community.

To test this, I've updated the index management of the pin-input component and it works pretty well.

## 💣 Is this a breaking change (Yes/No):

No
