### PR TITLE
fix(use-controllable): call `onChange` only if value changed

### DIFF
--- a/.changeset/dirty-radios-flash.md
+++ b/.changeset/dirty-radios-flash.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+`useControllableState`: The `onChange` callback will be called only if the new
+value isn't equal to the current one.

--- a/packages/hooks/src/use-controllable.ts
+++ b/packages/hooks/src/use-controllable.ts
@@ -43,9 +43,15 @@ export function useControllableState<T>(props: UseControllableStateProps<T>) {
   const updateValue = React.useCallback(
     (next: React.SetStateAction<T>) => {
       const nextValue = runIfFn(next, value)
+
+      if (nextValue === value) {
+        return
+      }
+
       if (!isControlled) {
         setValue(nextValue)
       }
+
       handleChange(nextValue)
     },
     [isControlled, handleChange, value],


### PR DESCRIPTION
Closes #3406

## 📝 Description

Example:
```ts
const [selectedIndex, setSelectedIndex] = useControllableState({
  defaultValue: 0,
  onChange,
})
```

## ⛳️ Current behavior (updates)

Currently, if user calls the `setSelectedIndex` function with the current value, the `onChange` callback will be still called.
This happens for example [here](https://github.com/chakra-ui/chakra-ui/blob/main/packages/tabs/src/use-tabs.ts#L315), because click on a `Tab` triggers both `onClick` and `onFocus`.

## 🚀 New behavior

If the new value is strictly equal (`===`) to the current one, the `onChange` callback won't be called.

## 💣 Is this a breaking change (Yes/No):

No?