### PR TITLE
docs: Migration docs for obsolete `onClose` prop on <ModalCloseButton />

### DIFF
--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -529,7 +529,7 @@ prop instead.
 - Only pass `size` values defined in the components theme. Hard-coded values
   will be ignored. Update the styles in `theme.components.Modal` to reflect your
   custom values.
-  
+
 - You can now disable focus trap by passing `trapFocus={false}`.
 
 - Modal comes with preset transitions to make it easy for you. You can remove

--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -522,10 +522,14 @@ prop instead.
 - Removed `preserveScrollBarGap` prop. We preserve scroll bar gap by default to
   prevent any layout shift.
 
+- `ModalCloseButton` now reads the `onClose` action from the `Modal` context - 
+  you no longer need to pass the `onClick` to it. Conversely, the `onClose` prop
+  on `Modal` is now a required prop if you specify `ModalCloseButton`.
+
 - Only pass `size` values defined in the components theme. Hard-coded values
   will be ignored. Update the styles in `theme.components.Modal` to reflect your
   custom values.
-
+  
 - You can now disable focus trap by passing `trapFocus={false}`.
 
 - Modal comes with preset transitions to make it easy for you. You can remove


### PR DESCRIPTION
## 📝 Description

Added migration docs for obsolete `onClose` prop on `<ModalCloseButton />`

If `onClose` is not specified on `<Modal />`, it throws an error. 

See comments here from inside the codebase: https://github.com/chakra-ui/chakra-ui/blob/main/packages/modal/src/modal.tsx#L495