### PR TITLE
feat(system): allow passing custom props to useStyleConfig

### DIFF
--- a/.changeset/orange-pens-destroy.md
+++ b/.changeset/orange-pens-destroy.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/system": patch
+---
+
+Allow passing custom props to useStyleConfig

--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -5,6 +5,7 @@ import {
   mergeWith,
   runIfFn,
   omit,
+  Dict,
 } from "@chakra-ui/utils"
 import { useMemo, useRef } from "react"
 import isEqual from "react-fast-compare"
@@ -13,13 +14,13 @@ import { ThemingProps } from "./system.types"
 
 export function useStyleConfig(
   themeKey: string,
-  props: ThemingProps,
+  props: ThemingProps & Dict,
   opts: { isMultiPart: true },
 ): Record<string, SystemStyleObject>
 
 export function useStyleConfig(
   themeKey: string,
-  props?: ThemingProps,
+  props?: ThemingProps & Dict,
   opts?: { isMultiPart?: boolean },
 ): SystemStyleObject
 


### PR DESCRIPTION
Closes #3758

## 📝 Description

TS type is too narrow to pass arbitrary props.

## ⛳️ Current behavior (updates)

It only allows `ThemingProps`.

## 🚀 New behavior

Allow arbitrary props with `ThemingProps & Dict`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
