### PR TITLE
feat(theme-typings): add autocomplete for negative space values

### DIFF
--- a/.changeset/curly-cameras-doubt.md
+++ b/.changeset/curly-cameras-doubt.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": minor
+"@chakra-ui/styled-system": minor
+---
+
+Theme Typings: Add autocomplete for negative space values

--- a/tooling/cli/src/command/tokens/config.ts
+++ b/tooling/cli/src/command/tokens/config.ts
@@ -12,7 +12,7 @@ export const themeKeyConfiguration: ThemeKeyOptions[] = [
   { key: "radii" },
   { key: "shadows" },
   { key: "sizes", maxScanDepth: 2 },
-  { key: "space" },
+  { key: "space", flatMap: (value) => [value, `-${value}`] },
   { key: "textStyles" },
   { key: "transition" },
   { key: "zIndices" },

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -93,7 +93,7 @@ describe("Theme typings", () => {
         radii: \\"sm\\" | \\"md\\"
         shadows: \\"sm\\" | \\"md\\"
         sizes: \\"sm\\" | \\"md\\"
-        space: \\"sm\\" | \\"md\\"
+        space: \\"sm\\" | \\"-sm\\" | \\"md\\" | \\"-md\\"
         textStyles: never
         transition: \\"sm\\" | \\"md\\"
         zIndices: \\"sm\\" | \\"md\\"


### PR DESCRIPTION
## 📝 Description

The theme typings only provide autocomplete for positive values:

```tsx
<Box mt="2" />
```

## ⛳️ Current behavior (updates)

Added a `flatMap` property to the theme tokens type generator to create for every value a type prefixed with `-`.

## 🚀 New behavior

Now we get autocomplete for negative values as well:

```tsx
<Box mt="-2" />
```

## 💣 Is this a breaking change (Yes/No):

No
