### PR TITLE
feat: add new textDecoration style props

### DIFF
--- a/.changeset/red-suns-join.md
+++ b/.changeset/red-suns-join.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Added style props for `textDecorationColor`, `textDecorationLine`,
+`textDecorationStyle`, and `textDecorationThickness`

--- a/packages/styled-system/src/config/typography.ts
+++ b/packages/styled-system/src/config/typography.ts
@@ -18,6 +18,10 @@ export const typography: Config = {
   whiteSpace: true,
   textDecoration: true,
   textDecor: { property: "textDecoration" },
+  textDecorationColor: t.colors("color"),
+  textDecorationLine: true,
+  textDecorationStyle: true,
+  textDecorationThickness: true,
   noOfLines: {
     static: {
       overflow: "hidden",
@@ -103,6 +107,22 @@ export interface TypographyProps {
    * The CSS `text-decoration` property
    */
   textDecor?: Token<CSS.Property.TextDecoration | number>
+  /**
+   * The CSS `text-decoration-color` property
+   */
+  textDecorationColor?: Token<CSS.Property.Color, "colors">
+  /**
+   * The CSS `text-decoration-line` property
+   */
+  textDecorationLine?: Token<CSS.Property.TextDecorationLine>
+  /**
+   * The CSS `text-decoration-style` property
+   */
+  textDecorationStyle?: Token<CSS.Property.TextDecorationStyle>
+  /**
+   * The CSS `text-decoration-thickness` property
+   */
+  textDecorationThickness?: Token<CSS.Property.TextDecorationThickness | number>
   /**
    * Used to visually truncate a text after a number of lines.
    */

--- a/website/pages/docs/features/style-props.mdx
+++ b/website/pages/docs/features/style-props.mdx
@@ -118,17 +118,21 @@ import { Text } from "@chakra-ui/react"
 <Text textAlign={[ 'left', 'center' ]} />
 ```
 
-| Prop             | CSS Property      | Theme Key        |
-| ---------------- | ----------------- | ---------------- |
-| `fontFamily`     | `font-family`     | `fonts`          |
-| `fontSize`       | `font-size`       | `fontSizes`      |
-| `fontWeight`     | `font-weight`     | `fontWeights`    |
-| `lineHeight`     | `line-height`     | `lineHeights`    |
-| `letterSpacing`  | `letter-spacing`  | `letterSpacings` |
-| `textAlign`      | `text-align`      | none             |
-| `fontStyle`      | `font-style`      | none             |
-| `textTransform`  | `text-transform`  | none             |
-| `textDecoration` | `text-decoration` | none             |
+| Prop                      | CSS Property                | Theme Key        |
+| ------------------------- | --------------------------- | ---------------- |
+| `fontFamily`              | `font-family`               | `fonts`          |
+| `fontSize`                | `font-size`                 | `fontSizes`      |
+| `fontWeight`              | `font-weight`               | `fontWeights`    |
+| `lineHeight`              | `line-height`               | `lineHeights`    |
+| `letterSpacing`           | `letter-spacing`            | `letterSpacings` |
+| `textAlign`               | `text-align`                | none             |
+| `fontStyle`               | `font-style`                | none             |
+| `textTransform`           | `text-transform`            | none             |
+| `textDecoration`          | `text-decoration`           | none             |
+| `textDecorationColor`     | `text-decoration-color`     | `colors`         |
+| `textDecorationLine`      | `text-decoration-line`      | None             |
+| `textDecorationStyle`     | `text-decoration-style`     | None             |
+| `textDecorationThickness` | `text-decoration-thickness` | None             |
 
 ### Layout, width and height
 
@@ -358,7 +362,7 @@ import { Box } from "@chakra-ui/react"
 ```jsx
 <SimpleGrid
   bg="gray.50"
-  columns={{sm: 2, md: 4}}
+  columns={{ sm: 2, md: 4 }}
   spacing="8"
   p="10"
   textAlign="center"


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3848 <!-- Github issue # here -->

## 📝 Description

This changes adds style props for `textDecorationColor`, `textDecorationLine`, `textDecorationStyle`, and `textDecorationThickness`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I wasn't sure if I should do anything more fancy with `textDecorationLine`, `textDecorationStyle`, or `textDecorationThickness`. I noticed that `borderWidth` and `borderStyle` correspond to the theme keys for `borderWidths` and `borderStyles`, but I've never seen those used so wasn't sure if that was a pattern we should keep following or not.