### PR TITLE
Fill height so icon centers correctly on lg size inputs elements

### DIFF
--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -16,6 +16,7 @@ const StyledElement = chakra("div", {
   baseStyle: {
     display: "flex",
     alignItems: "center",
+    height: "100%",
     justifyContent: "center",
     position: "absolute",
     top: "0",


### PR DESCRIPTION
## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Icons are not vertically aligned correctly in larger input elements containing an 

````
<InputLeftElement>
````
<img width="242" alt="Screen Shot 2021-02-18 at 5 17 34 PM" src="https://user-images.githubusercontent.com/31920/108395963-3dfc8500-720e-11eb-99f9-7c017e053e94.png">

## 🚀 New behavior

> This change will fill the vertical height of the element and align icon correctly

<img width="256" alt="Screen Shot 2021-02-18 at 5 17 52 PM" src="https://user-images.githubusercontent.com/31920/108396338-a481a300-720e-11eb-93a1-c082a9ecae4a.png">

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

None
