### PR TITLE
fix(progress): don't set opacity when `progress.value` is `0` and `isIndeterminate` is `true`

### DIFF
--- a/.changeset/tasty-cooks-dress.md
+++ b/.changeset/tasty-cooks-dress.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/progress": patch
+---
+
+Fix an issue where `CircularProgress` with `isIndeterminate` doesn't show the
+indicator

--- a/packages/progress/src/circular-progress.tsx
+++ b/packages/progress/src/circular-progress.tsx
@@ -174,7 +174,7 @@ export const CircularProgress: React.FC<CircularProgressProps> = (props) => {
            * fix issue in Safari where indictor still shows when value is 0
            * @see Issue https://github.com/chakra-ui/chakra-ui/issues/3754
            */
-          opacity={progress.value === 0 ? 0 : undefined}
+          opacity={progress.value === 0 && !isIndeterminate ? 0 : undefined}
           {...indicatorProps}
         />
       </Shape>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix an issue where `CircularProgress` with `isIndeterminate` doesn't show the indicator

## ⛳️ Current behavior (updates)

The component `<CircularProgress isIndeterminate />` doesn't show the indicator because the opacity is set to 0.

## 🚀 New behavior

The component `<CircularProgress isIndeterminate />` correctly shows the indicator.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
