### PR TITLE
fix: provide proper typings for ThemeOverride.components

### DIFF
--- a/.changeset/orange-tools-smell.md
+++ b/.changeset/orange-tools-smell.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Provide proper typings for `ThemeOverride.components`

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -219,6 +219,38 @@ describe("extendTheme", () => {
     extendTheme(override)
   })
 
+  it("should have proper typings for ThemeProps callbacks", () => {
+    const override: ThemeOverride = {
+      components: {
+        Button: {
+          variants: {
+            solid: ({ colorScheme }) => ({
+              borderColor: `${colorScheme}.600`,
+            }),
+          },
+        },
+      },
+    }
+
+    extendTheme(override)
+  })
+
+  it("should have proper typings for CSS Objects in sizes", () => {
+    const override: ThemeOverride = {
+      components: {
+        Button: {
+          sizes: {
+            lg: {
+              padding: "1.25rem 2rem",
+            },
+          },
+        },
+      },
+    }
+
+    extendTheme(override)
+  })
+
   it("should not extend with function that is inherited", () => {
     Array.prototype["customFunction"] = () => {}
 

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -1,7 +1,7 @@
-import { ColorModeOptions } from "@chakra-ui/system"
+import { ColorMode, ColorModeOptions, ThemingProps } from "@chakra-ui/system"
 import { Breakpoints, Styles } from "@chakra-ui/theme-tools"
 import { Dict } from "@chakra-ui/utils"
-import { StyleObjectOrFn, ThemeThunk } from "@chakra-ui/styled-system"
+import { StyleObjectOrFn, SystemStyleObject } from "@chakra-ui/styled-system"
 
 export type RecursiveProperty<Nested = string | number> =
   | RecursiveObject<Nested>
@@ -35,28 +35,35 @@ export type Colors = RecursiveObject<
 >
 export type ThemeDirection = "ltr" | "rtl"
 
-interface ComponentDefaultProps extends Record<string, any> {
-  size?: string
-  variant?: string
-  colorScheme?: string
-}
+export interface ComponentDefaultProps
+  extends Omit<ThemingProps, "styleConfig">,
+    Dict {}
 
-interface SystemStyleObjectRecord {
+export type ThemingPropsThunk<T> =
+  | T
+  | ((
+      props: Dict &
+        Omit<ThemingProps, "styleConfig"> & {
+          colorMode: ColorMode
+        },
+    ) => T)
+
+export interface SystemStyleObjectRecord {
   [key: string]: StyleObjectOrFn
 }
 
 export interface ComponentSingleStyleConfig {
-  baseStyle?: StyleObjectOrFn
-  sizes?: SystemStyleObjectRecord
-  variants?: SystemStyleObjectRecord
+  baseStyle?: ThemingPropsThunk<SystemStyleObject>
+  sizes?: Record<string, ThemingPropsThunk<SystemStyleObject>>
+  variants?: Record<string, ThemingPropsThunk<SystemStyleObject>>
   defaultProps?: ComponentDefaultProps
 }
 
 export interface ComponentMultiStyleConfig {
-  parts?: string[]
-  baseStyle?: ThemeThunk<SystemStyleObjectRecord>
-  sizes?: SystemStyleObjectRecord
-  variants?: SystemStyleObjectRecord
+  parts: string[]
+  baseStyle?: ThemingPropsThunk<SystemStyleObjectRecord>
+  sizes?: Record<string, ThemingPropsThunk<SystemStyleObjectRecord>>
+  variants?: Record<string, ThemingPropsThunk<SystemStyleObjectRecord>>
   defaultProps?: ComponentDefaultProps
 }
 


### PR DESCRIPTION
Closes #3418 

## 📝 Description

Provide proper typings for `ThemeOverride.components`.

Previously the typings for function in the components part of ThemeOverride have been typed as `(theme: Theme) => CSSObject` which is not correct.

## 💣 Is this a breaking change (Yes/No):

No
