### PR TITLE
feat: added menu arrow component to menu list

### DIFF
--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -8,6 +8,7 @@ import {
   SystemProps,
   SystemStyleObject,
   ThemingProps,
+  useColorModeValue,
   useMultiStyleConfig,
   useStyles,
 } from "@chakra-ui/system"
@@ -179,6 +180,32 @@ export const MenuList = forwardRef<MenuListProps, "div">((props, ref) => {
 
 if (__DEV__) {
   MenuList.displayName = "MenuList"
+}
+
+export interface MenuArrowProps extends HTMLChakraProps<"div"> {}
+
+export const MenuArrow: React.FC<MenuArrowProps> = (props) => {
+  const { popper } = useMenuContext()
+
+  const { getArrowProps, getArrowWrapperProps } = popper
+  const styles = useStyles()
+
+  return (
+    <chakra.div
+      {...getArrowWrapperProps()}
+      className={cx("chakra-popover__arrow-positioner", props.className)}
+    >
+      <chakra.div
+        className={cx("chakra-popover__arrow", props.className)}
+        {...getArrowProps(props)}
+        __css={styles.arrow}
+      />
+    </chakra.div>
+  )
+}
+
+if (__DEV__) {
+  MenuArrow.displayName = "MenuArrow"
 }
 
 export interface StyledMenuItemProps extends HTMLChakraProps<"button"> {}

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -12,6 +12,7 @@ import {
   useUpdateEffect,
 } from "@chakra-ui/hooks"
 import { usePopper, UsePopperProps } from "@chakra-ui/popper"
+import { useColorModeValue, useToken } from "@chakra-ui/system"
 import {
   addItem,
   callAllHandlers,
@@ -106,6 +107,9 @@ export function useMenu(props: UseMenuProps) {
     },
   })
 
+  const shadowColor = useColorModeValue("gray.200", "whiteAlpha.300")
+  const arrowColor = useToken("colors", shadowColor, "gray.200")
+
   /**
    * Add some popper.js for dynamic positioning
    */
@@ -113,6 +117,7 @@ export function useMenu(props: UseMenuProps) {
     placement,
     ...props,
     enabled: isOpen,
+    arrowShadowColor: arrowColor,
   })
 
   const [focusedIndex, setFocusedIndex] = React.useState(-1)

--- a/packages/menu/stories/menu.stories.tsx
+++ b/packages/menu/stories/menu.stories.tsx
@@ -19,6 +19,7 @@ import {
   MenuItemOption,
   MenuList,
   MenuOptionGroup,
+  MenuArrow,
 } from "../src"
 
 const words = [
@@ -51,6 +52,30 @@ export const Basic = () => (
         Open Wakanda menu
       </MenuButton>
       <MenuList>
+        {words.map((word) => (
+          <MenuItem key={word} onClick={logEvents}>
+            {word}
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Menu>
+  </div>
+)
+
+export const WithArrow = () => (
+  <div style={{ minHeight: 4000, paddingTop: 500 }}>
+    <Menu>
+      <MenuButton
+        as={Button}
+        variant="solid"
+        colorScheme="teal"
+        size="sm"
+        rightIcon={<FaUnlink />}
+      >
+        Open Wakanda menu with arrow
+      </MenuButton>
+      <MenuList>
+        <MenuArrow />
         {words.map((word) => (
           <MenuItem key={word} onClick={logEvents}>
             {word}

--- a/packages/menu/tests/menu.test.tsx
+++ b/packages/menu/tests/menu.test.tsx
@@ -18,6 +18,7 @@ import {
   MenuItemOption,
   MenuList,
   MenuOptionGroup,
+  MenuArrow,
 } from "../src"
 
 const words = [
@@ -48,6 +49,29 @@ test("passes a11y test", async () => {
       </MenuList>
     </Menu>,
   )
+})
+
+test("does render MenuArrow", async () => {
+  render(
+    <Menu>
+      <MenuButton
+        as={Button}
+        variant="solid"
+        colorScheme="teal"
+        size="sm"
+        // rightIcon={<FaUnlink />}
+      >
+        Open Wakanda menu
+      </MenuButton>
+      <MenuList>
+        <MenuArrow data-testid="menu-arrow" />
+        {words.map((word) => (
+          <MenuItem key={word}>{word}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+  expect(screen.getByTestId("menu-arrow")).not.toBeNull()
 })
 
 test("does not render MenuList Items if Menu isLazy", () => {

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -1,6 +1,14 @@
 import { mode } from "@chakra-ui/theme-tools"
 
-const parts = ["item", "command", "list", "button", "groupTitle", "divider"]
+const parts = [
+  "item",
+  "command",
+  "list",
+  "button",
+  "groupTitle",
+  "divider",
+  "arrow",
+]
 
 function baseStyleList(props: Record<string, any>) {
   return {
@@ -12,6 +20,12 @@ function baseStyleList(props: Record<string, any>) {
     zIndex: 1,
     borderRadius: "md",
     borderWidth: "1px",
+  }
+}
+
+function baseStyleArrow(props: Record<string, any>) {
+  return {
+    bg: mode("white", "gray.700")(props),
   }
 }
 
@@ -61,6 +75,7 @@ const baseStyle = (props: Record<string, any>) => ({
   groupTitle: baseStyleGroupTitle,
   command: baseStyleCommand,
   divider: baseStyleDivider,
+  arrow: baseStyleArrow(props),
 })
 
 export default {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3304

## 📝 Description

Added a new component: `MenuArrow`, similar to `PopoverArrow`

## ⛳️ Current behavior (updates)

Currently the `MenuList` component does not have an own Arrow

## 🚀 New behavior

Now `MenuList` can have or not an Arrow component

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Before

![image](https://user-images.githubusercontent.com/23138717/107419188-4231ef80-6af6-11eb-8525-7bf545022191.png)

After

![image](https://user-images.githubusercontent.com/23138717/107419128-31817980-6af6-11eb-857e-6988c09694f1.png)

New story code example

![image](https://user-images.githubusercontent.com/23138717/107419842-00ee0f80-6af7-11eb-875c-0200758ee3f4.png)


PS.: I think is need to adjust the css property, z-index, from `MenuArrow` to make it equal to `PopoverArrow`.  Waiting your feedback.
