### PR TITLE
fix(select): add baseStyle bg for optgroup element

### DIFF
--- a/.changeset/silly-mice-repair.md
+++ b/.changeset/silly-mice-repair.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/theme": patch
+"@chakra-ui/select": patch
+---
+
+Resolved an issue where `optgroup` in dark mode was unreadable on browsers that
+allow `select` contents styling.

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -10,7 +10,7 @@ function baseStyleField(props: Record<string, any>) {
     appearance: "none",
     paddingBottom: "1px",
     lineHeight: "normal",
-    "> option": {
+    "> option, > optgroup": {
       bg: mode("white", "gray.700")(props),
     },
   }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2853

## 📝 Description

For browsers that allow styling of `select` element contents, we set a default `bg` for `option` but not for `optgroup`. This change covers `optgroup`.

## 💣 Is this a breaking change (Yes/No):

No
