### PR TITLE
docs: remove ColorModeProvider mention in Principles

### DIFF
--- a/website/pages/docs/principles.mdx
+++ b/website/pages/docs/principles.mdx
@@ -26,9 +26,8 @@ us always be on that path.
   This includes keyboard navigation, focus management, color contrast, voice
   over, and the correct `aria-*` attributes.
 
-- **Dark Mode:** Make components dark mode compatible. Use our
-  `ColorModeProvider` component and `useColorMode` hook to handle styling.
-  [Learn more about dark mode](/docs/features/color-mode).
+- **Dark Mode:** Make components dark mode compatible. Use `useColorMode` hook
+  to handle styling. [Learn more about dark mode](/docs/features/color-mode).
 
 - **Naming Props:** We all know naming is the hardest thing in this industry.
   Generally, ensure a prop name is indicative of what it does. Boolean props


### PR DESCRIPTION
## 📝 Description

I think mentioning `ColorModeProvider` in `Design Principles` is not really needed and might be confusing for users. `ColorModeProvider` is already included in `ChakraProvider` and if users use another one, it will cause bugs.
I have already seen a few users got bitten by it.

## 💣 Is this a breaking change (Yes/No):

No