### PR TITLE
fix: export types from theme, styled-system

### DIFF
--- a/.changeset/afraid-eels-visit.md
+++ b/.changeset/afraid-eels-visit.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/styled-system": patch
+"@chakra-ui/theme": patch
+---
+
+fix: export types from theme, styled-system
+

--- a/packages/styled-system/src/types.ts
+++ b/packages/styled-system/src/types.ts
@@ -41,13 +41,13 @@ type PseudoKeys = keyof CSS.Pseudos | keyof Pseudos
 
 type PseudoSelectorDefinition<D> = D | RecursivePseudo<D>
 
-type RecursivePseudo<D> = {
+export type RecursivePseudo<D> = {
   [K in PseudoKeys]?: PseudoSelectorDefinition<D> & D
 }
 
 type CSSDefinition<D> = D | string | RecursiveCSSSelector<D | string>
 
-interface RecursiveCSSSelector<D> {
+export interface RecursiveCSSSelector<D> {
   [selector: string]: CSSDefinition<D> & D
 }
 

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -3,7 +3,7 @@ import foundations from "./foundations"
 import styles from "./styles"
 import { ChakraTheme, ThemeConfig, ThemeDirection } from "./theme.types"
 
-const direction: ThemeDirection = "ltr"
+const direction = "ltr" as ThemeDirection
 
 const config: ThemeConfig = {
   useSystemColorMode: false,

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -30,7 +30,9 @@ export interface ColorHues {
   800: string
   900: string
 }
-
+export type Colors = RecursiveObject<
+  Record<string, Partial<ColorHues>> | string
+>
 export type ThemeDirection = "ltr" | "rtl"
 
 interface ComponentDefaultProps extends Record<string, any> {
@@ -77,7 +79,7 @@ interface Typography {
 interface Foundations extends Typography {
   borders: RecursiveObject
   breakpoints: Breakpoints<Dict>
-  colors: RecursiveObject<Record<string, Partial<ColorHues>> | string>
+  colors: Colors
   radii: RecursiveObject
   shadows: RecursiveObject<string>
   sizes: RecursiveObject


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Exporting Types from them and style-system

## ⛳️ Current behavior (updates)

> some types were not exported and were throwing typescript error when extending the theme

## 🚀 New behavior

>  the types are exported now and this should fix the issue

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
