### PR TITLE
fix: cli tokens command ignores TS errors in theme file

### DIFF
--- a/.changeset/red-mayflies-reflect.md
+++ b/.changeset/red-mayflies-reflect.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+CLI tokens command now ignores TS errors in your theme.ts file

--- a/tooling/cli/bin/tsconfig.json
+++ b/tooling/cli/bin/tsconfig.json
@@ -5,5 +5,8 @@
     "allowJs": true,
     "strict": false,
     "noImplicitAny": false
+  },
+  "ts-node": {
+    "transpileOnly": true
   }
 }


### PR DESCRIPTION
Closes #3308 

## 📝 Description

Theme tokens typings are not generated if there are TS errors in the theme file.

## ⛳️ Current behavior (updates)

Using the ts-node flag `transpileOnly` we can disable the type checking.

## 🚀 New behavior

Chakra theme typings are generated even if there TS errors in the source theme file

## 💣 Is this a breaking change (Yes/No):

No
