### PR TITLE
fix incorrect part name in progress theme

### DIFF
--- a/.changeset/healthy-beds-drive.md
+++ b/.changeset/healthy-beds-drive.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Changes incorrect `panel` part name in `Progress` theme file to `label`

--- a/packages/theme/src/components/progress.ts
+++ b/packages/theme/src/components/progress.ts
@@ -2,7 +2,7 @@ import { generateStripe, getColor, mode } from "@chakra-ui/theme-tools"
 
 type Dict = Record<string, any>
 
-const parts = ["track", "filledTrack", "panel"]
+const parts = ["track", "filledTrack", "label"]
 
 function filledStyle(props: Dict) {
   const { colorScheme: c, theme: t, isIndeterminate, hasStripe } = props


### PR DESCRIPTION
## 📝 Description

Changes incorrect `panel` part name in `Progress` theme file to `label`

