### PR TITLE
fix: CLI exits unexpectedly on warnings

### DIFF
--- a/.changeset/loud-rivers-listen.md
+++ b/.changeset/loud-rivers-listen.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+- Fixed an issue where the cli tokens command exited unexpectedly

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -22,23 +22,24 @@ async function run() {
   const themeFile = process.argv[2]
 
   if (!themeFile) {
-    process.stderr.write("No path to theme file provided.")
-    process.exit(127)
-    return
+    throw new Error("No path to theme file provided.")
   }
 
   const theme = await readTheme(themeFile)
 
   if (!isObject(theme)) {
-    process.stderr.write("Theme not found in default or named `theme` export")
-    process.exit(1)
+    throw new Error("Theme not found in default or named `theme` export")
   }
 
   const template = await createThemeTypingsInterface(theme, {
     config: themeKeyConfiguration,
   })
 
-  process.stdout.write(template)
+  if (process.send) {
+    process.send(template)
+  } else {
+    process.stdout.write(template)
+  }
 }
 
 run().catch((e) => {


### PR DESCRIPTION
Mentioned in https://github.com/chakra-ui/chakra-ui/issues/3459#issuecomment-788210258

## 📝 Description

The CLI tokens command exited unexpectedly if a warning was logged in the theme file.

## ⛳️ Current behavior (updates)

The CLI uses a worker script to parse the theme file.
The parent process checked if the worker logged something on stderr and exited accordingly.

## 🚀 New behavior

Now the CLI uses [fork](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options) for IPC.
Now it only exits on _real_ errors.

## 💣 Is this a breaking change (Yes/No):

No
