### PR TITLE
fix: remove default theme type cast

### DIFF
--- a/.changeset/soft-knives-hide.md
+++ b/.changeset/soft-knives-hide.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Bring back the TS type `Theme` export and deprecated `DefaultChakraTheme`.

--- a/.changeset/sweet-otters-arrive.md
+++ b/.changeset/sweet-otters-arrive.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+The `extendTheme` function uses the type `Theme` again

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -1,4 +1,4 @@
-import defaultTheme, { ChakraTheme, DefaultChakraTheme } from "@chakra-ui/theme"
+import defaultTheme, { ChakraTheme, Theme } from "@chakra-ui/theme"
 import { isFunction, mergeWith } from "@chakra-ui/utils"
 
 type CloneKey<Target, Key> = Key extends keyof Target ? Target[Key] : unknown
@@ -20,7 +20,7 @@ type DeepThemeExtension<BaseTheme, ThemeType> = {
 }
 
 export type ThemeOverride = Partial<ChakraTheme> &
-  DeepThemeExtension<DefaultChakraTheme, ChakraTheme>
+  DeepThemeExtension<Theme, ChakraTheme>
 
 /**
  * Function to override or customize the Chakra UI theme conveniently
@@ -28,11 +28,11 @@ export type ThemeOverride = Partial<ChakraTheme> &
  * @param baseTheme - theme to customize
  */
 export function extendTheme<
-  BaseTheme extends ChakraTheme = DefaultChakraTheme,
+  BaseTheme extends ChakraTheme = Theme,
   Overrides extends ThemeOverride = ThemeOverride
 >(
   overrides: Overrides,
-  baseTheme: BaseTheme = defaultTheme as BaseTheme,
+  baseTheme: BaseTheme = (defaultTheme as unknown) as BaseTheme,
 ): BaseTheme & Overrides {
   function customizer(
     source: unknown,

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -237,4 +237,24 @@ describe("extendTheme", () => {
 
     expect((customTheme.breakpoints as any).customFunction).toBeUndefined()
   })
+
+  it("should allow custom breakpoints", () => {
+    const override = {
+      breakpoints: createBreakpoints({
+        sm: "1px",
+        md: "2px",
+        lg: "3px",
+        xl: "4px",
+        phone: "5px",
+      }),
+    }
+
+    const customTheme = extendTheme(override)
+
+    expect(customTheme.breakpoints).toHaveProperty("sm")
+    expect(customTheme.breakpoints).toHaveProperty("md")
+    expect(customTheme.breakpoints).toHaveProperty("lg")
+    expect(customTheme.breakpoints).toHaveProperty("xl")
+    expect(customTheme.breakpoints).toHaveProperty("phone")
+  })
 })

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,7 +1,7 @@
 import components from "./components"
 import foundations from "./foundations"
 import styles from "./styles"
-import { ChakraTheme, ThemeConfig, ThemeDirection } from "./theme.types"
+import { ThemeConfig, ThemeDirection } from "./theme.types"
 
 const direction = "ltr" as ThemeDirection
 
@@ -10,7 +10,7 @@ const config: ThemeConfig = {
   initialColorMode: "light",
 }
 
-const defaultTheme = {
+export const theme = {
   direction,
   ...foundations,
   components,
@@ -18,9 +18,13 @@ const defaultTheme = {
   config,
 }
 
-export const theme: ChakraTheme = defaultTheme
+export type Theme = typeof theme
 
-export type DefaultChakraTheme = typeof defaultTheme
+/**
+ * @deprecated
+ * Duplicate theme type. Please use `Theme`
+ */
+export type DefaultChakraTheme = Theme
 
 export * from "./theme.types"
 

--- a/packages/theme/tests/theme.test.ts
+++ b/packages/theme/tests/theme.test.ts
@@ -1,0 +1,9 @@
+import theme, { ChakraTheme } from "../src"
+
+describe("Theme", () => {
+  it("should be a ChakraTheme", () => {
+    // Check if default theme is of type ChakraTheme
+    const defaultThemeIsAChakraTheme: ChakraTheme = theme
+    expect(defaultThemeIsAChakraTheme).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Closes #3314

## 📝 Description

This PR removes the typecast of the default chakra theme to `ChakraTheme`.

Type `Theme` was replaced by `DefaultChakraTheme` in the last release. This PR brings it back again and deprecates `DefaultChakraTheme`.

`ChakaTheme` is the definition how **a** theme looks like. `Theme` and former `DefaultChakraTheme` are the exact types of the default chakra theme.

## 💣 Is this a breaking change (Yes/No):

No, it brings back a removed type.
