### PR TITLE
docs(wrap): add more descriptive meta

### DIFF
--- a/website/pages/docs/layout/wrap.mdx
+++ b/website/pages/docs/layout/wrap.mdx
@@ -2,11 +2,13 @@
 title: Wrap
 package: "@chakra-ui/layout"
 image: "components/wrap.svg"
-description: API docs for the Wrap components in Chakra UI
+description: "Wrap is a layout component that adds a defined space between its children. It
+wraps its children automatically if there isn't enough space to fit any more in the same row."
 ---
 
 Wrap is a layout component that adds a defined space between its children. It
-'wraps' its children automatically if there isn't enough space to fit any child.
+wraps its children automatically if there isn't enough space to fit any more in
+the same row.
 
 Think of it as a smarter `flex-wrap` with `spacing` support. It works really
 well with things like dialog buttons, tags, and chips.


### PR DESCRIPTION
## 📝 Description

I just noticed on Discord that the `Wrap` has a very generic meta description.


## ⛳️ Current behavior (updates)

<img width="487" alt="Screenshot 2021-02-14 at 01 22 52" src="https://user-images.githubusercontent.com/14360171/107865060-40a05880-6e63-11eb-930d-a36c7d37a1af.png">

## 💣 Is this a breaking change (Yes/No):

No
