### PR TITLE
docs: Fix typo in link overlay docs

### DIFF
--- a/website/pages/docs/navigation/link-overlay.mdx
+++ b/website/pages/docs/navigation/link-overlay.mdx
@@ -62,7 +62,7 @@ or around the title's content.
 The `LinkBox` lifts any nested links to the top using `z-index` to ensure proper
 keyboard navigation between links.
 
-> Use the keybaord to test how focus ring moves within the article
+> Use the keyboard to test how focus ring moves within the article
 
 ```jsx
 <LinkBox as="article" maxW="sm" p="5" borderWidth="1px" rounded="md">


### PR DESCRIPTION
## 📝 Description

Fixes a typo in the docs.

## 💣 Is this a breaking change (Yes/No):

No
