### PR TITLE
feat(toast-manager): take into account safe area

### DIFF
--- a/.changeset/shaggy-seahorses-call.md
+++ b/.changeset/shaggy-seahorses-call.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Take into account safe area insets for Toasts

--- a/packages/toast/src/toast-manager.tsx
+++ b/packages/toast/src/toast-manager.tsx
@@ -222,10 +222,18 @@ export class ToastManager extends React.Component<Props, State> {
     const isTopOrBottom = position === "top" || position === "bottom"
     const margin = isTopOrBottom ? "0 auto" : undefined
 
-    const top = position.includes("top") ? 0 : undefined
-    const bottom = position.includes("bottom") ? 0 : undefined
-    const right = !position.includes("left") ? 0 : undefined
-    const left = !position.includes("right") ? 0 : undefined
+    const top = position.includes("top")
+      ? "env(safe-area-inset-top)"
+      : undefined
+    const bottom = position.includes("bottom")
+      ? "env(safe-area-inset-bottom)"
+      : undefined
+    const right = !position.includes("left")
+      ? "env(safe-area-inset-left)"
+      : undefined
+    const left = !position.includes("right")
+      ? "env(safe-area-inset-right)"
+      : undefined
 
     return {
       position: "fixed",


### PR DESCRIPTION
Closes #3581 

## 📝 Description

Take into account safe area insets for Toasts.

## ⛳️ Current behavior (updates)

When setting `<meta name="viewport" content="viewport-fit=cover"/>` and running the webapp in fullscreen mode on an iPhone, toasts are placed behind the notch and the bottom bar.

## 🚀 New behavior

Toasts are positioned by taking into account safe area inset [env variables](https://developer.mozilla.org/en-US/docs/Web/CSS/env())

## 💣 Is this a breaking change (Yes/No):

No
