### PR TITLE
feat(menu): add `closeOnSelect` to `MenuItem` and `MenuItemOption`

### DIFF
--- a/.changeset/stale-rivers-wave.md
+++ b/.changeset/stale-rivers-wave.md
@@ -1,0 +1,12 @@
+---
+"@chakra-ui/menu": minor
+---
+
+Add `closeOnSelect` to `MenuItem` and `MenuItemOption`.
+
+This allows menu items to override their parent `Menu`'s `closeOnSelect`
+behavior.
+
+Can be useful for menus with a combination of `MenuItem`s (that generally close
+their menu when selected) and `MenuItemOption`s (that should keep the menu open
+for further edition).

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -171,3 +171,34 @@ options. Use the `MenuOptionGroup` and `MenuItemOption` components.
   </MenuList>
 </Menu>
 ```
+
+## `closeOnSelect`
+
+`MenuItem` and `MenuItemOption` can use the `closeOnSelect` prop to override
+their parent `Menu`'s behavior.
+
+```jsx
+<Menu>
+  <MenuButton>Open Menu</MenuButton>
+  <MenuList>
+    <MenuGroup title="Profile">
+      {/* Clicking on those items will close the menu (default behavior) */}
+      <MenuItem>My Account</MenuItem>
+      <MenuItem>Payments</MenuItem>
+    </MenuGroup>
+    <MenuDivider />
+    <MenuOptionGroup title="Country" type="checkbox">
+      {/* Clicking on those items will keep the menu open */}
+      <MenuItemOption value="email" closeOnSelect={false}>
+        Email
+      </MenuItemOption>
+      <MenuItemOption value="phone" closeOnSelect={false}>
+        Phone
+      </MenuItemOption>
+      <MenuItemOption value="country" closeOnSelect={false}>
+        Country
+      </MenuItemOption>
+    </MenuOptionGroup>
+  </MenuList>
+</Menu>
+```

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -220,7 +220,10 @@ const StyledMenuItem = forwardRef<StyledMenuItemProps, "button">(
 )
 
 interface MenuItemOptions
-  extends Pick<UseMenuItemProps, "isDisabled" | "isFocusable"> {
+  extends Pick<
+    UseMenuItemProps,
+    "isDisabled" | "isFocusable" | "closeOnSelect"
+  > {
   /**
    * The icon to render before the menu item's label.
    * @type React.ReactElement

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -490,7 +490,7 @@ export function useMenuItem(
     }
   }, [isFocused, trulyDisabled, menuRef, isOpen])
 
-  const tabbable = useClickable({
+  const clickableProps = useClickable({
     onClick,
     onMouseEnter,
     onMouseMove,
@@ -502,7 +502,7 @@ export function useMenuItem(
 
   return {
     ...htmlProps,
-    ...tabbable,
+    ...clickableProps,
     id,
     role: "menuitem",
     tabIndex: isFocused ? 0 : -1,
@@ -522,23 +522,12 @@ export interface UseMenuOptionProps
 
 export function useMenuOption(
   props: UseMenuOptionProps = {},
-  externalRef: React.Ref<any> = null,
+  ref: React.Ref<any> = null,
 ) {
-  const {
-    onClick,
-    isDisabled,
-    isFocusable,
-    type = "radio",
-    isChecked,
-    ...rest
-  } = props
-
-  const hookProps = { isDisabled, isFocusable, onClick }
-  const optionsProps = useMenuItem(hookProps, externalRef)
-
+  const { type = "radio", isChecked, ...menuItemProps } = props
+  const ownProps = useMenuItem(menuItemProps, ref)
   return {
-    ...rest,
-    ...optionsProps,
+    ...ownProps,
     role: `menuitem${type}`,
     "aria-checked": isChecked as React.AriaAttributes["aria-checked"],
   }

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -387,6 +387,10 @@ export interface UseMenuItemProps
   extends Omit<React.HTMLAttributes<Element>, "color"> {
   isDisabled?: boolean
   isFocusable?: boolean
+  /**
+   * Overrides the parent menu's `closeOnSelect` prop.
+   */
+  closeOnSelect?: boolean
 }
 
 export function useMenuItem(
@@ -400,6 +404,7 @@ export function useMenuItem(
     onClick: onClickProp,
     isDisabled,
     isFocusable,
+    closeOnSelect: menuItemCloseOnSelect,
     ...htmlProps
   } = props
 
@@ -409,7 +414,7 @@ export function useMenuItem(
     domContext,
     setFocusedIndex,
     focusedIndex,
-    closeOnSelect,
+    closeOnSelect: menuCloseOnSelect,
     onClose,
     menuRef,
     isOpen,
@@ -462,13 +467,14 @@ export function useMenuItem(
     (event: React.MouseEvent) => {
       onClickProp?.(event)
       /**
-       * Close menu and parent menu's if `closeOnSelect` is set to `true`
+       * Close menu and parent menus, allowing the MenuItem
+       * to override its parent menu's `closeOnSelect` prop.
        */
-      if (closeOnSelect) {
+      if (menuItemCloseOnSelect ?? menuCloseOnSelect) {
         onClose()
       }
     },
-    [onClose, onClickProp, closeOnSelect],
+    [onClose, onClickProp, menuCloseOnSelect, menuItemCloseOnSelect],
   )
 
   const isFocused = index === focusedIndex

--- a/packages/menu/stories/menu.stories.tsx
+++ b/packages/menu/stories/menu.stories.tsx
@@ -169,7 +169,7 @@ export const WithTogglableMenuItems = () => {
           Open menu
         </MenuButton>
         <MenuList>
-          {items.map(({ content, icon, isDisabled, command }, index) => (
+          {items.map(({ content, icon, isDisabled, command }) => (
             <MenuItem
               key={content}
               isDisabled={isDisabled}
@@ -249,7 +249,7 @@ export const withMenuRadio = () => (
 export const WithInternalState = () => (
   <Menu>
     {({ isOpen }) => (
-      <React.Fragment>
+      <>
         <MenuButton as={Button}>{isOpen ? "Close" : "Open"}</MenuButton>
         <MenuList>
           <MenuItem>Download</MenuItem>
@@ -257,7 +257,7 @@ export const WithInternalState = () => (
             Create a Copy
           </MenuItem>
         </MenuList>
-      </React.Fragment>
+      </>
     )}
   </Menu>
 )
@@ -392,3 +392,20 @@ export const GroupWithDivider = () => {
     </Menu>
   )
 }
+
+export const WithCloseOnSelect = () => (
+  <Menu>
+    <MenuButton>Welcome</MenuButton>
+    <MenuList>
+      <MenuOptionGroup type="radio">
+        <MenuItemOption closeOnSelect={false} value="A">
+          Option 1 (false)
+        </MenuItemOption>
+        <MenuItemOption value="B">Option 2</MenuItemOption>
+        <MenuItemOption value="C">Option 3</MenuItemOption>
+        <MenuDivider />
+        <MenuItemOption value="D">Option 4</MenuItemOption>
+      </MenuOptionGroup>
+    </MenuList>
+  </Menu>
+)

--- a/packages/menu/tests/menu.test.tsx
+++ b/packages/menu/tests/menu.test.tsx
@@ -395,3 +395,51 @@ test("onClose doesn't affect the state of other menus", async () => {
     screen.getByText("No 1").parentElement!.getAttribute("aria-expanded"),
   ).toBe("false")
 })
+
+test("MenuItem can override its parent menu's `closeOnSelect` and keep the menu open", async () => {
+  const onClose = jest.fn()
+  render(
+    <Menu onClose={onClose}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        <MenuItem closeOnSelect={false}>I do not close the menu</MenuItem>
+        <MenuItem>I close the menu</MenuItem>
+      </MenuList>
+    </Menu>,
+  )
+
+  const openMenuButton = screen.getByRole("button")
+  const menuItemThatDoesNotClose = screen.getByText("I do not close the menu")
+  const menuItemThatCloses = screen.getByText("I close the menu")
+
+  fireEvent.click(openMenuButton)
+  fireEvent.click(menuItemThatDoesNotClose)
+  expect(onClose).not.toHaveBeenCalled()
+
+  fireEvent.click(menuItemThatCloses)
+  expect(onClose).toHaveBeenCalled()
+})
+
+test("MenuItem can override its parent menu's `closeOnSelect` and close the menu", async () => {
+  const onClose = jest.fn()
+  render(
+    <Menu onClose={onClose} closeOnSelect={false}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        <MenuItem>I do not close the menu</MenuItem>
+        <MenuItem closeOnSelect>I close the menu</MenuItem>
+      </MenuList>
+    </Menu>,
+  )
+
+  const openMenuButton = screen.getByRole("button")
+  const menuItemThatDoesNotClose = screen.getByText("I do not close the menu")
+  const menuItemThatCloses = screen.getByText("I close the menu")
+
+  fireEvent.click(openMenuButton)
+  fireEvent.click(menuItemThatDoesNotClose)
+  expect(onClose).not.toHaveBeenCalled()
+
+  fireEvent.click(menuItemThatCloses)
+  expect(onClose).toHaveBeenCalled()
+})


### PR DESCRIPTION
Closes #2698

## 📝 Description

Allow `MenuItem` and `MenuItemOption` overriding their parent `Menu`'s `closeOnSelect` behavior.

## ⛳️ Current behavior (updates)

Menus do not offer per-item granularity on `closeOnSelect`: either all items close the menu (default `closeOnSelect={true}`), or none of them do (`closeOnSelect={false}`).

This can be problematic for menus with mixed content, where `MenuItem`s are expected to close on select, and `MenuItemOption` are not.

## 🚀 New behavior

This PR adds `closeOnSelect` overrides to `MenuItem` and `MenuItemOption`. Each item can declare if they want to close the menu (or keep it open) when selected.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

It works both ways:

- Menus with the default `closeOnSelect={true}` can include items with `closeOnSelect={false}` to keep the menu open
- Menus with `closeOnSelect={false}` can include items with `closeOnSelect={true}` to close the menu when clicked