### PR TITLE
docs: use extend-theme to create the theme

### DIFF
--- a/website/pages/guides/integrations/with-gatsby.mdx
+++ b/website/pages/guides/integrations/with-gatsby.mdx
@@ -75,8 +75,9 @@ Add this to your `gatsby-browser.js`:
 
 ```js live=false
 import React from "react"
-import { ChakraProvider, CSSReset } from "@chakra-ui/react"
-import customTheme from "./theme/theme"
+import { ChakraProvider, CSSReset, extendTheme } from "@chakra-ui/react"
+
+const customTheme = extendTheme({});
 
 export const wrapRootElement = ({ element }) => {
   return (


### PR DESCRIPTION
## 📝 Description

* Update the gatsby example to use `extendTheme` api as opposed to using the raw object.

## ⛳️ Current behavior (updates)

When I use the example provided in the doc I run into the following error:
```
// gatsby-browser.js

import './src/css/index.css';
import React from 'react';
import { ChakraProvider, CSSReset } from '@chakra-ui/react';

const customTheme = {};

export const wrapRootElement = ({ element }) => {
  return (
    <ChakraProvider theme={customTheme}>
      <CSSReset />
      {element}
    </ChakraProvider>
  );
};

```
![image](https://user-images.githubusercontent.com/25732808/110215927-4d203b80-7e7a-11eb-9941-87131de102af.png)


## 🚀 New behavior

* Update example for the gatsby plugin. Use `extendTheme` to create the theme.

```
/**
 * Implement Gatsby's Browser APIs in this file.
 *
 * See: https://www.gatsbyjs.org/docs/browser-apis/
 */
import './src/css/index.css';
import React from 'react';
import { ChakraProvider, CSSReset, extendTheme } from '@chakra-ui/react';

const customTheme = extendTheme({});

export const wrapRootElement = ({ element }) => {
  return (
    <ChakraProvider theme={customTheme}>
      <CSSReset />
      {element}
    </ChakraProvider>
  );
};
```

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
