### PR TITLE
docs: fix skeleton animation color prop names

### DIFF
--- a/website/pages/docs/feedback/skeleton.mdx
+++ b/website/pages/docs/feedback/skeleton.mdx
@@ -70,7 +70,7 @@ function Card() {
 
 ### Skeleton color
 
-You can change the animation color with `colorStart` and `colorEnd`.
+You can change the animation color with `startColor` and `endColor`.
 
 ```jsx
 <Skeleton startColor="pink.500" endColor="orange.500" height="20px" />


### PR DESCRIPTION
## 📝 Description

Fix two invalid prop names in the Skeleton docs

## ⛳️ Current behavior (updates)

> `colorStart` and `colorEnd`

## 🚀 New behavior

> `startColor` and `endColor`