### PR TITLE
refactor: update popper for better ssr

### DIFF
--- a/.changeset/eleven-frogs-kneel.md
+++ b/.changeset/eleven-frogs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react-utils": patch
+---
+
+Update prop getter v2 type to take second parameter

--- a/.changeset/smart-turkeys-build.md
+++ b/.changeset/smart-turkeys-build.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/popper": minor
+---
+
+Add prop getters for popper and arrow for better ssr support
+
+Replace `utils` dependency with `react-utils`

--- a/.changeset/stale-falcons-divide.md
+++ b/.changeset/stale-falcons-divide.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/theme": patch
+---
+
+**Popover**
+
+Fix: moved `maxW` from popover's `popper` to `content` to allow for better
+control of the popover's width.

--- a/.changeset/stale-falcons-divide.md
+++ b/.changeset/stale-falcons-divide.md
@@ -4,5 +4,15 @@
 
 **Popover**
 
-Fix: moved `maxW` from popover's `popper` to `content` to allow for better
-control of the popover's width.
+- Moved `maxW` from popover's `popper` to `content` to allow for better control
+  of the popover's width.
+- Use `width` instead of `maxW` to allow users more control of popover's width
+- Use `--popover-bg` css property to control popover and arrow background.
+
+```jsx live=false
+<PopoverContent style={{ "--popover-bg": "purple" }}>
+  <PopoverArrow />
+</PopoverContent>
+```
+
+- Add popover arrow shadow color

--- a/.changeset/yellow-ducks-look.md
+++ b/.changeset/yellow-ducks-look.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/popover": minor
+---
+
+Return prop getters for popover header and body and use `ref` callback to
+determine element's presense instead of `useEffect`.
+
+Mark `usePopover` as internal for now.
+
+Add support for `rootProps` to `PopoverContent` to allow passing props to
+popover's positioner.

--- a/.changeset/yellow-ducks-look.md
+++ b/.changeset/yellow-ducks-look.md
@@ -2,10 +2,17 @@
 "@chakra-ui/popover": minor
 ---
 
-Return prop getters for popover header and body and use `ref` callback to
-determine element's presense instead of `useEffect`.
+- Return prop getters for popover header and body and use `ref` callback to
+  determine element's presense instead of `useEffect`.
 
-Mark `usePopover` as internal for now.
+- Mark `usePopover` as internal for now.
 
-Add support for `rootProps` to `PopoverContent` to allow passing props to
-popover's positioner.
+- Add support for `rootProps` to `PopoverContent` to allow passing props to
+  popover's positioner.
+
+- Make it possible to add custom motion `variants` so users can orchestrate
+  custom transitions.
+
+- Remove unused dependencies
+
+- Move popover arrow shadow color computation to popover's theme.

