### PR TITLE
docs(menu): fix typo

### DIFF
--- a/website/pages/docs/overlay/menu.mdx
+++ b/website/pages/docs/overlay/menu.mdx
@@ -313,7 +313,7 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
 **For `MenuItem`:**
 
 - `role` is set to `menuitem`.
-- Gets one of these roles `menuitem`/`menuitenradio`/ `menuitemcheckbox`.
+- Gets one of these roles `menuitem`/`menuitemradio`/ `menuitemcheckbox`.
 
 ## Props
 


### PR DESCRIPTION
## 📝 Description

Just a small typo

