### PR TITLE
fix: improve switch accessibility

### DIFF
--- a/.changeset/giant-rules-switch.md
+++ b/.changeset/giant-rules-switch.md
@@ -1,0 +1,13 @@
+---
+"@chakra-ui/theme": minor
+---
+
+### `Switch`
+
+- Add `container` part
+- Use css vars to handle styles
+- Fix rtl issue
+
+### `Stats` and `Table`
+
+- Fix rtl issue

--- a/.changeset/gorgeous-flowers-impress.md
+++ b/.changeset/gorgeous-flowers-impress.md
@@ -1,5 +1,7 @@
 ---
-"@chakra-ui/switch": patch
+"@chakra-ui/switch": minor
 ---
 
-Fix use `getRootProps` from useCheckbox for the root element and memoize styles
+- Fix use `getRootProps` from useCheckbox for the root element and memoize
+  styles
+- Add support for `children` prop as a way to add an accessible label.

--- a/.changeset/gorgeous-flowers-impress.md
+++ b/.changeset/gorgeous-flowers-impress.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/switch": patch
+---
+
+Fix use `getRootProps` from useCheckbox for the root element and memoize styles

--- a/.changeset/pink-timers-explode.md
+++ b/.changeset/pink-timers-explode.md
@@ -2,4 +2,4 @@
 "@chakra-ui/machine": minor
 ---
 
-Add assign function to level out API with `@xstate/fsm`
+Add `assign` function to level out API with `@xstate/fsm`

--- a/.changeset/witty-ears-boil.md
+++ b/.changeset/witty-ears-boil.md
@@ -7,3 +7,6 @@
 
 - Forward `onFocus` and `onBlur` props to the input element for better
   integration with form libraries.
+
+- Ensure the checkbox works when the root element is not `label`. This helps to
+  fix the current accessibility issues with the `Switch` component.

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -39,16 +39,7 @@ const Label = chakra("label", {
   },
 })
 
-type OmittedProps =
-  | "size"
-  | "checked"
-  | "defaultChecked"
-  | "onChange"
-  | "onBlur"
-  | "onFocus"
-  | "value"
-
-type CheckboxControlProps = Omit<HTMLChakraProps<"div">, OmittedProps>
+type CheckboxControlProps = Omit<HTMLChakraProps<"div">, keyof UseCheckboxProps>
 
 type BaseInputProps = Pick<
   PropsOf<"input">,

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -101,6 +101,8 @@ export interface UseCheckboxProps {
    * Refers to the `id` of the element that labels the checkbox element.
    */
   "aria-labelledby"?: string
+  "aria-invalid"?: true | undefined
+  "aria-describedby"?: string
 }
 
 /**
@@ -128,6 +130,8 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     onFocus,
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
+    "aria-invalid": ariaInvalid,
+    "aria-describedby": ariaDescribedBy,
     ...htmlProps
   } = props
 
@@ -323,7 +327,8 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
         readOnly: isReadOnly,
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledBy,
-        "aria-invalid": isInvalid,
+        "aria-invalid": ariaInvalid ? Boolean(ariaInvalid) : isInvalid,
+        "aria-describedby": ariaDescribedBy,
         "aria-disabled": isDisabled,
         style: visuallyHiddenStyle,
       }
@@ -333,7 +338,8 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       value,
       id,
       handleChange,
-      setFocused,
+      setFocused.off,
+      setFocused.on,
       onBlurProp,
       onFocusProp,
       onKeyDown,
@@ -344,7 +350,9 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       isReadOnly,
       ariaLabel,
       ariaLabelledBy,
+      ariaInvalid,
       isInvalid,
+      ariaDescribedBy,
       isDisabled,
     ],
   )

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -56,10 +56,14 @@ export function getCss(options: GetCSSOptions) {
        * { --banner-height: "sizes.no-exist, 40px" } => { --banner-height: "40px" }
        */
       if (isCSSVariableTokenValue(key, value)) {
-        const [tokenValue, fallbackValue] = value
-          .split(",")
-          .map((v) => v.trim())
-        value = theme.__cssMap[tokenValue]?.varRef ?? fallbackValue
+        const valueSplit = value.split(",").map((v) => v.trim())
+        const hasFallback = valueSplit.length > 1
+        if (hasFallback) {
+          const [tokenValue, fallbackValue] = valueSplit
+          value = theme.__cssMap[tokenValue]?.varRef ?? fallbackValue
+        } else {
+          value = theme.__cssMap[value]?.varRef ?? value
+        }
       }
 
       let config = configs[key]

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -47,3 +47,8 @@ You can change the checked background color of the `switch` by passing the
 ```jsx
 <Switch colorScheme="blue" />
 ```
+
+## Resources
+
+- https://scottaohara.github.io/a11y_styled_form_controls/src/checkbox--switch/
+- https://www.lightningdesignsystem.com/components/checkbox-button/

