### PR TITLE
fix: number-input and form control

### DIFF
--- a/.changeset/beige-insects-scream.md
+++ b/.changeset/beige-insects-scream.md
@@ -1,5 +1,0 @@
----
-"@chakra-ui/number-input": patch
----
-
-Fix issue where onchange gets called on mount

--- a/.changeset/sweet-zoos-invite.md
+++ b/.changeset/sweet-zoos-invite.md
@@ -1,0 +1,16 @@
+---
+"@chakra-ui/form-control": minor
+---
+
+Refactor `useFormControlProvider` to return prop getters `getHelpTextProps`,
+`getErrorMessageProps`, and `getRootProps`.
+
+Detect helper text and error message using `ref` callback instead of
+`useLayoutEffect`
+
+Create `useFormControlProps` to provide a way to get the resolved form control
+props `isInvalid`, `isDisabled`, instead of HTML attributes. This will make it
+easier to integrate with number-input, checkbox, and switch.
+
+Update `aria-describedby` id to include `feedbackId` only when `isInvalid` is
+`true`,

--- a/.changeset/tidy-cameras-pay.md
+++ b/.changeset/tidy-cameras-pay.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/number-input": patch
+---
+
+### useNumberInput
+
+- Forward `aria-*` props to the input element.
+- Fix issue where `onChange` was called on mount.
+- Fix issue where `onBlur` was called twice.
+- Memoize all callback props `onFocus`, `onBlur`, `getAriaValueText`
+- Refactor implicit `useFormControl` logic to be called from `NumberInput`
+  instead.
+- Call `setFocused.on` with `ReactDOM.flushSync` to prevent concurrent mode
+  issue where setting state in `onFocus` affects `onChange` event handler.

