### PR TITLE
fix: localstorage error in iframe or incognito

### DIFF
--- a/.changeset/shy-swans-yawn.md
+++ b/.changeset/shy-swans-yawn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+Fix issue where reading from localStorage maybe fail due to several reasons (SecurityError, Uncaught DOMException, TypeError, etc.)

--- a/packages/color-mode/src/storage-manager.ts
+++ b/packages/color-mode/src/storage-manager.ts
@@ -1,10 +1,13 @@
+import { __DEV__ } from "@chakra-ui/utils"
 import { ColorMode } from "./color-mode.utils"
 
-const hasLocalStorage = typeof Storage !== "undefined"
+const hasSupport = () => typeof Storage !== "undefined"
 export const storageKey = "chakra-ui-color-mode"
 
+type MaybeColorMode = ColorMode | undefined
+
 export interface StorageManager {
-  get(init?: ColorMode): ColorMode | undefined
+  get(init?: ColorMode): MaybeColorMode
   set(value: ColorMode): void
   type: "cookie" | "localStorage"
 }
@@ -14,17 +17,25 @@ export interface StorageManager {
  */
 export const localStorageManager: StorageManager = {
   get(init?) {
-    if (!hasLocalStorage) {
+    if (!hasSupport()) return init
+    try {
+      const value = localStorage.getItem(storageKey) as MaybeColorMode
+      return value ?? init
+    } catch (error) {
+      if (__DEV__) {
+        console.log(error)
+      }
       return init
     }
-
-    const maybeValue = window.localStorage.getItem(storageKey) as ColorMode
-
-    return maybeValue ?? init
   },
   set(value) {
-    if (hasLocalStorage) {
+    if (!hasSupport()) return
+    try {
       window.localStorage.setItem(storageKey, value)
+    } catch (error) {
+      if (__DEV__) {
+        console.log(error)
+      }
     }
   },
   type: "localStorage",

--- a/packages/color-mode/src/storage-manager.ts
+++ b/packages/color-mode/src/storage-manager.ts
@@ -31,7 +31,7 @@ export const localStorageManager: StorageManager = {
   set(value) {
     if (!hasSupport()) return
     try {
-      window.localStorage.setItem(storageKey, value)
+     localStorage.setItem(storageKey, value)
     } catch (error) {
       if (__DEV__) {
         console.log(error)


### PR DESCRIPTION
Closes #3202 #3252

## 📝 Description

Reading from localStorage directly can fail due to several reasons. When rendered in an iframe or incognition, it could throw a SecurityError, Uncaught DOMException, TypeError, etc. To handle this, I wrapped the calls to localStorage in a try-catch block.

## ⛳️ Current behavior (updates)

Throws when rendered in an iframe or codesandbox incognito
