### PR TITLE
docs: add Next JS TypeScript starter link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,6 +43,9 @@ Create a minimal reproduction in CodeSandbox. We have created these official tem
 
 - TypeScript Template:
   [TypeScript CodeSandbox template](https://codesandbox.io/s/github/chakra-ui/codesandbox-react-ts-template/tree/master)
+
+- NextJS TypeScript Template:
+  [NextJS TypeScript CodeSandbox template](https://codesandbox.io/s/chakra-ui-next-js-typescript-kxvyr)
 -->
 
 CodeSandbox reproduction: https://your-codesandbox-link-goes-here.io

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ function Example() {
 
 - JavaScript Starter: https://codesandbox.io/s/chakra-ui-javascript-lzzg9
 - TypeScript Starter: https://codesandbox.io/s/chakra-ui-typescript-pomi8
+- NextJS TypeScript Starter: https://codesandbox.io/s/chakra-ui-next-js-typescript-kxvyr
 
 ## `create-react-app` Templates
 


### PR DESCRIPTION
## 📝 Description

Adding a Next JS TypeScript starter in the README file and Bug Report issue template.
