### PR TITLE
fix(stack): stack column-reverse extra margin fixed

### DIFF
--- a/.changeset/quick-cobras-invent.md
+++ b/.changeset/quick-cobras-invent.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+fixed the bug where a margin bottom would get applied to direction=row of stack

--- a/packages/layout/src/stack.utils.tsx
+++ b/packages/layout/src/stack.utils.tsx
@@ -20,10 +20,25 @@ export function getStackStyles(options: Options) {
   const { spacing, direction } = options
 
   const directionStyles = {
-    column: { marginTop: spacing, marginStart: 0 },
-    row: { marginStart: spacing, marginTop: 0 },
-    "column-reverse": { marginBottom: spacing, marginEnd: 0 },
-    "row-reverse": { marginEnd: spacing, marginBottom: 0 },
+    column: {
+      marginTop: spacing,
+      marginEnd: 0,
+      marginBottom: 0,
+      marginStart: 0,
+    },
+    row: { marginTop: 0, marginEnd: 0, marginBottom: 0, marginStart: spacing },
+    "column-reverse": {
+      marginTop: 0,
+      marginEnd: 0,
+      marginBottom: spacing,
+      marginStart: 0,
+    },
+    "row-reverse": {
+      marginTop: 0,
+      marginEnd: spacing,
+      marginBottom: 0,
+      marginStart: 0,
+    },
   }
 
   return {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3657 

## 📝 Description

> Fixed the bug where a margin bottom would get applied to direction=row of stack

## ⛳️ Current behavior (updates)

> When we set the first breakpoint (the base) of the direction property to column-reverse, there is extra padding.

## 🚀 New behavior

> Fixes the margins that get added

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
