### PR TITLE
feat(utils): add return value typings for `pipe`

### DIFF
--- a/.changeset/kind-rocks-kick.md
+++ b/.changeset/kind-rocks-kick.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/utils": minor
+---
+
+Add types for the return value of `pipe` function

--- a/packages/utils/src/function.ts
+++ b/packages/utils/src/function.ts
@@ -77,9 +77,8 @@ export const scheduleMicrotask = __TEST__
   ? queueMicrotask
   : promiseMicrotask
 
-const combineFunctions = (a: Function, b: Function) => (v: any) => b(a(v))
-export const pipe = (...transformers: Function[]) =>
-  transformers.reduce(combineFunctions)
+export const pipe = <R>(...fns: Array<(a: R) => R>) => (v: R) =>
+  fns.reduce((a, b) => b(a), v)
 
 const distance1D = (a: number, b: number) => Math.abs(a - b)
 type Point = { x: number; y: number }


### PR DESCRIPTION
Closes #3920 

## 📝 Description

This PR adds types to the return value of `pipe`. This helps resolving the return value typings of `extendTheme` .

## ⛳️ Current behavior (updates)

Return type of `pipe` is `any`

## 🚀 New behavior

Return type of `pipe` is the combination of all function argument result types.

## 💣 Is this a breaking change (Yes/No):

No
