### PR TITLE
fix: ChakraProvider `cssVarsRoot` & usage in shadow dom

### DIFF
--- a/.changeset/long-taxis-flow.md
+++ b/.changeset/long-taxis-flow.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+`ChakraProvider` now accepts the prop `cssVarsRoot` which defaults to
+`:host, :root`.

--- a/.changeset/nice-days-help.md
+++ b/.changeset/nice-days-help.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/system": patch
+---
+
+Attach CSS vars to `:host, :root` to fix usage in shadow dom.

--- a/packages/react/src/chakra-provider.tsx
+++ b/packages/react/src/chakra-provider.tsx
@@ -5,6 +5,7 @@ import {
   ColorModeProviderProps,
   GlobalStyle,
   ThemeProvider,
+  ThemeProviderProps,
 } from "@chakra-ui/system"
 import defaultTheme from "@chakra-ui/theme"
 import { Dict } from "@chakra-ui/utils"
@@ -14,7 +15,8 @@ import {
 } from "@chakra-ui/react-env"
 import * as React from "react"
 
-export interface ChakraProviderProps {
+export interface ChakraProviderProps
+  extends Pick<ThemeProviderProps, "cssVarsRoot"> {
   /**
    * a theme. if omitted, uses the default theme provided by chakra
    */
@@ -67,11 +69,12 @@ export const ChakraProvider = (props: ChakraProviderProps) => {
     resetCSS = true,
     theme = defaultTheme,
     environment,
+    cssVarsRoot,
   } = props
 
   return (
     <EnvironmentProvider environment={environment}>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme} cssVarsRoot={cssVarsRoot}>
         <ColorModeProvider
           colorModeManager={colorModeManager}
           options={theme.config}

--- a/packages/system/src/providers.tsx
+++ b/packages/system/src/providers.tsx
@@ -19,13 +19,13 @@ import * as React from "react"
 export interface ThemeProviderProps extends EmotionThemeProviderProps {
   /**
    * The element to attach the CSS custom properties to.
-   * @default ":root"
+   * @default ":host, :root"
    */
   cssVarsRoot?: string
 }
 
 export const ThemeProvider = (props: ThemeProviderProps) => {
-  const { cssVarsRoot = ":root", theme, children } = props
+  const { cssVarsRoot = ":host, :root", theme, children } = props
   const computedTheme = React.useMemo(() => toCSSVar(theme), [theme])
   return (
     <EmotionThemeProvider theme={computedTheme}>


### PR DESCRIPTION
Closes #2145

## 📝 Description

Forwarding `cssVarsRoot` and updated its default value to `:host, :root`.

## ⛳️ Current behavior (updates)

Only `ThemeProvider` accepts the prop `cssVarsRoot`. 

## 🚀 New behavior

`ChakraProvider` forwards the prop to `ThemeProvider`.
The default `cssVarsRoot` is updated to `:host, :root` to allow usage of Chakra UI in the shadow dom.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
