### PR TITLE
refactor(popper): dont return popper state

### DIFF
--- a/.changeset/kind-poems-turn.md
+++ b/.changeset/kind-poems-turn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popper": patch
+---
+
+refactor react-popper to not return unnecessary values

--- a/packages/popper/src/react-popper.ts
+++ b/packages/popper/src/react-popper.ts
@@ -6,7 +6,7 @@ import {
   Modifier,
   Options as PopperOptions,
   VirtualElement,
-  State as PopperState,
+  Placement,
 } from "@popperjs/core"
 import { dequal } from "dequal"
 import * as React from "react"
@@ -57,7 +57,9 @@ export function usePopper(
     modifiers: options.modifiers || EMPTY_MODIFIERS,
   }
 
-  const [popperState, setPopperState] = React.useState<PopperState | null>(null)
+  const [placement, setPlacement] = React.useState<Placement>(
+    optionsWithDefaults.placement,
+  )
   const [styles, setStyles] = React.useState<State["styles"]>({
     popper: {
       position: optionsWithDefaults.strategy,
@@ -76,7 +78,7 @@ export function usePopper(
       fn: ({ state }) => {
         const elements = Object.keys(state.elements)
 
-        setPopperState(state)
+        setPlacement(state.placement)
 
         setStyles(resolve(state.styles, elements))
         setAttrs(resolve(state.attributes, elements))
@@ -150,7 +152,7 @@ export function usePopper(
   }, [])
 
   return {
-    state: popperState || null,
+    placement,
     styles,
     attributes: attrs,
     update: popperInstanceRef.current ? popperInstanceRef.current.update : null,

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -142,10 +142,8 @@ export function usePopper(props: UsePopperProps = {}) {
     popperJS.forceUpdate?.()
   })
 
-  const finalPlacement = popperJS.state?.placement ?? placement
-
   const arrowStyles = getArrowStyles({
-    placement: finalPlacement,
+    placement: popperJS.placement,
     popperArrowStyles: popperJS.styles.arrow,
     arrowSize,
   })
@@ -183,7 +181,7 @@ export function usePopper(props: UsePopperProps = {}) {
       ...props,
       ref: _ref,
       style: {
-        boxShadow: getBoxShadow(finalPlacement, arrowShadowColor),
+        boxShadow: getBoxShadow(popperJS.placement, arrowShadowColor),
         ...props.style,
         position: "absolute",
         zIndex: -1,
@@ -192,19 +190,18 @@ export function usePopper(props: UsePopperProps = {}) {
         transform: "rotate(45deg)",
       },
     }),
-    [finalPlacement, arrowShadowColor],
+    [popperJS.placement, arrowShadowColor],
   )
 
   return {
-    transformOrigin: toTransformOrigin(finalPlacement),
+    transformOrigin: toTransformOrigin(popperJS.placement),
     getReferenceProps,
     getPopperProps,
     getArrowWrapperProps,
     getArrowProps,
-    state: popperJS.state,
     forceUpdate: popperJS.forceUpdate,
     update: popperJS.update,
-    placement: finalPlacement,
+    placement: popperJS.placement,
   }
 }
 


### PR DESCRIPTION
## 📝 Description

Following up on the discussion in https://github.com/chakra-ui/chakra-ui/pull/3477, I refactored the `react-popper`/`use-popper` a bit.

## ⛳️ Current behavior (updates)

The `react-popper` returns both the `state` property (which has additional properties like `style` and `attributes` on it) as well as the `style` and `attributes` properties individually.

It's not a bug per see but it can cause some confusion as for whether to "trust" the `style`/`attributes` property on the `state` object or the `style`/`attributes` properties returned directly from the `react-popper`.

Moreover, the `use-popper` hook returns the `state` property as well which isn't used anywhere in the codebase.

## 🚀 New behavior

As the `react-popper` only needs the `placement` property (apart from afore-mentioed `style` and `attributes` properties) from the `state` object, I refactored the hook in `react-popper` to *not* return the whole `state` object but only the `placement`.

I also removed the `state` object from the return values of the hook in `use-popper` as it's not used anywhere in the codebase.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
