### PR TITLE
docs: fix typo on getting-started page

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -76,7 +76,7 @@ Then add the plugin to your `gatsby-config`.
 // gatsby-config.js
 
 module.exports = {
-  plugins: ["@chakra-ui/gatsby-plugin],
+  plugins: ["@chakra-ui/gatsby-plugin"],
 }
 ```
 


### PR DESCRIPTION
## 📝 Description

Adds missing closing quote in gatsby-plugin example

## 💣 Is this a breaking change (Yes/No):

No
