### PR TITLE
fix(theme-textarea): disable transition height/width for textarea

### DIFF
--- a/packages/theme/src/components/textarea.ts
+++ b/packages/theme/src/components/textarea.ts
@@ -7,6 +7,11 @@ const baseStyle = {
   paddingY: "8px",
   minHeight: "80px",
   lineHeight: "short",
+  transition: [
+    ...Input.baseStyle.field.transition.split(","),
+    "height 0s",
+    "width 0s",
+  ].join(","),
 }
 
 const variants = {


### PR DESCRIPTION
## 📝 Description

Since `Input.baseStyle.field.transition` is `"all 0.2s"`, resizing the Textarea component feels sluggish because of the animation delay. We can exclude the height and width from transition by appending `"height 0s, width 0s"`.

## ⛳️ Current behavior (updates)

Resizing the Textarea component feels sluggish (can be checked in the [official docs](https://chakra-ui.com/docs/form/textarea)).

## 🚀 New behavior

Resizing the Textarea component is fast

## 💣 Is this a breaking change (Yes/No):

No for most use cases, but if the Textarea is resized via script (e.g. setting CSS `height: 10rem`) it will lose the smooth transition. A quick fix would be to restore the original value in theme:

```js
{
  Transition: {
    baseStyle: {
      transition: "all 0.2s"
    }
  }
}
```

## 📝 Additional Information

I am unsure if this is a proper fix for the issue. A couple of alternatives:

- We can just add note about resizing in the documentation.
- We can add more detailed handling in component-level, including adding a new prop and only disable the animation if `resize` is not `none`.

~~Also, I haven't tested this in the storybook because I encounter this error when running `yarn storybook` (Ubuntu 20.04 WSL, Node v14/v15, yarn 1.22.10):~~ Vercel preview looks okay

```
ModuleBuildError: Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module '/home/tkesgar/workspace/chakra-ui/node_modules/@chakra-ui/babel-plugin/dist/index.js'. Please verify that the package.json has a valid "main" entry
```

~~Any help would be appreciated 🙏~~