### PR TITLE
fix(modal): full size with long content (overflow)

### DIFF
--- a/.changeset/khaki-books-occur.md
+++ b/.changeset/khaki-books-occur.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+fix full size modal with y-overflowing content behaviour

--- a/packages/modal/stories/modal.stories.tsx
+++ b/packages/modal/stories/modal.stories.tsx
@@ -173,3 +173,25 @@ export const AnimationDisabled = () => {
     </>
   )
 }
+
+export const FullWithLongContent = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  return (
+    <>
+      <button onClick={onOpen}>Open</button>
+      <Modal onClose={onClose} isOpen={isOpen} size="full">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal Title2</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Lorem count={30} />
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={onClose}>Close</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -87,7 +87,7 @@ const baseStyle = (props: Dict) => ({
  */
 function getSize(value: string) {
   if (value === "full") {
-    return { dialog: { maxW: "100vw", h: "100vh" } }
+    return { dialog: { maxW: "100vw", minH: "100vh" } }
   }
   return { dialog: { maxW: value } }
 }


### PR DESCRIPTION
Closes #3453

## 📝 Description

This fixes a problem with using a `Modal` with `size="full"` which has a long content that causes scroll

## ⛳️ Current behavior (updates)


https://user-images.githubusercontent.com/22922179/109181389-27b17480-778c-11eb-988c-d93872328ebe.mp4



## 🚀 New behavior




https://user-images.githubusercontent.com/22922179/109183661-7829d180-778e-11eb-8861-cecc6f9bba42.mp4







## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
