### PR TITLE
fix(cli): silent failure

### DIFF
--- a/.changeset/slow-jokes-arrive.md
+++ b/.changeset/slow-jokes-arrive.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/cli": minor
+---
+
+Fixes issues with `tokens` command hanging forever if theme workers run into
+errors during runtime. Now when an error is discovered within a worker an
+`{ err: string }` object is passed to the parent which will cause the promise to
+reject. This will in turn, pass the same `err` upwards to allow the command to
+exit gracefully, printing the `err` in question to `stdout`

--- a/.changeset/slow-jokes-arrive.md
+++ b/.changeset/slow-jokes-arrive.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/cli": minor
+"@chakra-ui/cli": patch
 ---
 
 Fixes issues with `tokens` command hanging forever if theme workers run into

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -8,6 +8,8 @@ import {
   themeInterfaceDestination,
 } from "./resolve-output-path"
 
+type ErrorRecord = Record<"err", string>
+
 const writeFileAsync = promisify(writeFile)
 
 async function runTemplateWorker({
@@ -25,13 +27,11 @@ async function runTemplateWorker({
   )
 
   return new Promise((resolve, reject) => {
-    worker.on("message", (message: Record<"err", string> | Serializable) => {
-      const errMessage = (message as Record<"err", string>)?.err
+    worker.on("message", (message: ErrorRecord | Serializable) => {
+      const errMessage = (message as ErrorRecord)?.err
 
       if (errMessage) {
-        const error = new Error(errMessage)
-        reject(error)
-        throw error
+        reject(new Error(errMessage))
       }
 
       return resolve(String(message))

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -43,6 +43,10 @@ async function run() {
 }
 
 run().catch((e) => {
-  process.stderr.write(e.message)
+  if (process.send) {
+    process.send({ err: e.toString() })
+  } else {
+    process.stderr.write(e.message)
+  }
   process.exit(1)
 })


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3940 <!-- Github issue # here -->

## 📝 Description

Passes error messages from forked worker up to parent allowing the cli command to fail

## ⛳️ Current behavior (updates)

- `read-theme.worker` Will write errors to `stderr` but not send a message back to the parent process causing the parent to not handle worker errors, making script hang forever
- `runTemplateWorker` does not support handling errors a `ChildProcess` encounters (message needs to be passed)

## 🚀 New behavior

- An error message will be passed to the `parent` in the shape of `{ err: errMessage }`
- `runTemplateWorker` will check if the message matches the error shape if it does the promise will reject, passing the error message along

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
