### PR TITLE
fix: aspect ratio SSR style tag display

### DIFF
--- a/.changeset/few-wasps-judge.md
+++ b/.changeset/few-wasps-judge.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+fix: aspect ratio SSR style tag display

--- a/packages/layout/src/aspect-ratio.tsx
+++ b/packages/layout/src/aspect-ratio.tsx
@@ -62,6 +62,9 @@ export const AspectRatio = forwardRef<AspectRatioProps, "div">((props, ref) => {
         "& > img, & > video": {
           objectFit: "cover",
         },
+        "& > style": {
+          display: "none",
+        },
       }}
       {...rest}
     >

--- a/packages/layout/src/aspect-ratio.tsx
+++ b/packages/layout/src/aspect-ratio.tsx
@@ -46,7 +46,7 @@ export const AspectRatio = forwardRef<AspectRatioProps, "div">((props, ref) => {
         paddingBottom: mapResponsive(ratio, (r) => `${(1 / r) * 100}%`),
       }}
       __css={{
-        "& > *": {
+        "& > *:not(style)": {
           overflow: "hidden",
           position: "absolute",
           top: "0",
@@ -61,10 +61,7 @@ export const AspectRatio = forwardRef<AspectRatioProps, "div">((props, ref) => {
         },
         "& > img, & > video": {
           objectFit: "cover",
-        },
-        "& > style": {
-          display: "none",
-        },
+        }
       }}
       {...rest}
     >


### PR DESCRIPTION
## 📝 Description
On the SSR, `<style>` tag was displayed for a split second because of `display: "flex"` applied to all children.
A fix is to override the `display` property for style tags.

## 📝 Additional Information
You can reproduce this here
https://codesandbox.io/s/chakra-ssr-aspect-ratio-issue-qghp1

Preview (JS is disabled so only the HTML form server side is rendered)
<img width="1390" alt="diable-js" src="https://user-images.githubusercontent.com/4128883/111136254-d2dc6f00-857d-11eb-8398-e59d4a6ad606.png">