--- a/packages/counter/src/use-counter.ts
+++ b/packages/counter/src/use-counter.ts
@@ -70,7 +70,7 @@ export function useCounter(props: UseCounterProps = {}) {
 
   const [valueState, setValue] = useState<StringOrNumber>(() => {
     if (defaultValue == null) return ""
-    return cast(defaultValue, stepProp, precisionProp)
+    return cast(defaultValue, stepProp, precisionProp) ?? ""
   })
 
   /**
@@ -154,16 +154,17 @@ export function useCounter(props: UseCounterProps = {}) {
     if (defaultValue == null) {
       next = ""
     } else {
-      next = cast(defaultValue, stepProp, precisionProp)
+      next = cast(defaultValue, stepProp, precisionProp) ?? min
     }
     update(next)
-  }, [defaultValue, precisionProp, stepProp, update])
+  }, [defaultValue, precisionProp, stepProp, update, min])
 
   const castValue = useCallback(
     (value: StringOrNumber) => {
-      update(cast(value, stepProp, precision))
+      const nextValue = cast(value, stepProp, precision) ?? min
+      update(nextValue)
     },
-    [precision, stepProp, update],
+    [precision, stepProp, update, min],
   )
 
   const valueAsNumber = parse(value)
@@ -203,6 +204,8 @@ function getDecimalPlaces(value: number, step: number) {
 }
 
 function cast(value: StringOrNumber, step: number, precision?: number) {
-  const decimalPlaces = getDecimalPlaces(parse(value), step)
-  return toPrecision(parse(value), precision ?? decimalPlaces)
+  const parsedValue = parse(value)
+  if (Number.isNaN(parsedValue)) return undefined
+  const decimalPlaces = getDecimalPlaces(parsedValue, step)
+  return toPrecision(parsedValue, precision ?? decimalPlaces)
 }

--- a/packages/form-control/src/form-error.tsx
+++ b/packages/form-control/src/form-error.tsx
@@ -1,14 +1,13 @@
-import { useSafeLayoutEffect } from "@chakra-ui/hooks"
 import Icon, { IconProps } from "@chakra-ui/icon"
 import {
   chakra,
   forwardRef,
-  useStyles,
   HTMLChakraProps,
-  useMultiStyleConfig,
-  ThemingProps,
   omitThemingProps,
   StylesProvider,
+  ThemingProps,
+  useMultiStyleConfig,
+  useStyles,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -23,38 +22,23 @@ export interface FormErrorMessageProps
  * and suggest clear instructions on how to fix it.
  */
 export const FormErrorMessage = forwardRef<FormErrorMessageProps, "div">(
-  (passedProps, ref) => {
-    const styles = useMultiStyleConfig("FormError", passedProps)
-    const props = omitThemingProps(passedProps)
-
+  (props, ref) => {
+    const styles = useMultiStyleConfig("FormError", props)
+    const ownProps = omitThemingProps(props)
     const field = useFormControlContext()
 
-    /**
-     * Notify the field context when the error message is rendered on screen,
-     * so we can apply the correct `aria-describedby` to the field (e.g. input, textarea).
-     */
-    useSafeLayoutEffect(() => {
-      field?.setHasFeedbackText.on()
-      return () => field?.setHasFeedbackText.off()
-    }, [])
-
     if (!field?.isInvalid) return null
-
-    const _className = cx("chakra-form__error-message", props.className)
 
     return (
       <StylesProvider value={styles}>
         <chakra.div
-          aria-live="polite"
-          ref={ref}
-          {...props}
+          {...field?.getErrorMessageProps(ownProps, ref)}
+          className={cx("chakra-form__error-message", props.className)}
           __css={{
             display: "flex",
             alignItems: "center",
             ...styles.text,
           }}
-          className={_className}
-          id={props.id ?? field?.feedbackId}
         />
       </StylesProvider>
     )

--- a/packages/form-control/src/use-form-control.ts
+++ b/packages/form-control/src/use-form-control.ts
@@ -1,4 +1,4 @@
-import { ariaAttr, callAllHandlers, omit } from "@chakra-ui/utils"
+import { ariaAttr, callAllHandlers } from "@chakra-ui/utils"
 import { FocusEventHandler } from "react"
 import { FormControlOptions, useFormControlContext } from "./form-control"
 
@@ -22,32 +22,64 @@ export interface UseFormControlProps<T extends HTMLElement>
 export function useFormControl<T extends HTMLElement>(
   props: UseFormControlProps<T>,
 ) {
-  const field = useFormControlContext()
-  const describedBy: string[] = []
-
-  // Error message must be described first in all scenarios.
-  if (field?.hasFeedbackText) describedBy.push(field.feedbackId)
-  if (field?.hasHelpText) describedBy.push(field.helpTextId)
-  const ariaDescribedBy = describedBy.join(" ")
-
-  const rest = omit(props, [
-    "isInvalid",
-    "isDisabled",
-    "isReadOnly",
-    "isRequired",
-  ])
+  const {
+    isDisabled,
+    isInvalid,
+    isReadOnly,
+    isRequired,
+    ...rest
+  } = useFormControlProps(props)
 
   return {
     ...rest,
-    id: props.id ?? field?.id,
-    disabled: props.disabled || props.isDisabled || field?.isDisabled,
-    readOnly: props.readOnly || props.isReadOnly || field?.isReadOnly,
-    required: props.required || props.isRequired || field?.isRequired,
-    "aria-invalid": ariaAttr(props.isInvalid || field?.isInvalid),
-    "aria-required": ariaAttr(props.isRequired || field?.isRequired),
-    "aria-readonly": ariaAttr(props.isReadOnly || field?.isReadOnly),
-    "aria-describedby": ariaDescribedBy || undefined,
-    onFocus: callAllHandlers(field?.onFocus, props.onFocus),
-    onBlur: callAllHandlers(field?.onBlur, props.onBlur),
+    disabled: isDisabled,
+    readOnly: isReadOnly,
+    required: isRequired,
+    "aria-invalid": ariaAttr(isInvalid),
+    "aria-required": ariaAttr(isRequired),
+    "aria-readonly": ariaAttr(isReadOnly),
+  }
+}
+
+export function useFormControlProps<T extends HTMLElement>(
+  props: UseFormControlProps<T>,
+) {
+  const field = useFormControlContext()
+
+  const {
+    id,
+    disabled,
+    readOnly,
+    required,
+    isRequired,
+    isInvalid,
+    isReadOnly,
+    isDisabled,
+    onFocus,
+    onBlur,
+    ...rest
+  } = props
+
+  const labelIds: string[] = []
+
+  // Error message must be described first in all scenarios.
+  if (field?.hasFeedbackText && field?.isInvalid) {
+    labelIds.push(field.feedbackId)
+  }
+
+  if (field?.hasHelpText) {
+    labelIds.push(field.helpTextId)
+  }
+
+  return {
+    ...rest,
+    "aria-describedby": labelIds.join(" ") || undefined,
+    id: id ?? field?.id,
+    isDisabled: disabled ?? isDisabled ?? field?.isDisabled,
+    isReadOnly: readOnly ?? isReadOnly ?? field?.isReadOnly,
+    isRequired: required ?? isRequired ?? field?.isRequired,
+    isInvalid: isInvalid ?? field?.isInvalid,
+    onFocus: callAllHandlers(field?.onFocus, onFocus),
+    onBlur: callAllHandlers(field?.onBlur, onBlur),
   }
 }

--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -8,7 +8,8 @@ import {
   useStyles,
   HTMLChakraProps,
 } from "@chakra-ui/system"
-import { createContext, __DEV__ } from "@chakra-ui/utils"
+import { useFormControlProps } from "@chakra-ui/form-control"
+import { createContext, cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { TriangleDownIcon, TriangleUpIcon } from "./icons"
 import {
@@ -72,17 +73,20 @@ export interface NumberInputProps
  */
 export const NumberInput = forwardRef<NumberInputProps, "div">((props, ref) => {
   const styles = useMultiStyleConfig("NumberInput", props)
-  const ownProps = omitThemingProps(props)
 
-  const { htmlProps, ...context } = useNumberInput(ownProps)
+  const ownProps = omitThemingProps(props)
+  const controlProps = useFormControlProps(ownProps)
+
+  const { htmlProps, ...context } = useNumberInput(controlProps)
   const ctx = React.useMemo(() => context, [context])
 
   return (
     <NumberInputProvider value={ctx}>
       <StylesProvider value={styles}>
         <chakra.div
-          ref={ref}
           {...htmlProps}
+          ref={ref}
+          className={cx("chakra-numberinput", props.className)}
           __css={{
             position: "relative",
             zIndex: 0,
@@ -161,6 +165,7 @@ export const NumberInputField = forwardRef<NumberInputFieldProps, "input">(
     return (
       <chakra.input
         {...input}
+        className={cx("chakra-numberinput__field", props.className)}
         __css={{
           width: "100%",
           ...styles.field,

--- a/packages/number-input/stories/number-input.stories.tsx
+++ b/packages/number-input/stories/number-input.stories.tsx
@@ -85,7 +85,7 @@ export const HookWithFormatAndParse = () => {
       <div>current: {valueAsNumber}</div>
       <chakra.div display="flex">
         <Button {...getIncrementButtonProps()}>+</Button>
-        <Input {...(getInputProps() as any)} />
+        <Input {...getInputProps()} />
         <Button {...getDecrementButtonProps()}>-</Button>
       </chakra.div>
     </>
@@ -182,7 +182,12 @@ export const WithReactHookForm = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <NumberInput name="sales">
+      <NumberInput
+        name="sales"
+        onBlur={() => {
+          console.log("blurred")
+        }}
+      >
         <NumberInputField ref={register} />
         <NumberInputStepper>
           <NumberIncrementStepper />
@@ -212,14 +217,21 @@ export const WithFormControl = () => {
 
   return (
     <Stack align="start">
-      <FormControl id="first-name" isRequired isInvalid={isError}>
+      <FormControl id="first-name" isInvalid={isError}>
         <chakra.div display="flex" mb="2">
           <FormLabel mb="0" lineHeight="1em">
             Amount
           </FormLabel>
           <FormError>is invalid!</FormError>
         </chakra.div>
-        <NumberInput max={50} min={10}>
+        <NumberInput
+          max={50}
+          min={10}
+          defaultValue={20}
+          onBlur={() => {
+            console.log("blurred")
+          }}
+        >
           <NumberInputField />
           <NumberInputStepper>
             <NumberIncrementStepper />

--- a/packages/number-input/tests/number-input.test.tsx
+++ b/packages/number-input/tests/number-input.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
 import { FormControl, FormHelperText, FormLabel } from "@chakra-ui/form-control"
 import {
   testA11y,
@@ -18,6 +19,15 @@ import {
   NumberInputStepper,
   useNumberInput,
 } from "../src"
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.runOnlyPendingTimers()
+  jest.useRealTimers()
+})
 
 function renderComponent(props: NumberInputProps = {}) {
   return render(

--- a/packages/number-input/tests/number-input.test.tsx
+++ b/packages/number-input/tests/number-input.test.tsx
@@ -20,15 +20,6 @@ import {
   useNumberInput,
 } from "../src"
 
-beforeEach(() => {
-  jest.useFakeTimers()
-})
-
-afterEach(() => {
-  jest.runOnlyPendingTimers()
-  jest.useRealTimers()
-})
-
 function renderComponent(props: NumberInputProps = {}) {
   return render(
     <>
@@ -244,4 +235,13 @@ test("should derive values from surrounding FormControl", () => {
 
   fireEvent.blur(input)
   expect(onBlur).toHaveBeenCalled()
+})
+
+test("should fallback to min if `e` is typed", () => {
+  const { getByTestId } = renderComponent({ max: 30, min: 1 })
+  const input = getByTestId("input")
+  userEvent.type(input, "e")
+  // value is beyond max so it should reset to `max`
+  fireEvent.blur(input)
+  expect(input).toHaveValue("1")
 })


### PR DESCRIPTION
Closes #3676
Closes #3654

## 📝 Description

- Improve the number input logic
- Forwards all `aria-*` props to the input element
- Refactor implicit form control handling from `useNumberInput` to `NumberInput` in favor of composition
- Fix issue where typing `e` in input and blurring sets the value to `0`

## 💣 Is this a breaking change (Yes/No):

No