### PR TITLE
fix(docs): toggle omni search with hotkey (cmd/ctrl+k)

### DIFF
--- a/website/src/components/omni-search.tsx
+++ b/website/src/components/omni-search.tsx
@@ -133,7 +133,7 @@ function OmniSearch() {
     const hotkey = isMac ? "metaKey" : "ctrlKey"
     if (event?.key?.toLowerCase() === "k" && event[hotkey]) {
       event.preventDefault()
-      modal.onOpen()
+      modal.isOpen ? modal.onClose() : modal.onOpen()
     }
   })
 


### PR DESCRIPTION
Closes: N/A

## 📝 Description

I find myself instinctively trying to toggle the search bar closed with the hotkey when I navigate the docs. This PR adds the ability to close the search bar using the hotkey cmd/ctrl+k

## ⛳️ Current behavior (updates)

Hotkey opens the search bar, but doesn't close it

## 🚀 New behavior

Hotkey toggles the search bar open/closed

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
