### PR TITLE
Allow using different Motion components in transitions

### DIFF
--- a/packages/transition/src/collapse.tsx
+++ b/packages/transition/src/collapse.tsx
@@ -62,6 +62,12 @@ export interface CollapseOptions {
    * @default "auto"
    */
   endingHeight?: number | string
+
+  /**
+   * The Motion element to render as.
+   * @default motion.div
+   */
+  as?: React.ElementType
 }
 
 export type ICollapse = CollapseProps
@@ -139,11 +145,13 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
       custom,
     }
 
+    const MotionComponent = props.as ?? motion.div
+
     if (unmountOnExit) {
       return (
         <AnimatePresence initial={false} custom={custom}>
           {isOpen && (
-            <motion.div
+            <MotionComponent
               {...ownProps}
               initial="exit"
               animate="enter"
@@ -155,7 +163,7 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
     }
 
     return (
-      <motion.div
+      <MotionComponent
         {...ownProps}
         style={{ ...ownProps.style, display }}
         initial={false}

--- a/packages/transition/stories/collapse.stories.tsx
+++ b/packages/transition/stories/collapse.stories.tsx
@@ -1,4 +1,5 @@
 import { useBoolean } from "@chakra-ui/hooks"
+import { motion } from "framer-motion"
 import * as React from "react"
 import { Collapse, CollapseOptions } from "../src/collapse"
 
@@ -59,3 +60,5 @@ export const WithInitialIn = () => (
     </div>
   </Collapse>
 )
+
+export const WithNonDivElement = () => <CollapseExample as={motion.b} />


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3051

## 📝 Description

This allows consumers to pass a Motion component to transitions like Collapse to override the default `<motion.div/>`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

I've only implemented this for Collapse so far; I wanted to make sure everything looked good so far before I implement it for the other transitions.