--- a/examples/next-js/pages/popper.js
+++ b/examples/next-js/pages/popper.js
@@ -1,0 +1,35 @@
+import { usePopper } from "@chakra-ui/popper"
+import * as React from "react"
+
+const Page = () => {
+  const [isOpen, setIsOpen] = React.useState(true)
+  const { referenceRef, getPopperProps, getArrowProps } = usePopper({
+    gutter: 16,
+    placement: "right-end",
+    modifiers: [],
+  })
+  return (
+    <div style={{ minHeight: "200vh", paddingTop: "100vh" }}>
+      <button onClick={() => setIsOpen(!isOpen)} ref={referenceRef}>
+        Testing
+      </button>
+      {isOpen && (
+        <div
+          {...getPopperProps({
+            style: { padding: 20, background: "red" },
+          })}
+        >
+          <div
+            {...getArrowProps({
+              style: { background: "yellow" },
+              size: "10px",
+            })}
+          />
+          Popper
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Page

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -76,7 +76,7 @@ export interface UseMenuProps extends UsePopperProps, UseDisclosureProps {
  * It provides the logic and will be used with react context
  * to propagate its return value to all children
  */
-export function useMenu(props: UseMenuProps) {
+export function useMenu(props: UseMenuProps = {}) {
   const {
     id,
     closeOnSelect = true,
@@ -207,7 +207,7 @@ export interface UseMenuButtonProps
   extends Omit<React.HTMLAttributes<Element>, "color"> {}
 
 export function useMenuButton(
-  props: UseMenuButtonProps,
+  props: UseMenuButtonProps = {},
   externalRef: React.Ref<any> = null,
 ) {
   const menu = useMenuContext()
@@ -278,7 +278,7 @@ export interface UseMenuListProps
   extends Omit<React.HTMLAttributes<Element>, "color"> {}
 
 export function useMenuList(
-  props: UseMenuListProps,
+  props: UseMenuListProps = {},
   ref: React.Ref<any> = null,
 ) {
   const menu = useMenuContext()
@@ -390,7 +390,7 @@ export interface UseMenuItemProps
 }
 
 export function useMenuItem(
-  props: UseMenuItemProps,
+  props: UseMenuItemProps = {},
   externalRef: React.Ref<any> = null,
 ) {
   const {
@@ -515,7 +515,7 @@ export interface UseMenuOptionProps
     UseMenuOptionOptions {}
 
 export function useMenuOption(
-  props: UseMenuOptionProps,
+  props: UseMenuOptionProps = {},
   externalRef: React.Ref<any> = null,
 ) {
   const {
@@ -546,7 +546,7 @@ export interface UseMenuOptionGroupProps {
   children?: React.ReactNode
 }
 
-export function useMenuOptionGroup(props: UseMenuOptionGroupProps) {
+export function useMenuOptionGroup(props: UseMenuOptionGroupProps = {}) {
   const {
     children,
     type = "radio",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -55,9 +55,7 @@
     "@chakra-ui/close-button": "1.1.4",
     "@chakra-ui/hooks": "1.3.0",
     "@chakra-ui/popper": "2.0.1",
-    "@chakra-ui/portal": "1.2.0",
     "@chakra-ui/react-utils": "1.1.0",
-    "@chakra-ui/transition": "1.1.1",
     "@chakra-ui/utils": "1.5.0"
   },
   "devDependencies": {

--- a/packages/popover/src/popover-context.ts
+++ b/packages/popover/src/popover-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from "@chakra-ui/react-utils"
+import { UsePopoverReturn } from "./use-popover"
+
+export const [
+  PopoverProvider,
+  usePopoverContext,
+] = createContext<UsePopoverReturn>({
+  name: "PopoverContext",
+  errorMessage:
+    "usePopoverContext: `context` is undefined. Seems you forgot to wrap all popover components within `<Popover />`",
+})

--- a/packages/popover/src/popover-transition.tsx
+++ b/packages/popover/src/popover-transition.tsx
@@ -1,0 +1,81 @@
+import { chakra, HTMLChakraProps } from "@chakra-ui/system"
+import { HTMLMotionProps, motion, Variant } from "framer-motion"
+import { mergeWith } from "@chakra-ui/utils"
+import React from "react"
+import { usePopoverContext } from "./popover-context"
+
+// TODO: consider moving this to some util
+type HTMLMotionChakraProps<T extends keyof React.ReactHTML> = Omit<
+  HTMLChakraProps<T>,
+  keyof HTMLMotionProps<T>
+> &
+  Omit<
+    HTMLMotionProps<T>,
+    | "style"
+    | "onDrag"
+    | "onDragEnd"
+    | "onDragStart"
+    | "onAnimationStart"
+    | "variants"
+  > & {
+    variants?: MotionVariants
+  }
+
+type MotionVariants = Partial<Record<"enter" | "exit", Variant>>
+
+const mergeVariants = (variants?: MotionVariants) => {
+  if (!variants) return
+  return mergeWith(variants, {
+    enter: {
+      visibility: "visible",
+    },
+    exit: {
+      transitionEnd: {
+        visibility: "hidden",
+      },
+    },
+  })
+}
+
+const scaleFade: MotionVariants = {
+  exit: {
+    opacity: 0,
+    scale: 0.95,
+    transition: {
+      duration: 0.1,
+      ease: [0.4, 0, 1, 1],
+    },
+  },
+  enter: {
+    scale: 1,
+    opacity: 1,
+    transition: {
+      duration: 0.15,
+      ease: [0, 0, 0.2, 1],
+    },
+  },
+}
+
+const Section = motion(chakra.section)
+
+export interface PopoverTransitionProps
+  extends HTMLMotionChakraProps<"section"> {}
+
+export const PopoverTransition = React.forwardRef(
+  (props: HTMLMotionChakraProps<"section">, ref: React.Ref<any>) => {
+    const { isOpen } = usePopoverContext()
+    return (
+      <Section
+        ref={ref}
+        variants={mergeVariants(props.variants)}
+        {...props}
+        initial={false}
+        animate={isOpen ? "enter" : "exit"}
+      />
+    )
+  },
+)
+
+PopoverTransition.defaultProps = {
+  variants: scaleFade,
+}

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -101,12 +101,16 @@ if (__DEV__) {
   PopoverTrigger.displayName = "PopoverTrigger"
 }
 
-export interface PopoverContentProps extends HTMLChakraProps<"section"> {}
+export interface PopoverContentProps extends HTMLChakraProps<"section"> {
+  rootProps?: HTMLChakraProps<"div">
+}
 
-const Motion = chakra(motion.section)
+const MotionSection = chakra(motion.section)
 
 export const PopoverContent = forwardRef<PopoverContentProps, "section">(
   (props, ref) => {
+    const { rootProps, ...contentProps } = props
+
     const {
       isOpen,
       getPopoverProps,
@@ -122,12 +126,13 @@ export const PopoverContent = forwardRef<PopoverContentProps, "section">(
       ...styles.content,
     }
 
-    const popoverProps: any = getPopoverProps(props, ref)
-
     return (
-      <chakra.div __css={styles.popper} {...getPopoverPositionerProps()}>
-        <Motion
-          {...popoverProps}
+      <chakra.div
+        __css={styles.popper}
+        {...getPopoverPositionerProps(rootProps)}
+      >
+        <MotionSection
+          {...(getPopoverProps(contentProps, ref) as any)}
           onUpdate={onTransitionEnd}
           className={cx("chakra-popover__content", props.className)}
           __css={contentStyles}
@@ -152,21 +157,14 @@ export interface PopoverHeaderProps extends HTMLChakraProps<"header"> {}
  */
 export const PopoverHeader = forwardRef<PopoverHeaderProps, "header">(
   (props, ref) => {
-    const { headerId, setHasHeader } = usePopoverContext()
-
-    React.useEffect(() => {
-      setHasHeader.on()
-      return () => setHasHeader.off()
-    }, [setHasHeader])
+    const { getHeaderProps } = usePopoverContext()
 
     const styles = useStyles()
 
     return (
       <chakra.header
-        {...props}
+        {...getHeaderProps(props, ref)}
         className={cx("chakra-popover__header", props.className)}
-        id={headerId}
-        ref={ref}
         __css={styles.header}
       />
     )
@@ -184,21 +182,14 @@ export interface PopoverBodyProps extends HTMLChakraProps<"div"> {}
  * at least one interactive element.
  */
 export const PopoverBody = forwardRef<PopoverBodyProps, "div">((props, ref) => {
-  const { bodyId, setHasBody } = usePopoverContext()
-
-  React.useEffect(() => {
-    setHasBody.on()
-    return () => setHasBody.off()
-  }, [setHasBody])
+  const { getBodyProps } = usePopoverContext()
 
   const styles = useStyles()
 
   return (
     <chakra.div
-      {...props}
+      {...getBodyProps(props, ref)}
       className={cx("chakra-popover__body", props.className)}
-      id={bodyId}
-      ref={ref}
       __css={styles.body}
     />
   )
@@ -250,10 +241,14 @@ export interface PopoverArrowProps extends HTMLChakraProps<"div"> {}
 
 export const PopoverArrow: React.FC<PopoverArrowProps> = (props) => {
   const { bg, bgColor, backgroundColor } = props
+  const { getArrowProps } = usePopoverContext()
   const styles = useStyles()
   const arrowBg = bg ?? bgColor ?? backgroundColor
   return (
-    <chakra.div data-popper-arrow className="chakra-popover__arrow-positioner">
+    <chakra.div
+      {...getArrowProps()}
+      className="chakra-popover__arrow-positioner"
+    >
       <chakra.div
         className={cx("chakra-popover__arrow", props.className)}
         {...props}

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -12,7 +12,6 @@ import {
   UsePopperProps,
 } from "@chakra-ui/popper"
 import { HTMLProps, mergeRefs, PropGetter } from "@chakra-ui/react-utils"
-import { useColorModeValue, useToken } from "@chakra-ui/system"
 import {
   callAllHandlers,
   contains,
@@ -134,10 +133,10 @@ export function usePopover(props: UsePopoverProps = {}) {
     flip,
     gutter,
     id,
-    arrowSize,
     returnFocusOnClose = true,
     autoFocus = true,
-    arrowShadowColor: arrowShadowColorProp,
+    arrowSize,
+    arrowShadowColor,
     modifiers,
     trigger = TRIGGER.click,
     openDelay = 200,
@@ -162,10 +161,6 @@ export function usePopover(props: UsePopoverProps = {}) {
     "popover-header",
     "popover-body",
   )
-
-  const fallbackShadowColor = useColorModeValue("gray.200", "whiteAlpha.300")
-  const shadowColor = arrowShadowColorProp ?? fallbackShadowColor
-  const arrowShadowColor = useToken("colors", shadowColor, arrowShadowColorProp)
 
   const popper = usePopper({
     placement: placementProp,
@@ -352,10 +347,6 @@ export function usePopover(props: UsePopoverProps = {}) {
     }
   }, [])
 
-  const onTransitionEnd = () => {
-    popoverRef.current?.dispatchEvent(new Event("transitionend"))
-  }
-
   const getHeaderProps: PropGetter = useCallback(
     (props = {}, ref = null) => ({
       ...props,
@@ -382,8 +373,8 @@ export function usePopover(props: UsePopoverProps = {}) {
     forceUpdate: popper.forceUpdate,
     isOpen,
     onClose,
-    onTransitionEnd,
     getArrowProps: popper.getArrowProps,
+    getArrowInnerProps: popper.getArrowInnerProps,
     getPopoverPositionerProps,
     getPopoverProps,
     getTriggerProps,

--- a/packages/popover/stories/hover.stories.tsx
+++ b/packages/popover/stories/hover.stories.tsx
@@ -25,7 +25,7 @@ export function TwitterEx() {
   return (
     <Popover trigger="hover">
       <PopoverTrigger>
-        <Link href="#" color="blue.500">
+        <Link href="#test" color="blue.500">
           Hover to see @swyx profile
         </Link>
       </PopoverTrigger>
@@ -51,7 +51,7 @@ export function Bug() {
           <MdCheck />
         </IconButton>
       </PopoverTrigger>
-      <PopoverContent>
+      <PopoverContent maxW="md">
         <PopoverArrow />
         <PopoverBody>Are you sure you want to have that milkshake?</PopoverBody>
       </PopoverContent>

--- a/packages/popover/stories/hover.stories.tsx
+++ b/packages/popover/stories/hover.stories.tsx
@@ -43,7 +43,7 @@ export function TwitterEx() {
   )
 }
 
-export function Bug() {
+export function WithCustomAnimation() {
   return (
     <Popover>
       <PopoverTrigger>
@@ -51,7 +51,25 @@ export function Bug() {
           <MdCheck />
         </IconButton>
       </PopoverTrigger>
-      <PopoverContent maxW="md">
+      <PopoverContent
+        width="400px"
+        variants={{
+          enter: {
+            y: 0,
+            opacity: 1,
+            transition: {
+              duration: 0.15,
+            },
+          },
+          exit: {
+            y: -4,
+            opacity: 0,
+            transition: {
+              duration: 0.1,
+            },
+          },
+        }}
+      >
         <PopoverArrow />
         <PopoverBody>Are you sure you want to have that milkshake?</PopoverBody>
       </PopoverContent>

--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -56,7 +56,7 @@
     "lint:types": "tsc --noEmit"
   },
   "dependencies": {
-    "@chakra-ui/utils": "1.5.0",
+    "@chakra-ui/react-utils": "1.1.0",
     "@popperjs/core": "2.4.4"
   },
   "peerDependencies": {

--- a/packages/popper/src/index.tsx
+++ b/packages/popper/src/index.tsx
@@ -1,2 +1,2 @@
 export * from "./use-popper"
-export { popperCSSVars } from "./utils"
+export { cssVars as popperCSSVars } from "./utils"

--- a/packages/popper/src/modifiers.ts
+++ b/packages/popper/src/modifiers.ts
@@ -1,9 +1,5 @@
 import { Placement, Modifier, State } from "@popperjs/core"
-import {
-  getBoxShadow,
-  toTransformOrigin,
-  popperCSSVars as cssVars,
-} from "./utils"
+import { getBoxShadow, toTransformOrigin, cssVars } from "./utils"
 
 /* -------------------------------------------------------------------------------------------------
  The match width modifier sets the popper width to match the reference.

--- a/packages/popper/src/utils.ts
+++ b/packages/popper/src/utils.ts
@@ -5,7 +5,7 @@ const toVar = (value: string, fallback?: string) => ({
   varRef: fallback ? `var(${value}, ${fallback})` : `var(${value})`,
 })
 
-export const popperCSSVars = {
+export const cssVars = {
   arrowShadowColor: toVar("--popper-arrow-shadow-color"),
   arrowSize: toVar("--popper-arrow-size", "8px"),
   arrowSizeHalf: toVar("--popper-arrow-size-half"),
@@ -60,7 +60,7 @@ export function getEventListenerOptions(
   if (typeof value === "object") {
     eventListeners = {
       enabled: true,
-      options: Object.assign(defaultEventListeners, value),
+      options: { ...defaultEventListeners, ...value },
     }
   } else {
     eventListeners = {

--- a/packages/popper/stories/popper-v2.stories.tsx
+++ b/packages/popper/stories/popper-v2.stories.tsx
@@ -11,6 +11,14 @@ export const ExamplePopper = () => {
   const { referenceRef, popperRef } = usePopper({
     gutter: 16,
     placement: "right-end",
+    modifiers: [
+      {
+        name: "offset",
+        options: {
+          offset: [100, 100],
+        },
+      },
+    ],
   })
   return (
     <div style={{ minHeight: "200vh", paddingTop: "100vh" }}>
@@ -35,7 +43,7 @@ export const ExamplePopper = () => {
 
 function debounce(func: any, wait: number, immediate?: any) {
   let timeout: any
-  return function run(...args: any[]) {
+  return function run(this: any, ...args: any[]) {
     const context = this
     const later = function later() {
       timeout = null
@@ -71,13 +79,14 @@ export const VirtualElement = () => {
   React.useEffect(() => {
     referenceRef(node)
     const el = document.getElementById("root")
+    //@ts-ignore
     const handler = debounce(({ clientX: x, clientY: y }) => {
       setNode({ getBoundingClientRect: generateGetBoundingClientRect(x, y) })
       update?.()
     }, 10)
-    el.addEventListener("mousemove", handler)
+    el?.addEventListener("mousemove", handler)
     return () => {
-      el.removeEventListener("mousemove", handler)
+      el?.removeEventListener("mousemove", handler)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [node])
@@ -97,7 +106,12 @@ declare module "csstype" {
 
 export const WithAnimation = () => {
   const [isOpen, setIsOpen] = React.useState(true)
-  const { popperRef, referenceRef } = usePopper({
+  const {
+    getPopperProps,
+    referenceRef,
+    getArrowProps,
+    transformOrigin,
+  } = usePopper({
     placement: "bottom",
   })
   return (
@@ -105,10 +119,10 @@ export const WithAnimation = () => {
       <button ref={referenceRef} onClick={() => setIsOpen(!isOpen)}>
         Trigger
       </button>
-      <div ref={popperRef}>
+      <div {...getPopperProps()}>
         <motion.div
           style={{
-            transformOrigin: "var(--popper-transform-origin)",
+            transformOrigin,
             background: "red",
             padding: 8,
           }}
@@ -119,15 +133,12 @@ export const WithAnimation = () => {
           }
         >
           <div
-            data-popper-arrow=""
-            style={{
-              "--popper-arrow-shadow-color": "rgba(0,0,0,0.3)",
-              "--popper-arrow-size": "8px",
-              "--popper-arrow-bg": "red",
-            }}
-          >
-            <div data-popper-arrow-inner="" />
-          </div>
+            {...getArrowProps({
+              shadowColor: "rgba(0,0,0,0.3)",
+              size: "8px",
+              bg: "red",
+            })}
+          />
           Popper
         </motion.div>
       </div>

--- a/packages/popper/stories/popper-v2.stories.tsx
+++ b/packages/popper/stories/popper-v2.stories.tsx
@@ -110,6 +110,7 @@ export const WithAnimation = () => {
     getPopperProps,
     referenceRef,
     getArrowProps,
+    getArrowInnerProps,
     transformOrigin,
   } = usePopper({
     placement: "bottom",
@@ -138,7 +139,9 @@ export const WithAnimation = () => {
               size: "8px",
               bg: "red",
             })}
-          />
+          >
+            <div {...getArrowInnerProps()} />
+          </div>
           Popper
         </motion.div>
       </div>

--- a/packages/react-utils/src/types.ts
+++ b/packages/react-utils/src/types.ts
@@ -15,8 +15,8 @@ export type PropGetter<T extends HTMLElement = any, P = {}> = (
   ref?: React.Ref<any> | React.RefObject<any>,
 ) => Merge<HTMLProps<T>, P>
 
-export type PropGetterV2<T extends ElementType> = (
-  props?: WithoutStyleAttr<React.ComponentPropsWithoutRef<T>>,
+export type PropGetterV2<T extends ElementType, P = {}> = (
+  props?: WithoutStyleAttr<React.ComponentPropsWithoutRef<T>> & P,
   ref?: React.Ref<any> | React.RefObject<any>,
 ) => WithoutStyleAttr<React.ComponentPropsWithRef<T>>
 

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -12,14 +12,14 @@ const baseStyle = {
   title: {
     fontWeight: "bold",
     lineHeight: 6,
-    mr: 2,
+    marginEnd: 2,
   },
   description: {
     lineHeight: 6,
   },
   icon: {
     flexShrink: 0,
-    mr: 3,
+    marginEnd: 3,
     w: 5,
     h: 6,
   },

--- a/packages/theme/src/components/form.ts
+++ b/packages/theme/src/components/form.ts
@@ -6,7 +6,7 @@ const parts = ["requiredIndicator", "helperText"]
 
 function baseStyleRequiredIndicator(props: Dict) {
   return {
-    ml: 1,
+    marginStart: 1,
     color: mode("red.500", "red.300")(props),
   }
 }

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -10,10 +10,13 @@ const baseStylePopper = {
 
 function baseStyleContent(props: Dict) {
   const bg = mode("white", "gray.700")(props)
+  const shadowColor = mode("gray.200", "whiteAlpha.300")(props)
   return {
-    bg,
-    "--popper-arrow-bg": `colors.${bg}, ${bg}`,
-    maxW: "xs",
+    "--popover-bg": `colors.${bg}`,
+    bg: "var(--popover-bg)",
+    "--popper-arrow-bg": "var(--popover-bg)",
+    "--popper-arrow-shadow-color": `colors.${shadowColor}`,
+    width: "xs",
     border: "1px solid",
     borderColor: "inherit",
     borderRadius: "md",
@@ -23,12 +26,6 @@ function baseStyleContent(props: Dict) {
       outline: 0,
       boxShadow: "outline",
     },
-  }
-}
-
-function baseStyleArrow(props: Dict) {
-  return {
-    bg: mode("white", "gray.700")(props),
   }
 }
 
@@ -55,7 +52,7 @@ const baseStyle = (props: Dict) => ({
   header: baseStyleHeader,
   body: baseStyleBody,
   footer: baseStyleFooter,
-  arrow: baseStyleArrow(props),
+  arrow: {},
 })
 
 export default {

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -1,13 +1,10 @@
 import { mode } from "@chakra-ui/theme-tools"
-import { getCSSVar } from "@chakra-ui/utils"
 
 const parts = ["popper", "content", "header", "body", "footer", "arrow"]
 
 type Dict = Record<string, any>
 
 const baseStylePopper = {
-  w: "100%",
-  maxW: "xs",
   zIndex: 10,
 }
 
@@ -15,7 +12,8 @@ function baseStyleContent(props: Dict) {
   const bg = mode("white", "gray.700")(props)
   return {
     bg,
-    "--popper-arrow-bg": getCSSVar(props.theme, "colors", bg),
+    "--popper-arrow-bg": `colors.${bg}, ${bg}`,
+    maxW: "xs",
     border: "1px solid",
     borderColor: "inherit",
     borderRadius: "md",

--- a/packages/theme/src/components/tooltip.ts
+++ b/packages/theme/src/components/tooltip.ts
@@ -1,13 +1,13 @@
 import { mode } from "@chakra-ui/theme-tools"
-import { getCSSVar } from "@chakra-ui/utils"
 
 function baseStyle(props: Record<string, any>) {
   const bg = mode("gray.700", "gray.300")(props)
   return {
+    "--tooltip-bg": `colors.${bg}`,
     px: "8px",
     py: "2px",
-    bg,
-    "--popper-arrow-bg": getCSSVar(props.theme, "colors", bg),
+    bg: "var(--tooltip-bg)",
+    "--popper-arrow-bg": "var(--tooltip-bg)",
     color: mode("whiteAlpha.900", "gray.900")(props),
     borderRadius: "sm",
     fontWeight: "medium",


### PR DESCRIPTION
Closes #2481 
Closes #3713

## 📝 Description

- Updates popper code to expose prop getters in a way that improves SSR,
- Update popper to use `min-width: max-content` so it can be sized according to its child content
- Use `ref` callback to detect the presence of popover header and body instead of use-effect

## 💣 Is this a breaking change (Yes/No):

No