### PR TITLE
fix: styled system css and css vars

### DIFF
--- a/.changeset/olive-walls-promise.md
+++ b/.changeset/olive-walls-promise.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Fix: issue where responsive styles defined in textstyles not overriden wiht
+props.
+
+Fix: issue where `toCSSVars` omitted the transition tokens

--- a/packages/styled-system/src/config/others.ts
+++ b/packages/styled-system/src/config/others.ts
@@ -32,6 +32,14 @@ const srFocusable = {
   whiteSpace: "normal",
 }
 
+const getWithPriority = (theme: any, key: any, styles: any) => {
+  const expanded = get(theme, key, {})
+  for (const prop in expanded) {
+    if (prop in styles) delete expanded[prop]
+  }
+  return expanded
+}
+
 export const others: Config = {
   animation: true,
   appearance: true,
@@ -58,15 +66,17 @@ export const others: Config = {
   },
   layerStyle: {
     processResult: true,
-    transform: (value, theme) => get(theme, `layerStyles.${value}`, {}),
+    transform: (value, theme, styles) =>
+      getWithPriority(theme, `layerStyles.${value}`, styles),
   },
   textStyle: {
     processResult: true,
-    transform: (value, theme) => get(theme, `textStyles.${value}`, {}),
+    transform: (value, theme, styles = {}) =>
+      getWithPriority(theme, `textStyles.${value}`, styles),
   },
   apply: {
     processResult: true,
-    transform: (value, theme) => get(theme, value, {}),
+    transform: (value, theme, styles) => getWithPriority(theme, value, styles),
   },
 }
 
