### PR TITLE
feat: add format options to use-clipboard

### DIFF
--- a/.changeset/nervous-poems-grab.md
+++ b/.changeset/nervous-poems-grab.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+Add support to format parameter - String. Optional. Set the MIME type of what
+you want to copy as. Use text/html to copy as HTML, text/plain to avoid
+inherited styles showing when pasted into rich text editor.

--- a/.changeset/nervous-poems-grab.md
+++ b/.changeset/nervous-poems-grab.md
@@ -2,6 +2,8 @@
 "@chakra-ui/hooks": patch
 ---
 
-Add support to format parameter - String. Optional. Set the MIME type of what
-you want to copy as. Use text/html to copy as HTML, text/plain to avoid
-inherited styles showing when pasted into rich text editor.
+### useClipboard
+
+Add support to `format` - Optional string. Set the MIME type of what you want to
+copy as. Use text/html to copy as HTML, text/plain to avoid inherited styles
+showing when pasted into rich text editor.

--- a/packages/hooks/src/use-clipboard.ts
+++ b/packages/hooks/src/use-clipboard.ts
@@ -1,22 +1,36 @@
 import { useState, useCallback, useEffect } from "react"
 import copy from "copy-to-clipboard"
 
+export interface UseClipboardOptions {
+  /**
+   * timeout delay (in ms) to switch back to initial state once copied.
+   */
+  timeout?: number
+  /**
+   * Set the desired MIME type
+   */
+  format?: string
+}
+
 /**
  * React hook to copy content to clipboard
  *
  * @param text the text or value to copy
- * @param timeout delay (in ms) to switch back to initial state once copied.
+ * @param {Number} [optionsOrTimeout=1500] optionsOrTimeout - delay (in ms) to switch back to initial state once copied.
+ * @param {Object} optionsOrTimeout
+ * @param {string} optionsOrTimeout.format - set the desired MIME type
+ * @param {number} optionsOrTimeout.timeout - delay (in ms) to switch back to initial state once copied.
  */
 export function useClipboard(
   text: string,
-  timeout:
-    | number
-    | { timeout?: number; format?: "text/plain" | "text/html" } = 1500,
+  optionsOrTimeout: number | UseClipboardOptions = {},
 ) {
   const [hasCopied, setHasCopied] = useState(false)
 
-  const { timeout: milliseconds, ...copyOptions } =
-    typeof timeout === "number" ? { timeout } : timeout
+  const { timeout = 1500, ...copyOptions } =
+    typeof optionsOrTimeout === "number"
+      ? { timeout: optionsOrTimeout }
+      : optionsOrTimeout
 
   const onCopy = useCallback(() => {
     const didCopy = copy(text, copyOptions)
@@ -29,7 +43,7 @@ export function useClipboard(
     if (hasCopied) {
       timeoutId = window.setTimeout(() => {
         setHasCopied(false)
-      }, milliseconds)
+      }, timeout)
     }
 
     return () => {
@@ -37,7 +51,7 @@ export function useClipboard(
         window.clearTimeout(timeoutId)
       }
     }
-  }, [milliseconds, hasCopied])
+  }, [timeout, hasCopied])
 
   return { value: text, onCopy, hasCopied }
 }

--- a/packages/hooks/src/use-clipboard.ts
+++ b/packages/hooks/src/use-clipboard.ts
@@ -7,13 +7,21 @@ import copy from "copy-to-clipboard"
  * @param text the text or value to copy
  * @param timeout delay (in ms) to switch back to initial state once copied.
  */
-export function useClipboard(text: string, timeout = 1500) {
+export function useClipboard(
+  text: string,
+  timeout:
+    | number
+    | { timeout?: number; format?: "text/plain" | "text/html" } = 1500,
+) {
   const [hasCopied, setHasCopied] = useState(false)
 
+  const { timeout: milliseconds, ...copyOptions } =
+    typeof timeout === "number" ? { timeout } : timeout
+
   const onCopy = useCallback(() => {
-    const didCopy = copy(text)
+    const didCopy = copy(text, copyOptions)
     setHasCopied(didCopy)
-  }, [text])
+  }, [text, copyOptions])
 
   useEffect(() => {
     let timeoutId: number | null = null
@@ -21,7 +29,7 @@ export function useClipboard(text: string, timeout = 1500) {
     if (hasCopied) {
       timeoutId = window.setTimeout(() => {
         setHasCopied(false)
-      }, timeout)
+      }, milliseconds)
     }
 
     return () => {
@@ -29,7 +37,7 @@ export function useClipboard(text: string, timeout = 1500) {
         window.clearTimeout(timeoutId)
       }
     }
-  }, [timeout, hasCopied])
+  }, [milliseconds, hasCopied])
 
   return { value: text, onCopy, hasCopied }
 }

--- a/packages/hooks/tests/use-clipboard.test.tsx
+++ b/packages/hooks/tests/use-clipboard.test.tsx
@@ -1,0 +1,28 @@
+import copy from "copy-to-clipboard"
+import { invoke, renderHook } from "@chakra-ui/test-utils"
+
+import { useClipboard } from "../src"
+
+jest.mock("copy-to-clipboard")
+jest.useFakeTimers()
+
+const text = "lorem ipsum"
+
+test.each`
+  params               | expected
+  ${100}               | ${100}
+  ${{ timeout: 2000 }} | ${2000}
+  ${{}}                | ${1500}
+  ${0}                 | ${1500}
+`("calls setTimeout with proper value", ({ params, expected }) => {
+  ;(copy as jest.Mock).mockReturnValue(true)
+
+  const { result } = renderHook(() => useClipboard(text, params))
+
+  invoke(() => {
+    result.current.onCopy()
+  })
+
+  expect(copy).toBeCalledWith(text, {})
+  expect(setTimeout).toHaveBeenCalledWith(expect.anything(), expected)
+})


### PR DESCRIPTION
## 📝 Description

Users might want to copy text in `text/html` format for example from Rich-Text Editors

## ⛳️ Current behavior (updates)

Format option is not supported.

## 🚀 New behavior

We can pass option object, with `format` parameter.

## 💣 Is this a breaking change (Yes/No):

No.

