### PR TITLE
fix(popper): sync popper instance state

### DIFF
--- a/.changeset/odd-cooks-beam.md
+++ b/.changeset/odd-cooks-beam.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popper": patch
+---
+
+make the react-popper state in sync with the internal popper instance state

--- a/packages/popper/src/react-popper.ts
+++ b/packages/popper/src/react-popper.ts
@@ -6,6 +6,7 @@ import {
   Modifier,
   Options as PopperOptions,
   VirtualElement,
+  State as PopperState,
 } from "@popperjs/core"
 import { dequal } from "dequal"
 import * as React from "react"
@@ -56,6 +57,7 @@ export function usePopper(
     modifiers: options.modifiers || EMPTY_MODIFIERS,
   }
 
+  const [popperState, setPopperState] = React.useState<PopperState | null>(null)
   const [styles, setStyles] = React.useState<State["styles"]>({
     popper: {
       position: optionsWithDefaults.strategy,
@@ -73,6 +75,8 @@ export function usePopper(
       phase: "write",
       fn: ({ state }) => {
         const elements = Object.keys(state.elements)
+
+        setPopperState(state)
 
         setStyles(resolve(state.styles, elements))
         setAttrs(resolve(state.attributes, elements))
@@ -146,7 +150,7 @@ export function usePopper(
   }, [])
 
   return {
-    state: popperInstanceRef.current ? popperInstanceRef.current.state : null,
+    state: popperState || null,
     styles,
     attributes: attrs,
     update: popperInstanceRef.current ? popperInstanceRef.current.update : null,

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -240,3 +240,11 @@ export const withDefaultIsOpenProp = () => (
     </button>
   </Tooltip>
 )
+
+export const withAutoPlacement = () => (
+  <Tooltip label="Hello world" placement="auto" hasArrow>
+    <button style={{ fontSize: 25, pointerEvents: "all" }}>
+      Can't Touch This
+    </button>
+  </Tooltip>
+)


### PR DESCRIPTION
Closes #3160

## 📝 Description

This fix makes sure that we don't return stale popper state from the `usePopper` hook in `popper/react-popper.ts` which was causing wrong popper behaviour with using an auto-placed tooltip together with `AnimatedPresence` component.

## ⛳️ Current behavior (updates)

When we use an auto-places `Tooltip` which has an `AnimatedPresense` component in it, the `usePopper` hook returns stale state causing incorrect arrow positioning.

## 🚀 New behavior

I changed the `usePopper` behaviour to keep track of the PopperJS state property in a `useState` hook and update it in a modifier alongside updating `style` and `attrs` state.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I've got two additional ideas:
1) I think it would be a good idea to refactor the `react-popper` a bit so that we don't both the PopperJS `state` from it as well as `style`/`attributes` (as separate object keys). As `style`/`attributes` are in fact a subset of the `state` I think this can cause problems with not having a single source of truth and not knowing if we should trust the `style`/`attrs` in PopperJS `state` or the `style`/`attributes` which are returned from the `usePopper` hook as individual properties.

2) I tried writing a test for my fix but I failed due to the fact that the tests are run in a JSDom environment where calling things `getBoundingClientRect()` on elements returns an "empty" object (something like `{ top: 0, bottom: 0, ...}`).
I think running tests in JSDom makes it really hard to test these parts of ChakraUI which deal with positioning elements and would like to know if you'd be open to trying to run these test in a real browser (puppeteer / cypress / testcafe should all be supported by React Testing Library)
