### PR TITLE
feat(tabs): make new isLazy behavior toggleable via unmountHiddenPanels prop

### DIFF
--- a/.changeset/perfect-beans-raise.md
+++ b/.changeset/perfect-beans-raise.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/tabs": minor
+---
+
+This change restores the behavior of the `isLazy` prop (which was broken by
+`@chakra-ui/tabs@1.3.2`) and adds a new `unmountHiddenPanels` prop which
+configures the behavior of `isLazy`.
+
+If you'd like for your tab panel components to be unmounted when a different tab
+is selected, please continue to use `isLazy`. This is the default behavior.
+
+If you'd like for your tab panel components to remain mounted (but hidden) after
+when a different tab is selected, use `unmountHiddenPanels={false}` in
+combination with `isLazy`.

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -18,6 +18,7 @@ import {
   EventKeyMap,
 } from "@chakra-ui/react-utils"
 import * as React from "react"
+import { shouldTabPanelRenderChildren } from "./utils"
 
 export interface UseTabsProps {
   /**
@@ -50,10 +51,18 @@ export interface UseTabsProps {
   id?: string
   /**
    * Performance 🚀:
-   * If `true`, the TabPanel rendering will be deferred
-   * until it is open.
+   * If `true`, the TabPanel rendering will be deferred until it is open.
    */
   isLazy?: boolean
+  /**
+   * If `true`, tab panels will be unmounted when hidden. This prop only works
+   * if `isLazy={true}`. By default, lazy panels are always unmounted when not
+   * visible, but setting this to `false` overrides the behavior and leaves
+   * previously-selected panels mounted.
+   *
+   * @default true
+   */
+  unmountHiddenPanels?: boolean
 }
 
 /**
@@ -72,6 +81,7 @@ export function useTabs(props: UseTabsProps) {
     index,
     isManual,
     isLazy,
+    unmountHiddenPanels = true,
     orientation = "horizontal",
     ...htmlProps
   } = props
@@ -151,6 +161,7 @@ export function useTabs(props: UseTabsProps) {
     setFocusedIndex,
     isManual,
     isLazy,
+    unmountHiddenPanels,
     orientation,
     enabledDomContext,
     domContext,
@@ -382,14 +393,19 @@ export function useTabPanels<P extends UseTabPanelsProps>(props: P) {
  */
 export function useTabPanel(props: Dict) {
   const { isSelected, id, children, ...htmlProps } = props
-  const { isLazy } = useTabsContext()
+  const { isLazy, unmountHiddenPanels } = useTabsContext()
 
   const hasBeenSelected = React.useRef(false)
   if (isSelected) {
     hasBeenSelected.current = true
   }
 
-  const shouldRenderChildren = !isLazy || hasBeenSelected.current
+  const shouldRenderChildren = shouldTabPanelRenderChildren({
+    hasBeenSelected: hasBeenSelected.current,
+    isSelected,
+    isLazy,
+    unmountHiddenPanels,
+  })
 
   return {
     /**

--- a/packages/tabs/src/utils.ts
+++ b/packages/tabs/src/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Determines whether a tab panel's children should be rendered or not.
+ */
+export const shouldTabPanelRenderChildren = ({
+  hasBeenSelected,
+  isLazy,
+  isSelected,
+  unmountHiddenPanels,
+}: {
+  hasBeenSelected?: boolean
+  isLazy?: boolean
+  isSelected?: boolean
+  unmountHiddenPanels?: boolean
+}) => {
+  // if not lazy, always render every tab panel
+  if (!isLazy) {
+    return true
+  }
+
+  // lazy rendering is a bit more complicated
+  switch (true) {
+    // if the tab is selected, it's always rendered
+    case isSelected:
+      return true
+    // if we're not hiding hidden panels, and the tab was previously selected,
+    // show it
+    case !unmountHiddenPanels && hasBeenSelected:
+      return true
+    // default to not rendering the panel
+    default:
+      return false
+  }
+}

--- a/packages/tabs/tests/tabs.test.tsx
+++ b/packages/tabs/tests/tabs.test.tsx
@@ -164,6 +164,33 @@ test("renders only the currently active tab panel if isLazy", () => {
 
   userEvent.click(screen.getByText("Tab 2"))
 
+  expect(screen.queryByText("Panel 1")).not.toBeInTheDocument()
+  expect(screen.getByText("Panel 2")).toBeInTheDocument()
+})
+
+test("renders the currently active tab panel and previously-selected tabs if isLazy and unmountHiddenPanels={false}", () => {
+  render(
+    <Tabs isLazy unmountHiddenPanels={false}>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <p>Panel 1</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Panel 2</p>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>,
+  )
+
+  expect(screen.getByText("Panel 1")).toBeInTheDocument()
+  expect(screen.queryByText("Panel 2")).not.toBeInTheDocument()
+
+  userEvent.click(screen.getByText("Tab 2"))
+
   expect(screen.queryByText("Panel 1")).toBeInTheDocument()
   expect(screen.getByText("Panel 2")).toBeInTheDocument()
 })

--- a/packages/tabs/tests/utils.test.ts
+++ b/packages/tabs/tests/utils.test.ts
@@ -1,0 +1,53 @@
+import { shouldTabPanelRenderChildren } from "../src/utils"
+
+test("shouldTabPanelRenderChildren", () => {
+  // when not lazy, tab panels are always rendered
+  expect(shouldTabPanelRenderChildren({ isLazy: false })).toBe(true)
+  expect(
+    shouldTabPanelRenderChildren({ isLazy: false, isSelected: false }),
+  ).toBe(true)
+  expect(
+    shouldTabPanelRenderChildren({ isLazy: false, hasBeenSelected: false }),
+  ).toBe(true)
+  expect(
+    shouldTabPanelRenderChildren({
+      isLazy: false,
+      unmountHiddenPanels: true,
+    }),
+  ).toBe(true)
+
+  // when lazy and unmounting hidden panels, tab panels are only
+  // rendered when selected
+  expect(
+    shouldTabPanelRenderChildren({ isLazy: true, unmountHiddenPanels: true }),
+  ).toBe(false)
+  expect(
+    shouldTabPanelRenderChildren({
+      isLazy: true,
+      unmountHiddenPanels: true,
+      isSelected: true,
+    }),
+  ).toBe(true)
+  expect(
+    shouldTabPanelRenderChildren({
+      isLazy: true,
+      unmountHiddenPanels: true,
+      isSelected: false,
+      hasBeenSelected: true,
+    }),
+  ).toBe(false)
+
+  // when lazy and leaving hidden panels mounted, tab panels are only rendered
+  // when selected or if they were previously selected
+  expect(shouldTabPanelRenderChildren({ isLazy: true, isSelected: true })).toBe(
+    true,
+  )
+  expect(
+    shouldTabPanelRenderChildren({
+      isLazy: true,
+      isSelected: false,
+      hasBeenSelected: true,
+    }),
+  ).toBe(true)
+  expect(shouldTabPanelRenderChildren({ isLazy: true })).toBe(false)
+})


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3683 

## 📝 Description

The behavior of the `isLazy` prop was broken in `@chakra-ui/tabs@1.3.2` due to a change in its default behavior. This change reverts the default behavior `isLazy` behavior to its old default, and allows toggling the newer behavior through the new `umountHiddenPanels` prop available on the `Tabs` component.

## ⛳️ Current behavior (updates)

`isLazy` behavior was broken by `1.3.2`. `isLazy` leaves mounted the panels for any tabs that were previously selected.

## 🚀 New behavior

- `isLazy` default behavior restored to original pre-`1.3.2` behavior. When a tab is deselected, its panel is unmounted
- Added `unmountHiddenPanels` prop (defaults to `true`) to `Tabs`. This prop only works with `isLazy`, and allows the user to control whether tabs remain mounted or are unmounted (default behavior, `true`) when another tab is selected.

## 💣 Is this a breaking change (Yes/No):

No, but it is breaking a previous breaking change by reverting it back to the old behavior.

## 📝 Additional Information

See #3763 for the previous change to this behavior