### PR TITLE
feat: add env package

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -1,0 +1,11 @@
+# @chakra-ui/env
+
+A Quick description of the component
+
+## Installation
+
+```sh
+yarn add @chakra-ui/env
+# or
+npm i @chakra-ui/env
+```

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -1,11 +1,68 @@
-# @chakra-ui/env
+# @chakra-ui/react-env
 
-A Quick description of the component
+React component and hook for handling window and document object in iframe or
+ssr environment
 
 ## Installation
 
 ```sh
-yarn add @chakra-ui/env
+yarn add @chakra-ui/react-env
 # or
-npm i @chakra-ui/env
+npm i @chakra-ui/react-env
 ```
+
+## Usage
+
+To get it working, you need to wrap your app in `EnvironmentProvider` and call
+the `useEnvironment` hook anywhere in your app to get access to the correct
+`window` and `document`.
+
+```jsx
+import { EnvironmentProvider } from "@chakra-ui/react-env"
+
+// in your App
+const App = ({ children }) => {
+  return <EnvironmentProvider>{children}</EnvironmentProvider>
+}
+
+// read the environment
+const WindowSize = () => {
+  const { window } = useEnvironment()
+  return (
+    <pre>
+      {JSON.stringify({
+        w: window.innerWidth,
+        h: window.innerHeight,
+      })}
+    </pre>
+  )
+}
+```
+
+If you wrap specific aspects of your app within an `iframe`, you'll need to wrap
+the content in the iframe in `EnvironmentProvider` to provide the correct
+`window` and `document` to its content.
+
+```jsx
+// in your app
+const EmbeddedIFrame = () => {
+  return (
+    <Frame>
+      <EnvironmentProvider>
+        <WindowSize />
+      </EnvironmentProvider>
+    </Frame>
+  )
+}
+```
+
+## Contribution
+
+Yes please! See the
+[contributing guidelines](https://github.com/chakra-ui/chakra-ui/blob/master/CONTRIBUTING.md)
+for details.
+
+## Licence
+
+This project is licensed under the terms of the
+[MIT license](https://github.com/chakra-ui/chakra-ui/blob/master/LICENSE).

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -1,0 +1,1 @@
+export * from "./src"

--- a/packages/env/jest.config.js
+++ b/packages/env/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
+  transform: {
+    ".(ts|tsx)$": "ts-jest/dist",
+  },
+  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+}

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@chakra-ui/env",
+  "version": "1.0.0",
+  "description": "Component and hook for handling window and document object in iframe or ssr environment",
+  "keywords": [
+    "dom",
+    "environment context",
+    "ssr",
+    "iframe",
+    "window",
+    "document"
+  ],
+  "author": "Segun Adebayo <sage@adebayosegun.com>",
+  "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
+  "license": "MIT",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "typings": "dist/types/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/chakra-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/chakra-ui/issues"
+  },
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "start": "nodemon --watch src --exec yarn build -e ts,tsx",
+    "build": "concurrently yarn:build:*",
+    "test": "jest --env=jsdom --passWithNoTests",
+    "lint": "concurrently yarn:lint:*",
+    "version": "yarn build",
+    "build:esm": "cross-env BABEL_ENV=esm babel src --root-mode upward --extensions .ts,.tsx -d dist/esm --source-maps",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --root-mode upward --extensions .ts,.tsx -d dist/cjs --source-maps",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types",
+    "test:cov": "yarn test --coverage",
+    "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
+    "lint:types": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.6"
+  },
+  "devDependencies": {
+    "react": "^17.0.1"
+  }
+}

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chakra-ui/env",
+  "name": "@chakra-ui/react-env",
   "version": "1.0.0",
   "description": "Component and hook for handling window and document object in iframe or ssr environment",
   "keywords": [

--- a/packages/env/src/env.tsx
+++ b/packages/env/src/env.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo, useState, createContext, useContext } from "react"
+import { ssrWindow } from "./mock-window"
+import { ssrDocument } from "./mock-document"
+
+interface Environment {
+  window: Window | null
+  document: Document
+}
+
+const mockEnv = {
+  window: ssrWindow,
+  document: ssrDocument,
+}
+
+const defaultEnv: Environment =
+  typeof window !== "undefined" ? { window, document } : mockEnv
+
+const EnvironmentContext = createContext(defaultEnv)
+EnvironmentContext.displayName = "EnvironmentContext"
+
+export function useEnvironment() {
+  return useContext(EnvironmentContext)
+}
+
+export interface EnvironmentProviderProps {
+  children: React.ReactNode
+  environment?: Environment
+}
+
+export function EnvironmentProvider(props: EnvironmentProviderProps) {
+  const { children, environment: environmentProp } = props
+  const [env, setEnv] = useState<Environment | null>(null)
+
+  const context = useMemo(() => {
+    return environmentProp ?? env ?? defaultEnv
+  }, [env, environmentProp])
+
+  return (
+    <EnvironmentContext.Provider value={context}>
+      {children}
+      {!env && (
+        <span
+          ref={(node) => {
+            if (!node) return
+            setEnv({
+              document: node.ownerDocument,
+              window: node.ownerDocument.defaultView,
+            })
+          }}
+        />
+      )}
+    </EnvironmentContext.Provider>
+  )
+}

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./env"

