### PR TITLE
feat: added the ability to change the placeholder color of the Select component

### DIFF
--- a/.changeset/sharp-ties-film.md
+++ b/.changeset/sharp-ties-film.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/select": minor
+"@chakra-ui/docs": minor
+---
+
+Added a new placeholderColor prop in the Select component that can be used to
+define the placeholder color individually.

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -75,6 +75,10 @@ interface SelectOptions extends FormControlOptions {
    */
   placeholder?: string
   /**
+   * The color of the placeholder
+   */
+  placeholderColor?: string
+  /**
    * The size (width and height) of the icon
    */
   iconSize?: string
@@ -117,8 +121,15 @@ export const Select = forwardRef<SelectProps, "select">((props, ref) => {
     iconColor,
     iconSize,
     isFullWidth,
+    onChange,
+    placeholderColor,
     ...rest
   } = omitThemingProps(props)
+
+  const [
+    isPlaceholderSelected,
+    setIsPlaceholderSelected,
+  ] = React.useState<boolean>(true)
 
   const [layoutProps, otherProps] = split(rest, layoutPropNames as any[])
 
@@ -126,11 +137,11 @@ export const Select = forwardRef<SelectProps, "select">((props, ref) => {
     width: "100%",
     height: "fit-content",
     position: "relative",
-    color,
   }
 
   const fieldStyles: SystemStyleObject = mergeWith({}, styles.field, {
     paddingEnd: "2rem",
+    color: isPlaceholderSelected ? placeholderColor : color,
     _focus: { zIndex: "unset" },
   })
 
@@ -146,6 +157,10 @@ export const Select = forwardRef<SelectProps, "select">((props, ref) => {
         height={h ?? height}
         minH={minH ?? minHeight}
         placeholder={placeholder}
+        onChange={(event) => {
+          setIsPlaceholderSelected(event.currentTarget.value === "")
+          if (onChange) onChange(event)
+        }}
         {...otherProps}
         __css={fieldStyles}
       >

--- a/packages/select/stories/select.stories.tsx
+++ b/packages/select/stories/select.stories.tsx
@@ -1,4 +1,4 @@
-import { Container, Stack } from "@chakra-ui/layout"
+import { Container, Stack, Wrap } from "@chakra-ui/layout"
 import * as React from "react"
 import { Select } from "../src"
 
@@ -14,11 +14,20 @@ export default {
 }
 
 export const BasicUsage = () => (
-  <Select color="pink.500" placeholder="Select option">
-    <option value="Option 1">Option 1</option>
-    <option value="Option 2">Option 2</option>
-    <option value="Option 3">Option 3</option>
-  </Select>
+  <Wrap>
+    <Select
+      placeholder="Select option"
+      placeholderColor="gray.400"
+      color="green.500"
+      onChange={(event) => {
+        console.log("Event from outside", event)
+      }}
+    >
+      <option value="Option 1">Option 1</option>
+      <option value="Option 2">Option 2</option>
+      <option value="Option 3">Option 3</option>
+    </Select>
+  </Wrap>
 )
 
 export const SelectStates = () => (

--- a/packages/select/stories/select.stories.tsx
+++ b/packages/select/stories/select.stories.tsx
@@ -1,4 +1,4 @@
-import { Container, Stack, Wrap } from "@chakra-ui/layout"
+import { Container, Stack } from "@chakra-ui/layout"
 import * as React from "react"
 import { Select } from "../src"
 
@@ -14,20 +14,18 @@ export default {
 }
 
 export const BasicUsage = () => (
-  <Wrap>
-    <Select
-      placeholder="Select option"
-      placeholderColor="gray.400"
-      color="green.500"
-      onChange={(event) => {
-        console.log("Event from outside", event)
-      }}
-    >
-      <option value="Option 1">Option 1</option>
-      <option value="Option 2">Option 2</option>
-      <option value="Option 3">Option 3</option>
-    </Select>
-  </Wrap>
+  <Select
+    placeholder="Select option"
+    placeholderColor="gray.400"
+    color="green.500"
+    onChange={(event) => {
+      console.log("Event from outside", event)
+    }}
+  >
+    <option value="Option 1">Option 1</option>
+    <option value="Option 2">Option 2</option>
+    <option value="Option 3">Option 3</option>
+  </Select>
 )
 
 export const SelectStates = () => (

--- a/website/pages/docs/form/select.mdx
+++ b/website/pages/docs/form/select.mdx
@@ -70,6 +70,21 @@ either of these values.
 </Stack>
 ```
 
+### Changing the placeholder color of the Select
+
+You can change the placeholder color using the `placeholderColor` property:
+
+```jsx
+<Select variant="outline" placeholder="Select your favorite fruit" placeholderColor="gray.500">
+  <option value="apple">🍎 Apple</option>
+  <option value="banana">🍌 Banana</option>
+  <option value="cherry">🍒 Cherry</option>
+  <option value="orange">🍊 Orange</option>
+  <option value="kiwi">🥝 Kiwi</option>
+  <option value="watermelon">🍉 Watermelon</option>
+</Select>
+```
+
 ### Changing the icon in the Select
 
 As with most Chakra components, you can change the arrow icon used in the


### PR DESCRIPTION
## 📝 Description

Added a new `placeholderColor` prop in the `Select` component that can be used to define the placeholder color individually.

## ⛳️ Current behavior (updates)

The placeholder color cannot be set. It can be controlled with the `color` property, but that also changes the color of the selected value, not the placeholder only.

## 🚀 New behavior

The placeholder gets the `placeholderColor` color, while the selected value gets the `color` color.

## 💣 Is this a breaking change (Yes/No):

No. If no `placeholderColor` is being set the placeholder color will remain the default one.