@@ -136,12 +146,12 @@ export interface OtherProps {
    * The layer style object to apply.
    * Note: Styles must be located in `theme.layerStyles`
    */
-  layerStyle?: Token<(string & {}), 'layerStyles'>
+  layerStyle?: Token<string & {}, "layerStyles">
   /**
    * The text style object to apply.
    * Note: Styles must be located in `theme.textStyles`
    */
-  textStyle?: Token<(string & {}), 'textStyles'>
+  textStyle?: Token<string & {}, "textStyles">
   /**
    * Apply theme-aware style objects in `theme`
    */

--- a/packages/styled-system/src/css-var.ts
+++ b/packages/styled-system/src/css-var.ts
@@ -37,13 +37,14 @@ export const tokens = [
   "shadows",
   "sizes",
   "zIndices",
-  "transitions",
-  "transition.duration",
-  "transition.property",
-  "transition.easing",
+  "transition",
 ] as const
 
-export type ThemeScale = typeof tokens[number]
+export type ThemeScale =
+  | typeof tokens[number]
+  | "transition.duration"
+  | "transition.property"
+  | "transition.easing"
 
 function extractTokens(theme: Dict) {
   const _tokens = (tokens as unknown) as string[]

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -73,11 +73,12 @@ export function getCss(options: Options) {
       }
 
       if (isObject(value)) {
-        computedStyles[key] = css(value, true)
+        computedStyles[key] = computedStyles[key] ?? {}
+        computedStyles[key] = merge({}, computedStyles[key], css(value, true))
         continue
       }
 
-      let rawValue = config?.transform?.(value, theme) ?? value
+      let rawValue = config?.transform?.(value, theme, _styles) ?? value
       rawValue = config?.processResult ? css(rawValue, true) : rawValue
 
       const configProperty = runIfFn(config?.property, theme)

--- a/packages/styled-system/src/types.ts
+++ b/packages/styled-system/src/types.ts
@@ -88,7 +88,7 @@ export interface SystemProps extends StyleProps, PseudoProps {}
 
 export type CSSMap = Dict<{ value: string; var: string; varRef: string }>
 
-export type Transform = (value: any, theme: CssTheme) => any
+export type Transform = (value: any, theme: CssTheme, styles?: Dict) => any
 
 export type WithCSSVar<T> = T & {
   __cssVars: Dict

--- a/packages/styled-system/stories/css.stories.tsx
+++ b/packages/styled-system/stories/css.stories.tsx
@@ -54,3 +54,23 @@ export const HoverFocus = () => {
     </Box>
   )
 }
+
+export const TextAndLayerStyles = () => {
+  const theme = {
+    ...defaultTheme,
+    textStyles: {
+      big: { fontSize: "40px", lineHeight: "80px" },
+      responsiveValue: {
+        fontSize: { base: "10px", sm: "20px" },
+      },
+    },
+  }
+  return (
+    <ThemeProvider theme={toCSSVar(theme)}>
+      <Box css={{ textStyle: "responsiveValue", fontSize: "60px" }}>
+        Lorem ipsum is placeholder text commonly used in the graphic, print, and
+        publishing industries for previewing layouts and visual mockups.
+      </Box>
+    </ThemeProvider>
+  )
+}

--- a/packages/styled-system/tests/css-var.test.ts
+++ b/packages/styled-system/tests/css-var.test.ts
@@ -366,3 +366,44 @@ test("should add a css var prefix if provided", () => {
     }
   `)
 })
+
+test("should convert transition tokens", () => {
+  const theme = {
+    transition: {
+      property: {
+        colors: "background-color, background",
+      },
+    },
+  }
+  expect(toCSSVar(theme)).toMatchInlineSnapshot(`
+    Object {
+      "__breakpoints": null,
+      "__cssMap": Object {
+        "transition.property.colors": Object {
+          "value": "background-color, background",
+          "var": "--transition-property-colors",
+          "varRef": "var(--transition-property-colors)",
+        },
+      },
+      "__cssVars": Object {
+        "--chakra-ring": "var(--chakra-ring-offset-shadow), var(--chakra-ring-shadow), 0 0 transparent",
+        "--chakra-ring-color": "rgba(66, 153, 225, 0.6)",
+        "--chakra-ring-inset": "var(--chakra-empty, /*!*/ /*!*/)",
+        "--chakra-ring-offset": "0px",
+        "--chakra-ring-offset-shadow": "var(--chakra-ring-inset) 0 0 0 var(--chakra-ring-offset) var(--chakra-ring-offset-color, transparent)",
+        "--chakra-ring-shadow": "var(--chakra-ring-inset) 0 0 0 calc(var(--chakra-ring-width) + var(--chakra-ring-offset)) var(--chakra-ring-color)",
+        "--chakra-ring-width": "3px",
+        "--chakra-space-x-reverse": "0",
+        "--chakra-space-y-reverse": "0",
+        "--chakra-transform": "translateX(var(--chakra-translate-x, 0)) translateY(var(--chakra-translate-y, 0)) rotate(var(--chakra-rotate, 0)) scaleX(var(--chakra-scale-x, 1)) scaleY(var(--chakra-scale-y, 1)) skewX(var(--chakra-skew-x, 0)) skewY(var(--chakra-skew-y, 0))",
+        "--chakra-transform-gpu": "translate3d(var(--chakra-translate-x, 0), var(--chakra-translate-y, 0), 0) rotate(var(--chakra-rotate, 0)) scaleX(var(--chakra-scale-x, 1)) scaleY(var(--chakra-scale-y, 1)) skewX(var(--chakra-skew-x, 0)) skewY(var(--chakra-skew-y, 0))",
+        "--transition-property-colors": "background-color, background",
+      },
+      "transition": Object {
+        "property": Object {
+          "colors": "background-color, background",
+        },
+      },
+    }
+  `)
+})

--- a/packages/styled-system/tests/text-styles.test.ts
+++ b/packages/styled-system/tests/text-styles.test.ts
@@ -1,0 +1,77 @@
+import defaultTheme from "@chakra-ui/theme"
+import { toCSSVar, css } from "../src"
+
+const theme = toCSSVar({
+  ...defaultTheme,
+  textStyles: {
+    big: {
+      fontSize: "40px",
+      lineHeight: "80px",
+    },
+    responsiveValue: {
+      fontSize: { base: "10px", sm: "20px" },
+    },
+    h1: {
+      fontWeight: "bold",
+      fontSize: { base: "2xl", sm: "4xl" },
+      color: { base: "blue", sm: "red" },
+    },
+  },
+})
+
+test("should override text style", () => {
+  expect(css({ textStyle: "big", fontSize: "60px" })(theme)).toMatchObject({
+    fontSize: "60px",
+    lineHeight: "80px",
+  })
+})
+
+test("should override responsive style", () => {
+  expect(
+    css({ textStyle: "responsiveValue", fontSize: "60px" })(theme),
+  ).toMatchObject({
+    fontSize: "60px",
+  })
+})
+
+test("should merge reponsive values in textStyles with other responsive styles", () => {
+  expect(
+    css({
+      textStyle: "h1",
+      mt: [3, 4],
+    })(theme),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "@media screen and (min-width: 30em)": Object {
+        "color": "red",
+        "fontSize": "var(--chakra-fontSizes-4xl)",
+        "marginTop": "var(--chakra-space-4)",
+      },
+      "color": "blue",
+      "fontSize": "var(--chakra-fontSizes-2xl)",
+      "fontWeight": "var(--chakra-fontWeights-bold)",
+      "marginTop": "var(--chakra-space-3)",
+    }
+  `)
+})
+
+test("should merge reponsive values in textStyles + override", () => {
+  expect(
+    css({
+      textStyle: "h1",
+      mt: [3, 4],
+      fontSize: "30px",
+    })(theme),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "@media screen and (min-width: 30em)": Object {
+        "color": "red",
+        "marginTop": "var(--chakra-space-4)",
+      },
+      "color": "blue",
+      "fontSize": "30px",
+      "fontWeight": "var(--chakra-fontWeights-bold)",
+      "marginTop": "var(--chakra-space-3)",
+    }
+  `)
+})

--- a/packages/system/tests/style-resolver.test.ts
+++ b/packages/system/tests/style-resolver.test.ts
@@ -81,7 +81,7 @@ test("should resolve styles correctly", () => {
         "WebkitLineClamp": "var(--chakra-line-clamp)",
         "background": "tomato",
         "backgroundPosition": "top left",
-        "color": "var(--chakra-colors-red-300)",
+        "color": "var(--chakra-colors-pink-300)",
         "display": "-webkit-box",
         "fontSize": "10px",
         "letterSpacing": "2px",
@@ -89,7 +89,7 @@ test("should resolve styles correctly", () => {
         "paddingInlineEnd": "var(--chakra-space-5)",
         "paddingInlineStart": "var(--chakra-space-5)",
         "textOverflow": "ellipsis",
-        "textTransform": "uppercase",
+        "textTransform": "capitalize",
       },
       Object {
         "paddingLeft": 40,


### PR DESCRIPTION
Closes #3501
Closes #3514

## 📝 Description

- Fix issue where responsive styles defined in `textStyles` not overridden when passing props.
- Fix issue where `toCSSVars` omitted the transition tokens

## 🚀 New behavior

- Styles defined in `layerStyles` and `textStyles` and apply can now be overridden with props.
- Tokens now include transition values in css custom properties.

## 💣 Is this a breaking change (Yes/No):

No