### PR TITLE
fix: added full URL in og images in site-config.ts

### DIFF
--- a/website/configs/site-config.ts
+++ b/website/configs/site-config.ts
@@ -47,14 +47,14 @@ const siteConfig = {
         "Chakra UI: Simple, Modular and Accessible UI Components for your React Applications.",
       images: [
         {
-          url: "/og-image.png",
+          url: "https://chakra-ui.com/og-image.png",
           width: 1240,
           height: 480,
           alt:
             "Chakra UI: Simple, Modular and Accessible UI Components for your React Applications.",
         },
         {
-          url: "/twitter-og-image.png",
+          url: "https://chakra-ui.com/twitter-og-image.png",
           width: 1012,
           height: 506,
           alt:


### PR DESCRIPTION
## 📝 Description

Fixing the `og:image` URL by prefixing it with `https://chakra-ui.com`.

## 👀 Preview
![](https://media.discordapp.net/attachments/688384191230115879/827454284814745640/unknown.png)
