### PR TITLE
fix: fixed NumberInput paddingRight when Steppers are enabled

### DIFF
--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -7,6 +7,7 @@ import {
   useMultiStyleConfig,
   useStyles,
   HTMLChakraProps,
+  useToken,
 } from "@chakra-ui/system"
 import { createContext, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -133,6 +134,8 @@ export const NumberInputStepper = forwardRef<NumberInputStepperProps, "div">(
   },
 )
 
+NumberInputStepper.id = "NumberInputStepper"
+
 if (__DEV__) {
   NumberInputStepper.displayName = "NumberInputStepper"
 }
@@ -152,10 +155,17 @@ export interface NumberInputFieldProps extends HTMLChakraProps<"input"> {}
  */
 export const NumberInputField = forwardRef<NumberInputFieldProps, "input">(
   (props, ref) => {
-    const { getInputProps } = useNumberInputContext()
+    const { hasSteppers, getInputProps } = useNumberInputContext()
 
     const input = getInputProps(props, ref)
     const styles = useStyles()
+
+    const paddingRight = useToken("space", styles.field.px?.toString() ?? 0)
+    const stepperWidth = styles.stepperGroup.width
+
+    if (hasSteppers) {
+      styles.field.paddingRight = `calc(${paddingRight} + ${stepperWidth})`
+    }
 
     return (
       <chakra.input

--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -10,6 +10,7 @@ import {
   callAllHandlers,
   EventKeyMap,
   focus,
+  getValidChildren,
   isBrowser,
   isNull,
   maxSafeInteger,
@@ -105,7 +106,9 @@ const sanitize = (value: string) =>
  * @see Docs     https://www.chakra-ui.com/useNumberInput
  * @see WHATWG   https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)
  */
-export function useNumberInput(props: UseNumberInputProps = {}) {
+export function useNumberInput(
+  props: React.PropsWithChildren<UseNumberInputProps> = {},
+) {
   const {
     focusInputOnChange = true,
     clampValueOnBlur = true,
@@ -337,7 +340,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
 
   useEventListener(
     "wheel",
-    (event) => {
+    (event: WheelEvent) => {
       const isInputFocused = document.activeElement === inputRef.current
       if (!allowMouseWheel || !isInputFocused) return
 
@@ -467,6 +470,8 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
     ],
   )
 
+  const validChildren = getValidChildren(props.children)
+
   return {
     value: counter.value,
     valueAsNumber: counter.valueAsNumber,
@@ -477,6 +482,9 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
     getDecrementButtonProps,
     getInputProps,
     htmlProps,
+    hasSteppers: validChildren.some(
+      (child) => child.type["id"] === "NumberInputStepper",
+    ),
   }
 }
 

--- a/packages/number-input/stories/number-input.stories.tsx
+++ b/packages/number-input/stories/number-input.stories.tsx
@@ -122,6 +122,16 @@ export const withStep = () => (
   </NumberInput>
 )
 
+export const withRightTextAlignment = () => (
+  <NumberInput step={5} defaultValue={15} min={10} max={30}>
+    <NumberInputField textAlign="right" />
+    <NumberInputStepper>
+      <NumberIncrementStepper />
+      <NumberDecrementStepper />
+    </NumberInputStepper>
+  </NumberInput>
+)
+
 export const withPrecision = () => (
   <NumberInput defaultValue={15} precision={2} step={0.2}>
     <NumberInputField />


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3470

## 📝 Description

This PR fixes the missing `paddingRight` on the `NumberInputField` when the Stepper components are present. It's especially noticeable when you append `textAlign="right"` to the `NumberInputField` component.

## ⛳️ Current behavior (updates)

The Stepper components get rendered on top of the text.

## 🚀 New behavior

The Input Field gets a right padding when the Stepper components are present, so it separates the text from the buttons.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Check this codesandbox to see the current behavior: [link](https://codesandbox.io/s/focused-haze-nzni8?file=/src/index.tsx)