### PR TITLE
feat: add theme extension withDefaultColorScheme

### DIFF
--- a/.changeset/tiny-hornets-dress.md
+++ b/.changeset/tiny-hornets-dress.md
@@ -8,12 +8,41 @@ The `extendTheme` function allows you to pass multiple overrides or extensions:
 ```js
 import {
   extendTheme,
-  theme as baseTheme,
   withDefaultColorScheme,
+  withDefaultSize,
+  withDefaultVariant,
+  withDefaultProps,
 } from "@chakra-ui/react"
 
 const customTheme = extendTheme(
-  withDefaultColorScheme({ colorScheme: "red" }),
-  baseTheme,
+  {
+    colors: {
+      brand: {
+        // ...
+        500: "#b4d455",
+        // ...
+      },
+    },
+  },
+  withDefaultColorScheme({ colorScheme: "brand" }),
+  withDefaultSize({
+    size: "lg",
+    components: ["Input", "NumberInput", "PinInput"],
+  }),
+  withDefaultVariant({
+    variant: "outline",
+    components: ["Input", "NumberInput", "PinInput"],
+  }),
+  // or all in one:
+  withDefaultProps({
+    defaultProps: {
+      colorSchem: "brand",
+      variant: "outline",
+      size: "lg",
+    },
+    components: ["Input", "NumberInput", "PinInput"],
+  }),
+  // optional:
+  yourCustomBaseTheme, // defaults to our chakra default theme
 )
 ```

--- a/.changeset/tiny-hornets-dress.md
+++ b/.changeset/tiny-hornets-dress.md
@@ -1,0 +1,19 @@
+---
+"@chakra-ui/react": minor
+"@chakra-ui/theme": patch
+---
+
+The `extendTheme` function allows you to pass multiple overrides or extensions:
+
+```js
+import {
+  extendTheme,
+  theme as baseTheme,
+  withDefaultColorScheme,
+} from "@chakra-ui/react"
+
+const customTheme = extendTheme(
+  withDefaultColorScheme({ colorScheme: "red" }),
+  baseTheme,
+)
+```

