### PR TITLE
docs(number-input): reposition 'isReadOnly' in mobile spinner example

### DIFF
--- a/website/pages/docs/form/number-input.mdx
+++ b/website/pages/docs/form/number-input.mdx
@@ -291,11 +291,12 @@ function HookUsage() {
     min: 1,
     max: 6,
     precision: 2,
+    isReadOnly: true,
   })
 
   const inc = getIncrementButtonProps()
   const dec = getDecrementButtonProps()
-  const input = getInputProps({ isReadOnly: true })
+  const input = getInputProps()
 
   return (
     <HStack maxW="320px">


### PR DESCRIPTION
## 📝 Description

> Add a brief description

Moved `isReadOnly` property from `getInputProps` to `useNumberInput`.
