### PR TITLE
docs(accordion): add button heading wrappers and note

### DIFF
--- a/packages/accordion/stories/accordion.stories.tsx
+++ b/packages/accordion/stories/accordion.stories.tsx
@@ -64,12 +64,14 @@ export const Basic = () => (
 export const allowToggle = () => (
   <Accordion allowToggle>
     <AccordionItem>
-      <AccordionButton>
-        <chakra.div flex="1" textAlign="left">
-          Section 1 title
-        </chakra.div>
-        <AccordionIcon />
-      </AccordionButton>
+      <h2>
+        <AccordionButton>
+          <chakra.div flex="1" textAlign="left">
+            Section 1 title
+          </chakra.div>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
       <AccordionPanel pb={4}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -79,12 +81,14 @@ export const allowToggle = () => (
     </AccordionItem>
 
     <AccordionItem>
-      <AccordionButton>
-        <chakra.div flex="1" textAlign="left">
-          Section 2 title
-        </chakra.div>
-        <AccordionIcon />
-      </AccordionButton>
+      <h2>
+        <AccordionButton>
+          <chakra.div flex="1" textAlign="left">
+            Section 2 title
+          </chakra.div>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
       <AccordionPanel pb={4}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -98,12 +102,14 @@ export const allowToggle = () => (
 export const allowMultiple = () => (
   <Accordion allowMultiple>
     <AccordionItem>
-      <AccordionButton>
-        <chakra.div flex="1" textAlign="left">
-          Section 1 title
-        </chakra.div>
-        <AccordionIcon />
-      </AccordionButton>
+      <h2>
+        <AccordionButton>
+          <chakra.div flex="1" textAlign="left">
+            Section 1 title
+          </chakra.div>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
       <AccordionPanel pb={4}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -113,12 +119,14 @@ export const allowMultiple = () => (
     </AccordionItem>
 
     <AccordionItem>
-      <AccordionButton>
-        <chakra.div flex="1" textAlign="left">
-          Section 2 title
-        </chakra.div>
-        <AccordionIcon />
-      </AccordionButton>
+      <h2>
+        <AccordionButton>
+          <chakra.div flex="1" textAlign="left">
+            Section 2 title
+          </chakra.div>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
       <AccordionPanel pb={4}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -132,12 +140,14 @@ export const allowMultiple = () => (
 export const stylingExpanded = () => (
   <Accordion allowToggle>
     <AccordionItem>
-      <AccordionButton _expanded={{ bg: "tomato", color: "white" }}>
-        <chakra.div flex="1" textAlign="left">
-          Click me to see a different style
-        </chakra.div>
-        <AccordionIcon />
-      </AccordionButton>
+      <h2>
+        <AccordionButton _expanded={{ bg: "tomato", color: "white" }}>
+          <chakra.div flex="1" textAlign="left">
+            Click me to see a different style
+          </chakra.div>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
       <AccordionPanel>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -196,12 +206,14 @@ export function Bug_2160() {
         <Accordion allowToggle>
           {displayData.map((item, i) => (
             <AccordionItem key={`accordion-item-${i}`}>
-              <AccordionButton>
-                <chakra.div flex="1" textAlign="left">
-                  {item.title}
-                </chakra.div>
-                <AccordionIcon />
-              </AccordionButton>
+              <h2>
+                <AccordionButton>
+                  <chakra.div flex="1" textAlign="left">
+                    {item.title}
+                  </chakra.div>
+                  <AccordionIcon />
+                </AccordionButton>
+              </h2>
               <AccordionPanel pb={4}>{item.text}</AccordionPanel>
             </AccordionItem>
           ))}
@@ -228,12 +240,14 @@ export const FocusBug = () => {
             <DrawerBody>
               <Accordion allowMultiple>
                 <AccordionItem>
-                  <AccordionButton>
-                    <Box flex="1" textAlign="left">
-                      Section 1 title
-                    </Box>
-                    <AccordionIcon />
-                  </AccordionButton>
+                  <h2>
+                    <AccordionButton>
+                      <Box flex="1" textAlign="left">
+                        Section 1 title
+                      </Box>
+                      <AccordionIcon />
+                    </AccordionButton>
+                  </h2>
                   <AccordionPanel pb={4}>
                     <a href="https://chakra-ui.com/should-not-have-focus-if-panel-closed-1">
                       Chakra 1
@@ -248,12 +262,14 @@ export const FocusBug = () => {
                 </AccordionItem>
 
                 <AccordionItem>
-                  <AccordionButton>
-                    <Box flex="1" textAlign="left">
-                      Section 2 title
-                    </Box>
-                    <AccordionIcon />
-                  </AccordionButton>
+                  <h2>
+                    <AccordionButton>
+                      <Box flex="1" textAlign="left">
+                        Section 2 title
+                      </Box>
+                      <AccordionIcon />
+                    </AccordionButton>
+                  </h2>
                   <AccordionPanel pb={4}>
                     <a href="https://chakra-ui.com/should-not-have-focus-if-panel-closed-4">
                       Chakra 1

--- a/packages/accordion/tests/accordion.test.tsx
+++ b/packages/accordion/tests/accordion.test.tsx
@@ -17,7 +17,9 @@ it("passes a11y test", async () => {
   await testA11y(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>Section 1 title</AccordionButton>
+        <h2>
+          <AccordionButton>Section 1 title</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -28,7 +30,11 @@ test("uncontrolled: It opens the accordion panel", () => {
   render(
     <Accordion defaultIndex={0}>
       <AccordionItem>
-        <AccordionButton data-testid="button">Section 1 title</AccordionButton>
+        <h2>
+          <AccordionButton data-testid="button">
+            Section 1 title
+          </AccordionButton>
+        </h2>
         <AccordionPanel data-testid="panel">Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -41,7 +47,9 @@ test("uncontrolled: toggles the accordion on click", async () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>Trigger</AccordionButton>
+        <h2>
+          <AccordionButton>Trigger</AccordionButton>
+        </h2>
         <AccordionPanel>Panel</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -62,7 +70,9 @@ test("arrow up & down moves focus to next/previous accordion", () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>Section 1 title</AccordionButton>
+        <h2>
+          <AccordionButton>Section 1 title</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
@@ -87,17 +97,23 @@ test("home & end keys moves focus to first/last accordion", () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>First section</AccordionButton>
+        <h2>
+          <AccordionButton>First section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
       <AccordionItem>
-        <AccordionButton>Second section</AccordionButton>
+        <h2>
+          <AccordionButton>Second section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
       <AccordionItem>
-        <AccordionButton>Last section</AccordionButton>
+        <h2>
+          <AccordionButton>Last section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 2</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -117,12 +133,16 @@ test("only one accordion can be visible + is not togglable", () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>First section</AccordionButton>
+        <h2>
+          <AccordionButton>First section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
       <AccordionItem>
-        <AccordionButton>Second section</AccordionButton>
+        <h2>
+          <AccordionButton>Second section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -141,12 +161,16 @@ test("only one accordion can be visible + is togglable", () => {
   render(
     <Accordion allowToggle>
       <AccordionItem>
-        <AccordionButton>First section</AccordionButton>
+        <h2>
+          <AccordionButton>First section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
       <AccordionItem>
-        <AccordionButton>Second section</AccordionButton>
+        <h2>
+          <AccordionButton>Second section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -166,12 +190,16 @@ test("multiple accordions can be opened + is togglable", () => {
   render(
     <Accordion allowMultiple>
       <AccordionItem>
-        <AccordionButton>First section</AccordionButton>
+        <h2>
+          <AccordionButton>First section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
       <AccordionItem>
-        <AccordionButton>Second section</AccordionButton>
+        <h2>
+          <AccordionButton>Second section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -192,7 +220,9 @@ test("has the proper aria attributes", () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>Section 1 title</AccordionButton>
+        <h2>
+          <AccordionButton>Section 1 title</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -210,17 +240,23 @@ test("tab moves focus to the next focusable element", () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>First section</AccordionButton>
+        <h2>
+          <AccordionButton>First section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
       <AccordionItem>
-        <AccordionButton>Second section</AccordionButton>
+        <h2>
+          <AccordionButton>Second section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
 
       <AccordionItem>
-        <AccordionButton>Last section</AccordionButton>
+        <h2>
+          <AccordionButton>Last section</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 2</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -244,7 +280,9 @@ test("aria-contols for button is same as id for panel", () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>Section 1 title</AccordionButton>
+        <h2>
+          <AccordionButton>Section 1 title</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -259,11 +297,15 @@ test("aria-expanded is true/false when accordion is open/closed", () => {
   render(
     <Accordion defaultIndex={0}>
       <AccordionItem>
-        <AccordionButton>Section 1 title</AccordionButton>
+        <h2>
+          <AccordionButton>Section 1 title</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
       <AccordionItem>
-        <AccordionButton>Section 2 title</AccordionButton>
+        <h2>
+          <AccordionButton>Section 2 title</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 2</AccordionPanel>
       </AccordionItem>
     </Accordion>,
@@ -278,7 +320,9 @@ test("panel has role=region and aria-labelledby", () => {
   render(
     <Accordion>
       <AccordionItem>
-        <AccordionButton>Section 1 title</AccordionButton>
+        <h2>
+          <AccordionButton>Section 1 title</AccordionButton>
+        </h2>
         <AccordionPanel>Panel 1</AccordionPanel>
       </AccordionItem>
     </Accordion>,

--- a/website/pages/docs/disclosure/accordion.mdx
+++ b/website/pages/docs/disclosure/accordion.mdx
@@ -26,7 +26,7 @@ Chakra UI exports 5 accordion-related components.
   `AccordionItem` children.
 - `AccordionItem`: A single accordion item.
 - `AccordionButton`: The button that toggles the expand/collapse state of the
-  accordion item.
+  accordion item. This button must be wrapped in an element with role `heading`.
 - `AccordionPanel`: The container for the details to be revealed.
 - `AccordionIcon`: A `chevron-down` icon that rotates based on the
   expanded/collapsed state
@@ -52,12 +52,14 @@ the `up` and `down` arrow keys will move focus between accordion buttons.
 ```jsx
 <Accordion>
   <AccordionItem>
-    <AccordionButton>
-      <Box flex="1" textAlign="left">
-        Section 1 title
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          Section 1 title
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel pb={4}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -67,12 +69,14 @@ the `up` and `down` arrow keys will move focus between accordion buttons.
   </AccordionItem>
 
   <AccordionItem>
-    <AccordionButton>
-      <Box flex="1" textAlign="left">
-        Section 2 title
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          Section 2 title
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel pb={4}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -94,12 +98,14 @@ items to be expanded at once.
 ```jsx
 <Accordion defaultIndex={[0]} allowMultiple>
   <AccordionItem>
-    <AccordionButton>
-      <Box flex="1" textAlign="left">
-        Section 1 title
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          Section 1 title
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel pb={4}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -109,12 +115,14 @@ items to be expanded at once.
   </AccordionItem>
 
   <AccordionItem>
-    <AccordionButton>
-      <Box flex="1" textAlign="left">
-        Section 2 title
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          Section 2 title
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel pb={4}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -132,12 +140,14 @@ If you set `allowToggle` to `true`, any expanded item may be collapsed again.
 ```jsx
 <Accordion allowToggle>
   <AccordionItem>
-    <AccordionButton>
-      <Box flex="1" textAlign="left">
-        Section 1 title
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          Section 1 title
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel pb={4}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -147,12 +157,14 @@ If you set `allowToggle` to `true`, any expanded item may be collapsed again.
   </AccordionItem>
 
   <AccordionItem>
-    <AccordionButton>
-      <Box flex="1" textAlign="left">
-        Section 2 title
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          Section 2 title
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel pb={4}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -172,12 +184,14 @@ style this state.
 ```jsx
 <Accordion>
   <AccordionItem>
-    <AccordionButton _expanded={{ bg: "tomato", color: "white" }}>
-      <Box flex="1" textAlign="left">
-        Click me to see a different style
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton _expanded={{ bg: "tomato", color: "white" }}>
+        <Box flex="1" textAlign="left">
+          Click me to see a different style
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -196,12 +210,14 @@ render prop. It provides 2 internal state props: `isExpanded` and `isDisabled`.
 ```jsx
 <Accordion allowMultiple>
   <AccordionItem>
-    <AccordionButton>
-      <Box flex="1" textAlign="left">
-        Section 1 title
-      </Box>
-      <AccordionIcon />
-    </AccordionButton>
+    <h2>
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          Section 1 title
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+    </h2>
     <AccordionPanel pb={4}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -213,16 +229,18 @@ render prop. It provides 2 internal state props: `isExpanded` and `isDisabled`.
   <AccordionItem>
     {({ isExpanded }) => (
       <>
-        <AccordionButton>
-          <Box flex="1" textAlign="left">
-            Section 2 title
-          </Box>
-          {isExpanded ? (
-            <MinusIcon fontSize="12px" />
-          ) : (
-            <AddIcon fontSize="12px" />
-          )}
-        </AccordionButton>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">
+              Section 2 title
+            </Box>
+            {isExpanded ? (
+              <MinusIcon fontSize="12px" />
+            ) : (
+              <AddIcon fontSize="12px" />
+            )}
+          </AccordionButton>
+        </h2>
         <AccordionPanel pb={4}>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The [WAI-ARIA Authoring Practices document](https://www.w3.org/TR/wai-aria-practices-1.2/) notes that accordion headers [must be rendered inside an element with role `heading`](https://www.w3.org/TR/wai-aria-practices-1.2/#wai-aria-roles-states-and-properties). This PR wraps instances of `AccordionButton` in `heading` elements in stories, tests, and docs. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
