### PR TITLE
fix(modal): calc height correctly on iOS

### DIFF
--- a/.changeset/violet-chicken-fry.md
+++ b/.changeset/violet-chicken-fry.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": patch
+"@chakra-ui/theme": patch
+---
+
+Fixed an issue where the modal exceeded the viewport height on iOS

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -237,6 +237,9 @@ export const ModalContent = forwardRef<ModalContentProps, "section">(
       display: "flex",
       width: "100vw",
       height: "100vh",
+      "@supports(height: -webkit-fill-available)": {
+        height: "-webkit-fill-available",
+      },
       position: "fixed",
       left: 0,
       top: 0,

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -38,7 +38,7 @@ function baseStyleDialog(props: Dict) {
     color: "inherit",
     my: "3.75rem",
     zIndex: "modal",
-    maxH: scrollBehavior === "inside" ? "calc(100vh - 7.5rem)" : undefined,
+    maxH: scrollBehavior === "inside" ? "calc(100% - 7.5rem)" : undefined,
     boxShadow: mode("lg", "dark-lg")(props),
   }
 }


### PR DESCRIPTION
Closes #3801
Closes #3684

## 📝 Description

This PR fixes an invalid calculated height of the modal.

## ⛳️ Current behavior (updates)

The dialog container exceeds the viewport on iOS.

## 🚀 New behavior

Check if platform [@supports](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports) `-webkit-fill-available` to use correct container height. Then calculate height based on percentage value instead of viewport values, which are incorrect on iOS devices.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Open https://chakra-ui-git-fix-modal-height-ios-chakra-ui.vercel.app/docs/overlay/modal on an iOS device and scroll down to "Modal overflow behavior" and click "Trigger modal":

<div style="display: flex; justify-content: space-between">
<img src="https://user-images.githubusercontent.com/16899513/114618637-ddd40d80-9ca9-11eb-9957-d26f21f408ad.png" alt="broken version" height="400px" width="auto"/>
<img src="https://user-images.githubusercontent.com/16899513/114618517-ba10c780-9ca9-11eb-90df-d309dfc98e25.png" alt="fixed version" height="400px" width="auto"/>
</div>
