### PR TITLE
docs(container): add size example

### DIFF
--- a/website/pages/docs/layout/container.mdx
+++ b/website/pages/docs/layout/container.mdx
@@ -46,10 +46,10 @@ To set the size of a Container, use the `maxW` attribute.
 
 ```jsx
 <VStack>
-  <Container maxW="container.xl"> Extra-Large Container </Container>
-  <Container maxW="container.lg"> Large Container </Container>
-  <Container maxW="container.md"> Medium Container </Container>
-  <Container maxW="container.sm"> Small Container </Container>
+  <Container maxW="container.xl">Extra-Large Container</Container>
+  <Container maxW="container.lg">Large Container</Container>
+  <Container maxW="container.md">Medium Container</Container>
+  <Container maxW="container.sm">Small Container</Container>
 </VStack>
 ```
 

--- a/website/pages/docs/layout/container.mdx
+++ b/website/pages/docs/layout/container.mdx
@@ -45,12 +45,12 @@ To contain any piece of content, wrap it in the `Container` component.
 To set the size of a Container, use the `maxW` attribute.
 
 ```jsx
-<Block>
+<VStack>
   <Container maxW="container.xl"> Extra-Large Container </Container>
   <Container maxW="container.lg"> Large Container </Container>
   <Container maxW="container.md"> Medium Container </Container>
   <Container maxW="container.sm"> Small Container </Container>
-</Block>
+</VStack>
 ```
 
 ## Centering the children

--- a/website/pages/docs/layout/container.mdx
+++ b/website/pages/docs/layout/container.mdx
@@ -40,6 +40,19 @@ To contain any piece of content, wrap it in the `Container` component.
 </Container>
 ```
 
+## Container Size
+
+To set the size of a Container, use the `maxW` attribute.
+
+```jsx
+<Block>
+  <Container maxW="container.xl"> Extra-Large Container </Container>
+  <Container maxW="container.lg"> Large Container </Container>
+  <Container maxW="container.md"> Medium Container </Container>
+  <Container maxW="container.sm"> Small Container </Container>
+</Block>
+```
+
 ## Centering the children
 
 In some cases, the width of the content can be smaller than the container's


### PR DESCRIPTION
Adding missing documentation on how to set Container size

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Adding instructions on how to set the size of the Container

## ⛳️ Current behavior (updates)

Missing doc (I had to ask on Discord how to do it)

## 🚀 New behavior

Adding the `maxW` attribute and the desired size value `container.xl`, `container.lg`, `container.md` or `container.sm` 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
