### PR TITLE
fix: extend theme type with breakpoints

### DIFF
--- a/.changeset/rotten-panthers-worry.md
+++ b/.changeset/rotten-panthers-worry.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fixed an issue where extending the theme with custom breakpoints with
+`strictNullChecks: false` in `tsconfig.json` lead to an error.

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -14,6 +14,8 @@ type DeepThemeExtension<BaseTheme, ThemeType> = {
         Partial<ReturnType<BaseTheme[Key]>>,
         CloneKey<ThemeType, Key>
       >
+    : BaseTheme[Key] extends Array<any>
+    ? CloneKey<ThemeType, Key>
     : BaseTheme[Key] extends object
     ? DeepThemeExtension<Partial<BaseTheme[Key]>, CloneKey<ThemeType, Key>>
     : CloneKey<ThemeType, Key>


### PR DESCRIPTION
Closes #3372 

## 📝 Description

Fixed an issue where extending the theme with custom breakpoints with
`strictNullChecks: false` in `tsconfig.json` lead to an error.

## 💣 Is this a breaking change (Yes/No):

No
