### PR TITLE
fix(extend-theme): use DeepPartial to fix TS override error

### DIFF
--- a/.changeset/chilly-apples-lick.md
+++ b/.changeset/chilly-apples-lick.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fixed typing issues for `extendTheme` where variant overrides lead to an TS
+error.

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -3,6 +3,10 @@ import { isFunction, mergeWith } from "@chakra-ui/utils"
 
 type CloneKey<Target, Key> = Key extends keyof Target ? Target[Key] : unknown
 
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+}
+
 /**
  * Represents a loose but specific type for the theme override.
  * It provides autocomplete hints for extending the theme, but leaves room
@@ -11,19 +15,18 @@ type CloneKey<Target, Key> = Key extends keyof Target ? Target[Key] : unknown
 type DeepThemeExtension<BaseTheme, ThemeType> = {
   [Key in keyof BaseTheme]?: BaseTheme[Key] extends (...args: any[]) => any
     ? DeepThemeExtension<
-        Partial<ReturnType<BaseTheme[Key]>>,
+        DeepPartial<ReturnType<BaseTheme[Key]>>,
         CloneKey<ThemeType, Key>
       >
     : BaseTheme[Key] extends Array<any>
     ? CloneKey<ThemeType, Key>
     : BaseTheme[Key] extends object
-    ? DeepThemeExtension<Partial<BaseTheme[Key]>, CloneKey<ThemeType, Key>>
+    ? DeepThemeExtension<DeepPartial<BaseTheme[Key]>, CloneKey<ThemeType, Key>>
     : CloneKey<ThemeType, Key>
 }
 
-export type ThemeOverride = Partial<ChakraTheme> &
+export declare type ThemeOverride = DeepPartial<ChakraTheme> &
   DeepThemeExtension<Theme, ChakraTheme>
-
 /**
  * Function to override or customize the Chakra UI theme conveniently
  * @param overrides - Your custom theme object overrides


### PR DESCRIPTION
Closes #3662

## 📝 Description

Improve typings for `extendTheme`

## ⛳️ Current behavior (updates)

Overriding existing variants lead to the TS error 

```
X has no properties in common with type 'DeepThemeExtension<Partial<{ ...Y
```

I could only reproduce this in a next app locally 🤔 

## 🚀 New behavior

The `DeepPartial` solves this issue.

## 💣 Is this a breaking change (Yes/No):

No