### PR TITLE
Bugfix: issue 3774 add missing dependency issue of @chakra-ui/react-utils

### DIFF
--- a/.changeset/strong-games-love.md
+++ b/.changeset/strong-games-love.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/clickable": patch
+"@chakra-ui/system": patch
+"@chakra-ui/tooltip": patch
+---
+
+Add missing dependency issue of @chakra-ui/react-utils

--- a/packages/clickable/package.json
+++ b/packages/clickable/package.json
@@ -51,6 +51,7 @@
     "lint:types": "tsc --noEmit"
   },
   "dependencies": {
+    "@chakra-ui/react-utils": "1.1.1",
     "@chakra-ui/utils": "1.5.1"
   },
   "peerDependencies": {

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@chakra-ui/color-mode": "1.1.4",
+    "@chakra-ui/react-utils": "1.1.1",
     "@chakra-ui/styled-system": "1.10.1",
     "@chakra-ui/utils": "1.5.1",
     "react-fast-compare": "3.2.0"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -56,6 +56,7 @@
     "@chakra-ui/hooks": "1.3.1",
     "@chakra-ui/popper": "2.1.0",
     "@chakra-ui/portal": "1.2.1",
+    "@chakra-ui/react-utils": "1.1.1",
     "@chakra-ui/utils": "1.5.1",
     "@chakra-ui/visually-hidden": "1.0.8"
   },


### PR DESCRIPTION
Closes #3774

## 📝 Description

Add missing dependency issue of @chakra-ui/react-utils

## ⛳️ Current behavior (updates)

ModuleNotFoundError: Module not found: Error: @chakra-ui/tooltip tried to access @chakra-ui/react-utils, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

## 🚀 New behavior

*Should* be fine given the workaround from #3774

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A
