### PR TITLE
docs: add docs for ColorModeScript nonce

### DIFF
--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -35,6 +35,9 @@ function setScript(initialValue: Mode) {
 
 interface ColorModeScriptProps {
   initialColorMode?: Mode
+  /**
+   * Optional nonce that will be passed to the created `<script>` tag.
+   */
   nonce?: string
 }
 

--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -57,6 +57,9 @@ syncing to work correctly.
 > When setting the initial color mode, we recommend adding it as a config to
 > your theme and reference that in the `ColorModeScript`.
 
+> To use `ColorModeScript` on a site with strict `Content-Security-Policy`, you
+> can use the `nonce` prop that will be passed to the `<script>` tag.
+
 #### For Next.js
 
 For Next.js, you need to add the `ColorModeScript` to the `_document.js` file.
@@ -64,9 +67,9 @@ For Next.js, you need to add the `ColorModeScript` to the `_document.js` file.
 ```jsx live=false ln={16}
 // pages/_document.js
 
-import {ColorModeScript} from '@chakra-ui/react'
-import NextDocument, {Html, Head, Main, NextScript} from 'next/document'
-import theme from './theme'
+import { ColorModeScript } from "@chakra-ui/react"
+import NextDocument, { Html, Head, Main, NextScript } from "next/document"
+import theme from "./theme"
 
 export default class Document extends NextDocument {
   render() {
@@ -82,7 +85,6 @@ export default class Document extends NextDocument {
     )
   }
 }
-
 ```
 
 #### For Create React App


### PR DESCRIPTION
## 📝 Description

Added a little documentation for the `nonce` prop of `<ColorModeScript>`.

## 💣 Is this a breaking change (Yes/No):

No
