### PR TITLE
fix(slider): avoid excess onChange calls

### DIFF
--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -184,6 +184,8 @@ export function useSlider(props: UseSliderProps) {
    * or greater than max
    */
   const value = clampValue(computedValue, min, max)
+  const valueRef = useRef(value)
+  valueRef.current = value
 
   const reversedValue = max - value + min
   const trackValue = isReversed ? reversedValue : value
@@ -415,7 +417,7 @@ export function useSlider(props: UseSliderProps) {
     const run = (event: MouseEvent) => {
       const nextValue = getValueFromPointer(event)
 
-      if (nextValue != null) {
+      if (nextValue != null && nextValue !== valueRef.current) {
         setEventSource("mouse")
         setValue(nextValue)
       }
@@ -450,7 +452,7 @@ export function useSlider(props: UseSliderProps) {
     const run = (event: TouchEvent) => {
       const nextValue = getValueFromPointer(event)
 
-      if (nextValue != null) {
+      if (nextValue != null && nextValue !== valueRef.current) {
         setEventSource("touch")
         setValue(nextValue)
       }

--- a/packages/slider/stories/slider.stories.tsx
+++ b/packages/slider/stories/slider.stories.tsx
@@ -30,6 +30,33 @@ export const SliderBug = () => {
   )
 }
 
+export const SliderOnChangeBug = () => {
+  const [value, setValue] = React.useState(10)
+  const [counter, setCounter] = React.useState(0)
+
+  return (
+    <div>
+      <Slider
+        min={0}
+        max={20}
+        step={5}
+        value={value}
+        onChange={(value) => {
+          setCounter((c) => c + 1)
+          setValue(value)
+        }}
+      >
+        <SliderTrack bg="red.100">
+          <SliderFilledTrack bg="tomato" />
+        </SliderTrack>
+        <SliderThumb boxSize={6} />
+      </Slider>
+      <chakra.div mt="10px">Value: {value}</chakra.div>
+      <chakra.div mt="10px">Change Count: {counter}</chakra.div>
+    </div>
+  )
+}
+
 export function HorizontalSlider() {
   return (
     <Slider colorScheme="red" onChangeEnd={console.log}>


### PR DESCRIPTION


<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2210

## 📝 Description

This fixes a regression of #2210.

## ⛳️ Current behavior (updates)

While dragging `SliderThumb` a small amount such that the value does not change, `onChange` is fired rapidly

## 🚀 New behavior

`onChange` will only fire when the value changes.

## 💣 Is this a breaking change (Yes/No):

No, this is a bug fix

## 📝 Additional Information

It looks like the previous fix was
reverted in fa8273bb41ad667a113b99ed97d1ab39e5790e63 due to the fix
introducing a new issue:

- Begin drag from value X
- Drag to value X + 1 without finishing drag
- Continue drag back to value X is not allowed

That issue was because `onMouseDown`/`onTouchStart` had stale closures
around `value`. Using an evergreen ref of `value` resolves this.

I looked into added tests for these two issues to avoid further regressions, but had trouble creating `mousemove` events because the track's box is always `{ bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0 }` so `getValueFromPointer` is unable to interpolate based on track width. Let me know if there's a good way around this or if I should look into mocking out the track box.