### PR TITLE
feat: export type ThemeComponentProps with theme property

### DIFF
--- a/.changeset/wicked-apes-wink.md
+++ b/.changeset/wicked-apes-wink.md
@@ -1,0 +1,16 @@
+---
+"@chakra-ui/theme": patch
+---
+
+- Added typings for the `theme` prop in `ThemingPropsThunk` and export a
+  standalone type `ThemeComponentProps`
+
+  ```ts
+  import { ThemeComponentProps } from "@chakra-ui/react"
+
+  function baseStyle(props: ThemeComponentProps) {
+    return {
+      boxShadow: `0 1px 2px 0 rgba(0, 0, 0, 0.05) ${props.theme.colors.whiteAlpha[500]}`,
+    }
+  }
+  ```

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -42,14 +42,14 @@ export interface ComponentDefaultProps
   extends Omit<ThemingProps, "styleConfig">,
     Dict {}
 
-export type ThemingPropsThunk<T> =
-  | T
-  | ((
-      props: Dict &
-        Omit<ThemingProps, "styleConfig"> & {
-          colorMode: ColorMode
-        },
-    ) => T)
+export interface ThemeComponentProps<Theme extends ChakraTheme = ChakraTheme>
+  extends Dict,
+    Omit<ThemingProps, "styleConfig"> {
+  colorMode: ColorMode
+  theme: Theme
+}
+
+export type ThemingPropsThunk<T> = T | ((props: ThemeComponentProps) => T)
 
 export interface SystemStyleObjectRecord {
   [key: string]: StyleObjectOrFn

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -49,7 +49,14 @@ export interface ThemeComponentProps<Theme extends ChakraTheme = ChakraTheme>
   theme: Theme
 }
 
-export type ThemingPropsThunk<T> = T | ((props: ThemeComponentProps) => T)
+export type ThemeComponentFunction<
+  Style,
+  Theme extends ChakraTheme = ChakraTheme
+> = (props: ThemeComponentProps<Theme>) => Style
+
+export type ThemingPropsThunk<Style, Theme extends ChakraTheme = ChakraTheme> =
+  | Style
+  | ThemeComponentFunction<Style, Theme>
 
 export interface SystemStyleObjectRecord {
   [key: string]: StyleObjectOrFn


### PR DESCRIPTION
## 📝 Description

Context: https://github.com/chakra-ui/chakra-ui/discussions/3568

Added typings for the `theme` prop in `ThemingPropsThunk` and export a standalone type `ThemeComponentProps`

```ts
import { ThemeComponentProps } from "@chakra-ui/react"
function baseStyle(props: ThemeComponentProps) {
  return {
    boxShadow: `0 1px 2px 0 rgba(0, 0, 0, 0.05) ${props.theme.colors.whiteAlpha[500]}`,
  }
}
```

## ⛳️ Current behavior (updates)

Type is hidden in `ThemingPropsThunk`

## 🚀 New behavior

It is exported as standalone type.

## 💣 Is this a breaking change (Yes/No):

No