### PR TITLE
fix(stat): StatHelpText audit fails

### DIFF
--- a/.changeset/nice-cooks-switch.md
+++ b/.changeset/nice-cooks-switch.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/stat": patch
+---
+
+Fixed a11y issue related to `StatHelpText`. It was using an invalid `dl` child
+tag.

--- a/packages/stat/src/stat.tsx
+++ b/packages/stat/src/stat.tsx
@@ -31,20 +31,22 @@ if (__DEV__) {
   StatLabel.displayName = "StatLabel"
 }
 
-export interface StatHelpTextProps extends HTMLChakraProps<"p"> {}
+export interface StatHelpTextProps extends HTMLChakraProps<"dd"> {}
 
-export const StatHelpText = forwardRef<StatHelpTextProps, "p">((props, ref) => {
-  const styles = useStyles()
+export const StatHelpText = forwardRef<StatHelpTextProps, "dd">(
+  (props, ref) => {
+    const styles = useStyles()
 
-  return (
-    <chakra.p
-      ref={ref}
-      {...props}
-      className={cx("chakra-stat__help-text", props.className)}
-      __css={styles.helpText}
-    />
-  )
-})
+    return (
+      <chakra.dd
+        ref={ref}
+        {...props}
+        className={cx("chakra-stat__help-text", props.className)}
+        __css={styles.helpText}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   StatHelpText.displayName = "StatHelpText"

--- a/packages/stat/tests/stat.test.tsx
+++ b/packages/stat/tests/stat.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { render } from "@chakra-ui/test-utils"
+import { render, testA11y } from "@chakra-ui/test-utils"
 import {
   StatGroup,
   Stat,
@@ -9,27 +9,44 @@ import {
   StatArrow,
 } from "../src"
 
-test("Stat renders correctly", () => {
-  const { findByTestId } = render(
-    <StatGroup data-testid="group">
-      <Stat>
-        <StatLabel>Sent</StatLabel>
-        <StatNumber>345,670</StatNumber>
-        <StatHelpText>
-          <StatArrow type="increase" />
-          23.36%
-        </StatHelpText>
-      </Stat>
+describe("<StatGroup />", () => {
+  it("should renders correctly", () => {
+    const { findByTestId } = render(
+      <StatGroup data-testid="group">
+        <Stat>
+          <StatLabel>Sent</StatLabel>
+          <StatNumber>345,670</StatNumber>
+          <StatHelpText>
+            <StatArrow type="increase" />
+            23.36%
+          </StatHelpText>
+        </Stat>
 
-      <Stat>
-        <StatLabel>Clicked</StatLabel>
-        <StatNumber>45</StatNumber>
-        <StatHelpText>
-          <StatArrow type="decrease" />
-          9.05%
-        </StatHelpText>
-      </Stat>
-    </StatGroup>,
-  )
-  expect(findByTestId("group")).toBeTruthy()
+        <Stat>
+          <StatLabel>Clicked</StatLabel>
+          <StatNumber>45</StatNumber>
+          <StatHelpText>
+            <StatArrow type="decrease" />
+            9.05%
+          </StatHelpText>
+        </Stat>
+      </StatGroup>,
+    )
+    expect(findByTestId("group")).toBeTruthy()
+  })
+
+  it("should passes a11y test", async () => {
+    await testA11y(
+      <StatGroup data-testid="group">
+        <Stat>
+          <StatLabel>Sent</StatLabel>
+          <StatNumber>345,670</StatNumber>
+          <StatHelpText>
+            <StatArrow type="increase" />
+            23.36%
+          </StatHelpText>
+        </Stat>
+      </StatGroup>,
+    )
+  })
 })


### PR DESCRIPTION
Closes #3799 

## 📝 Description

The component `StatHelpText` wraps its content with an invalid `dd` tag child. What is throwing the below error related to a11y.

`<dl>s do not contain only properly ordered <dt> and <dd> groups, <script>, or <template> elements`

reference: https://web.dev/definition-list/?utm_source=lighthouse&utm_medium=devtools

## ⛳️ Current behavior (updates)

`StatHelpText` wraps its content with the tag `p`, which is an invalid `dd` tag child.

## 🚀 New behavior

`StatHelpText` wraps its content with the tag `dl`, which is a valid `dd` tag child.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
--