### PR TITLE
fix: theme typings for *group components

### DIFF
--- a/.changeset/violet-cats-march.md
+++ b/.changeset/violet-cats-march.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/accordion": patch
+"@chakra-ui/avatar": patch
+"@chakra-ui/button": patch
+"@chakra-ui/checkbox": patch
+"@chakra-ui/input": patch
+"@chakra-ui/radio": patch
+---
+
+Provide better typings for `size` and `variant` for AvatarGroup, CheckboxGroup,
+ButtonGroup, and RadioGroup

--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -33,7 +33,7 @@ import {
 export interface AccordionProps
   extends UseAccordionProps,
     Omit<HTMLChakraProps<"div">, keyof UseAccordionProps>,
-    ThemingProps {
+    ThemingProps<"Accordion"> {
   /**
    * If `true`, height animation and transitions will be disabled.
    */

--- a/packages/avatar/src/avatar-group.tsx
+++ b/packages/avatar/src/avatar-group.tsx
@@ -38,7 +38,7 @@ interface AvatarGroupOptions {
 export interface AvatarGroupProps
   extends AvatarGroupOptions,
     Omit<HTMLChakraProps<"div">, "children">,
-    ThemingProps<"AvatarGroup"> {}
+    ThemingProps<"Avatar"> {}
 
 /**
  * AvatarGroup displays a number of avatars grouped together in a stack.

--- a/packages/button/src/button-group.tsx
+++ b/packages/button/src/button-group.tsx
@@ -11,7 +11,7 @@ import * as React from "react"
 
 export interface ButtonGroupProps
   extends HTMLChakraProps<"div">,
-    ThemingProps<"ButtonGroup"> {
+    ThemingProps<"Button"> {
   /**
    * If `true`, the borderRadius of button that are direct children will be altered
    * to look flushed together

--- a/packages/checkbox/src/checkbox-group.tsx
+++ b/packages/checkbox/src/checkbox-group.tsx
@@ -9,13 +9,13 @@ import {
 
 export interface CheckboxGroupProps
   extends UseCheckboxGroupProps,
-    Omit<ThemingProps<"CheckboxGroup">, "orientation"> {
+    Omit<ThemingProps<"Checkbox">, "orientation"> {
   children?: React.ReactNode
 }
 
 export interface CheckboxGroupContext
   extends Pick<UseCheckboxGroupReturn, "onChange" | "value">,
-    Omit<ThemingProps<"CheckboxGroup">, "orientation"> {}
+    Omit<ThemingProps<"Checkbox">, "orientation"> {}
 
 const [
   CheckboxGroupProvider,

--- a/packages/input/src/input-group.tsx
+++ b/packages/input/src/input-group.tsx
@@ -12,7 +12,7 @@ import * as React from "react"
 
 export interface InputGroupProps
   extends HTMLChakraProps<"div">,
-    ThemingProps<"InputGroup"> {}
+    ThemingProps<"Input"> {}
 
 export const InputGroup = forwardRef<InputGroupProps, "div">((props, ref) => {
   const styles = useMultiStyleConfig("Input", props)

--- a/packages/radio/src/radio-group.tsx
+++ b/packages/radio/src/radio-group.tsx
@@ -14,11 +14,12 @@ import {
 
 export interface RadioGroupContext
   extends Pick<UseRadioGroupReturn, "onChange" | "value" | "name">,
-    Omit<ThemingProps, "orientation"> {}
+    Omit<ThemingProps<"Radio">, "orientation"> {}
 
-const [RadioGroupProvider, useRadioGroupContext] = createContext<
-  RadioGroupContext
->({
+const [
+  RadioGroupProvider,
+  useRadioGroupContext,
+] = createContext<RadioGroupContext>({
   name: "RadioGroupContext",
   strict: false,
 })
@@ -34,7 +35,7 @@ type Omitted =
 export interface RadioGroupProps
   extends UseRadioGroupProps,
     Omit<HTMLChakraProps<"div">, Omitted>,
-    Omit<ThemingProps, "orientation"> {
+    Omit<ThemingProps<"Radio">, "orientation"> {
   children: React.ReactNode
 }
 


### PR DESCRIPTION
## 📝 Description

Components like `ButtonGroup`, `AvatarGroup`, `CheckboxGroup` don't own their theming props, they only propagate the same theming props their child accepts.

For example:
If checkbox size can either sm, md, or lg, CheckboxGroup should also map to those values since it's purpose is to provide size, variant, etc to a group of checkboxes.

## ⛳️ Current behavior (updates)

No type autocomplete for these components

## 🚀 New behavior

There's now autocomplete