### PR TITLE
fix: allow custom breakpoint names in ResponsiveObject

### DIFF
--- a/.changeset/big-cherries-wash.md
+++ b/.changeset/big-cherries-wash.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Fixed an issue where TypeScript did not allow custom breakpoint names in
+ResponsiveObject

--- a/packages/styled-system/src/utils/types.ts
+++ b/packages/styled-system/src/utils/types.ts
@@ -3,7 +3,7 @@ import { ThemeTypings } from "../theming.types"
 export type ResponsiveArray<T> = Array<T | null>
 
 export type ResponsiveObject<T> = Partial<
-  Record<ThemeTypings["breakpoints"], T>
+  Record<ThemeTypings["breakpoints"] | string, T>
 >
 
 export type ResponsiveValue<T> = T | ResponsiveArray<T> | ResponsiveObject<T>

--- a/packages/styled-system/tests/css-type.test.ts
+++ b/packages/styled-system/tests/css-type.test.ts
@@ -109,3 +109,14 @@ test("should support deep nesting", () => {
 
   expect(styles).toBeTruthy()
 })
+
+test("should allow arbitrary breakpoint names by default", () => {
+  const styles: SystemStyleObject = {
+    mt: {
+      base: "130px",
+      tablet: "152px",
+    },
+  }
+
+  expect(styles).toBeTruthy()
+})


### PR DESCRIPTION
Closes #3305 

## 📝 Description

Custom breakpoint names are not allowed in ResponsiveObject. 
Current workaround is to use the [@chakra-ui/cli](https://chakra-ui.com/docs/theming/advanced) to generate new typings for the custom theme.

```jsx
<Box mt={{ base: "130px", tablet: "152px" }}  />
// => TS error `tablet` not allowed...
```

## ⛳️ Current behavior (updates)

Add `string` as valid key for `ResponsiveObject`.

## 🚀 New behavior

`string` is allowed as key in `ResponsiveObject`.

## 💣 Is this a breaking change (Yes/No):

No
