### PR TITLE
docs: remove duplicate preposition

### DIFF
--- a/website/pages/docs/contributing.mdx
+++ b/website/pages/docs/contributing.mdx
@@ -24,7 +24,7 @@ urgent hotfixes should be branched off the latest stable release rather than
 - Clone your fork to your local machine
   `git clone git@github.com:<yourname>/chakra-ui.git`
 - Create a branch `git checkout -b my-feature-branch`
-- Make your changes, lint, then push to to GitHub with
+- Make your changes, lint, then push to GitHub with
   `git push --set-upstream origin my-feature-branch`.
 - Visit GitHub and make your pull request.
 


### PR DESCRIPTION
Update 'push to to GitHub with ...'  =>  'push to GitHub with ...'

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Remove duplicate word ('to' preposition).

## ⛳️ Current behavior (updates)

> The word 'to' is repeated twice (push to to GitHub with ...)

## 🚀 New behavior

> Removed the repetition (push to GitHub with ...)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
