### PR TITLE
Fix #3862 Menu button issue with truncated text

### DIFF
--- a/.changeset/friendly-parents-mate.md
+++ b/.changeset/friendly-parents-mate.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fix issue where menu button doesn't work with truncated text

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -103,7 +103,7 @@ export const MenuButton = forwardRef<MenuButtonProps, "button">(
         {...buttonProps}
         className={cx("chakra-menu__menu-button", props.className)}
       >
-        <chakra.span __css={{ pointerEvents: "none", flex: "1 1 auto" }}>
+        <chakra.span __css={{ pointerEvents: "none", flex: "1 1 auto", minW: 0 }}>
           {props.children}
         </chakra.span>
       </Element>


### PR DESCRIPTION
Closes #3862 

Menu button text is not truncated correctly.
I've created a sandbox example of the issue here https://codesandbox.io/s/chakra-ui-menu-button-truncated-text-his57?file=/src/App.tsx:311-324