### PR TITLE
Fixing a sentence

### DIFF
--- a/website/pages/guides/as-prop.mdx
+++ b/website/pages/guides/as-prop.mdx
@@ -55,7 +55,7 @@ const Card = forwardRef<BoxProps, "div">((props, ref) => (
 The `ChakraComponent` is a type we use internally to mark specific components as
 Chakra components rather than using `React.FC`.
 
-This is because a `ChakraComponent` comes props from the React component or
+This is because a `ChakraComponent` gets its props from the React component or
 element type, and adds chakra specific style props.
 
 `ChakraComponent` takes 2 type generic, the element type (like "div", "button",


### PR DESCRIPTION
changing `ChakraComponent` --comes-- its props to `ChakraComponent` gets its props. I had to re-read the sentence several times to understand it, I hope my change doesn't change the intended meaning of it.

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Fixed a word, I had to re-read the sentence to understand what it was saying, I hope I make it easier for others without changing the meaning.

## 💣 Is this a breaking change (Yes/No):

No