### PR TITLE
docs: extract hook props for docs

### DIFF
--- a/.changeset/poor-numbers-burn.md
+++ b/.changeset/poor-numbers-burn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/props-docs": patch
+---
+
+Extract all hook props for documentation purposes

--- a/tooling/props-docs/src/build.ts
+++ b/tooling/props-docs/src/build.ts
@@ -77,12 +77,18 @@ async function findComponentFiles() {
 function parseInfo(filePaths: string[]) {
   const { parse } = docgen.withCustomConfig(tsConfigPath, {
     shouldRemoveUndefinedFromOptional: true,
-    propFilter: (prop) => {
+    propFilter: (prop, component) => {
       const isStyledSystemProp = excludedPropNames.includes(prop.name)
       const isHTMLElementProp =
         prop.parent?.fileName.includes("node_modules") ?? false
+      const isHook = component.name.startsWith("use")
+      const isTypeScriptNative =
+        prop.parent?.fileName.includes("node_modules/typescript") ?? false
 
-      return !(isStyledSystemProp || isHTMLElementProp)
+      return (
+        (isHook && !isTypeScriptNative) ||
+        !(isStyledSystemProp || isHTMLElementProp)
+      )
     },
   })
 


### PR DESCRIPTION
## 📝 Description

Extract all props for our hooks with the `props-docs` package if the first and only parameter is an object.
Now it only omits TypeScript native types and leaves all other props in there.

This helps to render the props table for `useToast` where the prop `position` was omitted.

Followup to https://github.com/chakra-ui/chakra-ui/pull/3494#discussion_r585515751
