### PR TITLE
fix(checkbox): respect FormControl context

### DIFF
--- a/.changeset/mighty-mugs-scream.md
+++ b/.changeset/mighty-mugs-scream.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+`Checkbox` now respect `FormControl` context such as `isInvalid`, `isDisabled`,
+`isReadOnly`, or `isRequired`.


### PR DESCRIPTION
Closes #3419

## 📝 Description

Respect `FormControl` context such as `isInvalid`, `isDisabled`, `isReadOnly`, or `isRequired`.

## ⛳️ Current behavior (updates)

Currently `FormControl` is not respected at all.

## 🚀 New behavior

If `<Checkbox>` is nested inside a `<FormControl>`, its props are respected.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Any thoughts on testing input components inside `FormControl`?