### PR TITLE
fix(form-control): workaround concurrent mode focus bug

### DIFF
--- a/packages/form-control/src/form-control.tsx
+++ b/packages/form-control/src/form-control.tsx
@@ -11,6 +11,7 @@ import {
 } from "@chakra-ui/system"
 import { createContext, cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
+import ReactDOM from "react-dom"
 
 export interface FormControlOptions {
   /**
@@ -101,13 +102,24 @@ function useFormControlProvider(props: FormControlContext) {
   // Track whether the form element (e.g, `input`) has focus.
   const [isFocused, setFocus] = useBoolean()
 
+  // This is a workaround for React Concurrent Mode issue https://github.com/facebook/react/issues/18591. Remove once it's fixed.
+  const onFocus = () => {
+    if (typeof (ReactDOM as any).flushSync === "function") {
+      ;(ReactDOM as any).flushSync(() => {
+        setFocus.on()
+      })
+    } else {
+      setFocus.on()
+    }
+  }
+
   const context = {
     isRequired: !!isRequired,
     isInvalid: !!isInvalid,
     isReadOnly: !!isReadOnly,
     isDisabled: !!isDisabled,
     isFocused: !!isFocused,
-    onFocus: setFocus.on,
+    onFocus,
     onBlur: setFocus.off,
     hasFeedbackText,
     setHasFeedbackText,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2350

## 📝 Description

Fixes form control preventing radio change event in React concurrent mode by applying workaround from https://github.com/facebook/react/issues/18591#issuecomment-697999763. This can be removed after the mentioned issue is resolved in React.

## ⛳️ Current behaviour (updates)

With React concurrent mode, radio inputs wrapped in form control require two clicks to update a selected state.

## 🚀 New behaviour

This fix only applies the workaround for projects that use experimental React. It should not affect other projects.

## 💣 Is this a breaking change (Yes/No):

No.
