### PR TITLE
fix: export `usePopoverContext`

### DIFF
--- a/.changeset/forty-kids-exercise.md
+++ b/.changeset/forty-kids-exercise.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/popover": major
+"@chakra-ui/popover": minor
 ---
 
 Add an export for `usePopoverContext` hook

--- a/.changeset/forty-kids-exercise.md
+++ b/.changeset/forty-kids-exercise.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popover": major
+---
+
+Add an export for `usePopoverContext` hook

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -17,6 +17,8 @@ import { PopoverProvider, usePopoverContext } from "./popover-context"
 import { PopoverTransition, PopoverTransitionProps } from "./popover-transition"
 import { usePopover, UsePopoverProps } from "./use-popover"
 
+export { usePopoverContext }
+
 export interface PopoverProps extends UsePopoverProps, ThemingProps<"Popover"> {
   /**
    * The content of the popover. It is usually the `PopoverTrigger`,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3899

## 📝 Description

The fix was a simple line and could be done just exporting the `usePopoverContext` hook that was already imported in the modified file.

## ⛳️ Current behavior (updates)

After [this changes](https://github.com/chakra-ui/chakra-ui/pull/3733/files#diff-90c4d042a18f8ae178e87611b561c7b86ddd6029b77d35b98b30f153dbe2a1f6L48), the `usePopoverContext` hook could not be imported from `@chakra-ui/react` anymore.

## 🚀 New behavior

Now should be possible to import the `usePopoverContext` hook from `@chakra-ui/react` normally.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

--