### PR TITLE
fix(theme): input flex overflow

### DIFF
--- a/.changeset/metal-snails-shout.md
+++ b/.changeset/metal-snails-shout.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Fixed an issue in Firefox where `Input` overflows it's flex container.

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -5,6 +5,7 @@ const parts = ["field", "addon"]
 const baseStyle = {
   field: {
     width: "100%",
+    minWidth: 0,
     outline: 0,
     position: "relative",
     appearance: "none",


### PR DESCRIPTION
Closes #3243

Fixed an issue in Firefox where `Input` overflows it's flex container.

## ⛳️ Current behavior (updates)

<img width="759" alt="Screenshot 2021-02-02 at 15 55 59" src="https://user-images.githubusercontent.com/14360171/106618022-6417f900-656f-11eb-9df4-212e7bdb661f.png">


## 🚀 New behavior

<img width="762" alt="Screenshot 2021-02-02 at 15 57 36" src="https://user-images.githubusercontent.com/14360171/106618043-68441680-656f-11eb-8f63-487a82f4e82b.png">


## 💣 Is this a breaking change (Yes/No):

No