--- a/packages/switch/src/switch.tsx
+++ b/packages/switch/src/switch.tsx
@@ -27,37 +27,42 @@ export const Switch = forwardRef<SwitchProps, "input">((props, ref) => {
   const styles = useMultiStyleConfig("Switch", props)
 
   const ownProps = omitThemingProps(props)
-  const { state, getInputProps, getCheckboxProps, htmlProps } = useCheckbox(
+
+  const { state, getInputProps, getCheckboxProps, getRootProps } = useCheckbox(
     ownProps,
   )
 
-  const inputProps = getInputProps({}, ref)
-  const checkboxProps = getCheckboxProps()
+  const containerStyles: SystemStyleObject = React.useMemo(
+    () => ({
+      display: "inline-block",
+      verticalAlign: "middle",
+      lineHeight: "normal",
+      ...styles.container,
+    }),
+    [styles.container],
+  )
 
-  const labelStyles: SystemStyleObject = {
-    display: "inline-block",
-    verticalAlign: "middle",
-    lineHeight: "normal",
-  }
-
-  const trackStyles: SystemStyleObject = {
-    display: "inline-flex",
-    flexShrink: 0,
-    justifyContent: "flex-start",
-    boxSizing: "content-box",
-    cursor: "pointer",
-    ...styles.track,
-  }
+  const trackStyles: SystemStyleObject = React.useMemo(
+    () => ({
+      display: "inline-flex",
+      flexShrink: 0,
+      justifyContent: "flex-start",
+      boxSizing: "content-box",
+      cursor: "pointer",
+      ...styles.track,
+    }),
+    [styles.track],
+  )
 
   return (
     <chakra.label
-      {...htmlProps}
+      {...getRootProps()}
       className={cx("chakra-switch", props.className)}
-      __css={labelStyles}
+      __css={containerStyles}
     >
-      <input className="chakra-switch__input" {...inputProps} />
+      <input className="chakra-switch__input" {...getInputProps({}, ref)} />
       <chakra.span
-        {...checkboxProps}
+        {...getCheckboxProps()}
         className="chakra-switch__track"
         __css={trackStyles}
       >

--- a/packages/switch/src/switch.tsx
+++ b/packages/switch/src/switch.tsx
@@ -12,16 +12,9 @@ import {
 import { cx, dataAttr, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
-type OmittedProps =
-  | "defaultChecked"
-  | "checked"
-  | "onChange"
-  | "onBlur"
-  | "onFocus"
-
 export interface SwitchProps
   extends Omit<UseCheckboxProps, "isIndeterminate">,
-    Omit<HTMLChakraProps<"label">, OmittedProps>,
+    Omit<HTMLChakraProps<"label">, keyof UseCheckboxProps>,
     ThemingProps<"Switch"> {
   /**
    * The spacing between the switch and its label text

--- a/packages/switch/src/switch.tsx
+++ b/packages/switch/src/switch.tsx
@@ -7,6 +7,7 @@ import {
   ThemingProps,
   useMultiStyleConfig,
   HTMLChakraProps,
+  SystemProps,
 } from "@chakra-ui/system"
 import { cx, dataAttr, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -21,16 +22,27 @@ type OmittedProps =
 export interface SwitchProps
   extends Omit<UseCheckboxProps, "isIndeterminate">,
     Omit<HTMLChakraProps<"label">, OmittedProps>,
-    ThemingProps<"Switch"> {}
+    ThemingProps<"Switch"> {
+  /**
+   * The spacing between the switch and its label text
+   * @default 0.5rem
+   * @type SystemProps["marginLeft"]
+   */
+  spacing?: SystemProps["marginLeft"]
+}
 
 export const Switch = forwardRef<SwitchProps, "input">((props, ref) => {
   const styles = useMultiStyleConfig("Switch", props)
 
-  const ownProps = omitThemingProps(props)
+  const { spacing = "0.5rem", children, ...ownProps } = omitThemingProps(props)
 
-  const { state, getInputProps, getCheckboxProps, getRootProps } = useCheckbox(
-    ownProps,
-  )
+  const {
+    state,
+    getInputProps,
+    getCheckboxProps,
+    getRootProps,
+    getLabelProps,
+  } = useCheckbox(ownProps)
 
   const containerStyles: SystemStyleObject = React.useMemo(
     () => ({
@@ -54,6 +66,15 @@ export const Switch = forwardRef<SwitchProps, "input">((props, ref) => {
     [styles.track],
   )
 
+  const labelStyles: SystemStyleObject = React.useMemo(
+    () => ({
+      userSelect: "none",
+      marginStart: spacing,
+      ...styles.label,
+    }),
+    [spacing, styles.label],
+  )
+
   return (
     <chakra.label
       {...getRootProps()}
@@ -73,6 +94,15 @@ export const Switch = forwardRef<SwitchProps, "input">((props, ref) => {
           data-hover={dataAttr(state.isHovered)}
         />
       </chakra.span>
+      {children && (
+        <chakra.span
+          className="chakra-switch__label"
+          {...getLabelProps()}
+          __css={labelStyles}
+        >
+          {children}
+        </chakra.span>
+      )}
     </chakra.label>
   )
 })

--- a/packages/theme/src/components/stat.ts
+++ b/packages/theme/src/components/stat.ts
@@ -15,7 +15,7 @@ const baseStyleNumber = {
 }
 
 const baseStyleIcon = {
-  mr: 1,
+  marginEnd: 1,
   w: "14px",
   h: "14px",
   verticalAlign: "middle",

--- a/packages/theme/src/components/switch.ts
+++ b/packages/theme/src/components/switch.ts
@@ -1,6 +1,6 @@
 import { mode } from "@chakra-ui/theme-tools"
 
-const parts = ["track", "thumb"]
+const parts = ["container", "track", "thumb"]
 
 function baseStyleTrack(props: Record<string, any>) {
   const { colorScheme: c } = props
@@ -8,6 +8,8 @@ function baseStyleTrack(props: Record<string, any>) {
   return {
     borderRadius: "full",
     p: "2px",
+    width: "var(--slider-track-width)",
+    height: "var(--slider-track-height)",
     transition: "all 120ms",
     bg: mode("gray.300", "whiteAlpha.400")(props),
     _focus: {
@@ -26,46 +28,44 @@ function baseStyleTrack(props: Record<string, any>) {
 const baseStyleThumb = {
   bg: "white",
   transition: "transform 250ms",
-  borderRadius: "full",
-  transform: "translateX(0)",
+  borderRadius: "inherit",
+  width: "var(--slider-track-height)",
+  height: "var(--slider-track-height)",
+  _checked: {
+    transform: "translateX(var(--slider-thumb-x))",
+  },
 }
 
 const baseStyle = (props: Record<string, any>) => ({
+  container: {
+    "--slider-track-diff":
+      "calc(var(--slider-track-width) - var(--slider-track-height))",
+    "--slider-thumb-x": "var(--slider-track-diff)",
+    _rtl: {
+      "--slider-thumb-x": "calc(-1 * var(--slider-track-diff))",
+    },
+  },
   track: baseStyleTrack(props),
   thumb: baseStyleThumb,
 })
 
 const sizes = {
   sm: {
-    track: { w: "1.375rem", h: "0.75rem" },
-    thumb: {
-      w: "0.75rem",
-      h: "0.75rem",
-      _checked: {
-        transform: "translateX(0.625rem)",
-      },
+    container: {
+      "--slider-track-width": "1.375rem",
+      "--slider-track-height": "0.75rem",
     },
   },
-
   md: {
-    track: { w: "1.875rem", h: "1rem" },
-    thumb: {
-      w: "1rem",
-      h: "1rem",
-      _checked: {
-        transform: "translateX(0.875rem)",
-      },
+    container: {
+      "--slider-track-width": "1.875rem",
+      "--slider-track-height": "1rem",
     },
   },
-
   lg: {
-    track: { w: "2.875rem", h: "1.5rem" },
-    thumb: {
-      w: "1.5rem",
-      h: "1.5rem",
-      _checked: {
-        transform: "translateX(1.375rem)",
-      },
+    container: {
+      "--slider-track-width": "2.875rem",
+      "--slider-track-height": "1.5rem",
     },
   },
 }

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -15,10 +15,10 @@ const baseStyle = {
     fontWeight: "bold",
     textTransform: "uppercase",
     letterSpacing: "wider",
-    textAlign: "left",
+    textAlign: "start",
   },
   td: {
-    textAlign: "left",
+    textAlign: "start",
   },
   caption: {
     mt: 4,


### PR DESCRIPTION
Closes #3480
Closes #3638

## 📝 Description

- Improves the accessibility for the Switch component. To prevent duplicate `labels` for the underlying `input` element, you can change the dom element for the switch container using the `as` prop.

```diff
<FormControl display="flex" alignItems="center">
  <FormLabel htmlFor="email-alerts" mb="0">
    Enable email alerts?
  </FormLabel>
-  <Switch id="email-alerts" />
+ <Switch as="div" id="email-alerts" />
</FormControl>
```

- The switch component can now accept children as well, just like radio and checkbox.

```diff
-  <Switch />
+ <Switch>
+      Hello
+ <Switch />
```

- Update RTL styles for the switch component and use CSS variables for most things.

## 🚀 New behavior

- Switch works in RTL
- Switch can be made more accessible by changing the dom node to `div`

## 💣 Is this a breaking change (Yes/No):

No