### PR TITLE
docs(hooks): improve wording for the use-outside-click page

### DIFF
--- a/.changeset/small-kings-call.md
+++ b/.changeset/small-kings-call.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Improve wording for the `use-outside-click` page

--- a/packages/hooks/src/use-outside-click.ts
+++ b/packages/hooks/src/use-outside-click.ts
@@ -3,7 +3,13 @@ import { RefObject, useEffect, useRef } from "react"
 import { useCallbackRef } from "./use-callback-ref"
 
 export interface UseOutsideClickProps {
+  /**
+   * The reference to a DOM element.
+   */
   ref: RefObject<HTMLElement>
+  /**
+   * Function invoked when a click is triggered outside the referenced element.
+   */
   handler?: (e: Event) => void
 }
 

--- a/website/pages/docs/hooks/use-disclosure.mdx
+++ b/website/pages/docs/hooks/use-disclosure.mdx
@@ -54,6 +54,6 @@ function Example() {
 
 ## Parameters
 
-The hook `useDisclosure` accepts an optional object with the following properties:
+The `useDisclosure` hook accepts an optional object with the following properties:
 
 <PropsTable of="useDisclosure" />

--- a/website/pages/docs/hooks/use-outside-click.mdx
+++ b/website/pages/docs/hooks/use-outside-click.mdx
@@ -4,25 +4,16 @@ package: "@chakra-ui/hooks"
 description: "React hook to detect clicks outside of a specified element."
 ---
 
-`useOutsideClick` is a custom hook that handles a click outside a specified DOM element, like a `div`.
+`useOutsideClick` is a custom hook that handles click events outside a specific DOM element, like a `div`. A
+handler is invoked when a click or touch event happens outside the referenced element.
+
+> This hook is compatible with mouse and touch events.
 
 ## Import
 
 ```js
 import { useOutsideClick } from "@chakra-ui/react"
 ```
-
-## Return value
-
-The `useOutsideClick` hook receives a reference to a DOM element and a handler when a clicks happens
-outside this given element.
-
-| Name        | Type       | Default | Description                              |
-| ----------- | ---------- | ------- | ---------------------------------------- |
-| `ref`       | `object`   |         | The ref to access the DOM.               |
-| `handler`   | `function` |         | Callback function to handle the click.   |
-
-> This hooks is compatible with mouse and touch events.
 
 ## Usage
 
@@ -48,3 +39,9 @@ function Example() {
   )
 }
 ```
+
+## Parameters
+
+The `useOutsideClick` hook accepts an object with the following properties:
+
+<PropsTable of="useOutsideClick" />


### PR DESCRIPTION
## 📝 Description

Improve wording for the `use-outside-click` page
Add jsodcs for the UseOutsideClickProps interface.
