### PR TITLE
feat(checkbox-group): add isDisabled prop to checkbox group

### DIFF
--- a/.changeset/bright-socks-hope.md
+++ b/.changeset/bright-socks-hope.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/checkbox": minor
+---
+
+Add `isDisabled` prop to `CheckboxGroup`

--- a/packages/checkbox/src/checkbox-group.tsx
+++ b/packages/checkbox/src/checkbox-group.tsx
@@ -15,7 +15,7 @@ export interface CheckboxGroupProps
 }
 
 export interface CheckboxGroupContext
-  extends Pick<UseCheckboxGroupReturn, "onChange" | "value">,
+  extends Pick<UseCheckboxGroupReturn, "onChange" | "value" | "isDisabled">,
     Omit<ThemingProps<"Checkbox">, "orientation"> {}
 
 const [
@@ -35,7 +35,7 @@ export { useCheckboxGroupContext }
  * @see Docs https://chakra-ui.com/docs/form/checkbox
  */
 export const CheckboxGroup: React.FC<CheckboxGroupProps> = (props) => {
-  const { colorScheme, size, variant, children } = props
+  const { colorScheme, size, variant, children, isDisabled } = props
   const { value, onChange } = useCheckboxGroup(props)
 
   const group = React.useMemo(
@@ -45,8 +45,9 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = (props) => {
       colorScheme,
       value,
       variant,
+      isDisabled,
     }),
-    [size, onChange, colorScheme, value, variant],
+    [size, onChange, colorScheme, value, variant, isDisabled],
   )
 
   return <CheckboxGroupProvider value={group}>{children}</CheckboxGroupProvider>

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -98,6 +98,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">((props, ref) => {
     iconSize,
     icon = <CheckboxIcon />,
     isChecked: isCheckedProp,
+    isDisabled = group?.isDisabled,
     onChange: onChangeProp,
     ...rest
   } = ownProps
@@ -120,6 +121,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">((props, ref) => {
     getRootProps,
   } = useCheckbox({
     ...rest,
+    isDisabled,
     isChecked,
     onChange,
   })

--- a/packages/checkbox/src/use-checkbox-group.ts
+++ b/packages/checkbox/src/use-checkbox-group.ts
@@ -24,6 +24,10 @@ export interface UseCheckboxGroupProps {
    */
   onChange?(value: StringOrNumber[]): void
   /**
+   * If `true`, all wrapped checkbox inputs will be disabled
+   */
+  isDisabled?: boolean
+  /**
    * If `true`, input elements will receive
    * `checked` attribute instead of `isChecked`.
    *
@@ -39,7 +43,13 @@ export interface UseCheckboxGroupProps {
  * It is consumed by the `CheckboxGroup` component
  */
 export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
-  const { defaultValue, value: valueProp, onChange, isNative } = props
+  const {
+    defaultValue,
+    value: valueProp,
+    onChange,
+    isDisabled,
+    isNative,
+  } = props
 
   const onChangeProp = useCallbackRef(onChange)
 
@@ -84,6 +94,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
 
   return {
     value,
+    isDisabled,
     onChange: handleChange,
     setValue,
     getCheckboxProps,

--- a/packages/checkbox/tests/checkbox.test.tsx
+++ b/packages/checkbox/tests/checkbox.test.tsx
@@ -191,6 +191,36 @@ test("Controlled CheckboxGroup", () => {
   expect(checked).toEqual(["one", "two", "three"])
 })
 
+test("Uncontrolled CheckboxGroup - should not check if group disabled", () => {
+  const Component = () => (
+    <CheckboxGroup isDisabled>
+      <Checkbox value="one">One</Checkbox>
+      <Checkbox value="two" isDisabled>
+        Two
+      </Checkbox>
+      <Checkbox value="three" isDisabled={false}>
+        Three
+      </Checkbox>
+    </CheckboxGroup>
+  )
+  const { container } = render(<Component />)
+  const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
+    container.querySelectorAll("input"),
+  )
+
+  expect(checkboxOne).toBeDisabled()
+  expect(checkboxTwo).toBeDisabled()
+  expect(checkboxThree).not.toBeDisabled()
+
+  fireEvent.click(checkboxOne)
+  fireEvent.click(checkboxTwo)
+  fireEvent.click(checkboxThree)
+
+  expect(checkboxOne).not.toBeChecked()
+  expect(checkboxTwo).not.toBeChecked()
+  expect(checkboxThree).toBeChecked()
+})
+
 test("uncontrolled CheckboxGroup handles change", () => {
   const onChange = jest.fn()
   render(


### PR DESCRIPTION
Closes #3718 

## 📝 Description

Used logic from `ButtonGroup` and adapt it to `CheckboxGroup`.

## ⛳️ Current behavior (updates)

`CheckboxGroup` does not have an `isDisabled` prop.

## 🚀 New behavior

`CheckboxGroup` now has the `isDisabled` prop implement, and it is used in all `Checkbox`es that don't have the `isDIsabled` prop defined.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

-