### PR TITLE
Fix: pin input last entry update fails to call onComplete

### DIFF
--- a/.changeset/tiny-apples-wait.md
+++ b/.changeset/tiny-apples-wait.md
@@ -1,0 +1,10 @@
+---
+"@chakra-ui/pin-input": minor
+---
+
+Previously isComplete was being determined based off of old state values as it
+was determined before the setState took effect. This caused the last pin-input
+entry to not call onComplete when updated. Updating the isComplete check to
+reference the next values (the value of the state after rerender) allows the
+check to use the most up to date values in the pin-input fields fixing the last
+digit update issue.

--- a/.changeset/tiny-apples-wait.md
+++ b/.changeset/tiny-apples-wait.md
@@ -2,9 +2,4 @@
 "@chakra-ui/pin-input": minor
 ---
 
-Previously isComplete was being determined based off of old state values as it
-was determined before the setState took effect. This caused the last pin-input
-entry to not call onComplete when updated. Updating the isComplete check to
-reference the next values (the value of the state after rerender) allows the
-check to use the most up to date values in the pin-input fields fixing the last
-digit update issue.
+Change isComplete flag to check next values instead of stale state values.

--- a/.changeset/tiny-apples-wait.md
+++ b/.changeset/tiny-apples-wait.md
@@ -2,4 +2,5 @@
 "@chakra-ui/pin-input": minor
 ---
 
-Change isComplete flag to check next values instead of stale state values.
+Resolved an issue where completing character entry in `PinInput` failed to call
+`onComplete`.

--- a/packages/pin-input/src/use-pin-input.ts
+++ b/packages/pin-input/src/use-pin-input.ts
@@ -162,7 +162,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
       const isComplete =
         value !== "" &&
         index === descendants.length - 1 &&
-        values.every((inputValue) => inputValue !== "")
+        nextValues.every((inputValue) => inputValue !== "")
 
       if (isComplete) {
         onComplete?.(nextValues.join(""))

--- a/packages/pin-input/tests/pin-input.test.tsx
+++ b/packages/pin-input/tests/pin-input.test.tsx
@@ -117,3 +117,23 @@ test('otp flag enables "one-time-code" autocomplete on fields', () => {
     "one-time-code",
   )
 })
+
+test("Replacing last input calls onComplete correctly", () => {
+  const onComplete = jest.fn()
+  const { getByTestId } = render(<Component onComplete={onComplete} />)
+
+  userEvent.type(getByTestId("1"), "1")
+  userEvent.type(getByTestId("2"), "2")
+  userEvent.type(getByTestId("3"), "3")
+
+  expect(onComplete).toHaveBeenCalledWith("123")
+  onComplete.mockClear()
+
+  userEvent.clear(getByTestId("3"))
+
+  expect(onComplete).not.toHaveBeenCalledWith("123")
+
+  userEvent.type(getByTestId("3"), "3")
+
+  expect(onComplete).toHaveBeenCalledWith("123")
+})


### PR DESCRIPTION
## 📝 Description

Previously `isComplete` was being determined based off of old state values as it was determined before the setState took effect. This caused the last pin-input entry to not call `onComplete` when updated. Updating the `isComplete` check to reference the next values (the value of the state after rerender) allows the check to use the most up to date values in the pin-input fields fixing the last digit update issue.

## ⛳️ Current behavior (updates)

Previously, when updating the last entry in a `PinInput`, the `onComplete` function would not be called.

![Before](https://user-images.githubusercontent.com/36650048/107106038-976cb900-67f7-11eb-97d8-f9edec698672.gif)

## 🚀 New behavior

This PR changes the `isComplete` flag to check the next values which is the most up to date value the user entered. With this change, the `onComplete` is now called when the last entry is updated as expected.

![After](https://user-images.githubusercontent.com/36650048/107106075-d26eec80-67f7-11eb-8fe8-984edaca8b0c.gif)

## 💣 Is this a breaking change (Yes/No):

No.
