### PR TITLE
fix(transition): use minimal `m` component

### DIFF
--- a/.changeset/curly-days-bake.md
+++ b/.changeset/curly-days-bake.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/checkbox": minor
+"@chakra-ui/menu": minor
+"@chakra-ui/modal": minor
+"@chakra-ui/popover": minor
+"@chakra-ui/toast": minor
+"@chakra-ui/tooltip": minor
+"@chakra-ui/transition": minor
+---
+
+use minimal `m` component to reduce bundle size

--- a/.changeset/fuzzy-glasses-count.md
+++ b/.changeset/fuzzy-glasses-count.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/transition": minor
+---
+
+use minimal `m` component to reduce bundle size

--- a/packages/checkbox/src/checkbox-icon.tsx
+++ b/packages/checkbox/src/checkbox-icon.tsx
@@ -1,5 +1,11 @@
 import { chakra, PropsOf } from "@chakra-ui/system"
-import { AnimatePresence, CustomDomComponent, motion } from "framer-motion"
+import {
+  AnimatePresence,
+  CustomDomComponent,
+  domAnimation,
+  LazyMotion,
+  m as motion,
+} from "framer-motion"
 import * as React from "react"
 
 // @future: only call `motion(chakra.svg)` when we drop framer-motion v3 support
@@ -62,25 +68,27 @@ const IndeterminateIcon = (props: PropsOf<typeof MotionSvg>) => (
 
 const CheckboxTransition = ({ open, children }: any) => (
   <AnimatePresence initial={false}>
-    {open && (
-      <motion.div
-        variants={{
-          unchecked: { scale: 0.5 },
-          checked: { scale: 1 },
-        }}
-        initial="unchecked"
-        animate="checked"
-        exit="unchecked"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          height: "100%",
-        }}
-      >
-        {children}
-      </motion.div>
-    )}
+    <LazyMotion features={domAnimation}>
+      {open && (
+        <motion.div
+          variants={{
+            unchecked: { scale: 0.5 },
+            checked: { scale: 1 },
+          }}
+          initial="unchecked"
+          animate="checked"
+          exit="unchecked"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+          }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </LazyMotion>
   </AnimatePresence>
 )
 

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -13,7 +13,13 @@ import {
   useStyles,
 } from "@chakra-ui/system"
 import { cx, runIfFn, __DEV__ } from "@chakra-ui/utils"
-import { CustomDomComponent, motion, Variants } from "framer-motion"
+import {
+  CustomDomComponent,
+  domAnimation,
+  m as motion,
+  Variants,
+  LazyMotion,
+} from "framer-motion"
 import * as React from "react"
 import {
   MenuDescendantsProvider,
@@ -167,22 +173,24 @@ export const MenuList = forwardRef<MenuListProps, "div">((props, ref) => {
       {...positionerProps}
       __css={{ zIndex: props.zIndex ?? styles.list?.zIndex }}
     >
-      <MotionDiv
-        {...menulistProps}
-        /**
-         * We could call this on either `onAnimationComplete` or `onUpdate`.
-         * It seems the re-focusing works better with the `onUpdate`
-         */
-        onUpdate={onTransitionEnd}
-        className={cx("chakra-menu__menu-list", menulistProps.className)}
-        variants={motionVariants}
-        initial={false}
-        animate={isOpen ? "enter" : "exit"}
-        __css={{
-          outline: 0,
-          ...styles.list,
-        }}
-      />
+      <LazyMotion features={domAnimation}>
+        <MotionDiv
+          {...menulistProps}
+          /**
+           * We could call this on either `onAnimationComplete` or `onUpdate`.
+           * It seems the re-focusing works better with the `onUpdate`
+           */
+          onUpdate={onTransitionEnd}
+          className={cx("chakra-menu__menu-list", menulistProps.className)}
+          variants={motionVariants}
+          initial={false}
+          animate={isOpen ? "enter" : "exit"}
+          __css={{
+            outline: 0,
+            ...styles.list,
+          }}
+        />
+      </LazyMotion>
     </chakra.div>
   )
 })

