### PR TITLE
fix(tooltip): move `pointerEvents:none` to parent

### DIFF
--- a/.changeset/fast-cars-raise.md
+++ b/.changeset/fast-cars-raise.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/theme": patch
+"@chakra-ui/tooltip": patch
+---
+
+Fixed an issue where a `Tooltip` with negative `gutter` causes flickering on
+hover.

--- a/packages/theme/src/components/tooltip.ts
+++ b/packages/theme/src/components/tooltip.ts
@@ -8,7 +8,6 @@ function baseStyle(props: Record<string, any>) {
     color: mode("whiteAlpha.900", "gray.900")(props),
     borderRadius: "sm",
     fontWeight: "medium",
-    pointerEvents: "none",
     fontSize: "sm",
     boxShadow: "md",
     maxW: "320px",

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -128,7 +128,10 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
           <Portal {...portalProps}>
             <chakra.div
               {...tooltip.getTooltipPositionerProps()}
-              __css={{ zIndex: styles.zIndex }}
+              __css={{
+                zIndex: styles.zIndex,
+                pointerEvents: "none",
+              }}
             >
               <StyledTooltip
                 variants={scale}


### PR DESCRIPTION
Closes #3257

## 📝 Description

The element with `role="tooltip"` already has `pointer-events: none` applied in the CSS, which seems to be in the spirit of resolving this issue.

But this doesn't do a lot when its parent, which in code seems to be named the "positioner" element, doesn't have the same rule applied! The positioner still receives the pointer events, which breaks my use case, and seems to contradict the intent of `pointer-events: none` on its child.

## 💣 Is this a breaking change (Yes/No):

No
