### PR TITLE
feat: migrate dark component styles to CSS using `_dark`  selector

### DIFF
--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -35,6 +35,24 @@ export const basic = () => (
     <Button colorScheme="cyan">Button</Button>
     <Button colorScheme="orange">Button</Button>
     <Button colorScheme="yellow">Button</Button>
+
+    {/* The solid buttons were themed with `_dark` nested under other selectors */}
+    {/* 
+    If we pass the `_dark` prop, it overrides only `color` and `bg`, so we end up with the light theme values
+    Hover styling is kept because of the nested `_dark` styling in the `_hover` object
+    */}
+    <Button colorScheme="yellow" _dark={{ _hover: {} }}>
+      _Dark
+    </Button>
+    {/* 
+    If we pass the `_hover` prop, it overrides only the styling on hover effect
+    Other styles from the top-level `_dark` object are inherited (like color and bg)
+    
+    The _hover styling is overridden for both dark and light themes
+    */}
+    <Button colorScheme="yellow" _hover={{ _dark: {} }}>
+      _Dark
+    </Button>
   </>
 )
 
@@ -77,6 +95,19 @@ export const withVariants = () => (
     </Button>
     <Button colorScheme="teal" variant="outline">
       Button
+    </Button>
+    {/* The outline buttons were themed with all `_dark` styles in a top-level object */}
+
+    {/* If we pass the `_dark` prop, ALL dark-specific styling is lost, as they were all placed in `_dark` object at the top-level of the theme */}
+    <Button colorScheme="teal" variant="outline" _dark={{}}>
+      _Dark
+    </Button>
+    {/* 
+    If we pass another prop like `_hover`, no dark styles are overridden.
+    Overrides hover effect works on light theme only, since the hover styling for dark theme is under `_dark`
+    */}
+    <Button colorScheme="teal" variant="outline" _hover={{}}>
+      _Dark
     </Button>
     <Button colorScheme="teal" variant="ghost">
       Button

--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -14,6 +14,7 @@ export type { ColorMode }
 export interface ColorModeOptions {
   initialColorMode?: ColorMode
   useSystemColorMode?: boolean
+  cssVarPrefix?: string
 }
 
 interface ColorModeContextType {
@@ -55,7 +56,7 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   const {
     value,
     children,
-    options: { useSystemColorMode, initialColorMode },
+    options: { useSystemColorMode, initialColorMode, cssVarPrefix },
     colorModeManager = localStorageManager,
   } = props
 
@@ -95,9 +96,9 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   React.useEffect(() => {
     const isDark = colorMode === "dark"
 
-    syncBodyClassName(isDark)
+    syncBodyClassName(isDark, cssVarPrefix)
     root.set(isDark ? "dark" : "light")
-  }, [colorMode])
+  }, [colorMode, cssVarPrefix])
 
   const setColorMode = React.useCallback(
     (value: ColorMode) => {

--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -3,7 +3,7 @@ import { ColorMode } from "./color-mode-provider"
 
 type Mode = ColorMode | "system" | undefined
 
-function setScript(initialValue: Mode) {
+function setScript(initialValue: Mode, classNamePrefix: string) {
   const mql = window.matchMedia("(prefers-color-scheme: dark)")
   const systemPreference = mql.matches ? "dark" : "light"
 
@@ -30,6 +30,7 @@ function setScript(initialValue: Mode) {
   if (colorMode) {
     const root = document.documentElement
     root.style.setProperty("--chakra-ui-color-mode", colorMode)
+    document.body.classList.add(`${classNamePrefix}-${colorMode}`)
   }
 }
 
@@ -39,6 +40,12 @@ interface ColorModeScriptProps {
    * Optional nonce that will be passed to the created `<script>` tag.
    */
   nonce?: string
+  /**
+   * Optional prefix to attach to the class name that identifies the color mode
+   *
+   * @default chakra
+   */
+  classNamePrefix?: string
 }
 
 /**
@@ -46,8 +53,10 @@ interface ColorModeScriptProps {
  * to help prevent flash of color mode that can happen during page load.
  */
 export const ColorModeScript = (props: ColorModeScriptProps) => {
-  const { initialColorMode = "light" } = props
-  const html = `(${String(setScript)})('${initialColorMode}')`
+  const { initialColorMode = "light", classNamePrefix = "chakra" } = props
+  const html = `(${String(
+    setScript,
+  )})('${initialColorMode}', '${classNamePrefix}')`
   return (
     <script nonce={props.nonce} dangerouslySetInnerHTML={{ __html: html }} />
   )

--- a/packages/color-mode/src/color-mode.utils.ts
+++ b/packages/color-mode/src/color-mode.utils.ts
@@ -1,8 +1,8 @@
 import { isBrowser, noop } from "@chakra-ui/utils"
 
 const classNames = {
-  light: "chakra-ui-light",
-  dark: "chakra-ui-dark",
+  light: "light",
+  dark: "dark",
 }
 
 export type ColorMode = "light" | "dark"
@@ -16,13 +16,23 @@ const mockBody = {
 
 const getBody = () => (isBrowser ? document.body : mockBody)
 
+// TODO: extract this into an appropriate utils file
+const applyPrefix = (value: string, prefix = "", separator = "-") =>
+  `${[prefix, value].filter(Boolean).join(separator)}`
+
 /**
  * Function to add/remove class from `body` based on color mode
  */
-export function syncBodyClassName(isDark: boolean) {
+export function syncBodyClassName(isDark: boolean, cssVarPrefix = "") {
   const body = getBody()
-  body.classList.add(isDark ? classNames.dark : classNames.light)
-  body.classList.remove(isDark ? classNames.light : classNames.dark)
+  const { light, dark } = classNames
+
+  body.classList.add(
+    isDark ? applyPrefix(dark, cssVarPrefix) : applyPrefix(light, cssVarPrefix),
+  )
+  body.classList.remove(
+    isDark ? applyPrefix(light, cssVarPrefix) : applyPrefix(dark, cssVarPrefix),
+  )
 }
 
 /**

--- a/packages/color-mode/test/color-mode-provider.test.tsx
+++ b/packages/color-mode/test/color-mode-provider.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import * as colorModeUtils from "../src/color-mode.utils"
 import { render } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import * as colorModeUtils from "../src/color-mode.utils"
 import {
   defaultThemeOptions,
   DummyComponent,
@@ -68,5 +68,22 @@ describe("<ColorModeProvider />", () => {
     userEvent.click(button)
 
     expect(getColorModeButton()).toHaveTextContent(value)
+  })
+
+  test("prefixes body classname using cssVarPrefix", () => {
+    const cssVarPrefix = "arkahc"
+
+    render(
+      <ColorModeProvider options={{ ...defaultThemeOptions, cssVarPrefix }}>
+        <DummyComponent />
+      </ColorModeProvider>,
+    )
+    const button = getColorModeButton()
+
+    expect(document.body).toHaveClass(`${cssVarPrefix}-${button.textContent}`)
+
+    userEvent.click(button)
+
+    expect(document.body).toHaveClass(`${cssVarPrefix}-${button.textContent}`)
   })
 })

--- a/packages/color-mode/test/color-mode-provider__browser.test.tsx
+++ b/packages/color-mode/test/color-mode-provider__browser.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { render } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import {
   mockIsBrowser,
   createMockStorageManager,
@@ -8,7 +9,7 @@ import {
   DummyComponent,
 } from "./utils"
 import * as colorModeUtils from "../src/color-mode.utils"
-import userEvent from "@testing-library/user-event"
+import { ColorModeProvider } from "../src"
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -17,8 +18,6 @@ beforeEach(() => {
 
 describe("<ColorModeProvider /> localStorage browser", () => {
   test("by default, picks from theme.config.initialColorMode", () => {
-    const { ColorModeProvider } = require("../src/color-mode-provider")
-
     render(
       <ColorModeProvider options={defaultThemeOptions}>
         <DummyComponent />
@@ -31,7 +30,6 @@ describe("<ColorModeProvider /> localStorage browser", () => {
   })
 
   test("prefers useSystemColorMode over root property", () => {
-    const { ColorModeProvider } = require("../src/color-mode-provider")
     const getColorSchemeSpy = jest
       .spyOn(colorModeUtils, "getColorScheme")
       .mockReturnValueOnce("dark")
@@ -57,9 +55,7 @@ describe("<ColorModeProvider /> localStorage browser", () => {
     )
   })
 
-  test("prefers root property over localStorage", () => {
-    const { ColorModeProvider } = require("../src/color-mode-provider")
-
+  test("prefers localStorage over initial color mode and root value", () => {
     const rootGetSpy = jest
       .spyOn(colorModeUtils.root, "get")
       // @ts-expect-error only happens if value doesn't exist, e.g. CSR
@@ -85,11 +81,11 @@ describe("<ColorModeProvider /> localStorage browser", () => {
     expect(getColorModeButton()).not.toHaveTextContent(
       defaultThemeOptions.initialColorMode,
     )
+
+    expect(getColorModeButton()).toHaveTextContent("dark")
   })
 
   test("onChange sets value to all listeners", () => {
-    const { ColorModeProvider } = require("../src/color-mode-provider")
-
     const rootSet = jest.spyOn(colorModeUtils.root, "set")
 
     const mockLocalStorageManager = createMockStorageManager("localStorage")
@@ -120,8 +116,6 @@ describe("<ColorModeProvider /> localStorage browser", () => {
 
 describe("<ColorModeProvider /> cookie browser", () => {
   test("by default, picks from cookie", () => {
-    const { ColorModeProvider } = require("../src/color-mode-provider")
-
     const getColorSchemeSpy = jest
       .spyOn(colorModeUtils, "getColorScheme")
       .mockReturnValueOnce("dark")
@@ -145,8 +139,6 @@ describe("<ColorModeProvider /> cookie browser", () => {
   })
 
   test("onChange sets value to all listeners", () => {
-    const { ColorModeProvider } = require("../src/color-mode-provider")
-
     const rootSet = jest.spyOn(colorModeUtils.root, "set")
 
     const mockCookieStorageManager = createMockStorageManager("cookie")

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -9,7 +9,7 @@ import {
 import * as CSS from "csstype"
 import { expandResponsive } from "./expand-responsive"
 import { Config, PropConfig } from "./prop-config"
-import { pseudoSelectors } from "./pseudos"
+import { getPrefixedPseudoSelectors } from "./pseudos"
 import { systemProps as systemPropConfigs } from "./system"
 import { CssTheme, StyleObjectOrFn } from "./types"
 
@@ -142,7 +142,7 @@ export function getCss(options: GetCSSOptions) {
 export const css = (styles: StyleObjectOrFn) => (theme: any) => {
   const cssFn = getCss({
     theme,
-    pseudos: pseudoSelectors,
+    pseudos: getPrefixedPseudoSelectors(theme),
     configs: systemPropConfigs,
   })
   return cssFn(styles)

--- a/packages/styled-system/src/pseudos.ts
+++ b/packages/styled-system/src/pseudos.ts
@@ -221,8 +221,26 @@ export const pseudoSelectors = {
    * this component or element.
    */
   _dark: ".dark &, [data-theme=dark] &",
+  /**
+   * Styles for when `.light` is applied to any parent of
+   * this component or element.
+   */
+  _light: ".light &, [data-theme=light] &",
 }
 
 export type Pseudos = typeof pseudoSelectors
+
+export const getPrefixedPseudoSelectors = (theme: any) => {
+  const prefix = theme?.config?.cssVarPrefix ?? ""
+  return {
+    ...pseudoSelectors,
+    _dark: `.${applyPrefix("dark", prefix)} &, [data-theme=dark] &`,
+    _light: `.${applyPrefix("light", prefix)} &, [data-theme=light] &`,
+  }
+}
+
+// TODO: extract this into an appropriate utils file
+const applyPrefix = (value: string, prefix = "", separator = "-") =>
+  `${[prefix, value].filter(Boolean).join(separator)}`
 
 export const pseudoPropNames = objectKeys(pseudoSelectors)

--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -1,5 +1,14 @@
 import { SystemStyleObject } from "@chakra-ui/system"
-import { Dict, runIfFn } from "@chakra-ui/utils"
+import {
+  Dict,
+  runIfFn,
+  isArray,
+  isNotEmptyObject,
+  isNumber,
+  isString,
+  mergeWith,
+  split,
+} from "@chakra-ui/utils"
 
 export interface StyleConfig {
   baseStyle?: SystemStyleObject
@@ -39,6 +48,151 @@ export type Styles = GlobalStyles & JSXElementStyles
 
 export function mode(light: any, dark: any) {
   return (props: Dict) => (props.colorMode === "dark" ? dark : light)
+}
+
+/* 
+Some quick attempt at replicating `mode` but using `_dark` pseudo prop
+This code is pretty rough but it gives a general idea 
+*/
+interface DarkStylesDict {
+  [key: string]: any[] | string | number | DarkStylesDict
+}
+
+/**
+ * Pass a 2-tuple to use the first value as the light theme and second value as dark theme style
+ * i.e. you could pass something like:
+ * ```
+ * {
+ *  color: ["teal.600", "teal.300"],
+ * _hover: {
+ *    color: ["teal.800", "teal.400"]
+ *  }
+ * padding: 24
+ * }
+ * ```
+ *
+ *
+ * --- Note ---
+ * I tried to make the API accept a 2-tuple since it seems clean, but it might clash with the responsive style array syntax...
+ * So this might have to be changed to look like
+ *
+ * ```
+ * {
+ *  color: {light: "teal.600", dark: "teal.300"},
+ * _hover: {
+ *    color: {light: "teal.800", dark: "teal.400"}
+ *  }
+ * padding: 24
+ * }
+ * ```
+ */
+export function modeCssNested(styles: DarkStylesDict) {
+  return Object.entries(styles).reduce(reducerFnNested, { _dark: {} })
+}
+
+export function modeCssGrouped(styles: DarkStylesDict) {
+  return Object.entries(styles).reduce(reducerFnGrouped, { _dark: {} })
+}
+
+/**
+ * Nests `_dark` styles exactly as they are passed, so they could be children of other selectors such as `_hover`
+ * This is implemented in the `solid` button
+ *
+ * i.e.
+ * ```
+ * {
+ *  color: ["teal.600", "teal.300"],
+ *  _hover: {
+ *    color: ["teal.800", "teal.400"]
+ *  },
+ *  padding: 4,
+ * }
+ *
+ *
+ * becomes
+ * ```
+ * {
+ *  color: "teal.600"
+ *  _dark: "teal.300",
+ *  _hover: {
+ *    color: "teal.800",
+ *    _dark: "teal.400"
+ *  },
+ *  padding: 4,
+ * }
+ */
+const reducerFnNested = (
+  acc: Dict & { _dark: Dict },
+  [key, value]: [string, any[] | string | number | DarkStylesDict],
+) => {
+  if (isString(value) || isNumber(value)) {
+    acc[key] = value
+  } else if (isArray(value) && value.length > 0) {
+    if (value[0] != null) acc[key] = value[0]
+    if (value[1] != null) acc._dark[key] = value[1]
+  } else if (isNotEmptyObject(value)) {
+    acc[key] = mergeWith(
+      acc[key] || {},
+      Object.entries(value).reduce(reducerFnNested, { _dark: {} }),
+    )
+  }
+  return acc
+}
+
+/**
+ * Groups all _dark styles into a single parent object, no matter how they're passed
+ * This is implemented in the `ghost` button
+ *
+ * i.e.
+ * ```
+ * {
+ *  color: ["teal.600", "teal.300"],
+ *  _hover: {
+ *    color: ["teal.800", "teal.400"]
+ *  },
+ *  padding: 4,
+ * }
+ *
+ *
+ * becomes
+ * ```
+ * {
+ *  color: "teal.600",
+ *  _hover: {
+ *    color: "teal.800"
+ *  },
+ *  _dark: {
+ *    color: "teal.300",
+ *    _hover: {
+ *      color: "teal.400"
+ *    },
+ *  },
+ *  padding: 4,
+ * }
+ */
+const reducerFnGrouped = (
+  acc: Dict & { _dark: Dict },
+  [key, value]: [string, any[] | string | number | DarkStylesDict],
+) => {
+  if (isString(value) || isNumber(value)) {
+    acc[key] = value
+  } else if (isArray(value) && value.length > 0) {
+    // Take the first value in the tuple as the light theme style
+    // and the second value as the dark theme style
+    if (value[0] != null) acc[key] = value[0]
+    if (value[1] != null) acc._dark[key] = value[1]
+  } else if (isNotEmptyObject(value)) {
+    // Recursively reduce the nested object
+    const nestedValuesReduced = Object.entries(value).reduce(reducerFnGrouped, {
+      _dark: {},
+    })
+
+    // Lift up the dark styles to a single parent object
+    const [picked, omitted] = split(nestedValuesReduced, ["_dark"])
+    acc[key] = mergeWith(acc[key] || {}, omitted)
+    acc._dark[key] = mergeWith(acc._dark[key] || {}, picked._dark)
+  }
+  return acc
 }
 
 export function orient(options: {

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -1,4 +1,11 @@
-import { mode, transparentize } from "@chakra-ui/theme-tools"
+import {
+  modeCssNested,
+  modeCssGrouped,
+  mode,
+  transparentize,
+} from "@chakra-ui/theme-tools"
+import { mergeWith } from "@chakra-ui/utils"
+import isEqual from "react-fast-compare"
 
 type Dict = Record<string, any>
 
@@ -21,23 +28,26 @@ const baseStyle = {
   },
 }
 
+/* 
+In this example, I generate the dark mode styles all grouped at the top level
+*/
 function variantGhost(props: Dict) {
   const { colorScheme: c, theme } = props
 
   if (c === "gray") {
-    return {
-      color: mode(`inherit`, `whiteAlpha.900`)(props),
+    return modeCssGrouped({
+      color: ["inherit", `whiteAlpha.900`],
       _hover: {
-        bg: mode(`gray.100`, `whiteAlpha.200`)(props),
+        bg: [`gray.100`, `whiteAlpha.200`],
       },
-      _active: { bg: mode(`gray.200`, `whiteAlpha.300`)(props) },
-    }
+      _active: { bg: [`gray.200`, `whiteAlpha.300`] },
+    })
   }
 
   const darkHoverBg = transparentize(`${c}.200`, 0.12)(theme)
   const darkActiveBg = transparentize(`${c}.200`, 0.24)(theme)
 
-  return {
+  /* const oldStyles = {
     color: mode(`${c}.600`, `${c}.200`)(props),
     bg: "transparent",
     _hover: {
@@ -46,17 +56,56 @@ function variantGhost(props: Dict) {
     _active: {
       bg: mode(`${c}.100`, darkActiveBg)(props),
     },
+  } */
+
+  // If we were to manually write out the styles
+  const newStylesManual = {
+    color: `${c}.600`,
+    bg: "transparent",
+    _hover: {
+      bg: `${c}.50`,
+    },
+    _active: {
+      bg: `${c}.100`,
+    },
+    _dark: {
+      color: `${c}.200`,
+      _hover: { bg: darkHoverBg },
+      _active: { bg: darkActiveBg },
+    },
   }
+
+  // If we generate the new styles using syntax that looks very close to the previous use of `mode`
+  const newStylesCalculated = modeCssGrouped({
+    color: [`${c}.600`, `${c}.200`],
+    bg: "transparent",
+    _hover: { bg: [`${c}.50`, darkHoverBg] },
+    _active: { bg: [`${c}.100`, darkActiveBg] },
+  })
+
+  // The generated styles object should be equivalent to the manually written one
+  // console.log("Compare ghost:", newStylesManual, newStylesCalculated)
+  console.log(
+    "Are ghost manual and generated styles equal:",
+    isEqual(newStylesManual, newStylesCalculated),
+  )
+
+  return newStylesManual
 }
 
 function variantOutline(props: Dict) {
   const { colorScheme: c } = props
-  const borderColor = mode(`gray.200`, `whiteAlpha.300`)(props)
-  return {
-    border: "1px solid",
-    borderColor: c === "gray" ? borderColor : "currentColor",
-    ...variantGhost(props),
-  }
+
+  return mergeWith(
+    {
+      border: "1px solid",
+      borderColor: c === "gray" ? `gray.200` : "currentColor",
+      _dark: {
+        borderColor: c === "gray" ? `whiteAlpha.300` : "currentColor",
+      },
+    },
+    variantGhost(props),
+  )
 }
 
 type AccessibleColor = {
@@ -82,22 +131,25 @@ const accessibleColorMap: { [key: string]: AccessibleColor } = {
   },
 }
 
+/* 
+In this example, I generate the dark mode styles nested in other selectors like _hover
+*/
 function variantSolid(props: Dict) {
   const { colorScheme: c } = props
 
   if (c === "gray") {
-    const bg = mode(`gray.100`, `whiteAlpha.200`)(props)
+    const bg = [`gray.100`, `whiteAlpha.200`]
 
-    return {
+    return modeCssNested({
       bg,
       _hover: {
-        bg: mode(`gray.200`, `whiteAlpha.300`)(props),
+        bg: [`gray.200`, `whiteAlpha.300`],
         _disabled: {
           bg,
         },
       },
-      _active: { bg: mode(`gray.300`, `whiteAlpha.400`)(props) },
-    }
+      _active: { bg: [`gray.300`, `whiteAlpha.400`] },
+    })
   }
 
   const {
@@ -107,9 +159,9 @@ function variantSolid(props: Dict) {
     activeBg = `${c}.700`,
   } = accessibleColorMap[c] || {}
 
-  const background = mode(bg, `${c}.200`)(props)
+  const background = [bg, `${c}.200`]
 
-  return {
+  /*  const oldStyle = {
     bg: background,
     color: mode(color, `gray.800`)(props),
     _hover: {
@@ -119,7 +171,42 @@ function variantSolid(props: Dict) {
       },
     },
     _active: { bg: mode(activeBg, `${c}.400`)(props) },
+  } */
+
+  // If we were to manually write out the styles
+  const newStylesManual = {
+    bg,
+    color,
+    _dark: { bg: `${c}.200`, color: `gray.800` },
+    _hover: {
+      bg: hoverBg,
+      _dark: { bg: `${c}.300` },
+      _disabled: { bg, _dark: { bg: `${c}.200` } },
+    },
+    _active: { bg: activeBg, _dark: { bg: `${c}.400` } },
   }
+
+  // If we generate the new styles using syntax that looks very close to the previous use of `mode`
+  const newStylesCalculated = modeCssNested({
+    bg: background,
+    color: [color, `gray.800`],
+    _hover: {
+      bg: [hoverBg, `${c}.300`],
+      _disabled: {
+        bg: background,
+      },
+    },
+    _active: { bg: [activeBg, `${c}.400`] },
+  })
+
+  // The generated styles object should be equivalent to the manually written one
+  // console.log("Compare Solid:", newStylesManual, newStylesCalculated)
+  console.log(
+    "Are solid manual and generated styles equal:",
+    isEqual(newStylesManual, newStylesCalculated),
+  )
+
+  return newStylesCalculated
 }
 
 function variantLink(props: Dict) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes N/A (I can make an issue to track this if desired)

## 📝 Description

I've been tinkering around with Chakra's color mode and I saw some comments on migrating component styles to use CSS for dark theming rather than javaScript (`mode` and context). I took an initial stab at doing this to see what the changes would look like!

The idea is to change the component styles to rely on the `body` class `chakra-ui-dark` (selected via `_dark` pseudo prop). This will not only improve performance, but hopefully also help minimize the dark mode "flashing" that occurs. These initial PoC changes are based on:
* https://github.com/chakra-ui/chakra-ui/commit/ff7c36764650dc7f01957c417eae1ec8ce356495
* https://github.com/chakra-ui/chakra-ui/pull/3727#issuecomment-813310418

So far...
* I've implemented a quick PoC of what this would look like by migrating the styles in a single file (`Button`). I tried two different ways of nesting the `_dark` selectors, they have different impact on how a user would style a component using style props. I did my best to [illustrate the difference in a CodeSandbox](https://codesandbox.io/s/create-react-app-ts-forked-g1qq3?file=/src/App.tsx), would love for some feedback on what is preferred!
* I also adjusted `pseudoSelectors` to take in a prefix for the class name. I thought this might make it more customizable, for example if a user wanted to select `.myapp-dark` rather than `.chakra-ui-dark`. But if this isn't desired, can definitely revert this.
* I'd love some initial thoughts on the API and changes so far, if it looks ok I can maybe go ahead with migrating more of the styles!

## ⛳️ Current behavior (updates)

Component themes have light/dark styling using JS (the `mode` function and React context from `ColorModeProvider`)

## 🚀 New behavior

Component themes use `_dark` pseudo prop (selects `body.chakra-dark`) for dark theme styling

## 💣 Is this a breaking change (Yes/No):

No, but it would be a huge change as we would rewrite all the component theme files

## 📝 Additional Information

* Testing such a change would be pretty challenging, not sure if there's anything in place for theming — this might be a case where Storybook screenshots test could be super valuable? 

High-level todo list for this looks something like:

- [ ] Get feedback/verify API of `_dark` selector nesting [(relevant Sandbox)](https://codesandbox.io/s/create-react-app-ts-forked-g1qq3?file=/src/App.tsx)
- [ ] Get feedback/verify API of using `cssVarPrefix` in `pseudos` 
- [ ] Migrate all component styles
- [ ] Test test test everything
- [ ] Update docs

Support for `_dark` was added in https://github.com/chakra-ui/chakra-ui/commit/d189ae5020d5e72a252e0c59d681617c190bd0ab