### PR TITLE
docs: fix command for changeset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ https://www.conventionalcommits.org/ or check out the
 4. Run `yarn changeset` to create a detailed description of your changes. This
    will be used to generate a changelog when we publish an update.
    [Learn more about Changeset](https://github.com/atlassian/changesets/tree/master/packages/cli).
-   Please note that you might have to run `git fetch origin master:master`
+   Please note that you might have to run `git fetch origin main:master`
    (where origin will be your fork on GitHub) before `yarn changeset` works.
 
 > If you made minor changes like CI config, prettier, etc, you can run


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

<!-- Github issue # here -->

## 📝 Description

> fix command that needs to be run before running `yarn changeset`.

## ⛳️ Current behavior (updates)

> The current command `git fetch origin master:master` is erroneous because we do not have a master branch in the repo and the `main` branch is the source of truth.

## 🚀 New behavior

> Updated the docs with the proper command that needs to be run before running `yarn changeset`

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
