### PR TITLE
chore(input): refactor input group styling

### DIFF
--- a/.changeset/itchy-sheep-drum.md
+++ b/.changeset/itchy-sheep-drum.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/input": patch
+"@chakra-ui/theme": patch
+---
+
+Refactored styling of InputGroup elements to use CSS selectors instead of
+JavaScript logic.

--- a/packages/input/src/input-addon.tsx
+++ b/packages/input/src/input-addon.tsx
@@ -9,16 +9,6 @@ import * as React from "react"
 
 type Placement = "left" | "right"
 
-const StyledAddon = chakra("div", {
-  baseStyle: {
-    flex: "0 0 auto",
-    width: "auto",
-    display: "flex",
-    alignItems: "center",
-    whiteSpace: "nowrap",
-  },
-})
-
 export interface InputAddonProps extends HTMLChakraProps<"div"> {
   placement?: Placement
 }
@@ -32,11 +22,25 @@ export const InputAddon = forwardRef<InputAddonProps, "div">((props, ref) => {
   const { placement = "left", ...rest } = props
   const styles = useStyles()
 
+  const cssStyles = {
+    flex: "0 0 auto",
+    width: "auto",
+    display: "flex",
+    alignItems: "center",
+    whiteSpace: "nowrap",
+    ...styles.addon,
+    // Workaround to force the following css to be always placed _after_ the all above styes.
+    // Otherwise, if css above contains any media queries,
+    // they would be moved to the end and increased their priority.
+    // See: https://github.com/emotion-js/emotion/issues/1860
+    "&&": props.__css,
+  }
+
   return (
-    <StyledAddon
+    <chakra.div
       ref={ref}
       {...rest}
-      __css={styles.addon}
+      __css={cssStyles}
       className={cx(`chakra-input__${placement}-addon`, props.className)}
     />
   )
@@ -52,7 +56,18 @@ if (__DEV__) {
  * Element to append to the left of an input
  */
 export const InputLeftAddon = forwardRef<InputAddonProps, "div">(
-  (props, ref) => <InputAddon ref={ref} placement="left" {...props} />,
+  (props, ref) => (
+    <InputAddon
+      ref={ref}
+      placement="left"
+      __css={{
+        marginRight: "-1px",
+        borderRightColor: "transparent",
+        borderRightRadius: 0,
+      }}
+      {...props}
+    />
+  ),
 )
 
 if (__DEV__) {
@@ -68,7 +83,18 @@ InputLeftAddon.id = "InputLeftAddon"
  * Element to append to the right of an input
  */
 export const InputRightAddon = forwardRef<InputAddonProps, "div">(
-  (props, ref) => <InputAddon ref={ref} placement="right" {...props} />,
+  (props, ref) => (
+    <InputAddon
+      ref={ref}
+      placement="right"
+      __css={{
+        marginLeft: "-1px",
+        borderLeftColor: "transparent",
+        borderLeftRadius: 0,
+      }}
+      {...props}
+    />
+  ),
 )
 
 if (__DEV__) {

--- a/packages/input/src/input-addon.tsx
+++ b/packages/input/src/input-addon.tsx
@@ -9,19 +9,6 @@ import * as React from "react"
 
 type Placement = "left" | "right"
 
-const placements = {
-  left: {
-    marginRight: "-1px",
-    borderRightRadius: 0,
-    borderRightColor: "transparent",
-  },
-  right: {
-    marginLeft: "-1px",
-    borderLeftRadius: 0,
-    borderLeftColor: "transparent",
-  },
-}
-
 const StyledAddon = chakra("div", {
   baseStyle: {
     flex: "0 0 auto",
@@ -43,17 +30,14 @@ export interface InputAddonProps extends HTMLChakraProps<"div"> {
  */
 export const InputAddon = forwardRef<InputAddonProps, "div">((props, ref) => {
   const { placement = "left", ...rest } = props
-  const placementStyles = placements[placement] ?? {}
   const styles = useStyles()
 
   return (
     <StyledAddon
       ref={ref}
       {...rest}
-      __css={{
-        ...styles.addon,
-        ...placementStyles,
-      }}
+      __css={styles.addon}
+      className={cx(`chakra-input__${placement}-addon`, props.className)}
     />
   )
 })
@@ -68,14 +52,7 @@ if (__DEV__) {
  * Element to append to the left of an input
  */
 export const InputLeftAddon = forwardRef<InputAddonProps, "div">(
-  (props, ref) => (
-    <InputAddon
-      ref={ref}
-      placement="left"
-      {...props}
-      className={cx("chakra-input__left-addon", props.className)}
-    />
-  ),
+  (props, ref) => <InputAddon ref={ref} placement="left" {...props} />,
 )
 
 if (__DEV__) {
@@ -91,14 +68,7 @@ InputLeftAddon.id = "InputLeftAddon"
  * Element to append to the right of an input
  */
 export const InputRightAddon = forwardRef<InputAddonProps, "div">(
-  (props, ref) => (
-    <InputAddon
-      ref={ref}
-      placement="right"
-      {...props}
-      className={cx("chakra-input__right-addon", props.className)}
-    />
-  ),
+  (props, ref) => <InputAddon ref={ref} placement="right" {...props} />,
 )
 
 if (__DEV__) {

--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -2,7 +2,6 @@ import {
   chakra,
   forwardRef,
   SystemStyleObject,
-  useStyles,
   HTMLChakraProps,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
@@ -12,32 +11,24 @@ export interface InputElementProps extends HTMLChakraProps<"div"> {
   placement?: "left" | "right"
 }
 
-const StyledElement = chakra("div", {
-  baseStyle: {
+const InputElement = forwardRef<InputElementProps, "div">((props, ref) => {
+  const { placement = "left", ...rest } = props
+
+  const elementStyles: SystemStyleObject = {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
     position: "absolute",
     top: "0",
     zIndex: 2,
-  },
-})
-
-const InputElement = forwardRef<InputElementProps, "div">((props, ref) => {
-  const { placement = "left", ...rest } = props
-
-  const styles = useStyles()
-  const input: any = styles.field
-
-  const elementStyles: SystemStyleObject = {
     [placement]: "0",
-    width: input?.height ?? input?.h,
-    height: input?.height ?? input?.h,
-    fontSize: input?.fontSize,
-    paddingX: input?.paddingLeft ?? input?.pl,
+    width: "var(--chakra-input-group-height)",
+    height: "var(--chakra-input-group-height)",
+    fontSize: "var(--chakra-input-group-font-size)",
+    paddingX: "var(--chakra-input-group-padding-left)",
   }
 
-  return <StyledElement ref={ref} __css={elementStyles} {...rest} />
+  return <chakra.div ref={ref} __css={elementStyles} {...rest} />
 })
 
 // This is used in `input-group.tsx`

--- a/packages/input/src/input-group.tsx
+++ b/packages/input/src/input-group.tsx
@@ -12,42 +12,38 @@ import * as React from "react"
 
 export interface InputGroupProps
   extends HTMLChakraProps<"div">,
-    ThemingProps<"Input"> {}
+    ThemingProps<"InputGroup"> {}
 
 export const InputGroup = forwardRef<InputGroupProps, "div">((props, ref) => {
   const styles = useMultiStyleConfig("Input", props)
   const { children, className, ...rest } = omitThemingProps(props)
 
-  const _className = cx("chakra-input__group", className)
-  const groupStyles: InputGroupProps = {}
-
   const validChildren = getValidChildren(children)
 
-  const input: any = styles.field
+  const hasLeftAddon = validChildren.some(
+    (child: any) => child.type.id === "InputLeftAddon",
+  )
+  const hasRightAddon = validChildren.some(
+    (child: any) => child.type.id === "InputRightAddon",
+  )
 
-  validChildren.forEach((child: any) => {
-    if (!styles) return
+  const hasLeftElement = validChildren.some(
+    (child: any) => child.type.id === "InputLeftElement",
+  )
+  const hasRightElement = validChildren.some(
+    (child: any) => child.type.id === "InputRightElement",
+  )
 
-    if (input && child.type.id === "InputLeftElement") {
-      groupStyles.paddingLeft = input.height ?? input.h
-    }
-
-    if (input && child.type.id === "InputRightElement") {
-      groupStyles.paddingRight = input.height ?? input.h
-    }
-
-    if (child.type.id === "InputRightAddon") {
-      groupStyles.borderRightRadius = 0
-    }
-
-    if (child.type.id === "InputLeftAddon") {
-      groupStyles.borderLeftRadius = 0
-    }
-  })
+  const _className = cx(
+    "chakra-input__group",
+    hasLeftAddon && "chakra-input__group--has-left-addon",
+    hasRightAddon && "chakra-input__group--has-right-addon",
+    hasLeftElement && "chakra-input__group--has-left-element",
+    hasRightElement && "chakra-input__group--has-right-element",
+    className,
+  )
 
   const clones = validChildren.map((child: any) => {
-    const { pl, paddingLeft, pr, paddingRight } = child.props
-
     /**
      * Make it possible to override the size and variant from `Input`
      */
@@ -56,15 +52,7 @@ export const InputGroup = forwardRef<InputGroupProps, "div">((props, ref) => {
       variant: child.props?.variant || props.variant,
     }
 
-    return child.type.id !== "Input"
-      ? React.cloneElement(child, theming)
-      : React.cloneElement(child, {
-          ...theming,
-          paddingLeft: pl ?? paddingLeft ?? groupStyles?.paddingLeft,
-          paddingRight: pr ?? paddingRight ?? groupStyles?.paddingRight,
-          borderLeftRadius: groupStyles?.borderLeftRadius,
-          borderRightRadius: groupStyles?.borderRightRadius,
-        })
+    return React.cloneElement(child, theming)
   })
 
   return (

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -55,7 +55,27 @@ export const Input = forwardRef<InputProps, "input">((props, ref) => {
   return (
     <chakra.input
       {...input}
-      __css={styles.field}
+      __css={{
+        ...styles.field,
+        // Workaround to force the following css to be always placed _after_ the all above styes.
+        // Otherwise, if css above contains any media queries,
+        // they would be moved to the end and increased their priority.
+        // See: https://github.com/emotion-js/emotion/issues/1860
+        "&&": {
+          ".chakra-input__group.chakra-input__group--has-left-element &": {
+            paddingLeft: "var(--chakra-input-group-height)",
+          },
+          ".chakra-input__group.chakra-input__group--has-right-element &": {
+            paddingRight: "var(--chakra-input-group-height)",
+          },
+          ".chakra-input__group.chakra-input__group--has-left-addon &": {
+            borderLeftRadius: 0,
+          },
+          ".chakra-input__group.chakra-input__group--has-right-addon &": {
+            borderRightRadius: 0,
+          },
+        },
+      }}
       ref={ref}
       className={_className}
     />

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -20,34 +20,8 @@ function makeSize(props: {
   h: number
 }) {
   return {
-    field: {
-      ...props,
-      ".chakra-input__group.chakra-input__group--has-left-element &": {
-        paddingLeft: props.h,
-      },
-      ".chakra-input__group.chakra-input__group--has-right-element &": {
-        paddingRight: props.h,
-      },
-      ".chakra-input__group.chakra-input__group--has-left-addon &": {
-        borderLeftRadius: 0,
-      },
-      ".chakra-input__group.chakra-input__group--has-right-addon &": {
-        borderRightRadius: 0,
-      },
-    },
-    addon: {
-      ...props,
-      "&.chakra-input__left-addon": {
-        marginRight: "-1px",
-        borderRightColor: "transparent",
-        borderRightRadius: 0,
-      },
-      "&.chakra-input__right-addon": {
-        marginLeft: "-1px",
-        borderLeftColor: "transparent",
-        borderLeftRadius: 0,
-      },
-    },
+    field: props,
+    addon: props,
   }
 }
 

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -13,53 +13,72 @@ const baseStyle = {
   },
 }
 
-const size = {
-  lg: {
-    fontSize: "lg",
-    px: 4,
-    h: 12,
-    borderRadius: "md",
-  },
-
-  md: {
-    fontSize: "md",
-    px: 4,
-    h: 10,
-    borderRadius: "md",
-  },
-
-  sm: {
-    fontSize: "sm",
-    px: 3,
-    h: 8,
-    borderRadius: "sm",
-  },
-
-  xs: {
-    fontSize: "xs",
-    px: 2,
-    h: 6,
-    borderRadius: "sm",
-  },
+function makeSize(props: {
+  fontSize: string
+  borderRadius: string
+  px: number
+  h: number
+}) {
+  return {
+    field: {
+      ...props,
+      ".chakra-input__group.chakra-input__group--has-left-element &": {
+        paddingLeft: props.h,
+      },
+      ".chakra-input__group.chakra-input__group--has-right-element &": {
+        paddingRight: props.h,
+      },
+      ".chakra-input__group.chakra-input__group--has-left-addon &": {
+        borderLeftRadius: 0,
+      },
+      ".chakra-input__group.chakra-input__group--has-right-addon &": {
+        borderRightRadius: 0,
+      },
+    },
+    addon: {
+      ...props,
+      "&.chakra-input__left-addon": {
+        marginRight: "-1px",
+        borderRightColor: "transparent",
+        borderRightRadius: 0,
+      },
+      "&.chakra-input__right-addon": {
+        marginLeft: "-1px",
+        borderLeftColor: "transparent",
+        borderLeftRadius: 0,
+      },
+    },
+  }
 }
 
 const sizes = {
-  lg: {
-    field: size.lg,
-    addon: size.lg,
-  },
-  md: {
-    field: size.md,
-    addon: size.md,
-  },
-  sm: {
-    field: size.sm,
-    addon: size.sm,
-  },
-  xs: {
-    field: size.xs,
-    addon: size.xs,
-  },
+  lg: makeSize({
+    fontSize: "lg",
+    borderRadius: "md",
+    px: 4,
+    h: 12,
+  }),
+
+  md: makeSize({
+    fontSize: "md",
+    borderRadius: "md",
+    px: 4,
+    h: 10,
+  }),
+
+  sm: makeSize({
+    fontSize: "sm",
+    borderRadius: "sm",
+    px: 3,
+    h: 8,
+  }),
+
+  xs: makeSize({
+    fontSize: "xs",
+    borderRadius: "sm",
+    px: 2,
+    h: 6,
+  }),
 }
 
 function getDefaults(props: Record<string, any>) {

--- a/website/pages/docs/form/input.mdx
+++ b/website/pages/docs/form/input.mdx
@@ -65,9 +65,9 @@ The input component comes in 4 variants: `outline`, `unstyled`, `flushed`, and
 
 ### Left and Right Addons
 
-Like bootstrap, you can add addons to the left and right of the `Input`
-component. Chakra UI exports `InputGroup`, `InputLeftAddon`, and
-`InputRightAddon` to help with this use case.
+You can add addons to the left and right of the `Input` component. Chakra UI
+exports `InputGroup`, `InputLeftAddon`, and `InputRightAddon` to help with this
+use case.
 
 ```jsx
 <Stack spacing={4}>

--- a/website/pages/docs/form/input.mdx
+++ b/website/pages/docs/form/input.mdx
@@ -91,10 +91,6 @@ In some scenarios, you might need to add an icon or button inside the input
 component. Chakra UI exports `InputLeftElement` and `InputRightElement` to help
 with this use case.
 
-If the left or right is an icon or text, you can pass `pointerEvents="none"` to
-`InputLeftElement` or `InputRightElement` to ensure that clicking on them
-focused the input.
-
 ```jsx
 <Stack spacing={4}>
   <InputGroup>


### PR DESCRIPTION
## 📝 Description

Refactored styling of InputGroup elements to use CSS selectors instead of JavaScript logic.

Moving all styling to the theme fixes issue we have in #3258 when using responsive size with `InputGroup`.

## 💣 Is this a breaking change (Yes/No):

Debatable, probably no.
