### PR TITLE
fix(button): #3859 fix button type as undefined

### DIFF
--- a/.changeset/lovely-dancers-guess.md
+++ b/.changeset/lovely-dancers-guess.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/button": patch
+---
+
+Fixed #3859 issue where button type was reciving undefined

--- a/.changeset/lovely-dancers-guess.md
+++ b/.changeset/lovely-dancers-guess.md
@@ -2,4 +2,5 @@
 "@chakra-ui/button": patch
 ---
 
-Fixed #3859 issue where button type was reciving undefined
+Resolved an issue where the `type` prop of the `Button` component was set to
+`undefined`.

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -1,4 +1,3 @@
-import { mergeRefs } from "@chakra-ui/react-utils"
 import { Spinner } from "@chakra-ui/spinner"
 import {
   chakra,
@@ -118,17 +117,12 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     ...(!!group && { _focus }),
   }
 
-  const [isButton, setIsButton] = React.useState(!as)
-  const refCallback = React.useCallback((node: HTMLElement | null) => {
-    if (node?.tagName !== "BUTTON") {
-      setIsButton(false)
-    }
-  }, [])
+  const isButton = Boolean(!as)
 
   return (
     <chakra.button
       disabled={isDisabled || isLoading}
-      ref={mergeRefs(ref, refCallback)}
+      ref={ref}
       as={as}
       type={isButton ? type : undefined}
       data-active={dataAttr(isActive)}

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -1,3 +1,4 @@
+import { mergeRefs } from "@chakra-ui/react-utils"
 import { Spinner } from "@chakra-ui/spinner"
 import {
   chakra,
@@ -117,12 +118,17 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     ...(!!group && { _focus }),
   }
 
-  const isButton = Boolean(!as)
+  const [isButton, setIsButton] = React.useState(!as || as === "button")
+  const refCallback = React.useCallback((node: HTMLElement | null) => {
+    if (node && node.tagName !== "BUTTON") {
+      setIsButton(false)
+    }
+  }, [])
 
   return (
     <chakra.button
       disabled={isDisabled || isLoading}
-      ref={ref}
+      ref={mergeRefs(ref, refCallback)}
       as={as}
       type={isButton ? type : undefined}
       data-active={dataAttr(isActive)}

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -86,7 +86,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     rightIcon,
     loadingText,
     iconSpacing = "0.5rem",
-    type = "button",
+    type,
     spinner,
     spinnerPlacement = "start",
     className,
@@ -123,13 +123,14 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     if (!node) return
     setIsButton(node.tagName === "BUTTON")
   }, [])
+  const defaultType = isButton ? "button" : undefined
 
   return (
     <chakra.button
       disabled={isDisabled || isLoading}
       ref={mergeRefs(ref, refCallback)}
       as={as}
-      type={isButton ? type : undefined}
+      type={type ?? defaultType}
       data-active={dataAttr(isActive)}
       data-loading={dataAttr(isLoading)}
       __css={buttonStyles}

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -118,11 +118,10 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     ...(!!group && { _focus }),
   }
 
-  const [isButton, setIsButton] = React.useState(!as || as === "button")
+  const [isButton, setIsButton] = React.useState(!as)
   const refCallback = React.useCallback((node: HTMLElement | null) => {
-    if (node && node.tagName !== "BUTTON") {
-      setIsButton(false)
-    }
+    if (!node) return
+    setIsButton(node.tagName === "BUTTON")
   }, [])
 
   return (

--- a/packages/button/tests/button.test.tsx
+++ b/packages/button/tests/button.test.tsx
@@ -62,3 +62,24 @@ test("has the proper aria attributes", () => {
   button = screen.getByRole("button")
   expect(button).toHaveAttribute("disabled", "")
 })
+
+test("Has the proper type attribute", () => {
+  const { getByTestId, rerender } = render(
+    <Button data-testid="btn">Email</Button>,
+  )
+  expect(getByTestId("btn")).toHaveAttribute("type", "button")
+
+  rerender(
+    <Button data-testid="btn" type="submit">
+      Email
+    </Button>,
+  )
+  expect(getByTestId("btn")).toHaveAttribute("type", "submit")
+
+  rerender(
+    <Button data-testid="btn" as="span">
+      Email
+    </Button>,
+  )
+  expect(getByTestId("btn")).not.toHaveAttribute("type")
+})

--- a/packages/button/tests/button.test.tsx
+++ b/packages/button/tests/button.test.tsx
@@ -77,6 +77,13 @@ test("Has the proper type attribute", () => {
   expect(getByTestId("btn")).toHaveAttribute("type", "submit")
 
   rerender(
+    <Button data-testid="btn" as="button">
+      Email
+    </Button>,
+  )
+  expect(getByTestId("btn")).toHaveAttribute("type")
+
+  rerender(
     <Button data-testid="btn" as="span">
       Email
     </Button>,


### PR DESCRIPTION
Closes #3859 , #3871 

## 📝 Description

Fixes issue where button wasn't receiving type prop on first mount

## ⛳️ Current behavior (updates)

Button does not receive type="button", even when passed in as a prop.

## 🚀 New behavior

If is a button, so doesn't have a as props should receive `type={type}` where default type is a button

## 💣 Is this a breaking change (Yes/No):

No