--- a/packages/env/src/mock-document.ts
+++ b/packages/env/src/mock-document.ts
@@ -1,0 +1,41 @@
+const doc = {
+  body: {
+    classList: {
+      add() {},
+      remove() {},
+    },
+  },
+  addEventListener() {},
+  removeEventListener() {},
+  activeElement: {
+    blur() {},
+    nodeName: "",
+  },
+  querySelector() {
+    return null
+  },
+  querySelectorAll() {
+    return []
+  },
+  getElementById() {
+    return null
+  },
+  createEvent() {
+    return {
+      initEvent() {},
+    }
+  },
+  createElement() {
+    return {
+      children: [],
+      childNodes: [],
+      style: {},
+      setAttribute() {},
+      getElementsByTagName() {
+        return []
+      },
+    }
+  },
+}
+
+export const ssrDocument = (doc as unknown) as Document

--- a/packages/env/src/mock-window.ts
+++ b/packages/env/src/mock-window.ts
@@ -1,0 +1,42 @@
+import { ssrDocument } from "./mock-document"
+
+const win = {
+  document: ssrDocument,
+  navigator: {
+    userAgent: "",
+  },
+  CustomEvent: function CustomEvent() {
+    return this
+  },
+  addEventListener() {},
+  removeEventListener() {},
+  getComputedStyle() {
+    return {
+      getPropertyValue() {
+        return ""
+      },
+    }
+  },
+  Image() {},
+  Date() {},
+  setTimeout() {},
+  clearTimeout() {},
+  matchMedia() {
+    return {}
+  },
+  requestAnimationFrame(callback: () => void) {
+    if (typeof setTimeout === "undefined") {
+      callback()
+      return null
+    }
+    return setTimeout(callback, 0)
+  },
+  cancelAnimationFrame(id: number) {
+    if (typeof setTimeout === "undefined") {
+      return
+    }
+    clearTimeout(id)
+  },
+}
+
+export const ssrWindow = (win as unknown) as typeof window

--- a/packages/env/stories/env.stories.tsx
+++ b/packages/env/stories/env.stories.tsx
@@ -27,3 +27,23 @@ export function WithIframe() {
     </div>
   )
 }
+
+function WindowSize() {
+  const { window } = useEnvironment()
+  return (
+    <pre>{JSON.stringify({ w: window.innerWidth, h: window.innerHeight })}</pre>
+  )
+}
+
+export function SizeWithinIframe() {
+  return (
+    <>
+      <WindowSize />
+      <Frame style={{ background: "yellow" }}>
+        <EnvironmentProvider>
+          <WindowSize />
+        </EnvironmentProvider>
+      </Frame>
+    </>
+  )
+}

--- a/packages/env/stories/env.stories.tsx
+++ b/packages/env/stories/env.stories.tsx
@@ -1,0 +1,29 @@
+import React, { createPortal } from "react-dom"
+import Frame from "react-frame-component"
+
+import { useEnvironment, EnvironmentProvider } from ".."
+
+export default {
+  title: "Environment",
+}
+
+const Portal = ({ children }) => {
+  const env = useEnvironment()
+  return createPortal(children, env.document.body)
+}
+
+export function WithIframe() {
+  return (
+    <div className="App">
+      <h1>Hello CodeSandbox</h1>
+      <h2>Start editing to see some magic happen!</h2>
+      <Portal>Outside iframe</Portal>
+      <Frame style={{ background: "yellow" }}>
+        <EnvironmentProvider>
+          <span>Welcome home</span>
+          <Portal>Inside iframe</Portal>
+        </EnvironmentProvider>
+      </Frame>
+    </div>
+  )
+}

--- a/packages/env/tests/env.test.tsx
+++ b/packages/env/tests/env.test.tsx
@@ -1,0 +1,5 @@
+describe("useEnv", () => {
+  test("it works", () => {
+    expect(true).toBeTruthy()
+  })
+})

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "../../types"],
+  "exclude": [
+    "src/tests",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*/*.stories.tsx"
+  ]
+}

--- a/plop-templates/component-pkg/README.md.hbs
+++ b/plop-templates/component-pkg/README.md.hbs
@@ -9,3 +9,14 @@ yarn add @chakra-ui/{{componentName}}
 # or
 npm i @chakra-ui/{{componentName}}
 ```
+
+## Contribution
+
+Yes please! See the
+[contributing guidelines](https://github.com/chakra-ui/chakra-ui/blob/master/CONTRIBUTING.md)
+for details.
+
+## Licence
+
+This project is licensed under the terms of the
+[MIT license](https://github.com/chakra-ui/chakra-ui/blob/master/LICENSE).


### PR DESCRIPTION
## 📝 Description

This PR introduces a new package `@chakra-ui/env` that provides the correct `window` and `document` object globally to all components and hooks.

It leverages the ref callback in react to determine the owner window and document using a temporarily rendered `span` element.

Let's say we need to design a portal component, we can leverage the `EnvironmentProvider` and `useEnvironment`

```jsx
// 1. create the portal that appends to the env's `document.body`

const Portal = ({ children }) => {
  const env = useEnvironment()
  return createPortal(children, env.document.body)
}

// 2. Render the portal in an iframe to see that the portal automatically appends to the iframe's
// `document.body`, not the root window

 <IFrame style={{ background: "yellow" }}>
        <EnvironmentProvider>
          <Portal>Inside iframe</Portal>
        </EnvironmentProvider>
 </IFrame>
```

My goals:
- Add `EnvironmentProvider` within `ChakraProvider` so that users don't have to think about it.
- Within our hooks where have `useOutsideClick` or `useWindowSize`, we can leverage the `useEnvironment` to gain access to the correct `window` or `document` instead of using the root window or document.
