### PR TITLE
Fix/select icon rtl

### DIFF
--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -130,7 +130,7 @@ export const Select = forwardRef<SelectProps, "select">((props, ref) => {
   }
 
   const fieldStyles: SystemStyleObject = mergeWith({}, styles.field, {
-    pr: "2rem",
+    pe: "2rem",
     _focus: { zIndex: "unset" },
   })
 

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -19,7 +19,7 @@ function baseStyleField(props: Record<string, any>) {
 const baseStyleIcon = {
   width: "1.5rem",
   height: "100%",
-  right: "0.5rem",
+  insetEnd: "0.5rem",
   position: "relative",
   color: "currentColor",
   fontSize: "1.25rem",
@@ -36,7 +36,7 @@ const baseStyle = (props: Record<string, any>) => ({
 const sizes = merge({}, Input.sizes, {
   xs: {
     icon: {
-      right: "0.25rem",
+      insetEnd: "0.25rem",
     },
   },
 })

--- a/packages/theme/src/components/skip-link.ts
+++ b/packages/theme/src/components/skip-link.ts
@@ -8,7 +8,7 @@ const baseStyle = (props: Record<string, any>) => ({
     padding: "1rem",
     position: "fixed",
     top: "1.5rem",
-    left: "1.5rem",
+    insetStart: "1.5rem",
     bg: mode("white", "gray.700")(props),
   },
 })

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -30,7 +30,7 @@ const baseStyle = {
 
 const numericStyles = {
   "&[data-is-numeric=true]": {
-    textAlign: "right",
+    textAlign: "end",
   },
 }
 

--- a/website/configs/docs-sidebar.json
+++ b/website/configs/docs-sidebar.json
@@ -35,8 +35,7 @@
             },
             {
               "title": "Gradient",
-              "path": "/docs/features/gradient",
-              "new": true
+              "path": "/docs/features/gradient"
             },
             {
               "title": "Color Mode",
@@ -64,8 +63,7 @@
             },
             {
               "title": "RTL Support",
-              "path": "/docs/features/rtl-support",
-              "new": true
+              "path": "/docs/features/rtl-support"
             }
           ]
         },

--- a/website/pages/docs/features/rtl-support.mdx
+++ b/website/pages/docs/features/rtl-support.mdx
@@ -252,6 +252,8 @@ Here's a list of the RTL-aware style props you can use alongside other
 | `roundedBottomRight`, `borderBottomRightRadius` | `roundedBottomEnd`, `borderBottomEndRadius`     | rounded borders in bottom end direction   |
 | `borderLeft`                                    | `borderStart`, `borderInlineStart`              | border width in start direction           |
 | `borderRight`                                   | `borderEnd`, `borderInlineEnd`                  | border width in end direction             |
+| `left`                                          | `insetStart`,                                   | horizontal position in start direction    |
+| `right`                                         | `insetEnd`,                                     | horizontal position in end direction      |
 
 4. Add a way to switch between LTR and RTL
 


### PR DESCRIPTION
Closes #3755

## 📝 Description

Updated RTL support such that we use `inlineStart` instead of `left` and `inlineEnd` instead of `right` for Select Component theme.

## ⛳️ Current behavior (updates)

On RTL, the select icon was still showing up on the right instead of flipping to the left.

## 🚀 New behavior

On RTL, the select icon shows on the left. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
