### PR TITLE
fix: export of styles provider

### DIFF
--- a/.changeset/giant-seahorses-laugh.md
+++ b/.changeset/giant-seahorses-laugh.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/system": patch
+---
+
+- Fixed an issue where the StylesProvider export was not working in every
+  environment

--- a/packages/system/src/providers.tsx
+++ b/packages/system/src/providers.tsx
@@ -52,13 +52,12 @@ export function useTheme<T extends object = Dict>() {
   return theme as WithCSSVar<T>
 }
 
-export const [StylesProvider, useStyles] = createContext<
-  Dict<SystemStyleObject>
->({
+const [StylesProvider, useStyles] = createContext<Dict<SystemStyleObject>>({
   name: "StylesContext",
   errorMessage:
     "useStyles: `styles` is undefined. Seems you forgot to wrap the components in `<StylesProvider />` ",
 })
+export { StylesProvider, useStyles }
 
 /**
  * Applies styles defined in `theme.styles.global` globally


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

StylesProvider is not defined in CSB - this is a try to fix this. 

## ⛳️ Current behavior (updates)

`export const [StylesProvider, useStyles]`

## 🚀 New behavior

`export { StylesProvider, useStyles }`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

CSB deployment does not work for me, but I think this approach is worth a try.
