### PR TITLE
fix(toast): set maxWidth on container component

### DIFF
--- a/.changeset/shy-clouds-smash.md
+++ b/.changeset/shy-clouds-smash.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+limit title and description width to the width of the toast message.

--- a/.changeset/shy-clouds-smash.md
+++ b/.changeset/shy-clouds-smash.md
@@ -2,4 +2,4 @@
 "@chakra-ui/toast": patch
 ---
 
-limit title and description width to the width of the toast message.
+Resolved an issue where `overflowX` couldn't be used within a toast's `title` or `description` by adding `maxWidth="100%"` to the containing `div`.

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -89,7 +89,7 @@ const Toast: React.FC<any> = (props) => {
       width="auto"
     >
       <AlertIcon />
-      <chakra.div flex="1">
+      <chakra.div flex="1" maxWidth="100%">
         {title && <AlertTitle>{title}</AlertTitle>}
         {description && (
           <AlertDescription display="block">{description}</AlertDescription>


### PR DESCRIPTION


## 📝 Description

I noticed that showing a toast with content that is bigger than the toast maximum width is cut-off. Instead, I expected the child elements to respect the width of the toast.

```tsx
toast({
  title: `Error while evaluating template`,
  description: (
    <Code
      overflowX="scroll"
      display="block"
      whiteSpace="pre"
      children={result.chatMessageCreate.error.reason}
    />
  ),
  status: "error",
  duration: null,
  isClosable: true,
  position: "top"
});
```

## ⛳️ Current behavior (updates)

![image](https://user-images.githubusercontent.com/14338007/116780967-1cc2db00-aa80-11eb-89cd-aee9d27fd26c.png)

Reproduction on CodeSandbox: https://codesandbox.io/s/beautiful-cache-1yc6d?file=/src/index.tsx:576-2422

No overflow-x scroll bar possible 😢 

## 🚀 New behavior

![image](https://user-images.githubusercontent.com/14338007/116780984-3ebc5d80-aa80-11eb-9b95-b6342f5f5503.png)

overflow-x is possible, as child elements cannot be bigger than the max-width of the toast ✅

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