--- a/.changeset/tiny-hornets-dress.md
+++ b/.changeset/tiny-hornets-dress.md
@@ -36,7 +36,7 @@ const customTheme = extendTheme(
   // or all in one:
   withDefaultProps({
     defaultProps: {
-      colorSchem: "brand",
+      colorScheme: "brand",
       variant: "outline",
       size: "lg",
     },

--- a/.changeset/young-fishes-tap.md
+++ b/.changeset/young-fishes-tap.md
@@ -2,4 +2,5 @@
 "@chakra-ui/utils": minor
 ---
 
-Add `pipe` function
+- Add `pipe` function
+- Add generic to `isFunction` guard

--- a/.changeset/young-fishes-tap.md
+++ b/.changeset/young-fishes-tap.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/utils": minor
+---
+
+Add `pipe` function

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -3,7 +3,13 @@ import defaultTheme, {
   isChakraTheme,
   Theme,
 } from "@chakra-ui/theme"
-import { Dict, isFunction, mergeWith, pipe } from "@chakra-ui/utils"
+import {
+  AnyFunction,
+  Dict,
+  isFunction,
+  mergeWith,
+  pipe,
+} from "@chakra-ui/utils"
 
 type CloneKey<Target, Key> = Key extends keyof Target ? Target[Key] : unknown
 
@@ -29,9 +35,9 @@ type DeepThemeExtension<BaseTheme, ThemeType> = {
     : CloneKey<ThemeType, Key>
 }
 
-export declare type ThemeOverride<BaseTheme = Theme> = DeepPartial<ChakraTheme> &
-  DeepThemeExtension<BaseTheme, ChakraTheme> &
-  Dict
+export declare type ThemeOverride<
+  BaseTheme = Theme
+> = DeepPartial<ChakraTheme> & DeepThemeExtension<BaseTheme, ChakraTheme> & Dict
 
 export type ThemeExtension<Override extends ThemeOverride = ThemeOverride> = (
   themeOverride: Override,
@@ -42,7 +48,7 @@ export type BaseThemeWithExtensions<
   Extensions extends readonly [...any]
 > = BaseTheme &
   (Extensions extends [infer L, ...infer R]
-    ? L extends (...args: any[]) => any
+    ? L extends AnyFunction
       ? ReturnType<L> & BaseThemeWithExtensions<BaseTheme, R>
       : L & BaseThemeWithExtensions<BaseTheme, R>
     : Extensions)

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -44,7 +44,7 @@ export type BaseThemeWithExtensions<
   ? L extends (...args: any[]) => any
     ? ReturnType<L> & BaseThemeWithExtensions<BaseTheme, R>
     : L & BaseThemeWithExtensions<BaseTheme, R>
-  : ThemeOverride<BaseTheme>
+  : BaseTheme & Extensions
 /**
  * Function to override or customize the Chakra UI theme conveniently.
  * First extension overrides the baseTheme and following extensions override the preceding extensions.
@@ -78,24 +78,6 @@ export type BaseThemeWithExtensions<
  */
 export function extendTheme<
   BaseTheme extends ChakraTheme = Theme,
-  Override extends ThemeOverride<BaseTheme> = ThemeOverride<BaseTheme>
->(override: Override): BaseTheme & Override
-
-export function extendTheme<
-  BaseTheme extends ChakraTheme = Theme,
-  Override extends ThemeOverride<BaseTheme> = ThemeOverride<BaseTheme>
->(override: Override, baseTheme: BaseTheme): BaseTheme & Override
-
-export function extendTheme<
-  BaseTheme extends ChakraTheme = Theme,
-  Override extends ThemeOverride<BaseTheme> = ThemeOverride<BaseTheme>
->(
-  extension: ThemeExtension<ThemeOverride<BaseTheme>>,
-  baseTheme: BaseTheme,
-): BaseTheme & Override
-
-export function extendTheme<
-  BaseTheme extends ChakraTheme = Theme,
   Extensions extends (
     | BaseTheme
     | ThemeOverride<BaseTheme>
@@ -103,16 +85,7 @@ export function extendTheme<
   )[] = (ThemeOverride<BaseTheme> | ThemeExtension<ThemeOverride<BaseTheme>>)[]
 >(
   ...extensions: [...Extensions]
-): BaseThemeWithExtensions<BaseTheme, Extensions>
-
-export function extendTheme<
-  BaseTheme extends ChakraTheme = Theme,
-  Extensions extends (
-    | BaseTheme
-    | ThemeOverride<BaseTheme>
-    | ThemeExtension<ThemeOverride<BaseTheme>>
-  )[] = (ThemeOverride<BaseTheme> | ThemeExtension<ThemeOverride<BaseTheme>>)[]
->(...extensions: [...Extensions]) {
+): BaseThemeWithExtensions<BaseTheme, Extensions> {
   const overrides = [...extensions]
     .slice(0, extensions.length - (extensions.length > 1 ? 1 : 0))
     .reverse()
@@ -138,11 +111,13 @@ export function extendTheme<
   )(baseTheme as BaseThemeWithExtensions<BaseTheme, Extensions>)
 }
 
-export function mergeThemeOverride(...overrides: ThemeOverride[]) {
+export function mergeThemeOverride<BaseTheme extends ChakraTheme = ChakraTheme>(
+  ...overrides: ThemeOverride<BaseTheme>[]
+): ThemeOverride<BaseTheme> {
   return mergeWith({}, ...overrides, mergeThemeCustomizer)
 }
 
-function compose<R>(...fns: Array<(a: R) => R>) {
+export function compose<R>(...fns: Array<(a: R) => R>) {
   return fns.reduce((prevFn, nextFn) => (value) => prevFn(nextFn(value)))
 }
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,5 +1,6 @@
 export * from "./chakra-provider"
 export * from "./extend-theme"
+export * from "./theme-extensions"
 export * from "@chakra-ui/accordion"
 export * from "@chakra-ui/alert"
 export * from "@chakra-ui/avatar"

--- a/packages/react/src/theme-extensions/index.ts
+++ b/packages/react/src/theme-extensions/index.ts
@@ -1,0 +1,1 @@
+export * from "./with-default-color-scheme"

--- a/packages/react/src/theme-extensions/index.ts
+++ b/packages/react/src/theme-extensions/index.ts
@@ -1,1 +1,4 @@
 export * from "./with-default-color-scheme"
+export * from "./with-default-size"
+export * from "./with-default-variant"
+export * from "./with-default-props"

--- a/packages/react/src/theme-extensions/with-default-color-scheme.ts
+++ b/packages/react/src/theme-extensions/with-default-color-scheme.ts
@@ -1,6 +1,6 @@
 import defaultTheme from "@chakra-ui/theme"
 import { ThemingProps } from "@chakra-ui/system"
-import { Dict } from "@chakra-ui/utils"
+import { Dict, isObject } from "@chakra-ui/utils"
 import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
 
 export function withDefaultColorScheme({
@@ -11,11 +11,13 @@ export function withDefaultColorScheme({
   components?: string[] | Dict
 }): ThemeExtension {
   return (theme) => {
-    const names = Array.isArray(components)
-      ? components
-      : components && typeof components === "object"
-      ? Object.keys(components)
-      : Object.keys(theme.components || {})
+    let names = Object.keys(theme.components || {})
+
+    if (Array.isArray(components)) {
+      names = components
+    } else if (isObject(components)) {
+      names = Object.keys(components)
+    }
 
     return mergeThemeOverride(theme, {
       components: Object.fromEntries(

--- a/packages/react/src/theme-extensions/with-default-color-scheme.ts
+++ b/packages/react/src/theme-extensions/with-default-color-scheme.ts
@@ -1,0 +1,33 @@
+import defaultTheme from "@chakra-ui/theme"
+import { ThemingProps } from "@chakra-ui/system"
+import { Dict } from "@chakra-ui/utils"
+import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
+
+export function withDefaultColorScheme({
+  colorScheme,
+  components = defaultTheme.components,
+}: {
+  colorScheme: ThemingProps["colorScheme"]
+  components?: string[] | Dict
+}): ThemeExtension {
+  return (theme) => {
+    const names = Array.isArray(components)
+      ? components
+      : components && typeof components === "object"
+      ? Object.keys(components)
+      : Object.keys(theme.components || {})
+
+    return mergeThemeOverride(theme, {
+      components: Object.fromEntries(
+        names.map((componentName) => {
+          const withColorScheme = {
+            defaultProps: {
+              colorScheme,
+            },
+          }
+          return [componentName, withColorScheme]
+        }),
+      ),
+    })
+  }
+}

--- a/packages/react/src/theme-extensions/with-default-color-scheme.ts
+++ b/packages/react/src/theme-extensions/with-default-color-scheme.ts
@@ -1,11 +1,10 @@
-import defaultTheme from "@chakra-ui/theme"
 import { ThemingProps } from "@chakra-ui/system"
 import { Dict, isObject } from "@chakra-ui/utils"
 import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
 
 export function withDefaultColorScheme({
   colorScheme,
-  components = defaultTheme.components,
+  components,
 }: {
   colorScheme: ThemingProps["colorScheme"]
   components?: string[] | Dict

--- a/packages/react/src/theme-extensions/with-default-props.ts
+++ b/packages/react/src/theme-extensions/with-default-props.ts
@@ -1,6 +1,6 @@
 import { ChakraTheme, ComponentDefaultProps } from "@chakra-ui/theme"
-import { Dict } from "@chakra-ui/utils"
-import { compose, mergeThemeOverride, ThemeOverride } from "../extend-theme"
+import { Dict, pipe } from "@chakra-ui/utils"
+import { mergeThemeOverride, ThemeOverride } from "../extend-theme"
 import { withDefaultColorScheme } from "./with-default-color-scheme"
 import { withDefaultVariant } from "./with-default-variant"
 import { withDefaultSize } from "./with-default-size"
@@ -24,6 +24,5 @@ export function withDefaultProps<
     variant ? withDefaultVariant({ variant, components }) : identity,
   ]
 
-  return (theme: Override) =>
-    mergeThemeOverride<BaseTheme>(compose(...fns)(theme))
+  return (theme: Override) => mergeThemeOverride<BaseTheme>(pipe(...fns)(theme))
 }

--- a/packages/react/src/theme-extensions/with-default-props.ts
+++ b/packages/react/src/theme-extensions/with-default-props.ts
@@ -1,7 +1,4 @@
-import defaultTheme, {
-  ChakraTheme,
-  ComponentDefaultProps,
-} from "@chakra-ui/theme"
+import { ChakraTheme, ComponentDefaultProps } from "@chakra-ui/theme"
 import { Dict } from "@chakra-ui/utils"
 import { compose, mergeThemeOverride, ThemeOverride } from "../extend-theme"
 import { withDefaultColorScheme } from "./with-default-color-scheme"
@@ -13,7 +10,7 @@ export function withDefaultProps<
   Override extends ThemeOverride<BaseTheme>
 >({
   defaultProps: { colorScheme, variant, size },
-  components = defaultTheme.components,
+  components,
 }: {
   defaultProps: ComponentDefaultProps
   components?: string[] | Dict

--- a/packages/react/src/theme-extensions/with-default-props.ts
+++ b/packages/react/src/theme-extensions/with-default-props.ts
@@ -1,0 +1,32 @@
+import defaultTheme, {
+  ChakraTheme,
+  ComponentDefaultProps,
+} from "@chakra-ui/theme"
+import { Dict } from "@chakra-ui/utils"
+import { compose, mergeThemeOverride, ThemeOverride } from "../extend-theme"
+import { withDefaultColorScheme } from "./with-default-color-scheme"
+import { withDefaultVariant } from "./with-default-variant"
+import { withDefaultSize } from "./with-default-size"
+
+export function withDefaultProps<
+  BaseTheme extends ChakraTheme,
+  Override extends ThemeOverride<BaseTheme>
+>({
+  defaultProps: { colorScheme, variant, size },
+  components = defaultTheme.components,
+}: {
+  defaultProps: ComponentDefaultProps
+  components?: string[] | Dict
+}) {
+  const identity = <T>(t: T) => t
+  const fns = [
+    colorScheme
+      ? withDefaultColorScheme({ colorScheme, components })
+      : identity,
+    size ? withDefaultSize({ size, components }) : identity,
+    variant ? withDefaultVariant({ variant, components }) : identity,
+  ]
+
+  return (theme: Override) =>
+    mergeThemeOverride<BaseTheme>(compose(...fns)(theme))
+}

--- a/packages/react/src/theme-extensions/with-default-size.ts
+++ b/packages/react/src/theme-extensions/with-default-size.ts
@@ -1,11 +1,10 @@
-import defaultTheme from "@chakra-ui/theme"
 import { ThemingProps } from "@chakra-ui/system"
 import { Dict, isObject } from "@chakra-ui/utils"
 import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
 
 export function withDefaultSize({
   size,
-  components = defaultTheme.components,
+  components,
 }: {
   size: ThemingProps["size"]
   components?: string[] | Dict

--- a/packages/react/src/theme-extensions/with-default-size.ts
+++ b/packages/react/src/theme-extensions/with-default-size.ts
@@ -1,0 +1,35 @@
+import defaultTheme from "@chakra-ui/theme"
+import { ThemingProps } from "@chakra-ui/system"
+import { Dict, isObject } from "@chakra-ui/utils"
+import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
+
+export function withDefaultSize({
+  size,
+  components = defaultTheme.components,
+}: {
+  size: ThemingProps["size"]
+  components?: string[] | Dict
+}): ThemeExtension {
+  return (theme) => {
+    let names = Object.keys(theme.components || {})
+
+    if (Array.isArray(components)) {
+      names = components
+    } else if (isObject(components)) {
+      names = Object.keys(components)
+    }
+
+    return mergeThemeOverride(theme, {
+      components: Object.fromEntries(
+        names.map((componentName) => {
+          const withSize = {
+            defaultProps: {
+              size,
+            },
+          }
+          return [componentName, withSize]
+        }),
+      ),
+    })
+  }
+}

--- a/packages/react/src/theme-extensions/with-default-variant.ts
+++ b/packages/react/src/theme-extensions/with-default-variant.ts
@@ -1,11 +1,10 @@
-import defaultTheme from "@chakra-ui/theme"
 import { ThemingProps } from "@chakra-ui/system"
 import { Dict, isObject } from "@chakra-ui/utils"
 import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
 
 export function withDefaultVariant({
   variant,
-  components = defaultTheme.components,
+  components,
 }: {
   variant: ThemingProps["variant"]
   components?: string[] | Dict

--- a/packages/react/src/theme-extensions/with-default-variant.ts
+++ b/packages/react/src/theme-extensions/with-default-variant.ts
@@ -1,0 +1,35 @@
+import defaultTheme from "@chakra-ui/theme"
+import { ThemingProps } from "@chakra-ui/system"
+import { Dict, isObject } from "@chakra-ui/utils"
+import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
+
+export function withDefaultVariant({
+  variant,
+  components = defaultTheme.components,
+}: {
+  variant: ThemingProps["variant"]
+  components?: string[] | Dict
+}): ThemeExtension {
+  return (theme) => {
+    let names = Object.keys(theme.components || {})
+
+    if (Array.isArray(components)) {
+      names = components
+    } else if (isObject(components)) {
+      names = Object.keys(components)
+    }
+
+    return mergeThemeOverride(theme, {
+      components: Object.fromEntries(
+        names.map((componentName) => {
+          const withVariant = {
+            defaultProps: {
+              variant,
+            },
+          }
+          return [componentName, withVariant]
+        }),
+      ),
+    })
+  }
+}

--- a/packages/react/tests/theme-extension.test.tsx
+++ b/packages/react/tests/theme-extension.test.tsx
@@ -1,0 +1,175 @@
+import defaultTheme from "@chakra-ui/theme"
+import {
+  extendTheme,
+  mergeThemeOverride,
+  ThemeExtension,
+  withDefaultColorScheme,
+} from "../src"
+
+describe("Theme Extension", () => {
+  it("should be backwards compatible", () => {
+    const theme = extendTheme(
+      {
+        colors: {
+          brand: {
+            500: "#b4d455",
+          },
+        },
+      },
+      defaultTheme,
+    )
+
+    expect(Object.keys(theme.components).length).toBeGreaterThan(1)
+    expect(theme.colors.brand[500]).toBe("#b4d455")
+  })
+
+  it("should compose all extensions", () => {
+    const theme = extendTheme(
+      {
+        colors: {
+          brand: {
+            500: "#b4d455",
+          },
+        },
+      },
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      defaultTheme,
+    )
+
+    expect(theme.components.Alert.defaultProps.colorScheme).toBe("brand")
+    expect(Object.keys(theme.components).length).toBeGreaterThan(1)
+    expect(theme.colors.brand[500]).toBe("#b4d455")
+  })
+
+  it("should override from right to left", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({ colorScheme: "banana" }),
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      {
+        colors: {
+          brand: {
+            500: "papayawhip",
+          },
+        },
+      },
+      {
+        colors: {
+          brand: {
+            500: "#b4d455",
+          },
+        },
+        components: {
+          Alert: {
+            defaultProps: {
+              size: "lg",
+            },
+          },
+        },
+      },
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Alert.defaultProps.size).toBe("lg")
+    expect(Object.keys(customTheme.components).length).toBeGreaterThan(1)
+    expect(customTheme.colors.brand[500]).toBe("#b4d455")
+  })
+
+  it("should pass on the computed value", () => {
+    const customTheme = extendTheme(
+      (theme) => ({ ...theme, step1: "completed" }),
+      (theme) => ({ ...theme, step1: "overriden", step2: theme.step1 }),
+      defaultTheme,
+    )
+
+    expect(customTheme.step1).toBe("overriden")
+    expect(customTheme.step2).toBe("completed")
+  })
+
+  it("should allow overrides of default color scheme with extension", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      (theme: typeof defaultTheme) =>
+        mergeThemeOverride(theme, {
+          colors: {
+            brand: theme.colors.red,
+          },
+          components: {
+            Alert: {
+              defaultProps: {
+                colorScheme: "blue",
+              },
+            },
+          },
+        }),
+      defaultTheme,
+    )
+
+    expect(customTheme.colors.brand).toHaveProperty("500")
+    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
+  })
+
+  it("should allow overrides of default color scheme with override", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      {
+        colors: {
+          brand: defaultTheme.colors.red,
+        },
+        components: {
+          Alert: {
+            defaultProps: {
+              colorScheme: "blue",
+            },
+          },
+        },
+      },
+      defaultTheme,
+    )
+
+    expect(customTheme.colors.brand).toHaveProperty("500")
+    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
+  })
+
+  it("should allow overrides only mentioned components", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({
+        colorScheme: "red",
+        components: ["Button", "Badge"],
+      }),
+      withDefaultColorScheme({
+        colorScheme: "blue",
+        components: ["Alert", "Table"],
+      }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.colorScheme).toBe("red")
+    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("red")
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
+    expect(customTheme.components.Table.defaultProps.colorScheme).toBe("blue")
+  })
+
+  it("should allow userland extensions", () => {
+    function withBrandColorExtension(colorName: string): ThemeExtension {
+      return (theme) =>
+        mergeThemeOverride(theme, {
+          colors: {
+            brand: theme.colors![colorName],
+          },
+        })
+    }
+
+    const customTheme = extendTheme(
+      withBrandColorExtension("red"),
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      defaultTheme,
+    )
+
+    expect(customTheme.colors.brand).toHaveProperty("500")
+    expect(customTheme.components.Button.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
+  })
+})

--- a/packages/react/tests/theme-extension.test.tsx
+++ b/packages/react/tests/theme-extension.test.tsx
@@ -1,5 +1,4 @@
 import { extendTheme, mergeThemeOverride, ThemeOverride } from "../src"
-import { ChakraTheme } from "@chakra-ui/theme"
 
 describe("Theme Extension", () => {
   it("should be backwards compatible", () => {

--- a/packages/react/tests/theme-extension.test.tsx
+++ b/packages/react/tests/theme-extension.test.tsx
@@ -1,18 +1,15 @@
-import defaultTheme from "@chakra-ui/theme"
 import { extendTheme, mergeThemeOverride, ThemeOverride } from "../src"
+import { ChakraTheme } from "@chakra-ui/theme"
 
 describe("Theme Extension", () => {
   it("should be backwards compatible", () => {
-    const theme = extendTheme(
-      {
-        colors: {
-          brand: {
-            500: "#b4d455",
-          },
+    const theme = extendTheme({
+      colors: {
+        brand: {
+          500: "#b4d455",
         },
       },
-      defaultTheme,
-    )
+    })
 
     expect(Object.keys(theme.components).length).toBeGreaterThan(1)
     expect(theme.colors.brand[500]).toBe("#b4d455")
@@ -28,11 +25,51 @@ describe("Theme Extension", () => {
         })
     }
 
+    const customTheme = extendTheme(withBrandColorExtension("red"))
+
+    expect(customTheme.colors.brand).toHaveProperty("500")
+  })
+
+  it("should use a custom base theme", () => {
+    const customBaseTheme = {
+      borders: {},
+      breakpoints: {
+        base: "0em" as const,
+      },
+      colors: {},
+      components: {},
+      config: {},
+      direction: "ltr" as const,
+      fonts: {},
+      fontSizes: {},
+      fontWeights: {},
+      letterSpacings: {},
+      lineHeights: {},
+      radii: {},
+      shadows: {},
+      sizes: {},
+      space: {},
+      styles: {},
+      transition: {
+        duration: {},
+        easing: {},
+        property: {},
+      },
+      zIndices: {},
+    }
+
     const customTheme = extendTheme(
-      withBrandColorExtension("red"),
-      defaultTheme,
+      {
+        colors: {
+          brand: {
+            500: "#b4d455",
+          },
+        },
+      },
+      customBaseTheme,
     )
 
     expect(customTheme.colors.brand).toHaveProperty("500")
+    expect(Object.keys(customTheme.components)).toHaveLength(0)
   })
 })

--- a/packages/react/tests/theme-extension.test.tsx
+++ b/packages/react/tests/theme-extension.test.tsx
@@ -1,10 +1,5 @@
 import defaultTheme from "@chakra-ui/theme"
-import {
-  extendTheme,
-  mergeThemeOverride,
-  ThemeExtension,
-  withDefaultColorScheme,
-} from "../src"
+import { extendTheme, mergeThemeOverride, ThemeOverride } from "../src"
 
 describe("Theme Extension", () => {
   it("should be backwards compatible", () => {
@@ -23,138 +18,9 @@ describe("Theme Extension", () => {
     expect(theme.colors.brand[500]).toBe("#b4d455")
   })
 
-  it("should compose all extensions", () => {
-    const theme = extendTheme(
-      {
-        colors: {
-          brand: {
-            500: "#b4d455",
-          },
-        },
-      },
-      withDefaultColorScheme({ colorScheme: "brand" }),
-      defaultTheme,
-    )
-
-    expect(theme.components.Alert.defaultProps.colorScheme).toBe("brand")
-    expect(Object.keys(theme.components).length).toBeGreaterThan(1)
-    expect(theme.colors.brand[500]).toBe("#b4d455")
-  })
-
-  it("should override from right to left", () => {
-    const customTheme = extendTheme(
-      withDefaultColorScheme({ colorScheme: "banana" }),
-      withDefaultColorScheme({ colorScheme: "brand" }),
-      {
-        colors: {
-          brand: {
-            500: "papayawhip",
-          },
-        },
-      },
-      {
-        colors: {
-          brand: {
-            500: "#b4d455",
-          },
-        },
-        components: {
-          Alert: {
-            defaultProps: {
-              size: "lg",
-            },
-          },
-        },
-      },
-      defaultTheme,
-    )
-
-    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("brand")
-    expect(customTheme.components.Alert.defaultProps.size).toBe("lg")
-    expect(Object.keys(customTheme.components).length).toBeGreaterThan(1)
-    expect(customTheme.colors.brand[500]).toBe("#b4d455")
-  })
-
-  it("should pass on the computed value", () => {
-    const customTheme = extendTheme(
-      (theme) => ({ ...theme, step1: "completed" }),
-      (theme) => ({ ...theme, step1: "overriden", step2: theme.step1 }),
-      defaultTheme,
-    )
-
-    expect(customTheme.step1).toBe("overriden")
-    expect(customTheme.step2).toBe("completed")
-  })
-
-  it("should allow overrides of default color scheme with extension", () => {
-    const customTheme = extendTheme(
-      withDefaultColorScheme({ colorScheme: "brand" }),
-      (theme: typeof defaultTheme) =>
-        mergeThemeOverride(theme, {
-          colors: {
-            brand: theme.colors.red,
-          },
-          components: {
-            Alert: {
-              defaultProps: {
-                colorScheme: "blue",
-              },
-            },
-          },
-        }),
-      defaultTheme,
-    )
-
-    expect(customTheme.colors.brand).toHaveProperty("500")
-    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
-    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
-  })
-
-  it("should allow overrides of default color scheme with override", () => {
-    const customTheme = extendTheme(
-      withDefaultColorScheme({ colorScheme: "brand" }),
-      {
-        colors: {
-          brand: defaultTheme.colors.red,
-        },
-        components: {
-          Alert: {
-            defaultProps: {
-              colorScheme: "blue",
-            },
-          },
-        },
-      },
-      defaultTheme,
-    )
-
-    expect(customTheme.colors.brand).toHaveProperty("500")
-    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
-    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
-  })
-
-  it("should allow overrides only mentioned components", () => {
-    const customTheme = extendTheme(
-      withDefaultColorScheme({
-        colorScheme: "red",
-        components: ["Button", "Badge"],
-      }),
-      withDefaultColorScheme({
-        colorScheme: "blue",
-        components: ["Alert", "Table"],
-      }),
-      defaultTheme,
-    )
-
-    expect(customTheme.components.Button.defaultProps.colorScheme).toBe("red")
-    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("red")
-    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
-    expect(customTheme.components.Table.defaultProps.colorScheme).toBe("blue")
-  })
-
   it("should allow userland extensions", () => {
-    function withBrandColorExtension(colorName: string): ThemeExtension {
-      return (theme) =>
+    function withBrandColorExtension(colorName: string) {
+      return (theme: ThemeOverride) =>
         mergeThemeOverride(theme, {
           colors: {
             brand: theme.colors![colorName],
@@ -164,12 +30,9 @@ describe("Theme Extension", () => {
 
     const customTheme = extendTheme(
       withBrandColorExtension("red"),
-      withDefaultColorScheme({ colorScheme: "brand" }),
       defaultTheme,
     )
 
     expect(customTheme.colors.brand).toHaveProperty("500")
-    expect(customTheme.components.Button.defaultProps.colorScheme).toBe("brand")
-    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
   })
 })

--- a/packages/react/tests/with-default-color-scheme.test.tsx
+++ b/packages/react/tests/with-default-color-scheme.test.tsx
@@ -1,0 +1,137 @@
+import defaultTheme from "@chakra-ui/theme"
+import { extendTheme, mergeThemeOverride, withDefaultColorScheme } from "../src"
+
+describe("", () => {
+  it("should compose all extensions", () => {
+    const theme = extendTheme(
+      {
+        colors: {
+          brand: {
+            500: "#b4d455",
+          },
+        },
+      },
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      defaultTheme,
+    )
+
+    expect(theme.components.Alert.defaultProps.colorScheme).toBe("brand")
+    expect(Object.keys(theme.components).length).toBeGreaterThan(1)
+    expect(theme.colors.brand[500]).toBe("#b4d455")
+  })
+
+  it("should override from right to left", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({ colorScheme: "banana" }),
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      {
+        colors: {
+          brand: {
+            500: "papayawhip",
+          },
+        },
+      },
+      {
+        colors: {
+          brand: {
+            500: "#b4d455",
+          },
+        },
+        components: {
+          Alert: {
+            defaultProps: {
+              size: "lg",
+            },
+          },
+        },
+      },
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Alert.defaultProps.size).toBe("lg")
+    expect(Object.keys(customTheme.components).length).toBeGreaterThan(1)
+    expect(customTheme.colors.brand[500]).toBe("#b4d455")
+  })
+
+  it("should pass on the computed value", () => {
+    const customTheme = extendTheme(
+      (theme) => ({ ...theme, step1: "completed" }),
+      (theme) => ({ ...theme, step1: "overriden", step2: theme.step1 }),
+      defaultTheme,
+    )
+
+    expect(customTheme.step1).toBe("overriden")
+    expect(customTheme.step2).toBe("completed")
+  })
+
+  it("should allow overrides of default color scheme with extension", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      (theme: typeof defaultTheme) =>
+        mergeThemeOverride(theme, {
+          colors: {
+            brand: theme.colors.red,
+          },
+          components: {
+            Alert: {
+              defaultProps: {
+                colorScheme: "blue",
+              },
+            },
+          },
+        }),
+      defaultTheme,
+    )
+
+    expect(customTheme.colors.brand).toHaveProperty("500")
+    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
+  })
+
+  it("should allow overrides of default color scheme with override", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({ colorScheme: "brand" }),
+      {
+        colors: {
+          brand: defaultTheme.colors.red,
+        },
+        components: {
+          Alert: {
+            defaultProps: {
+              colorScheme: "blue",
+            },
+          },
+        },
+      },
+      defaultTheme,
+    )
+
+    expect(customTheme.colors.brand).toHaveProperty("500")
+    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
+  })
+
+  it("should allow overrides only mentioned components", () => {
+    const customTheme = extendTheme(
+      withDefaultColorScheme({
+        colorScheme: "red",
+        components: ["Button", "Badge"],
+      }),
+      withDefaultColorScheme({
+        colorScheme: "blue",
+        components: ["Alert", "Table"],
+      }),
+      withDefaultColorScheme({
+        colorScheme: "blue",
+        components: ["Container"],
+      }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.colorScheme).toBe("red")
+    expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("red")
+    expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
+    expect(customTheme.components.Table.defaultProps.colorScheme).toBe("blue")
+  })
+})

--- a/packages/react/tests/with-default-color-scheme.test.tsx
+++ b/packages/react/tests/with-default-color-scheme.test.tsx
@@ -1,7 +1,7 @@
 import defaultTheme from "@chakra-ui/theme"
 import { extendTheme, mergeThemeOverride, withDefaultColorScheme } from "../src"
 
-describe("", () => {
+describe("Theme extension: withDefaultColorScheme", () => {
   it("should compose all extensions", () => {
     const theme = extendTheme(
       {

--- a/packages/react/tests/with-default-color-scheme.test.tsx
+++ b/packages/react/tests/with-default-color-scheme.test.tsx
@@ -12,7 +12,6 @@ describe("", () => {
         },
       },
       withDefaultColorScheme({ colorScheme: "brand" }),
-      defaultTheme,
     )
 
     expect(theme.components.Alert.defaultProps.colorScheme).toBe("brand")
@@ -20,7 +19,7 @@ describe("", () => {
     expect(theme.colors.brand[500]).toBe("#b4d455")
   })
 
-  it("should override from right to left", () => {
+  it("should override from left to right", () => {
     const customTheme = extendTheme(
       withDefaultColorScheme({ colorScheme: "banana" }),
       withDefaultColorScheme({ colorScheme: "brand" }),
@@ -45,7 +44,6 @@ describe("", () => {
           },
         },
       },
-      defaultTheme,
     )
 
     expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("brand")
@@ -57,11 +55,10 @@ describe("", () => {
   it("should pass on the computed value", () => {
     const customTheme = extendTheme(
       (theme) => ({ ...theme, step1: "completed" }),
-      (theme) => ({ ...theme, step1: "overriden", step2: theme.step1 }),
-      defaultTheme,
+      (theme) => ({ ...theme, step1: "overridden", step2: theme.step1 }),
     )
 
-    expect(customTheme.step1).toBe("overriden")
+    expect(customTheme.step1).toBe("overridden")
     expect(customTheme.step2).toBe("completed")
   })
 
@@ -81,7 +78,6 @@ describe("", () => {
             },
           },
         }),
-      defaultTheme,
     )
 
     expect(customTheme.colors.brand).toHaveProperty("500")
@@ -104,7 +100,6 @@ describe("", () => {
           },
         },
       },
-      defaultTheme,
     )
 
     expect(customTheme.colors.brand).toHaveProperty("500")
@@ -126,12 +121,32 @@ describe("", () => {
         colorScheme: "blue",
         components: ["Container"],
       }),
-      defaultTheme,
     )
 
     expect(customTheme.components.Button.defaultProps.colorScheme).toBe("red")
     expect(customTheme.components.Badge.defaultProps.colorScheme).toBe("red")
     expect(customTheme.components.Alert.defaultProps.colorScheme).toBe("blue")
     expect(customTheme.components.Table.defaultProps.colorScheme).toBe("blue")
+  })
+
+  it("should override colorScheme of custom components", () => {
+    const themeWithCustomComponent = {
+      components: {
+        MyCustomComponent: {
+          defaultProps: {
+            colorScheme: "purple",
+          },
+        },
+      },
+    }
+
+    const theme = extendTheme(
+      themeWithCustomComponent,
+      withDefaultColorScheme({ colorScheme: "brand" }),
+    )
+
+    expect(theme.components.MyCustomComponent.defaultProps.colorScheme).toBe(
+      "brand",
+    )
   })
 })

--- a/packages/react/tests/with-default-props.test.tsx
+++ b/packages/react/tests/with-default-props.test.tsx
@@ -1,0 +1,51 @@
+import defaultTheme from "@chakra-ui/theme"
+import { extendTheme, withDefaultProps } from "../src"
+
+describe("withDefaultProps", () => {
+  it("should set a defaultProps", () => {
+    const customTheme = extendTheme(
+      withDefaultProps({
+        defaultProps: {
+          colorScheme: "brand",
+          size: "veryBig",
+          variant: "my-custom-variant",
+        },
+      }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Button.defaultProps.size).toBe("veryBig")
+    expect(customTheme.components.Button.defaultProps.variant).toBe(
+      "my-custom-variant",
+    )
+  })
+
+  it("should allow overrides only mentioned components", () => {
+    const customTheme = extendTheme(
+      withDefaultProps({
+        defaultProps: {
+          colorScheme: "brand",
+          size: "veryBig",
+          variant: "my-custom-variant",
+        },
+        components: ["Button", "Badge"],
+      }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.colorScheme).toBe("brand")
+    expect(customTheme.components.Button.defaultProps.size).toBe("veryBig")
+    expect(customTheme.components.Button.defaultProps.variant).toBe(
+      "my-custom-variant",
+    )
+
+    expect(customTheme.components.Tabs.defaultProps.colorScheme).not.toBe(
+      "brand",
+    )
+    expect(customTheme.components.Tabs.defaultProps.size).not.toBe("veryBig")
+    expect(customTheme.components.Tabs.defaultProps.variant).not.toBe(
+      "my-custom-variant",
+    )
+  })
+})

--- a/packages/react/tests/with-default-props.test.tsx
+++ b/packages/react/tests/with-default-props.test.tsx
@@ -1,4 +1,3 @@
-import defaultTheme from "@chakra-ui/theme"
 import { extendTheme, withDefaultProps } from "../src"
 
 describe("withDefaultProps", () => {
@@ -11,7 +10,6 @@ describe("withDefaultProps", () => {
           variant: "my-custom-variant",
         },
       }),
-      defaultTheme,
     )
 
     expect(customTheme.components.Button.defaultProps.colorScheme).toBe("brand")
@@ -31,7 +29,6 @@ describe("withDefaultProps", () => {
         },
         components: ["Button", "Badge"],
       }),
-      defaultTheme,
     )
 
     expect(customTheme.components.Button.defaultProps.colorScheme).toBe("brand")

--- a/packages/react/tests/with-default-props.test.tsx
+++ b/packages/react/tests/with-default-props.test.tsx
@@ -1,6 +1,6 @@
 import { extendTheme, withDefaultProps } from "../src"
 
-describe("withDefaultProps", () => {
+describe("Theme extension: withDefaultProps", () => {
   it("should set a defaultProps", () => {
     const customTheme = extendTheme(
       withDefaultProps({

--- a/packages/react/tests/with-default-size.test.tsx
+++ b/packages/react/tests/with-default-size.test.tsx
@@ -1,0 +1,27 @@
+import defaultTheme from "@chakra-ui/theme"
+import { extendTheme, withDefaultSize } from "../src"
+
+describe("withDefaultSize", () => {
+  it("should set a defaultSize", () => {
+    const customTheme = extendTheme(
+      withDefaultSize({ size: "veryBig" }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.size).toBe("veryBig")
+  })
+
+  it("should allow overrides only mentioned components", () => {
+    const customTheme = extendTheme(
+      withDefaultSize({
+        size: "veryBig",
+        components: ["Button", "Badge"],
+      }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.size).toBe("veryBig")
+    expect(customTheme.components.Badge.defaultProps.size).toBe("veryBig")
+    expect(customTheme.components.Alert.defaultProps.size).not.toBe("veryBig")
+  })
+})

--- a/packages/react/tests/with-default-size.test.tsx
+++ b/packages/react/tests/with-default-size.test.tsx
@@ -1,12 +1,8 @@
-import defaultTheme from "@chakra-ui/theme"
 import { extendTheme, withDefaultSize } from "../src"
 
 describe("withDefaultSize", () => {
   it("should set a defaultSize", () => {
-    const customTheme = extendTheme(
-      withDefaultSize({ size: "veryBig" }),
-      defaultTheme,
-    )
+    const customTheme = extendTheme(withDefaultSize({ size: "veryBig" }))
 
     expect(customTheme.components.Button.defaultProps.size).toBe("veryBig")
   })
@@ -17,7 +13,6 @@ describe("withDefaultSize", () => {
         size: "veryBig",
         components: ["Button", "Badge"],
       }),
-      defaultTheme,
     )
 
     expect(customTheme.components.Button.defaultProps.size).toBe("veryBig")

--- a/packages/react/tests/with-default-size.test.tsx
+++ b/packages/react/tests/with-default-size.test.tsx
@@ -1,6 +1,6 @@
 import { extendTheme, withDefaultSize } from "../src"
 
-describe("withDefaultSize", () => {
+describe("Theme extension: withDefaultSize", () => {
   it("should set a defaultSize", () => {
     const customTheme = extendTheme(withDefaultSize({ size: "veryBig" }))
 

--- a/packages/react/tests/with-default-variant.test.tsx
+++ b/packages/react/tests/with-default-variant.test.tsx
@@ -1,11 +1,9 @@
-import defaultTheme from "@chakra-ui/theme"
 import { extendTheme, withDefaultVariant } from "../src"
 
 describe("withDefaultVariant", () => {
   it("should set a defaultVariant", () => {
     const customTheme = extendTheme(
       withDefaultVariant({ variant: "my-custom-variant" }),
-      defaultTheme,
     )
 
     expect(customTheme.components.Button.defaultProps.variant).toBe(
@@ -19,7 +17,6 @@ describe("withDefaultVariant", () => {
         variant: "my-custom-variant",
         components: ["Button", "Badge"],
       }),
-      defaultTheme,
     )
 
     expect(customTheme.components.Button.defaultProps.variant).toBe(

--- a/packages/react/tests/with-default-variant.test.tsx
+++ b/packages/react/tests/with-default-variant.test.tsx
@@ -1,6 +1,6 @@
 import { extendTheme, withDefaultVariant } from "../src"
 
-describe("withDefaultVariant", () => {
+describe("Theme extension: withDefaultVariant", () => {
   it("should set a defaultVariant", () => {
     const customTheme = extendTheme(
       withDefaultVariant({ variant: "my-custom-variant" }),

--- a/packages/react/tests/with-default-variant.test.tsx
+++ b/packages/react/tests/with-default-variant.test.tsx
@@ -1,0 +1,35 @@
+import defaultTheme from "@chakra-ui/theme"
+import { extendTheme, withDefaultVariant } from "../src"
+
+describe("withDefaultVariant", () => {
+  it("should set a defaultVariant", () => {
+    const customTheme = extendTheme(
+      withDefaultVariant({ variant: "my-custom-variant" }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.variant).toBe(
+      "my-custom-variant",
+    )
+  })
+
+  it("should allow overrides only mentioned components", () => {
+    const customTheme = extendTheme(
+      withDefaultVariant({
+        variant: "my-custom-variant",
+        components: ["Button", "Badge"],
+      }),
+      defaultTheme,
+    )
+
+    expect(customTheme.components.Button.defaultProps.variant).toBe(
+      "my-custom-variant",
+    )
+    expect(customTheme.components.Badge.defaultProps.variant).toBe(
+      "my-custom-variant",
+    )
+    expect(customTheme.components.Alert.defaultProps.variant).not.toBe(
+      "my-custom-variant",
+    )
+  })
+})

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -28,5 +28,6 @@ export type Theme = typeof theme
 export type DefaultChakraTheme = Theme
 
 export * from "./theme.types"
+export * from "./utils"
 
 export default theme

--- a/packages/theme/src/utils.ts
+++ b/packages/theme/src/utils.ts
@@ -2,22 +2,24 @@ import { isObject } from "@chakra-ui/utils"
 import { ChakraTheme } from "./theme.types"
 
 export const requiredChakraThemeKeys: (keyof ChakraTheme)[] = [
+  "borders",
+  "breakpoints",
+  "colors",
+  "components",
+  "config",
+  "direction",
   "fonts",
   "fontSizes",
   "fontWeights",
   "letterSpacings",
   "lineHeights",
-  "borders",
-  "breakpoints",
-  "colors",
   "radii",
   "shadows",
   "sizes",
   "space",
+  "styles",
   "transition",
   "zIndices",
-  "config",
-  "direction",
 ]
 
 export function isChakraTheme(unit: unknown): unit is ChakraTheme {

--- a/packages/theme/src/utils.ts
+++ b/packages/theme/src/utils.ts
@@ -26,6 +26,6 @@ export function isChakraTheme(unit: unknown): unit is ChakraTheme {
   }
 
   return requiredChakraThemeKeys.every((propertyName) =>
-    unit.hasOwnProperty(propertyName),
+    Object.prototype.hasOwnProperty.call(unit, propertyName),
   )
 }

--- a/packages/theme/src/utils.ts
+++ b/packages/theme/src/utils.ts
@@ -1,0 +1,31 @@
+import { isObject } from "@chakra-ui/utils"
+import { ChakraTheme } from "./theme.types"
+
+export const requiredChakraThemeKeys: (keyof ChakraTheme)[] = [
+  "fonts",
+  "fontSizes",
+  "fontWeights",
+  "letterSpacings",
+  "lineHeights",
+  "borders",
+  "breakpoints",
+  "colors",
+  "radii",
+  "shadows",
+  "sizes",
+  "space",
+  "transition",
+  "zIndices",
+  "config",
+  "direction",
+]
+
+export function isChakraTheme(unit: unknown): unit is ChakraTheme {
+  if (!isObject(unit)) {
+    return false
+  }
+
+  return requiredChakraThemeKeys.every((propertyName) =>
+    unit.hasOwnProperty(propertyName),
+  )
+}

--- a/packages/theme/tests/theme.test.ts
+++ b/packages/theme/tests/theme.test.ts
@@ -1,9 +1,17 @@
-import theme, { ChakraTheme } from "../src"
+import theme, { ChakraTheme, isChakraTheme } from "../src"
 
 describe("Theme", () => {
-  it("should be a ChakraTheme", () => {
+  it("should be of type ChakraTheme", () => {
     // Check if default theme is of type ChakraTheme
     const defaultThemeIsAChakraTheme: ChakraTheme = theme
     expect(defaultThemeIsAChakraTheme).toBeTruthy()
+  })
+
+  it("should be check that this is a ChakraTheme", () => {
+    expect(isChakraTheme(theme)).toBeTruthy()
+  })
+
+  it("should be check that this is not a ChakraTheme", () => {
+    expect(isChakraTheme({ colors: {} })).toBeFalsy()
   })
 })

--- a/packages/utils/src/assertion.ts
+++ b/packages/utils/src/assertion.ts
@@ -25,7 +25,9 @@ export function isEmptyArray(value: any) {
 }
 
 // Function assertions
-export function isFunction(value: any): value is Function {
+export function isFunction<T extends Function = Function>(
+  value: any,
+): value is T {
   return typeof value === "function"
 }
 

--- a/packages/utils/src/function.ts
+++ b/packages/utils/src/function.ts
@@ -33,10 +33,6 @@ export const compose = <T>(
   ...fns: Array<(...args: T[]) => T>
 ) => fns.reduce((f1, f2) => (...args) => f1(f2(...args)), fn1)
 
-export function pipe<R>(...fns: Array<(a: R) => R>) {
-  return (x: R) => fns.reduce((prevResult, fn) => fn(prevResult), x)
-}
-
 export function once<T extends AnyFunction>(fn?: T | null) {
   let result: any
 

--- a/packages/utils/src/function.ts
+++ b/packages/utils/src/function.ts
@@ -33,6 +33,10 @@ export const compose = <T>(
   ...fns: Array<(...args: T[]) => T>
 ) => fns.reduce((f1, f2) => (...args) => f1(f2(...args)), fn1)
 
+export function pipe<R>(...fns: Array<(a: R) => R>) {
+  return (x: R) => fns.reduce((prevResult, fn) => fn(prevResult), x)
+}
+
 export function once<T extends AnyFunction>(fn?: T | null) {
   let result: any
 

--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -253,14 +253,9 @@ best suggestion on how to write style overrides and organize your custom theme.
 The `extendTheme` function allows you to pass multiple overrides or extensions:
 
 ```js
-import {
-  extendTheme,
-  theme as baseTheme,
-  withDefaultColorScheme,
-} from "@chakra-ui/react"
+import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react"
 
 const customTheme = extendTheme(
-  withDefaultColorScheme({ colorScheme: "brand" }),
   {
     colors: {
       brand: baseTheme.colors.red,
@@ -273,47 +268,40 @@ const customTheme = extendTheme(
       },
     },
   },
-  baseTheme,
+  withDefaultColorScheme({ colorScheme: "brand" }),
 )
 ```
 
-The order of overrides is from right to left, except the base:
+The order of overrides is from left to right. E.g. the second extension
+overrides the first one, and so on.
+
+> Please note that you can pass a base theme as last parameter. If no base theme
+> is provided, we use the Chakra UI default theme
 
 ```js
 extendTheme(
-  extionsionONEoverridesBase,
-  extensionTWOoverridesONE,
-  extensionNEXToverridesPRECEDING,
-  base,
+  withFirstExtension,
+  withSecondExtension,
+  withThirdExtension,
+  optionalBaseTheme,
 )
 ```
 
 ## Theme Extension: withDefaultColorScheme
 
-You can apply a default color scheme to all components in your `baseTheme`.
+You can apply a default color scheme to all components.
 
 ```js
-import {
-  extendTheme,
-  theme as baseTheme,
-  withDefaultColorScheme,
-} from "@chakra-ui/react"
+import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react"
 
-const customTheme = extendTheme(
-  withDefaultColorScheme({ colorScheme: "red" }),
-  baseTheme,
-)
+const customTheme = extendTheme(withDefaultColorScheme({ colorScheme: "red" }))
 ```
 
 Or pass the component names you want to apply a default `colorScheme` to. This
 lets you apply different color schemes to a group of components.
 
 ```js
-import {
-  extendTheme,
-  theme as baseTheme,
-  withDefaultColorScheme,
-} from "@chakra-ui/react"
+import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react"
 
 const customTheme = extendTheme(
   withDefaultColorScheme({
@@ -324,60 +312,45 @@ const customTheme = extendTheme(
     colorScheme: "blue",
     components: ["Alert", "Table"],
   }),
-  baseTheme,
 )
 ```
 
 ## Theme Extension: withDefaultSize
 
-You can apply a default size to all components in your `baseTheme`.
+You can apply a default size to all components.
 
 ```js
-import {
-  extendTheme,
-  theme as baseTheme,
-  withDefaultSize,
-} from "@chakra-ui/react"
+import { extendTheme, withDefaultSize } from "@chakra-ui/react"
 
 const customTheme = extendTheme(
   withDefaultSize({
     size: "lg",
     components: ["Button", "Badge"],
   }),
-  baseTheme,
 )
 ```
 
 ## Theme Extension: withDefaultVariant
 
-You can apply a default variant to all components in your `baseTheme`.
+You can apply a default variant to all components.
 
 ```js
-import {
-  extendTheme,
-  theme as baseTheme,
-  withDefaultVariant,
-} from "@chakra-ui/react"
+import { extendTheme, withDefaultVariant } from "@chakra-ui/react"
 
 const customTheme = extendTheme(
   withDefaultVariant({
     variant: "outline",
     components: ["Input", "NumberInput", "PinInput"],
   }),
-  baseTheme,
 )
 ```
 
 ## Theme Extension: withDefaultProps
 
-You can apply default props to all components in your `baseTheme`.
+You can apply default props to all components.
 
 ```js
-import {
-  extendTheme,
-  theme as baseTheme,
-  withDefaultProps,
-} from "@chakra-ui/react"
+import { extendTheme, withDefaultProps } from "@chakra-ui/react"
 
 const customTheme = extendTheme(
   withDefaultProps({
@@ -387,7 +360,6 @@ const customTheme = extendTheme(
     },
     components: ["Input", "NumberInput", "PinInput"],
   }),
-  baseTheme,
 )
 ```
 

--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -244,6 +244,90 @@ None of these is strictly required to use Chakra - but we've learned some hard
 lessons on the "right" way and the "wrong" way to write styles. The above is our
 best suggestion on how to write style overrides and organize your custom theme.
 
+## Using Theme extensions
+
+<Badge fontSize="sm" colorScheme="teal" letterSpacing="wider">
+  v1.4.0
+</Badge>
+
+The `extendTheme` function allows you to pass multiple overrides or extensions:
+
+```js
+import {
+  extendTheme,
+  theme as baseTheme,
+  withDefaultColorScheme,
+} from "@chakra-ui/react"
+
+const customTheme = extendTheme(
+  withDefaultColorScheme({ colorScheme: "brand" }),
+  {
+    colors: {
+      brand: baseTheme.colors.red,
+    },
+    components: {
+      Alert: {
+        defaultProps: {
+          colorScheme: "blue",
+        },
+      },
+    },
+  },
+  baseTheme,
+)
+```
+
+The order of overrides is from right to left, except the base:
+
+```js
+extendTheme(
+  extionsionONEoverridesBase,
+  extensionTWOoverridesONE,
+  extensionNEXToverridesPRECEDING,
+  base,
+)
+```
+
+## Theme Extension: withDefaultColorScheme
+
+You can apply a default color scheme to all components in your baseTheme.
+
+```js
+import {
+  extendTheme,
+  theme as baseTheme,
+  withDefaultColorScheme,
+} from "@chakra-ui/react"
+
+const customTheme = extendTheme(
+  withDefaultColorScheme({ colorScheme: "red" }),
+  baseTheme,
+)
+```
+
+Or pass the component names you want to apply a default `colorScheme` to. This
+lets you apply different color schemes to a group of components.
+
+```js
+import {
+  extendTheme,
+  theme as baseTheme,
+  withDefaultColorScheme,
+} from "@chakra-ui/react"
+
+const customTheme = extendTheme(
+  withDefaultColorScheme({
+    colorScheme: "red",
+    components: ["Button", "Badge"],
+  }),
+  withDefaultColorScheme({
+    colorScheme: "blue",
+    components: ["Alert", "Table"],
+  }),
+  baseTheme,
+)
+```
+
 ---
 
 [In the next section](/docs/theming/component-style), we'll show some examples

--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -290,7 +290,7 @@ extendTheme(
 
 ## Theme Extension: withDefaultColorScheme
 
-You can apply a default color scheme to all components in your baseTheme.
+You can apply a default color scheme to all components in your `baseTheme`.
 
 ```js
 import {
@@ -323,6 +323,69 @@ const customTheme = extendTheme(
   withDefaultColorScheme({
     colorScheme: "blue",
     components: ["Alert", "Table"],
+  }),
+  baseTheme,
+)
+```
+
+## Theme Extension: withDefaultSize
+
+You can apply a default size to all components in your `baseTheme`.
+
+```js
+import {
+  extendTheme,
+  theme as baseTheme,
+  withDefaultSize,
+} from "@chakra-ui/react"
+
+const customTheme = extendTheme(
+  withDefaultSize({
+    size: "lg",
+    components: ["Button", "Badge"],
+  }),
+  baseTheme,
+)
+```
+
+## Theme Extension: withDefaultVariant
+
+You can apply a default variant to all components in your `baseTheme`.
+
+```js
+import {
+  extendTheme,
+  theme as baseTheme,
+  withDefaultVariant,
+} from "@chakra-ui/react"
+
+const customTheme = extendTheme(
+  withDefaultVariant({
+    variant: "outline",
+    components: ["Input", "NumberInput", "PinInput"],
+  }),
+  baseTheme,
+)
+```
+
+## Theme Extension: withDefaultProps
+
+You can apply default props to all components in your `baseTheme`.
+
+```js
+import {
+  extendTheme,
+  theme as baseTheme,
+  withDefaultProps,
+} from "@chakra-ui/react"
+
+const customTheme = extendTheme(
+  withDefaultProps({
+    defaultProps: {
+      variant: "outline",
+      size: "lg",
+    },
+    components: ["Input", "NumberInput", "PinInput"],
   }),
   baseTheme,
 )

--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -247,7 +247,7 @@ best suggestion on how to write style overrides and organize your custom theme.
 ## Using Theme extensions
 
 <Badge fontSize="sm" colorScheme="teal" letterSpacing="wider">
-  v1.4.0
+  v1.6.0
 </Badge>
 
 The `extendTheme` function allows you to pass multiple overrides or extensions:

--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -253,7 +253,11 @@ best suggestion on how to write style overrides and organize your custom theme.
 The `extendTheme` function allows you to pass multiple overrides or extensions:
 
 ```js
-import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react"
+import {
+  extendTheme,
+  withDefaultColorScheme,
+  theme as baseTheme,
+} from "@chakra-ui/react"
 
 const customTheme = extendTheme(
   {


### PR DESCRIPTION
Closes #2828

## 📝 Description

This PR introduces theme extentions. `extendTheme` now composes all overrides and extensions onto the baseTheme.

## ⛳️ Current behavior (updates)

`extendTheme` accepts one override object.

## 🚀 New behavior

You can apply a default color scheme to all components in your baseTheme.

```js
import {
  extendTheme,
  theme as baseTheme,
  withDefaultColorScheme,
} from "@chakra-ui/react"

const customTheme = extendTheme(
  withDefaultColorScheme({ colorScheme: "red" }),
  baseTheme, // optional
)
```

Or pass the component names you want to apply a default `colorScheme` to. This
lets you apply different color schemes to a group of components.

```js
import {
  extendTheme,
  withDefaultColorScheme,
} from "@chakra-ui/react"

const customTheme = extendTheme(
  withDefaultColorScheme({
    colorScheme: "red",
    components: ["Button", "Badge"],
  }),
  withDefaultColorScheme({
    colorScheme: "blue",
    components: ["Alert", "Table"],
  }),
)
```

You can even write you own theme extensions:

```ts
import { 
  extendTheme,
  withDefaultColorScheme,
  mergeThemeOverride, 
  ThemeExtension 
} from '@chakra-ui/react'

function withBrandColorExtension(colorName: string): ThemeExtension {
  return (theme) =>
    mergeThemeOverride(theme, {
      colors: {
        brand: theme.colors![colorName],
      },
    })
}

const customTheme = extendTheme(
  withBrandColorExtension("red"),
  withDefaultColorScheme({ colorScheme: "brand" }),
)
```

## 💣 Is this a breaking change (Yes/No):

No, the current API for a single override and an optional third-party base theme are still supported.