--- a/packages/modal/src/modal-transition.tsx
+++ b/packages/modal/src/modal-transition.tsx
@@ -1,6 +1,11 @@
 import { chakra, ChakraProps } from "@chakra-ui/system"
 import { scaleFadeConfig, slideFadeConfig } from "@chakra-ui/transition"
-import { HTMLMotionProps, motion } from "framer-motion"
+import {
+  domAnimation,
+  HTMLMotionProps,
+  LazyMotion,
+  m as motion,
+} from "framer-motion"
 import * as React from "react"
 
 export interface ModalTransitionProps
@@ -31,6 +36,10 @@ export const ModalTransition = React.forwardRef(
   (props: ModalTransitionProps, ref: React.Ref<any>) => {
     const { preset, ...rest } = props
     const motionProps = transitions[preset]
-    return <Motion ref={ref} {...(motionProps as ChakraProps)} {...rest} />
+    return (
+      <LazyMotion features={domAnimation}>
+        <Motion ref={ref} {...(motionProps as ChakraProps)} {...rest} />
+      </LazyMotion>
+    )
   },
 )

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -22,8 +22,10 @@ import {
 import { createContext } from "@chakra-ui/react-utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m as motion,
   usePresence,
 } from "framer-motion"
 import * as React from "react"
@@ -355,13 +357,15 @@ export const ModalOverlay = forwardRef<ModalOverlayProps, "div">(
     const motionProps: any = motionPreset === "none" ? {} : fadeConfig
 
     return (
-      <MotionDiv
-        {...motionProps}
-        __css={overlayStyle}
-        ref={ref}
-        className={_className}
-        {...rest}
-      />
+      <LazyMotion features={domAnimation}>
+        <MotionDiv
+          {...motionProps}
+          __css={overlayStyle}
+          ref={ref}
+          className={_className}
+          {...rest}
+        />
+      </LazyMotion>
     )
   },
 )

--- a/packages/popover/src/popover-transition.tsx
+++ b/packages/popover/src/popover-transition.tsx
@@ -1,5 +1,11 @@
 import { chakra, HTMLChakraProps } from "@chakra-ui/system"
-import { HTMLMotionProps, motion, Variant } from "framer-motion"
+import {
+  domAnimation,
+  HTMLMotionProps,
+  LazyMotion,
+  m as motion,
+  Variant,
+} from "framer-motion"
 import { mergeWith } from "@chakra-ui/utils"
 import React from "react"
 import { usePopoverContext } from "./popover-context"
@@ -65,13 +71,15 @@ export const PopoverTransition = React.forwardRef(
   (props: HTMLMotionChakraProps<"section">, ref: React.Ref<any>) => {
     const { isOpen } = usePopoverContext()
     return (
-      <Section
-        ref={ref}
-        variants={mergeVariants(props.variants)}
-        {...props}
-        initial={false}
-        animate={isOpen ? "enter" : "exit"}
-      />
+      <LazyMotion features={domAnimation}>
+        <Section
+          ref={ref}
+          variants={mergeVariants(props.variants)}
+          {...props}
+          initial={false}
+          animate={isOpen ? "enter" : "exit"}
+        />
+      </LazyMotion>
     )
   },
 )

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -1,7 +1,13 @@
 import { useTimeout, useUpdateEffect } from "@chakra-ui/hooks"
 import { isFunction, __DEV__ } from "@chakra-ui/utils"
 import ReachAlert from "@reach/alert"
-import { motion, useIsPresent, Variants } from "framer-motion"
+import {
+  domAnimation,
+  LazyMotion,
+  m as motion,
+  useIsPresent,
+  Variants,
+} from "framer-motion"
 import * as React from "react"
 import { ToastOptions } from "./toast.types"
 import { getToastStyle } from "./toast.utils"
