### PR TITLE
fix(styled-system): transform transition theme tokens correctly

### DIFF
--- a/.changeset/lemon-ravens-poke.md
+++ b/.changeset/lemon-ravens-poke.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Fixed an issue where the transition props are not resolved correctly

--- a/packages/styled-system/src/config/transition.ts
+++ b/packages/styled-system/src/config/transition.ts
@@ -1,21 +1,12 @@
 import * as CSS from "csstype"
 import { Config } from "../prop-config"
-import { ResponsiveValue } from "../utils"
+import { ResponsiveValue, t } from "../utils"
 
 export const transition: Config = {
   transition: true,
-  transitionDuration: {
-    property: "transitionDuration",
-    scale: "transition.duration",
-  },
-  transitionProperty: {
-    property: "transitionProperty",
-    scale: "transition.property",
-  },
-  transitionTimingFunction: {
-    property: "transitionTimingFunction",
-    scale: "transition.easing",
-  },
+  transitionDuration: t.transitionDuration("transitionDuration"),
+  transitionProperty: t.transitionProperty("transitionProperty"),
+  transitionTimingFunction: t.transitionEasing("transitionTimingFunction"),
 }
 
 export interface TransitionProps {

--- a/packages/styled-system/src/utils/index.ts
+++ b/packages/styled-system/src/utils/index.ts
@@ -34,5 +34,8 @@ export const t = {
   sizes: toConfig("sizes", pxTransform),
   sizesT: toConfig("sizes", fractionalValue),
   shadows: toConfig("shadows"),
+  transitionDuration: toConfig("transition.duration"),
+  transitionProperty: toConfig("transition.property"),
+  transitionEasing: toConfig("transition.easing"),
   logical,
 }

--- a/packages/styled-system/tests/css.test.ts
+++ b/packages/styled-system/tests/css.test.ts
@@ -64,6 +64,17 @@ const theme = toCSSVar({
   textTransform: {
     header: "uppercase",
   },
+  transition: {
+    duration: {
+      slow: "1s",
+    },
+    easing: {
+      smooth: "ease-in-out",
+    },
+    property: {
+      common: "opacity, transform, background-color, color",
+    },
+  },
 })
 
 test("returns system props styles", () => {
@@ -620,6 +631,22 @@ test("should expand textStyle and layerStyle", () => {
       "fontSize": "lg",
       "letterSpacing": "wide",
       "textTransform": "uppercase",
+    }
+  `)
+})
+
+test("transition tokens are replaced correctly", () => {
+  expect(
+    css({
+      transitionProperty: "common",
+      transitionDuration: "slow",
+      transitionTimingFunction: "smooth",
+    })(theme),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "transitionDuration": "var(--transition-duration-slow)",
+      "transitionProperty": "var(--transition-property-common)",
+      "transitionTimingFunction": "var(--transition-easing-smooth)",
     }
   `)
 })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3840

## 📝 Description

Fix the resolution of transition tokens to css vars from the theme.

I extended the `t` helper object with `transitionProperty`, `transitionDuration` and `transitionEasing` and use them in the transition config. 

## ⛳️ Current behavior (updates)

Transition tokens were not resolved correctly.

## 🚀 New behavior

Transition tokens are resolved correctly

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
