### PR TITLE
docs(color-mode): add a reminder about passing theme to ChakraProvider

### DIFF
--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -49,6 +49,9 @@ const theme = extendTheme({ config })
 export default theme
 ```
 
+> Remember to pass your custom `theme` to the `ChakraProvider`, otherwise your
+> color mode config won't be taken into consideration.
+
 ### Adding the `ColorModeScript`
 
 The color mode script needs to added before the `body` tag for local storage


### PR DESCRIPTION
## 📝 Description

Using custom theme is optional and I didn't use it until I started to implement dark mode.
This guide shows how to change the theme's configuration, but it misses one point that I initially didn't know about: you need to pass the custom theme to the ChakraProvider in order to make it work.
And that's why I think this guide needs at least this quick reminder.

## 💣 Is this a breaking change (Yes/No):

No