### PR TITLE
fix(tabs): do not unmount tab content when lazy

### DIFF
--- a/.changeset/hot-dodos-reflect.md
+++ b/.changeset/hot-dodos-reflect.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tabs": patch
+---
+
+Do not unmount lazy tabs when unselected

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -383,6 +383,9 @@ export function useTabPanels<P extends UseTabPanelsProps>(props: P) {
 export function useTabPanel(props: Dict) {
   const { isSelected, id, children, ...htmlProps } = props
   const { isLazy } = useTabsContext()
+  const hasBeenSelected = React.useRef(false)
+
+  if (isSelected) hasBeenSelected.current = true
 
   return {
     /**
@@ -390,7 +393,9 @@ export function useTabPanel(props: Dict) {
      */
     tabIndex: 0,
     ...htmlProps,
-    children: !isLazy || isSelected ? children : null,
+    // Do not render tab panel content if tab is lazy and has never been
+    // selected
+    children: !isLazy || hasBeenSelected.current ? children : null,
     role: "tabpanel",
     hidden: !isSelected,
     id,

--- a/packages/tabs/tests/tabs.test.tsx
+++ b/packages/tabs/tests/tabs.test.tsx
@@ -164,6 +164,6 @@ test("renders only the currently active tab panel if isLazy", () => {
 
   userEvent.click(screen.getByText("Tab 2"))
 
-  expect(screen.queryByText("Panel 1")).not.toBeInTheDocument()
+  expect(screen.queryByText("Panel 1")).toBeInTheDocument()
   expect(screen.getByText("Panel 2")).toBeInTheDocument()
 })


### PR DESCRIPTION
fix(tabs): do not unmount tab content when lazy

Closes #3683

## 📝 Description

Tabs' isLazy behavior is now to mount on first select and never unmount.

## ⛳️ Current behavior (updates)

Current behavior is to unmount on navigating away from a tab.

## 🚀 New behavior

Tabs' isLazy behavior is now to mount on first select and never unmount.

## 💣 Is this a breaking change (Yes/No):

No