### PR TITLE
docs: improved ssr info about color mode

### DIFF
--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -278,20 +278,28 @@ export function getServerSideProps({ req }) {
 2. Import your wrapper component setting up Chakra:
 
 ```jsx live=false
-// e.g pages/index.js
+// setup your wrapper in the _app file (e.g: pages/_app.js)
 import { Chakra } from "../src/Chakra"
 
-export default function Index({ cookies }) {
-  return (
-    <Chakra cookies={cookies}>
-      <h1>Example</h1>
-    </Chakra>
-  )
+export default function App({ Component, pageProps }) {
+    return (
+    	<Chakra cookies={pageProps.cookies}>
+    		<Component {...pageProps} />
+    	</Chakra>
+    );
+}
+
+// e.g pages/index.js
+export default function Index() {
+  return <h1>Example</h1>
 }
 
 // re-export the reusable `getServerSideProps` function
 export { getServerSideProps } from "./Chakra"
 ```
+
+> If you need to know the name of the Chakra cookie for specific reasons,
+> it's `chakra-ui-color-mode`.
 
 > **Important:** if you're using `Next.js 9.3` or newer, the Next.js team
 > recommends avoiding `getInitialProps`. The following example is for Next 9.2

--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -227,7 +227,7 @@ function Example() {
 }
 ```
 
-## Add colorModeManager (Optional)
+## Add colorModeManager (Optional, for SSR)
 
 For server-side rendered sites, e.g. in Next.js, you may want to know the color
 preference of a user upfront so you can avoid rendering the initial color mode
@@ -299,7 +299,8 @@ export { getServerSideProps } from "./Chakra"
 ```
 
 > If you need to know the name of the Chakra cookie for specific reasons,
-> it's `chakra-ui-color-mode`.
+> it's `chakra-ui-color-mode`. Also, if you use `colorModeManager`, you can
+> avoid adding the `<ColorModeScript />` to `_document.js`.
 
 > **Important:** if you're using `Next.js 9.3` or newer, the Next.js team
 > recommends avoiding `getInitialProps`. The following example is for Next 9.2


### PR DESCRIPTION
## 📝 Description

I was trying to setup the Color Mode manager to prevent flash issues in a Next.js app and noticed that the approach currently described in the documentation doesn't work.
I faced two main issues:
- ChakraProvider should be set at the _app level, not in the index page;
- I couldn't force dark mode to be the default because I didn't know straight away the cookie name.

Therefore, I found the cookie name and setup the ChakraProvider at the _app level, providing the `cookies` value through the individual `pageProps`.

I also noticed that, when using the `cookieStorageManager`, `ColorModeScript` in `_document.js` has no effect. Am I missing something? Or should we maybe add a note to the docs saying that "If you use `cookieStorageManager`, you can remove `ColorModeScript` from `_document.js`"?

## 💣 Is this a breaking change (Yes/No):

No
