### PR TITLE
docs: specify version range for peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ link to your website.
 To use Chakra UI components, all you need to do is install the
 `@chakra-ui/react` package and its peer dependencies:
 
-```sh
-$ yarn add @chakra-ui/react @emotion/react @emotion/styled framer-motion
+```bash
+npm i @chakra-ui/react @emotion/react@^11.0.0 @emotion/styled@^11.0.0 framer-motion@^3.0.0
 
 # or
 
-$ npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion
+yarn add @chakra-ui/react @emotion/react@^11.0.0 @emotion/styled@^11.0.0 framer-motion@^3.0.0
 ```
 
 ## Usage

--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -5,13 +5,15 @@ description: How to install and set up Chakra UI in your project
 
 ## Installation
 
-Inside your React project directory, install Chakra UI by running either of the following:
+Inside your React project directory, install Chakra UI by running either of the
+following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion
+npm i @chakra-ui/react @emotion/react@^11.0.0 @emotion/styled@^11.0.0 framer-motion@^3.0.0
 ```
+
 ```bash
-yarn add @chakra-ui/react @emotion/react @emotion/styled framer-motion
+yarn add @chakra-ui/react @emotion/react@^11.0.0 @emotion/styled@^11.0.0 framer-motion@^3.0.0
 ```
 
 > For `create-react-app` installation instructions, check this
@@ -43,29 +45,34 @@ function App() {
 > - For Create React App, you need to set this up in `index.js` or `index.tsx`
 
 ### Next.js
-Go to `pages/_app.js` or `pages/_app.tsx` (create if it doesn't exist) and add this:
+
+Go to `pages/_app.js` or `pages/_app.tsx` (create if it doesn't exist) and add
+this:
 
 ```jsx live=false
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider } from "@chakra-ui/react"
 
 function MyApp({ Component, pageProps }) {
   return (
     <ChakraProvider>
       <Component {...pageProps} />
     </ChakraProvider>
-  );
+  )
 }
 
-export default MyApp;
-
+export default MyApp
 ```
 
 ### Gatsby
-Add the [@chakra-ui/gatsby-plugin](gatsbyjs.com/plugins/@chakra-ui/gatsby-plugin/). It does everything automatically for you!
+
+Add the
+[@chakra-ui/gatsby-plugin](gatsbyjs.com/plugins/@chakra-ui/gatsby-plugin/). It
+does everything automatically for you!
 
 ```bash
 npm i @chakra-ui/gatsby-plugin
 ```
+
 ```bash
 yarn add @chakra-ui/gatsby-plugin
 ```
@@ -79,7 +86,6 @@ module.exports = {
   plugins: ["@chakra-ui/gatsby-plugin"],
 }
 ```
-
 
 ## Add custom theme (Optional)
 


### PR DESCRIPTION
## 📝 Description

As of this morning, `framer-motion` is now at version 4. This is not a version that Chakra currently supports. Unfortunately, due to a combination of `peerDependencies` ranges being too wide in our packages and the installation instructions not specifying a version range, we're instructing people to always install the latest which is breaking fresh projects.

## ⛳️ Current behavior (updates)

Users are instructed to install the latest version of our peer dependencies.

## 🚀 New behavior

Users are instructed to install specific major version ranges of our peer dependencies. This future-proofs projects, so that when one of our peer dependencies has a `major` version bump that we don't support, it won't break anyone's project.

## 💣 Is this a breaking change (Yes/No):

No