### PR TITLE
fix: support negative values for css variable theme tokens

### DIFF
--- a/.changeset/silly-bugs-dance.md
+++ b/.changeset/silly-bugs-dance.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/utils": minor
+"@chakra-ui/styled-system": patch
+---
+
+Support negative scale values for css variables.

--- a/packages/styled-system/src/utils/positive-or-negative.ts
+++ b/packages/styled-system/src/utils/positive-or-negative.ts
@@ -1,4 +1,4 @@
-import { StringOrNumber, isString, isNumber } from "@chakra-ui/utils"
+import { StringOrNumber, isString, isNumber, isCssVar } from "@chakra-ui/utils"
 import unit from "./get-unit"
 
 const startsWith = (string: string, target: string) =>
@@ -17,7 +17,7 @@ export function positiveOrNegative(
   if (startsWith(valueString, "-")) {
     const raw = scale[valueString.slice(1)]
     if (isString(raw)) {
-      result = `-${raw}`
+      result = isCssVar(raw) ? `calc(${raw} * -1)` : `-${raw}`
     } else if (isNumber(raw)) {
       result = raw * -1
     } else {

--- a/packages/styled-system/tests/css.test.ts
+++ b/packages/styled-system/tests/css.test.ts
@@ -238,6 +238,30 @@ test("handles negative margins from scale", () => {
   })
 })
 
+test("handles negative values from custom css var scale", () => {
+  const customTheme = {
+    ...theme,
+    space: ["var(--size-0)", "var(--size-1)", "var(--size-2)", "var(--size-3)"],
+  }
+  const result = css({
+    mt: -1,
+    mx: -2,
+    top: -3,
+    right: -3,
+    bottom: -3,
+    left: -3,
+  })(customTheme)
+  expect(result).toEqual({
+    marginTop: `calc(var(--size-1) * -1)`,
+    marginLeft: `calc(var(--size-2) * -1)`,
+    marginRight: `calc(var(--size-2) * -1)`,
+    top: `calc(var(--size-3) * -1)`,
+    right: `calc(var(--size-3) * -1)`,
+    bottom: `calc(var(--size-3) * -1)`,
+    left: `calc(var(--size-3) * -1)`,
+  })
+})
+
 test("handles negative top, left, bottom, and right from scale", () => {
   const result = css({
     top: -1,

--- a/packages/utils/src/assertion.ts
+++ b/packages/utils/src/assertion.ts
@@ -56,6 +56,10 @@ export function isString(value: any): value is string {
   return Object.prototype.toString.call(value) === "[object String]"
 }
 
+export function isCssVar(value: string) {
+  return /^var\(--.+\)$/.test(value)
+}
+
 // Event assertions
 export function isInputEvent(value: any): value is ChangeEvent {
   return value && isObject(value) && isObject(value.target)

--- a/packages/utils/tests/assertion.test.ts
+++ b/packages/utils/tests/assertion.test.ts
@@ -14,6 +14,7 @@ import {
   isInputEvent,
   isEmpty,
   isNotEmptyObject,
+  isCssVar,
 } from "../src"
 
 test("is number", () => {
@@ -81,6 +82,11 @@ test("is null", () => {
 
 test("is string", () => {
   expect(isString("1")).toBeTruthy()
+})
+
+test("is css var", () => {
+  expect(isCssVar("var(--whatever-you-want)")).toBeTruthy()
+  expect(isCssVar("4")).not.toBeTruthy()
 })
 
 test("is input event", () => {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3111 

## 📝 Description
This handles negative scale values for css variables used in custom themes

## ⛳️ Current behavior (updates)
If css variables are used for theme values, negative scales will be ignored and be treated as positive.

## 🚀 New behavior
This PR will use `calc()` to convert them to convert css variable to negative values.

## 💣 Is this a breaking change (Yes/No):
no.

## 📝 Additional Information
