### PR TITLE
chore: speed up test runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,4 @@ jobs:
         run: yarn lint
 
       - name: Run tests
-        run: yarn test
-
-      - name: Run tests (ci)
         run: yarn test:ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Run tests
         run: yarn test
+
+      - name: Run tests (ci)
+        run: yarn test:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: yarn build:templates ../cra-templates
 
       - name: Run tests
-        run: yarn test
+        run: yarn test:ci
 
       - name: Publish packages
         uses: changesets/action@master

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,12 @@
 module.exports = {
   preset: "ts-jest",
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  modulePathIgnorePatterns: [
+    "<rootDir>/website/.cache",
+    "<rootDir>/examples",
+    "<rootDir>/tooling/cra-template*",
+  ],
   transform: {
     "^.+\\.(ts|tsx)?$": "ts-jest/dist",
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prebuild": "yarn pkg babel-plugin build",
     "build": "lerna run build --ignore @chakra-ui/test-utils --no-private --stream",
     "build:templates": "ts-node -T scripts/build-templates.ts",
-    "test": "jest",
+    "test": "jest --maxWorkers=50%",
     "lint": "lerna run lint --no-private --stream",
     "lint:types": "lerna run lint:types --no-private --stream",
     "prestorybook": "rimraf node_modules/.cache/storybook",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build": "lerna run build --ignore @chakra-ui/test-utils --no-private --stream",
     "build:templates": "ts-node -T scripts/build-templates.ts",
     "test": "jest --maxWorkers=50%",
+    "test:ci": "jest --runInBand",
     "lint": "lerna run lint --no-private --stream",
     "lint:types": "lerna run lint:types --no-private --stream",
     "prestorybook": "rimraf node_modules/.cache/storybook",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prebuild": "yarn pkg babel-plugin build",
     "build": "lerna run build --ignore @chakra-ui/test-utils --no-private --stream",
     "build:templates": "ts-node -T scripts/build-templates.ts",
-    "test": "lerna run test --no-private --stream",
+    "test": "jest",
     "lint": "lerna run lint --no-private --stream",
     "lint:types": "lerna run lint:types --no-private --stream",
     "prestorybook": "rimraf node_modules/.cache/storybook",

--- a/packages/styled-system/tests/interpolation.test.ts
+++ b/packages/styled-system/tests/interpolation.test.ts
@@ -9,7 +9,7 @@ test("should handle array interpolations", () => {
     xl: "70em",
   })
 
-  // @ts-expect-error "&" is technically disallowed
+  // @ts-ignore
   const result = css({ "&": [{ bg: "red" }, { bg: "green" }] })(
     toCSSVar({
       breakpoints: customBreakpoints,


### PR DESCRIPTION
## 📝 Description

This PR greatly improves `test` speed. 

- dropped `lerna run` in favor of a single `jest` process
- changed `test` script to `jest --maxWorkers=50%` which makes local runs even faster
- created `test:ci` script which runs `jest --runInBand`

## ⛳️ Current behavior (updates)

Local tests take multiple minutes to run. CI tests takes 6-8 minutes to run.

## 🚀 New behavior

Local tests take less than a minute to run. CI tests take 1-3 minutes to run.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
