### PR TITLE
feat(color-mode): add support for nonce

### DIFF
--- a/.changeset/hungry-coins-hang.md
+++ b/.changeset/hungry-coins-hang.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/color-mode": minor
+---
+
+You can now customize the `nonce` of the `<script>` that `ColorModeScript`
+creates by passing `nonce` prop.

--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -35,6 +35,7 @@ function setScript(initialValue: Mode) {
 
 interface ColorModeScriptProps {
   initialColorMode?: Mode
+  nonce?: string
 }
 
 /**
@@ -44,5 +45,7 @@ interface ColorModeScriptProps {
 export const ColorModeScript = (props: ColorModeScriptProps) => {
   const { initialColorMode = "light" } = props
   const html = `(${String(setScript)})('${initialColorMode}')`
-  return <script dangerouslySetInnerHTML={{ __html: html }} />
+  return (
+    <script nonce={props.nonce} dangerouslySetInnerHTML={{ __html: html }} />
+  )
 }


### PR DESCRIPTION
Closes #3294

## 📝 Description

You can now customize the `nonce` of the `<script>` that `ColorModeScript` creates by passing `nonce` prop.

## 💣 Is this a breaking change (Yes/No):

No