### PR TITLE
docs: fix broken external link

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -66,7 +66,7 @@ export default MyApp
 ### Gatsby
 
 Add the
-[@chakra-ui/gatsby-plugin](gatsbyjs.com/plugins/@chakra-ui/gatsby-plugin/). It
+[@chakra-ui/gatsby-plugin](https://www.gatsbyjs.com/plugins/@chakra-ui/gatsby-plugin/). It
 does everything automatically for you!
 
 ```bash


### PR DESCRIPTION
## 📝 Description

Missing URL protocol is causing the link to be interpreted as a relative URL.

## ⛳️ Current behavior (updates)

Links to: https://chakra-ui.com/docs/gatsbyjs.com/plugins/@chakra-ui/gatsby-plugin

## 🚀 New behavior

Links to: https://www.gatsbyjs.com/plugins/@chakra-ui/gatsby-plugin/

## 💣 Is this a breaking change (Yes/No):

No
