### PR TITLE
Fix: broken peer deps modal and focus-lock on React 17

### DIFF
--- a/.changeset/blue-games-join.md
+++ b/.changeset/blue-games-join.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/focus-lock": minor
+"@chakra-ui/modal": minor
+---
+
+Upgrade to react-remove-scroll@2.4.1 and react-focus-lock@2.5.0 to fix React 17
+peer dependencies compatibility

--- a/packages/focus-lock/package.json
+++ b/packages/focus-lock/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@chakra-ui/utils": "1.2.0",
-    "react-focus-lock": "2.4.1"
+    "react-focus-lock": "2.5.0"
   },
   "peerDependencies": {
     "react": ">=16.8.6"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -66,7 +66,7 @@
     "@chakra-ui/transition": "1.0.8",
     "@chakra-ui/utils": "1.2.0",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.4.0"
+    "react-remove-scroll": "2.4.1"
   },
   "devDependencies": {
     "@chakra-ui/system": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12625,11 +12625,6 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
-  integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
-
 focus-lock@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.8.1.tgz#bb36968abf77a2063fa173cb6c47b12ac8599d33"
@@ -21640,19 +21635,7 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-focus-lock@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.4.1.tgz#e842cc93da736b5c5d331799012544295cbcee4f"
-  integrity sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    focus-lock "^0.7.0"
-    prop-types "^15.6.2"
-    react-clientside-effect "^1.2.2"
-    use-callback-ref "^1.2.1"
-    use-sidecar "^1.0.1"
-
-react-focus-lock@^2.1.0:
+react-focus-lock@2.5.0, react-focus-lock@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.0.tgz#12e3a3940e897c26e2c2a0408cd25ea3c99b3709"
   integrity sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==
@@ -21833,10 +21816,10 @@ react-remove-scroll-bar@^2.1.0:
     react-style-singleton "^2.1.0"
     tslib "^1.0.0"
 
-react-remove-scroll@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.0.tgz#190c16eb508c5927595935499e8f5dd9ab0e75cf"
-  integrity sha512-BZIO3GaEs0Or1OhA5C//n1ibUP1HdjJmqUVUsOCMxwoIpaCocbB9TFKwHOkBa/nyYy3slirqXeiPYGwdSDiseA==
+react-remove-scroll@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.1.tgz#e0af6126621083a5064591d367291a81b2d107f5"
+  integrity sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==
   dependencies:
     react-remove-scroll-bar "^2.1.0"
     react-style-singleton "^2.1.0"


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2820 and Closes #3327

## 📝 Description

Upgrade to react-remove-scroll@2.4.1 and react-focus-lock@2.5.0 which adds support for React 17.

## ⛳️ Current behavior (updates)

@chakra-ui/modal@1.5.1 and @chakra-ui/focus-lock@1.0.4 seem to have broken dependencies. Seems to expect react ^16.8.0 and brakes on react 17. react-remove-scroll@2.4.1 and react-focus-lock@2.5.0 add the compatibility with react 17.

--legacy-peer-deps seems to be the workaround at the moment. 

npm WARN Could not resolve dependency:
npm WARN peer react@"^16.8.0" from react-remove-scroll@2.4.0
npm WARN node_modules/@chakra-ui/modal/node_modules/react-remove-scroll
npm WARN react-remove-scroll@"2.4.0" from @chakra-ui/modal@1.5.1

npm WARN Could not resolve dependency:
npm WARN peer react@"^16.8.0" from react-focus-lock@2.4.1
npm WARN node_modules/@chakra-ui/focus-lock/node_modules/react-focus-lock
npm WARN react-focus-lock@"2.4.1" from @chakra-ui/focus-lock@1.0.4

## 🚀 New behavior

Upgraded react-remove-scroll from 2.4.0 to 2.4.1 and react-focus-lock from 2.4.1 to 2.5.0.
Both seem to be minor changes on each packages according to their change logs.

## 💣 Is this a breaking change (Yes/No):

No, both use the following.

```json
"peerDependencies": {
    "react": "^16.8.0 || ^17.0.0"
  },
```

## 📝 Additional Information

Build and test passed.