### PR TITLE
docs(contributing): fixed typo "has an" -> "as an"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ cd chakra-ui
 ## Development
 
 To improve our development process, we've set up tooling and systems. Chakra UI
-uses a monorepo structure and we treat each component has an independent package
+uses a monorepo structure and we treat each component as an independent package
 that can be consumed in isolation.
 
 ### Tooling
@@ -178,8 +178,8 @@ https://www.conventionalcommits.org/ or check out the
 4. Run `yarn changeset` to create a detailed description of your changes. This
    will be used to generate a changelog when we publish an update.
    [Learn more about Changeset](https://github.com/atlassian/changesets/tree/master/packages/cli).
-   Please note that you might have to run `git fetch origin main:master`
-   (where origin will be your fork on GitHub) before `yarn changeset` works.
+   Please note that you might have to run `git fetch origin main:master` (where
+   origin will be your fork on GitHub) before `yarn changeset` works.
 
 > If you made minor changes like CI config, prettier, etc, you can run
 > `yarn changeset add --empty` to generate an empty changeset file to document


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

There's a typo in `CONTRIBUTING.md`.

Instead of being:
- "we treat each component as an independent package"

It is:
- "we treat each component has an independent package".

This PR fixes that.
