### PR TITLE
docs(modal): fix scrolling example Lorem usage

### DIFF
--- a/website/pages/docs/overlay/modal.mdx
+++ b/website/pages/docs/overlay/modal.mdx
@@ -373,7 +373,7 @@ function ScrollingExample() {
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem size={5} />
+            <Lorem count={15} />
           </ModalBody>
           <ModalFooter>
             <Button onClick={onClose}>Close</Button>


### PR DESCRIPTION
## 📝 Description

This change resolves two issues:

- `Lorem` uses the `count` prop to determine how much text to generate,
  not the `size` prop
- 5 paragraphs of text was not enough to trigger scrolling on larger
  screens, so I bumped it to 15

## ⛳️ Current behavior (updates)

Example doesn't work.

## 🚀 New behavior

Example works and for large screens too!

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
