### PR TITLE
fix(accordion): calc index correctly for Accordions with disabled Panels

### DIFF
--- a/.changeset/good-gorillas-doubt.md
+++ b/.changeset/good-gorillas-doubt.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/accordion": patch
+---
+
+Fixed an issue where the isOpen index was calculated incorrectly if disabled
+AccordionPanels were present

--- a/packages/accordion/src/use-accordion.ts
+++ b/packages/accordion/src/use-accordion.ts
@@ -208,13 +208,15 @@ export function useAccordionItem(props: UseAccordionItemProps) {
   const index = useDescendant({
     element: buttonRef.current,
     context: domContext,
-    disabled: isDisabled,
+    disabled: false /* passing `isDisabled` would lead to incorrect index */,
     focusable: isFocusable,
   })
 
-  const { isOpen, onChange } = getAccordionItemProps(
+  const { isOpen: _isOpen, onChange } = getAccordionItemProps(
     index === -1 ? null : index,
   )
+
+  const isOpen = !isDisabled && _isOpen
 
   const onOpen = () => {
     onChange?.(true)

--- a/packages/accordion/stories/accordion.stories.tsx
+++ b/packages/accordion/stories/accordion.stories.tsx
@@ -297,3 +297,31 @@ export const FocusBug = () => {
     </Box>
   )
 }
+
+// See https://github.com/chakra-ui/chakra-ui/issues/3785
+export function IsOpenWithDisabled() {
+  return (
+    <Accordion index={2}>
+      <AccordionItem isDisabled>
+        <AccordionButton>Button 0</AccordionButton>
+        <AccordionPanel>One Content</AccordionPanel>
+      </AccordionItem>
+      <AccordionItem isDisabled>
+        <AccordionButton>Button 1</AccordionButton>
+        <AccordionPanel>Two Content</AccordionPanel>
+      </AccordionItem>
+      <AccordionItem>
+        <AccordionButton>Button 2</AccordionButton>
+        <AccordionPanel>I should be open by default</AccordionPanel>
+      </AccordionItem>
+      <AccordionItem isDisabled>
+        <AccordionButton>Button 3</AccordionButton>
+        <AccordionPanel>Four Content</AccordionPanel>
+      </AccordionItem>
+      <AccordionItem>
+        <AccordionButton>Button 4</AccordionButton>
+        <AccordionPanel>Five Content</AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/packages/accordion/tests/accordion.test.tsx
+++ b/packages/accordion/tests/accordion.test.tsx
@@ -332,3 +332,21 @@ test("panel has role=region and aria-labelledby", () => {
   expect(panel).toHaveAttribute("aria-labelledby")
   expect(panel).toHaveAttribute("role", "region")
 })
+
+test("computes open index correctly", () => {
+  render(
+    <Accordion index={1}>
+      <AccordionItem isDisabled>
+        <AccordionButton>Button 0</AccordionButton>
+        <AccordionPanel>One Content</AccordionPanel>
+      </AccordionItem>
+      <AccordionItem>
+        <AccordionButton>Button 2</AccordionButton>
+        <AccordionPanel>I should be open by default</AccordionPanel>
+      </AccordionItem>
+    </Accordion>,
+  )
+
+  const button = screen.getByText("Button 2")
+  expect(button).toHaveAttribute("aria-expanded", "true")
+})


### PR DESCRIPTION
Closes #3785

## 📝 Description

isOpen index is not correctly calculated.

## ⛳️ Current behavior (updates)

The useDescendant hook skips disabled elements by default.

## 🚀 New behavior

`useAccordionItem` does not forward `isDisabled` to `useDescendant` anymore and the isOpen index is calculated correctly.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
