### PR TITLE
fix: allow numbers in borderTop and autocomplete for fontWeight

### DIFF
--- a/.changeset/cuddly-ladybugs-suffer.md
+++ b/.changeset/cuddly-ladybugs-suffer.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Allow numbers for `borderTop` and provide autocomplete for `fontWeight` prop

--- a/packages/styled-system/src/config/border.ts
+++ b/packages/styled-system/src/config/border.ts
@@ -168,7 +168,7 @@ export interface BorderProps {
   /**
    * The CSS `border-top` property
    */
-  borderTop?: Token<CSS.Property.BorderTop, "borders">
+  borderTop?: Token<CSS.Property.BorderTop | number, "borders">
   borderBlockStart?: Token<CSS.Property.BorderBlockStart | number>
   /**
    * The CSS `border-top-width` property

--- a/packages/styled-system/src/config/typography.ts
+++ b/packages/styled-system/src/config/typography.ts
@@ -43,7 +43,7 @@ export interface TypographyProps {
   /**
    * The CSS `font-weight` property
    */
-  fontWeight?: Token<string, "fontWeights">
+  fontWeight?: Token<string | {}, "fontWeights">
   /**
    * The CSS `line-height` property
    */

--- a/packages/styled-system/src/config/typography.ts
+++ b/packages/styled-system/src/config/typography.ts
@@ -43,7 +43,7 @@ export interface TypographyProps {
   /**
    * The CSS `font-weight` property
    */
-  fontWeight?: Token<string | {}, "fontWeights">
+  fontWeight?: Token<number | (string & {}), "fontWeights">
   /**
    * The CSS `line-height` property
    */


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3246

## 📝 Description

`borderTop` did not allow numbers

`fontWeight` did not use the autocomplete string value `string & {}`

## ⛳️ Current behavior (updates)

Updated the types

## 🚀 New behavior

`borderTop` allows numbers and there is autocomplete for the prop `fontWeight`

## 💣 Is this a breaking change (Yes/No):

No