### PR TITLE
fix: fixed vertically center modal cutoff #2871

### DIFF
--- a/.changeset/great-months-check.md
+++ b/.changeset/great-months-check.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/modal": patch
+"@chakra-ui/theme": patch
+---
+
+Fixed vertically center modal cutoff by changing modal container styles and
+adding another wrapping div.

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -234,13 +234,20 @@ export const ModalContent = forwardRef<ModalContentProps, "section">(
     }
 
     const dialogContainerStyles: SystemStyleObject = {
-      display: "flex",
+      display: "block",
       width: "100vw",
       height: "100vh",
       position: "fixed",
       left: 0,
       top: 0,
       ...styles.dialogContainer,
+    }
+
+    const dialogInnerContainerStyles: SystemStyleObject = {
+      display: "flex",
+      minHeight: "100%",
+      alignItems: "inherit",
+      justifyContent: "inherit",
     }
 
     const { motionPreset } = useModalContext()
@@ -252,14 +259,16 @@ export const ModalContent = forwardRef<ModalContentProps, "section">(
           className="chakra-modal__content-container"
           __css={dialogContainerStyles}
         >
-          <ModalTransition
-            preset={motionPreset}
-            className={_className}
-            {...dialogProps}
-            __css={dialogStyles}
-          >
-            {children}
-          </ModalTransition>
+          <chakra.div __css={dialogInnerContainerStyles}>
+            <ModalTransition
+              preset={motionPreset}
+              className={_className}
+              {...dialogProps}
+              __css={dialogStyles}
+            >
+              {children}
+            </ModalTransition>
+          </chakra.div>
         </chakra.div>
       </ModalFocusScope>
     )

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -21,7 +21,7 @@ function baseStyleDialogContainer(props: Dict) {
   const { isCentered, scrollBehavior } = props
 
   return {
-    display: "flex",
+    display: "block",
     zIndex: "modal",
     justifyContent: "center",
     alignItems: isCentered ? "center" : "flex-start",


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2871

## 📝 Description

This PR fixes a bug in vertically centered modals that get cutoff when they are larger than the screens.

## ⛳️ Current behavior (updates)

Currently vertically centered modals get cutoff at the top if they are higher than the screen.

## 🚀 New behavior

This fix fixes that issue by modifying some css styles on the modal container and adding one additional div wrapper.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

While this change passes all tests and was tested in browsers (Chrome, Edge, Firefox) it might still be good to test it on iOS. 
Also there might be a need to add some class names to the added div element but I will leave that up to the maintainers to decide.

While this change is not breaking when using the default modal theme settings it might need some changes for users running modified modal theme settings.
