### PR TITLE
feat: add `legend` and `video` to chakra factory

### DIFF
--- a/.changeset/weak-mugs-sip.md
+++ b/.changeset/weak-mugs-sip.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/system": minor
+---
+
+### `chakra`
+
+Adds support for `legend` and `video` in chakra factory

--- a/packages/system/src/system.utils.ts
+++ b/packages/system/src/system.utils.ts
@@ -38,6 +38,7 @@ export const domElements = [
   "input",
   "kbd",
   "label",
+  "legend",
   "li",
   "main",
   "mark",
@@ -66,6 +67,7 @@ export const domElements = [
   "thead",
   "tr",
   "ul",
+  "video",
 ] as const
 
 export type DOMElements = UnionStringArray<typeof domElements>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds support for `legend` and `video` elements in [chakra factory](https://chakra-ui.com/docs/features/chakra-factory).

## ⛳️ Current behavior (updates)

I've been moving most of my arbitrary `Box` usage over to chakra factory when I noticed `legend` (which I'm using for my custom forms) isn't supported.

`video` added by @auto200's request

## 🚀 New behavior

Adds `legend` and `video`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
