### PR TITLE
Update useTabIndicator to works with react-router

### DIFF
--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -451,8 +451,8 @@ export function useTabIndicator(): React.CSSProperties {
     }
 
     // Prevent unwanted transition from 0 to measured rect
-    // by setting the measured state in the next tick
-    const id = requestAnimationFrame(() => {
+    // by setting the measured state in the next react tick
+    const id = requestIdleCallback(() => {
       setHasMeasured(true)
     })
 


### PR DESCRIPTION
## 📝 Description

React-router is triggering multiple re-renders at start. The indicator move to initial position with a transition.
Waiting for an idle callback before applying TabIndication transition style property fix the issue.

## ⛳️ Current behavior (updates)

TabIndicator is moving to initial position with a transition. 

## 🚀 New behavior

TabIndicator doesn't move to the initial position. 

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

The `useTabIndicator` hook is not **really** waiting for the next tick (as commented) to return a filled transition style property.