### PR TITLE
docs: refactor props table

### DIFF
--- a/.changeset/quiet-rules-share.md
+++ b/.changeset/quiet-rules-share.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/input": patch
+---
+
+Fixed the typo in `InputProps` interface due to which theming types were not correct.

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -38,10 +38,8 @@ type Omitted = "disabled" | "required" | "readOnly" | "size"
 export interface InputProps
   extends Omit<HTMLChakraProps<"input">, Omitted>,
     InputOptions,
-    ThemingProps<"InputGroup">,
-    FormControlOptions {
-  size?: string
-}
+    ThemingProps<"Input">,
+    FormControlOptions {}
 
 /**
  * Input

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -89,6 +89,7 @@ const variants = {
 
 const defaultProps = {
   variant: "subtle",
+  colorScheme: "blue",
 }
 
 export default {

--- a/website/pages/docs/media-and-icons/avatar.mdx
+++ b/website/pages/docs/media-and-icons/avatar.mdx
@@ -28,7 +28,7 @@ Chakra UI exports 3 avatar-related components:
 - `AvatarGroup`: A wrapper to stack multiple Avatars together.
 
 ```js
-import { Avatar, AvatarBadge } from "@chakra-ui/react"
+import { Avatar, AvatarBadge, AvatarGroup } from "@chakra-ui/react"
 ```
 
 ## Usage
@@ -178,6 +178,14 @@ prop.
 
 ## Props
 
-The Avatar component composes `Box` component so you can pass props for `Box`.
+### Avatar Props
 
-<PropsTable of="Avatar" />
+`Avatar` composes the `Box` component so you can pass all its props. These are
+props specific to the `Avatar` component:
+
+### Avatar Group Props
+
+`AvatarGroup` composes the `Box` component so you can pass all its props. These
+are props specific to the `AvatarGroup` component:
+
+<PropsTable of="AvatarGroup" />

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -4,6 +4,15 @@ import * as ComponentProps from "@chakra-ui/props-docs"
 import { Tag, theme } from "@chakra-ui/react"
 import MDXComponents from "./mdx-components"
 
+/**
+ * A map of components that use foreign theme key.
+ * The key is name of the component and value is the theme key it uses.
+ */
+const themeComponentKeyAliases = {
+  AlertDialog: "Modal",
+  IconButton: "Button",
+}
+
 export type PropsTableProps = {
   /**
    * displayName of the target component
@@ -109,7 +118,8 @@ const TYPE_GENERIC_THEMABLE = "(string & {})"
 function makePropsTable({ of, omit, only }: MakePropsTableOptions) {
   const props = ComponentProps[of]?.props as Record<string, any>
 
-  const componentTheme = theme.components[of]
+  const themeKey = themeComponentKeyAliases[of] ?? of
+  const componentTheme = theme.components[themeKey]
 
   const featNotImplemented = (feat: string) => (
     <>

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -74,7 +74,8 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
                 <Tag
                   size="sm"
                   colorScheme="red"
-                  mr={1}
+                  px={1}
+                  mr="0.125rem"
                   verticalAlign="baseline"
                 >
                   required

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import Link from "next/link"
 import * as ComponentProps from "@chakra-ui/props-docs"
+import { Tag, theme } from "@chakra-ui/react"
 import MDXComponents from "./mdx-components"
-import { theme } from "@chakra-ui/react"
 
 export type PropsTableProps = {
   /**
@@ -32,100 +32,13 @@ const PropsTable = ({
   ],
   only,
 }: PropsTableProps) => {
-  const info: { props: Record<string, any> } = ComponentProps[of]
-  if (!info || !info.props) {
-    return null
-  }
+  const propList = React.useMemo(() => makePropsTable({ of, omit, only }), [
+    of,
+    omit,
+    only,
+  ])
 
-  const themeComponent = theme.components[of]
-  const sizeValues = themeComponent?.sizes && Object.keys(themeComponent.sizes)
-  const variantValues =
-    themeComponent?.variants && Object.keys(themeComponent.variants)
-
-  const extendThemeLink = (
-    <Link
-      href="/docs/theming/customize-theme#customizing-component-styles"
-      passHref
-    >
-      <MDXComponents.a>extend the theme</MDXComponents.a>
-    </Link>
-  )
-
-  /**
-   * If component has size prop, override the rendered value
-   * for `size` prop with the component's size values formatted as TS type.
-   */
-  if (info.props.size) {
-    if (sizeValues) {
-      info.props.size.type.name = sizeValues
-        .map((size) => `"${size}"`)
-        .join(" | ")
-    } else {
-      info.props.size.description = (
-        <>
-          Sizes for {of} are not implemented in the default theme, but you can{" "}
-          {extendThemeLink} to implement them.
-        </>
-      )
-    }
-  }
-
-  /**
-   * If component has variant prop, override the rendered value
-   * for `variant` prop with the component's variant values formatted as TS type.
-   */
-  if (info.props.variant) {
-    if (variantValues) {
-      info.props.variant.type.name = variantValues
-        .map((variant) => `"${variant}"`)
-        .join(" | ")
-    } else {
-      info.props.variant.description = (
-        <>
-          Variants for {of} are not implemented in the default theme, but you
-          can {extendThemeLink} to implement them.
-        </>
-      )
-    }
-  }
-
-  const defaultSize = themeComponent?.defaultProps?.size
-  const defaultVariant = themeComponent?.defaultProps?.variant
-
-  if (defaultSize != null) {
-    info.props.size.defaultValue = {
-      value: defaultSize,
-    }
-  }
-
-  if (defaultVariant != null) {
-    info.props.variant.defaultValue = {
-      value: defaultVariant,
-    }
-  }
-
-  const entries = React.useMemo(
-    () =>
-      Object.entries(info.props)
-        .filter(([propName]) => {
-          if (Array.isArray(only)) {
-            return only.includes(propName)
-          }
-          if (Array.isArray(omit)) {
-            return !omit.includes(propName)
-          }
-          return true
-        })
-        .sort(([a, aDef], [b, bDef]) => {
-          const aRequired = aDef.required ? 1000 : 0
-          const bRequired = bDef.required ? 1000 : 0
-          const requiredOffset = aRequired - bRequired
-          return String(a).localeCompare(b) - requiredOffset
-        }),
-    [info.props, omit, only],
-  )
-
-  if (!entries.length) {
+  if (!propList.length) {
     // this error breaks the build to notify you when there would be an empty table
     throw new Error(
       `No props left to render for component ${of}.
@@ -141,39 +54,45 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
           <MDXComponents.th>Type</MDXComponents.th>
           <MDXComponents.th>Description</MDXComponents.th>
           <MDXComponents.th>Default</MDXComponents.th>
-          {/* <MDXComponents.th>Required</MDXComponents.th> */}
         </tr>
       </thead>
       <tbody>
-        {entries.map(([propName, values]) => (
-          <tr key={propName}>
-            <MDXComponents.td>{propName}</MDXComponents.td>
+        {propList.map((prop) => (
+          <tr key={prop.name}>
+            <MDXComponents.td>{prop.name}</MDXComponents.td>
             <MDXComponents.td>
+              {prop.required && (
+                <Tag
+                  size="sm"
+                  colorScheme="red"
+                  mr={1}
+                  verticalAlign="baseline"
+                >
+                  required
+                </Tag>
+              )}
               <MDXComponents.inlineCode
                 whiteSpace="wrap"
                 d="inline-block"
                 lineHeight="tall"
               >
-                {values.type?.name}
+                {prop.type}
               </MDXComponents.inlineCode>
             </MDXComponents.td>
-            <MDXComponents.td>{values.description}</MDXComponents.td>
+            <MDXComponents.td>{prop.description}</MDXComponents.td>
             <MDXComponents.td>
-              {values.defaultValue?.value ? (
+              {prop.defaultValue ? (
                 <MDXComponents.inlineCode
                   whiteSpace="wrap"
                   d="inline-block"
                   lineHeight="tall"
                 >
-                  {values.defaultValue.value}
+                  {prop.defaultValue}
                 </MDXComponents.inlineCode>
               ) : (
                 "-"
               )}
             </MDXComponents.td>
-            {/* <MDXComponents.td>
-              {values.required ? "required" : "-"}
-            </MDXComponents.td> */}
           </tr>
         ))}
       </tbody>
@@ -182,3 +101,105 @@ Remove the use of <PropsTable of="${of}" /> for this component in the docs.`,
 }
 
 export default PropsTable
+
+interface MakePropsTableOptions extends PropsTableProps {}
+
+const TYPE_GENERIC_THEMABLE = "(string & {})"
+
+function makePropsTable({ of, omit, only }: MakePropsTableOptions) {
+  const props = ComponentProps[of]?.props as Record<string, any>
+
+  const componentTheme = theme.components[of]
+
+  const featNotImplemented = (feat: string) => (
+    <>
+      {feat} for <MDXComponents.inlineCode>{of}</MDXComponents.inlineCode> are
+      not implemented in the default theme. You can{" "}
+      <Link
+        href="/docs/theming/customize-theme#customizing-component-styles"
+        passHref
+      >
+        <MDXComponents.a>extend the theme</MDXComponents.a>
+      </Link>{" "}
+      to implement them.
+    </>
+  )
+
+  return Object.entries(props)
+    .filter(([name]) => {
+      if (Array.isArray(only) && !only.includes(name)) {
+        return false
+      }
+
+      if (Array.isArray(omit) && omit.includes(name)) {
+        return false
+      }
+
+      return true
+    })
+    .map(([name, { defaultValue, description, required, type }]) => {
+      const prop = {
+        name,
+        defaultValue: defaultValue?.value,
+        description,
+        required,
+        type: type.name,
+      }
+
+      if (name === "size") {
+        const defaultSize = componentTheme?.defaultProps?.size
+
+        if (defaultSize != null) {
+          prop.defaultValue = `"${defaultSize}"`
+        }
+
+        if (prop.type === TYPE_GENERIC_THEMABLE) {
+          prop.type = "string"
+          prop.description = featNotImplemented("Sizes")
+        } else {
+          prop.type = omitGenericThemableType(prop.type)
+        }
+      }
+
+      if (name === "variant") {
+        const defaultVariant = componentTheme?.defaultProps?.variant
+
+        if (defaultVariant != null) {
+          prop.defaultValue = `"${defaultVariant}"`
+        }
+
+        if (prop.type === TYPE_GENERIC_THEMABLE) {
+          prop.type = "string"
+          prop.description = featNotImplemented("Variants")
+        } else {
+          prop.type = omitGenericThemableType(prop.type)
+        }
+      }
+
+      if (name === "colorScheme") {
+        prop.type = omitGenericThemableType(prop.type)
+
+        const defaultColorScheme = componentTheme?.defaultProps?.colorScheme
+
+        if (defaultColorScheme != null) {
+          prop.defaultValue = `"${defaultColorScheme}"`
+        } else {
+          prop.description = featNotImplemented("Color Schemes")
+        }
+      }
+
+      return prop
+    })
+    .sort((propA, propB) => {
+      const aRequired = propA.required ? 1000 : 0
+      const bRequired = propB.required ? 1000 : 0
+      const requiredOffset = aRequired - bRequired
+      return String(propA.name).localeCompare(propB.name) - requiredOffset
+    })
+}
+
+const omitGenericThemableType = (type: string) =>
+  type
+    .split(" | ")
+    .filter((type) => type !== TYPE_GENERIC_THEMABLE)
+    .join(" | ")


### PR DESCRIPTION
## 📝 Description

Refactored the props table while improving few details.

- strip the `(string & {})` from type in `size`, `variant` and `colorScheme`
- handle components that use foreign theme key, so we can still show default props for them (e.g. `IconButton` uses `theme.components.Button`)
- show default `colorScheme` value where possible
- note where `colorScheme` is not implemented in the default theme
- show `required` tag in front of `type` for required props
- don't mutate objects imported from `@chakra-ui/props-docs`

## ⛳️ Current behavior

example shown: `IconButton`

<img width="606" alt="Screenshot 2021-02-02 at 23 08 02" src="https://user-images.githubusercontent.com/14360171/106669318-c68eea80-65ab-11eb-8c88-07ec3c4e119a.png">

## 🚀 New behavior

<img width="581" alt="Screenshot 2021-02-02 at 23 07 11" src="https://user-images.githubusercontent.com/14360171/106669322-cb539e80-65ab-11eb-99b7-ed27158cbf3c.png">


## 💣 Is this a breaking change (Yes/No):

No
