### PR TITLE
docs: fix typo

### DIFF
--- a/website/pages/docs/feedback/toast.mdx
+++ b/website/pages/docs/feedback/toast.mdx
@@ -7,7 +7,7 @@ description: VThe toast is used to show alerts on top of an overlay
 
 The toast is used to show alerts on top of an overlay. The toast will close
 itself when the close button is clicked, or after a timeout — the default is 5
-seconds. The toast component is used to give feeback to users after an action
+seconds. The toast component is used to give feedback to users after an action
 has taken place.
 
 <ComponentLinks


### PR DESCRIPTION
## 📝 Description
Fixes a typo in the docs.

## 💣 Is this a breaking change (Yes/No):
No.