### PR TITLE
Add support for `main` in chakra factory

### DIFF
--- a/.changeset/wicked-taxis-greet.md
+++ b/.changeset/wicked-taxis-greet.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/system": minor
+---
+
+### `chakra`
+
+Adds support for `main` in chakra factory

--- a/packages/system/src/system.utils.ts
+++ b/packages/system/src/system.utils.ts
@@ -39,6 +39,7 @@ export const domElements = [
   "kbd",
   "label",
   "li",
+  "main",
   "mark",
   "nav",
   "ol",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds support for the [`main`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) element to [chakra factory](https://chakra-ui.com/docs/features/chakra-factory).

## ⛳️ Current behavior (updates)

I've been moving most of my arbitrary `Box` usage over to chakra factory when I noticed `main` (which I'm using for my page layout) isn't supported

## 🚀 New behavior

Adds `main`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
