### PR TITLE
docs: Update suggested required TS version to 4.1

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -141,10 +141,10 @@ That's it, you're good to go!
 ## Notes on TypeScript 🚨
 
 Please note that when adding Chakra UI to a TypeScript project, a minimum
-TypeScript version of `3.8.0` is required.
+TypeScript version of `4.1.0` is required.
 
 If you're adding Chakra UI to a `create-react-app` project, this means you'll
-need to manually upgrade `typescript` to `^3.8.0`.
+need to manually upgrade `typescript` to `^4.1.0`.
 
 See [the guide for our create-react-app](/guides/integrations/with-cra)
 templates if you'd like to generate a Chakra-enabled `create-react-app` project


### PR DESCRIPTION
## 📝 Description

Chakra website currently suggests a required version of TS 3.8 is required, however Chakra has a dependency on TS 4.1. 

This could potentially cause some confusion, e.g. https://github.com/chakra-ui/chakra-ui/discussions/3686

## ⛳️ Current behavior (updates)

Docs suggest required TS version 3.8.

## 🚀 New behavior

Docs suggest required TS version 4.1.

## 💣 Is this a breaking change (Yes/No):
No

