### PR TITLE
Update drawer docs

### DIFF
--- a/.changeset/chatty-deers-flash.md
+++ b/.changeset/chatty-deers-flash.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/modal": patch
+"@chakra-ui/docs": patch
+---
+
+- Add drawer example to modal readme
+- Fix github references in drawer and alert-dialog docs

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -188,3 +188,78 @@ function AlertDialogExample() {
   )
 }
 ```
+
+# Drawer
+
+The Drawer component is a panel that slides out from the edge of the screen. 
+It can be useful when you need users to complete a task or view some details 
+without leaving the current page.
+
+## Installation
+
+```sh
+yarn add @chakra-ui/drawer
+
+# or
+
+npm i @chakra-ui/drawer
+```
+
+## Import components
+
+```jsx
+import {
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerBody,
+  DrawerCloseButton,
+} from "@chakra-ui/react"
+```
+
+## Basic usage
+
+## Usage
+
+By default focus is placed on `DrawerCloseButton` when the drawer opens.
+
+```jsx
+function DrawerExample() {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const btnRef = React.useRef()
+
+  return (
+    <>
+      <Button ref={btnRef} colorScheme="teal" onClick={onOpen}>
+        Open
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        onClose={onClose}
+        finalFocusRef={btnRef}
+      >
+        <DrawerOverlay>
+          <DrawerContent>
+            <DrawerCloseButton />
+            <DrawerHeader>Create your account</DrawerHeader>
+
+            <DrawerBody>
+              <Input placeholder="Type here..." />
+            </DrawerBody>
+
+            <DrawerFooter>
+              <Button variant="outline" mr={3} onClick={onClose}>
+                Cancel
+              </Button>
+              <Button color="blue">Save</Button>
+            </DrawerFooter>
+          </DrawerContent>
+        </DrawerOverlay>
+      </Drawer>
+    </>
+  )
+}
+```

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -198,11 +198,11 @@ without leaving the current page.
 ## Installation
 
 ```sh
-yarn add @chakra-ui/drawer
+yarn add @chakra-ui/modal
 
 # or
 
-npm i @chakra-ui/drawer
+npm i @chakra-ui/modal
 ```
 
 ## Import components

--- a/website/pages/docs/overlay/alert-dialog.mdx
+++ b/website/pages/docs/overlay/alert-dialog.mdx
@@ -12,7 +12,7 @@ confirmation or action.
 
 <ComponentLinks
   github={{ package: "modal" }}
-  npm={{ package: "@chakra-ui/dialog" }}
+  npm={{ package: "@chakra-ui/modal" }}
 />
 
 <carbon-ad></carbon-ad>

--- a/website/pages/docs/overlay/alert-dialog.mdx
+++ b/website/pages/docs/overlay/alert-dialog.mdx
@@ -11,7 +11,7 @@ description:
 confirmation or action.
 
 <ComponentLinks
-  github={{ package: "dialog" }}
+  github={{ package: "modal" }}
   npm={{ package: "@chakra-ui/dialog" }}
 />
 

--- a/website/pages/docs/overlay/drawer.mdx
+++ b/website/pages/docs/overlay/drawer.mdx
@@ -15,7 +15,7 @@ without leaving the current page.
 <ComponentLinks
   theme={{ componentName: "drawer" }}
   github={{ package: "modal" }}
-  npm={{ package: "@chakra-ui/drawer" }}
+  npm={{ package: "@chakra-ui/modal" }}
 />
 
 <carbon-ad></carbon-ad>

--- a/website/pages/docs/overlay/drawer.mdx
+++ b/website/pages/docs/overlay/drawer.mdx
@@ -14,7 +14,7 @@ without leaving the current page.
 
 <ComponentLinks
   theme={{ componentName: "drawer" }}
-  github={{ package: "drawer" }}
+  github={{ package: "modal" }}
   npm={{ package: "@chakra-ui/drawer" }}
 />
 


### PR DESCRIPTION
Closes #3425 

## 📝 Description

The link in drawer documentation was broken because drawer component was moved to the modal package. I also found that alert dialog link was also broken.

## ⛳️ Current behavior (updates)

Links in documentation lead to 404 pages.

## 🚀 New behavior

I changed links to lead to modal source code and added basic example for drawer to modal readme.

## 💣 Is this a breaking change (Yes/No):

No
