### PR TITLE
feat(tabs): make TabPanels themable

### DIFF
--- a/.changeset/shiny-dots-buy.md
+++ b/.changeset/shiny-dots-buy.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/tabs": minor
+"@chakra-ui/theme": minor
+---
+
+`TabPanels` component can now be styled from `Tabs` component theme, specifying
+the `tabpanels` part.

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -176,12 +176,15 @@ export interface TabPanelsProps extends HTMLChakraProps<"div"> {}
  */
 export const TabPanels = forwardRef<TabPanelsProps, "div">((props, ref) => {
   const panelsProps = useTabPanels(props)
+  const styles = useStyles()
+
   return (
     <chakra.div
       {...panelsProps}
       width="100%"
       ref={ref}
       className={cx("chakra-tabs__tab-panels", props.className)}
+      __css={styles.tabpanels}
     />
   )
 })

--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -1,6 +1,6 @@
 import { getColor, mode } from "@chakra-ui/theme-tools"
 
-const parts = ["root", "tablist", "tab", "tabpanel", "indicator"]
+const parts = ["root", "tablist", "tab", "tabpanels", "tabpanel", "indicator"]
 
 type Dict = Record<string, any>
 


### PR DESCRIPTION
## 📝 Description

Allow styling `TabPanels` component from theme.

## ⛳️ Current behavior (updates)

`TabPanels` does not accept styles from theme.

## 🚀 New behavior

`TabPanels` can be styled from `Tabs` component theme, specifying the `tabpanels` part.

## 💣 Is this a breaking change (Yes/No):

No