### PR TITLE
fix(checkbox): Chakra Checkbox HTML Validation fix

### DIFF
--- a/.changeset/four-bees-tell.md
+++ b/.changeset/four-bees-tell.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+Improve the semantic HTML structure of checkbox. `label` is a phrasing content element and should not contain block element `div`. Replaced `div` with `span` which is an inline element.

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -170,7 +170,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">((props, ref) => {
         {clonedIcon}
       </StyledControl>
       {children && (
-        <chakra.div
+        <chakra.span
           className="chakra-checkbox__label"
           {...labelProps}
           __css={{

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -15,7 +15,7 @@ import { useCheckboxGroupContext } from "./checkbox-group"
 import { CheckboxIcon } from "./checkbox-icon"
 import { useCheckbox, UseCheckboxProps } from "./use-checkbox"
 
-const StyledControl = chakra("div", {
+const StyledControl = chakra("span", {
   baseStyle: {
     display: "inline-flex",
     alignItems: "center",
@@ -179,7 +179,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">((props, ref) => {
           }}
         >
           {children}
-        </chakra.div>
+        </chakra.span>
       )}
     </StyledContainer>
   )


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3363 

## 📝 Description

When validating the Chakra checkbox element in the w3 HTML validator an error for each rendered checkbox comes up: "Element div not allowed as child of element label in this context. (Suppressing further errors from this subtree.)" because each StyledContainer `<label>` contains a StyledControl `<div>` and a "chakra-checkbox__label" `<div>`. This is causing errors in my project which requires that I have 0 errors when my HTML is validated, so I would like to propose that these `<div>` elements are converted to `<span>` elements to resolve the issue.

## ⛳️ Current behavior (updates)

StyledControl is a `<div>`, so is "chakra-checkbox__label"

## 🚀 New behavior

Changing those 2 elements to `<span>`s instead.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
