### PR TITLE
fix: narrow theme types for defaultProps and ComponentMultiStyleConfig

### DIFF
--- a/.changeset/tricky-beers-smell.md
+++ b/.changeset/tricky-beers-smell.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react": patch
+"@chakra-ui/theme": patch
+---
+
+Fixed an issue where the TypeScript types were too narrow for component
+defaultProps and ComponentMultiStyleConfig

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Build CRA templates
         run: yarn build:templates ../cra-templates
 
-      - name: Lint types and code
-        run: yarn lint
-
       - name: Run tests
         run: yarn test
 

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -90,6 +90,20 @@ describe("extendTheme", () => {
     expect(Object.keys(solidStyles).length).toBeGreaterThan(1)
   })
 
+  it("should be able to extend a multipart component", () => {
+    const override: ThemeOverride = {
+      components: {
+        Textarea: {
+          defaultProps: {
+            focusBorderColor: "green.200",
+          },
+        },
+      },
+    }
+
+    extendTheme(override)
+  })
+
   it("should pass typescript lint with random custom theme", () => {
     const override = {
       shadows: {

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -33,7 +33,7 @@ export interface ColorHues {
 
 export type ThemeDirection = "ltr" | "rtl"
 
-interface ComponentDefaultProps {
+interface ComponentDefaultProps extends Record<string, any> {
   size?: string
   variant?: string
   colorScheme?: string
@@ -51,7 +51,7 @@ export interface ComponentSingleStyleConfig {
 }
 
 export interface ComponentMultiStyleConfig {
-  parts: string[]
+  parts?: string[]
   baseStyle?: ThemeThunk<SystemStyleObjectRecord>
   sizes?: SystemStyleObjectRecord
   variants?: SystemStyleObjectRecord


### PR DESCRIPTION
## 📝 Description

Fixes 

```
 Type '{ defaultProps: { focusBorderColor: string; }; }' is not assignable to type 'ComponentStyleConfig'.
        Property 'parts' is missing in type '{ defaultProps: { focusBorderColor: string; }; }' but required in type 'ComponentMultiStyleConfig'.
```

