### PR TITLE
docs: fixed typo on example usage from emotion/is-prop-valid package

### DIFF
--- a/website/pages/docs/features/chakra-factory.mdx
+++ b/website/pages/docs/features/chakra-factory.mdx
@@ -138,7 +138,7 @@ const Div = chakra("div", {
     if (isChakraProp) return false
 
     // forward valid HTML props
-    const isValidProp = isValidHMTLProp(prop)
+    const isValidProp = isValidHTMLProp(prop)
     if (isValidProp) return true
 
     // else, only forward `sample` prop


### PR DESCRIPTION
## 📝 Description

> Fixed typo on Chakra Factory Documentation

## ⛳️ Current behavior (updates)

> Invalid usage `isValidHMTLProp` where the import is `isValidHTMLProp`

## 🚀 New behavior

Fixes Typo isValidH**MT**LProp

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

Link to the current Docs: https://chakra-ui.com/docs/features/chakra-factory