@@ -102,30 +108,32 @@ export const Toast: React.FC<ToastProps> = (props) => {
   const style = React.useMemo(() => getToastStyle(position), [position])
 
   return (
-    <motion.li
-      layout
-      className="chakra-toast"
-      variants={toastMotionVariants}
-      initial="initial"
-      animate="animate"
-      exit="exit"
-      onHoverStart={onMouseEnter}
-      onHoverEnd={onMouseLeave}
-      custom={{ position }}
-      style={style}
-    >
-      <ReachAlert
-        className="chakra-toast__inner"
-        style={{
-          pointerEvents: "auto",
-          maxWidth: 560,
-          minWidth: 300,
-          margin: "0.5rem",
-        }}
+    <LazyMotion features={domAnimation}>
+      <motion.li
+        layout
+        className="chakra-toast"
+        variants={toastMotionVariants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        onHoverStart={onMouseEnter}
+        onHoverEnd={onMouseLeave}
+        custom={{ position }}
+        style={style}
       >
-        {isFunction(message) ? message({ id, onClose: close }) : message}
-      </ReachAlert>
-    </motion.li>
+        <ReachAlert
+          className="chakra-toast__inner"
+          style={{
+            pointerEvents: "auto",
+            maxWidth: 560,
+            minWidth: 300,
+            margin: "0.5rem",
+          }}
+        >
+          {isFunction(message) ? message({ id, onClose: close }) : message}
+        </ReachAlert>
+      </motion.li>
+    </LazyMotion>
   )
 }
 

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -11,7 +11,12 @@ import {
 } from "@chakra-ui/system"
 import { isString, omit, pick, __DEV__, getCSSVar } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
-import { AnimatePresence, motion } from "framer-motion"
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m as motion,
+} from "framer-motion"
 import * as React from "react"
 import { scale } from "./tooltip.transition"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
@@ -137,31 +142,35 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
                 pointerEvents: "none",
               }}
             >
-              <StyledTooltip
-                variants={scale}
-                {...(tooltipProps as any)}
-                initial="exit"
-                animate="enter"
-                exit="exit"
-                __css={styles}
-              >
-                {label}
-                {hasAriaLabel && (
-                  <VisuallyHidden {...hiddenProps}>{ariaLabel}</VisuallyHidden>
-                )}
-                {hasArrow && (
-                  <chakra.div
-                    data-popper-arrow
-                    className="chakra-tooltip__arrow-wrapper"
-                  >
+              <LazyMotion features={domAnimation}>
+                <StyledTooltip
+                  variants={scale}
+                  {...(tooltipProps as any)}
+                  initial="exit"
+                  animate="enter"
+                  exit="exit"
+                  __css={styles}
+                >
+                  {label}
+                  {hasAriaLabel && (
+                    <VisuallyHidden {...hiddenProps}>
+                      {ariaLabel}
+                    </VisuallyHidden>
+                  )}
+                  {hasArrow && (
                     <chakra.div
-                      data-popper-arrow-inner
-                      className="chakra-tooltip__arrow"
-                      __css={{ bg: styles.bg }}
-                    />
-                  </chakra.div>
-                )}
-              </StyledTooltip>
+                      data-popper-arrow
+                      className="chakra-tooltip__arrow-wrapper"
+                    >
+                      <chakra.div
+                        data-popper-arrow-inner
+                        className="chakra-tooltip__arrow"
+                        __css={{ bg: styles.bg }}
+                      />
+                    </chakra.div>
+                  )}
+                </StyledTooltip>
+              </LazyMotion>
             </chakra.div>
           </Portal>
         )}

