### PR TITLE
fix: fixed Benjamin Carlson's resource URL

### DIFF
--- a/website/configs/resources.json
+++ b/website/configs/resources.json
@@ -102,7 +102,7 @@
       "tags": ["Next.js", "Dark Mode", "v1.0"],
       "author": "Benjamin Carlson",
       "description": "Learn about the basic components of chakra-ui, add it to Next.js and make a dark switch component.",
-      "url": "https://www.pscp.tv/thekitze/1OyJAgleVMbKb"
+      "url": "https://www.youtube.com/watch?v=lhOvI9s5gQY"
     },
     {
       "heading": "The Chakra UI Component Library",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Benjamin Carlson's resource URL was pointing to a wrong URL. I found the correct one and replaced the URL.

## ⛳️ Current behavior (updates)

> Clicking on `Chakra UI Quickstart - With Next.js` in Resources opens up Kitze's live streaming link (previous resource)

## 🚀 New behavior

> Clicking on `Chakra UI Quickstart - With Next.js` in Resources opens up the correct YouTube video

## 💣 Is this a breaking change (Yes/No):
> No
