### PR TITLE
docs (global styles) Correction of example config

### DIFF
--- a/website/pages/docs/features/global-styles.mdx
+++ b/website/pages/docs/features/global-styles.mdx
@@ -60,20 +60,20 @@ like:
 ```js
 const styles = {
   global: (props) => ({
-    fontFamily: "body",
-    color: mode("gray.800", "whiteAlpha.900")(props),
-    bg: mode("white", "gray.800")(props),
-    lineHeight: "base",
+    "body": {
+      fontFamily: "body",
+      color: mode("gray.800", "whiteAlpha.900")(props),
+      bg: mode("white", "gray.800")(props),
+      lineHeight: "base"
+    },
     "*::placeholder": {
       color: mode("gray.400", "whiteAlpha.400")(props),
     },
     "*, *::before, &::after": {
       borderColor: mode("gray.200", "whiteAlpha.300")(props),
       wordWrap: "break-word",
-    },
-    fontFeatureSettings: `"pnum"`,
-    fontVariantNumeric: "proportional-nums",
-  }),
+    }
+  })
 }
 ```
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes nothing. I spotted the mistake and quickly fixed it without making an Issue first.

## 📝 Description

While defining global styles, I copied and pasted the example in the docs hoping to see them apply.

## ⛳️ Current behavior (updates)

The Global Styles from the docs weren't having any effect. 

## 🚀 New behavior

Typo in the docs. Global styles need to be nested under a selector e.g. `html, body`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

None