--- a/packages/transition/src/collapse.tsx
+++ b/packages/transition/src/collapse.tsx
@@ -2,7 +2,9 @@ import { cx, mergeWith, warn, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
+  m as motion,
+  domAnimation,
+  LazyMotion,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -133,25 +135,27 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
     const show = unmountOnExit ? isOpen : true
     const animate = isOpen || unmountOnExit ? "enter" : "exit"
 
-    return (
+return (
       <AnimatePresence initial={false} custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            {...rest}
-            className={cx("chakra-collapse", className)}
-            style={{
-              overflow: "hidden",
-              display: "block",
-              ...style,
-            }}
-            custom={custom}
-            variants={variants as _Variants}
-            initial={unmountOnExit ? "exit" : false}
-            animate={animate}
-            exit="exit"
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <motion.div
+              ref={ref}
+              {...rest}
+              className={cx("chakra-collapse", className)}
+              style={{
+                overflow: "hidden",
+                display: "block",
+                ...style,
+              }}
+              custom={custom}
+              variants={variants as _Variants}
+              initial={unmountOnExit ? "exit" : false}
+              animate={animate}
+              exit="exit"
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/packages/transition/src/fade.tsx
+++ b/packages/transition/src/fade.tsx
@@ -1,8 +1,10 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m as motion,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -57,16 +59,18 @@ export const Fade = React.forwardRef<HTMLDivElement, FadeProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            className={cx("chakra-fade", className)}
-            custom={custom}
-            {...fadeConfig}
-            animate={animate}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <motion.div
+              ref={ref}
+              className={cx("chakra-fade", className)}
+              custom={custom}
+              {...fadeConfig}
+              animate={animate}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/packages/transition/src/scale-fade.tsx
+++ b/packages/transition/src/scale-fade.tsx
@@ -1,8 +1,10 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m as motion,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -75,16 +77,18 @@ export const ScaleFade = React.forwardRef<HTMLDivElement, ScaleFadeProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            className={cx("chakra-offset-slide", className)}
-            {...scaleFadeConfig}
-            animate={animate}
-            custom={custom}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <motion.div
+              ref={ref}
+              className={cx("chakra-offset-slide", className)}
+              {...scaleFadeConfig}
+              animate={animate}
+              custom={custom}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/packages/transition/src/slide-fade.tsx
+++ b/packages/transition/src/slide-fade.tsx
@@ -1,8 +1,10 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m as motion,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -102,16 +104,18 @@ export const SlideFade = React.forwardRef<HTMLDivElement, SlideFadeProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            className={cx("chakra-offset-slide", className)}
-            custom={custom}
-            {...slideFadeConfig}
-            animate={animate}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <motion.div
+              ref={ref}
+              className={cx("chakra-offset-slide", className)}
+              custom={custom}
+              {...slideFadeConfig}
+              animate={animate}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/packages/transition/src/slide.tsx
+++ b/packages/transition/src/slide.tsx
@@ -2,9 +2,11 @@ import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
+  m as motion,
   MotionStyle,
   Variants as _Variants,
+  LazyMotion,
+  domAnimation,
 } from "framer-motion"
 import * as React from "react"
 import {
@@ -91,19 +93,21 @@ export const Slide = React.forwardRef<HTMLDivElement, SlideProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            initial="exit"
-            className={cx("chakra-slide", className)}
-            animate={animate}
-            exit="exit"
-            custom={custom}
-            variants={variants as _Variants}
-            style={computedStyle}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <motion.div
+              ref={ref}
+              initial="exit"
+              className={cx("chakra-slide", className)}
+              animate={animate}
+              exit="exit"
+              custom={custom}
+              variants={variants as _Variants}
+              style={computedStyle}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

(Partially) closes #3369

## 📝 Description

`framer-motion>3.8.0` [supports tree-shaking in Webpack](https://github.com/framer/motion/pull/1008). by switching to `m` component (and adding obligatory `MotionConfig`) we can reduce bundle size a little. for a simple `<Collapse />` animation, gzipped bundle size dropped by 7 kB.

## ⛳️ Current behavior (updates)
Chakra bundles entire `framer-motion` library

## 🚀 New behavior

Chakra bundles smaller subset of `framer-motion`

## 💣 Is this a breaking change (Yes/No): 
no.

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

