### PR TITLE
docs(progress): fix circular progress Docs link

### DIFF
--- a/.changeset/purple-rockets-jog.md
+++ b/.changeset/purple-rockets-jog.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/progress": patch
+---
+
+Fix hyperlink to docs

--- a/packages/progress/src/circular-progress.tsx
+++ b/packages/progress/src/circular-progress.tsx
@@ -98,7 +98,7 @@ export interface CircularProgressProps
  * It is built using `svg` and `circle` components with support for
  * theming and `indeterminate` state
  *
- * @see Docs https://chakra-ui.com/docs/feedback/progress
+ * @see Docs https://chakra-ui.com/docs/feedback/circular-progress
  * @todo add theming support for circular progress
  */
 export const CircularProgress: React.FC<CircularProgressProps> = (props) => {


### PR DESCRIPTION
## 📝 Description

Fix circular-progress link to docs from 

## ⛳️ Current behavior (updates)

Displays wrong documentation link to Doc on  JSDoc `https://chakra-ui.com/docs/feedback/progress`

## 🚀 New behavior
Fix JSDocs to display correctly link `https://chakra-ui.com/docs/feedback/circular-progress`

## 💣 Is this a breaking change (Yes/No):

No
