### PR TITLE
fix(button): #3879 button type is preserved between render

### DIFF
--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -120,7 +120,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
 
   const [isButton, setIsButton] = React.useState(!as)
   const refCallback = React.useCallback((node: HTMLElement | null) => {
-    if (node?.tagName !== "BUTTON") {
+    if (node && node.tagName !== "BUTTON") {
       setIsButton(false)
     }
   }, [])

--- a/packages/button/tests/button.test.tsx
+++ b/packages/button/tests/button.test.tsx
@@ -1,5 +1,14 @@
+/**
+ * @jest-environment jsdom
+ */
 import * as React from "react"
-import { render, testA11y, screen } from "@chakra-ui/test-utils"
+import {
+  render,
+  testA11y,
+  screen,
+  userEvent,
+  waitFor,
+} from "@chakra-ui/test-utils"
 import { EmailIcon, ArrowForwardIcon } from "@chakra-ui/icons"
 import { Button, ButtonGroup } from "../src"
 
@@ -61,4 +70,21 @@ test("has the proper aria attributes", () => {
   rerender(<Button isDisabled>Hello</Button>)
   button = screen.getByRole("button")
   expect(button).toHaveAttribute("disabled", "")
+})
+
+function ButtonTestReRender() {
+  const [, setState] = React.useState(false)
+  return <Button onClick={() => setState((s) => !s)} />
+}
+test("type is preserved between renders", async () => {
+  render(<ButtonTestReRender />)
+
+  let button = screen.getByRole("button")
+  expect(button).toHaveAttribute("type", "button")
+  userEvent.click(button)
+
+  await waitFor(() => {
+    button = screen.getByRole("button")
+    expect(button).toHaveAttribute("type", "button")
+  })
 })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3879

## 📝 Description

Fix a problem where the type props for the `<Button />` was lost between renders
