### PR TITLE
Fix a mistake in the Getting Started documentation

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -32,11 +32,11 @@ import * as React from "react"
 // 1. import `ChakraProvider` component
 import { ChakraProvider } from "@chakra-ui/react"
 
-function App() {
+function App({ Component }) {
   // 2. Use at the root of your app
   return (
     <ChakraProvider>
-      <App />
+      <Component />
     </ChakraProvider>
   )
 }
@@ -127,10 +127,10 @@ const colors = {
 const theme = extendTheme({ colors })
 
 // 3. Pass the `theme` prop to the `ChakraProvider`
-function App() {
+function App({ Component }) {
   return (
     <ChakraProvider theme={theme}>
-      <App />
+      <Component />
     </ChakraProvider>
   )
 }


### PR DESCRIPTION
The `App` component was returning itself in two sections of this page. This is incorrect, as it would create an infinite compilation loop
