### PR TITLE
fix(popper): lazy init popper instance

### DIFF
--- a/.changeset/twenty-bags-approve.md
+++ b/.changeset/twenty-bags-approve.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/popper": patch
+---
+
+The Popper.js instance is now created only once it is actually needed for
+positioning.

--- a/packages/popper/src/react-popper.ts
+++ b/packages/popper/src/react-popper.ts
@@ -69,7 +69,7 @@ export function usePopper(
   const updateStateModifier: Modifier<"updateState", any> = React.useMemo(
     () => ({
       name: "updateState",
-      enabled,
+      enabled: true,
       phase: "write",
       fn: ({ state }) => {
         const elements = Object.keys(state.elements)
@@ -79,7 +79,7 @@ export function usePopper(
       },
       requires: ["computeStyles"],
     }),
-    [enabled],
+    [],
   )
 
   const popperOptions = React.useMemo(() => {
@@ -117,7 +117,7 @@ export function usePopper(
   }, [popperOptions])
 
   useSafeLayoutEffect(() => {
-    if (referenceElement == null || popperElement == null) {
+    if (!enabled || referenceElement == null || popperElement == null) {
       return
     }
 
@@ -134,7 +134,7 @@ export function usePopper(
       popperInstance.destroy()
       popperInstanceRef.current = null
     }
-  }, [referenceElement, popperElement, options.createPopper])
+  }, [enabled, referenceElement, popperElement, options.createPopper])
 
   React.useEffect(() => {
     const id = requestAnimationFrame(() => {

--- a/website/pages/docs/overlay/menu.mdx
+++ b/website/pages/docs/overlay/menu.mdx
@@ -166,8 +166,8 @@ the letter you typed.
 
 ### Adding icons and commands
 
-You can add icon to each `MenuItem` by passing the `icon` prop.
-To add a commands (or hotkeys) to menu items, you can use the `command` prop.
+You can add icon to each `MenuItem` by passing the `icon` prop. To add a
+commands (or hotkeys) to menu items, you can use the `command` prop.
 
 ```jsx
 <Menu>
@@ -179,10 +179,18 @@ To add a commands (or hotkeys) to menu items, you can use the `command` prop.
     variant="outline"
   />
   <MenuList>
-    <MenuItem icon={<AddIcon />} command="⌘T">New Tab</MenuItem>
-    <MenuItem icon={<ExternalLinkIcon />} command="⌘N">New Window</MenuItem>
-    <MenuItem icon={<RepeatIcon />} command="⌘⇧N">Open Closed Tab</MenuItem>
-    <MenuItem icon={<EditIcon />} command="⌘O">Open File...</MenuItem>
+    <MenuItem icon={<AddIcon />} command="⌘T">
+      New Tab
+    </MenuItem>
+    <MenuItem icon={<ExternalLinkIcon />} command="⌘N">
+      New Window
+    </MenuItem>
+    <MenuItem icon={<RepeatIcon />} command="⌘⇧N">
+      Open Closed Tab
+    </MenuItem>
+    <MenuItem icon={<EditIcon />} command="⌘O">
+      Open File...
+    </MenuItem>
   </MenuList>
 </Menu>
 ```
@@ -199,9 +207,7 @@ the component is displayed.
 
 ```jsx
 <Menu isLazy>
-  <MenuButton size="sm" colorScheme="teal">
-    Open menu
-  </MenuButton>
+  <MenuButton>Open menu</MenuButton>
   <MenuList>
     {/* MenuItems are not rendered unless Menu is open */}
     <MenuItem>New Window</MenuItem>
@@ -218,9 +224,7 @@ To render menus in a portal, import the `Portal` component and wrap the
 
 ```jsx
 <Menu>
-  <MenuButton size="sm" colorScheme="teal">
-    Open menu
-  </MenuButton>
+  <MenuButton>Open menu</MenuButton>
   <Portal>
     <MenuList>
       <MenuItem>Menu 1</MenuItem>


### PR DESCRIPTION
Closes #2531

## 📝 Description

The Popper.js instance is now created only once it is actually needed for positioning.

## 💣 Is this a breaking change (Yes/No):

No