### PR TITLE
feat(accordion): make accordion icon themable

### DIFF
--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -233,16 +233,25 @@ export const AccordionIcon: React.FC<IconProps> = (props) => {
   const { isOpen, isDisabled } = useAccordionItemContext()
   const { reduceMotion } = useAccordionContext()
 
+  const _className = cx("chakra-accordion__icon", props.className)
+  const styles = useStyles()
+
   const iconStyles: SystemStyleObject = {
-    fontSize: "1.25em",
     opacity: isDisabled ? 0.4 : 1,
     transform: isOpen ? "rotate(-180deg)" : undefined,
     transition: reduceMotion ? undefined : "transform 0.2s",
     transformOrigin: "center",
+    ...styles.icon,
   }
 
   return (
-    <Icon viewBox="0 0 24 24" aria-hidden __css={iconStyles} {...props}>
+    <Icon
+      viewBox="0 0 24 24"
+      aria-hidden
+      className={_className}
+      __css={iconStyles}
+      {...props}
+    >
       <path
         fill="currentColor"
         d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"

--- a/packages/theme/src/components/accordion.ts
+++ b/packages/theme/src/components/accordion.ts
@@ -1,4 +1,4 @@
-const parts = ["container", "button", "panel"]
+const parts = ["container", "button", "panel", "icon"]
 
 const baseStyleContainer = {
   borderTopWidth: "1px",
@@ -30,10 +30,15 @@ const baseStylePanel = {
   pb: 5,
 }
 
+const baseStyleIcon = {
+  fontSize: "1.25em",
+}
+
 const baseStyle = {
   container: baseStyleContainer,
   button: baseStyleButton,
   panel: baseStylePanel,
+  icon: baseStyleIcon,
 }
 
 export default {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3375

## 📝 Description

Allow Accordion Icon to be themed

## ⛳️ Current behavior (updates)

Accordion Icon is currently not exposed to be themable

## 🚀 New behavior

Able to style Accordion Icon through the `extendTheme`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
