### PR TITLE
feat: append functional baseStyle 

### DIFF
--- a/.changeset/shy-geese-think.md
+++ b/.changeset/shy-geese-think.md
@@ -1,0 +1,19 @@
+---
+"@chakra-ui/system": minor
+---
+
+The `styled` function allows a functional `baseStyle` property:
+
+```js
+import { styled } from '@chakra-ui/react'
+
+const MyComponent = styled('div', { 
+  baseStyle: (props) => ({ 
+    bg: props.highlightColor 
+  })
+})
+
+// ...
+
+<MyComponent highlightColor="red.500" />
+```

--- a/packages/system/src/system.ts
+++ b/packages/system/src/system.ts
@@ -4,7 +4,7 @@ import {
   StyleProps,
   SystemStyleObject,
 } from "@chakra-ui/styled-system"
-import { objectFilter } from "@chakra-ui/utils"
+import { objectFilter, runIfFn } from "@chakra-ui/utils"
 import _styled, { CSSObject, FunctionInterpolation } from "@emotion/styled"
 import { shouldForwardProp } from "./should-forward-prop"
 import { As, ChakraComponent, ChakraProps, PropsOf } from "./system.types"
@@ -19,7 +19,9 @@ type StyleResolverProps = SystemStyleObject & {
 
 interface GetStyleObject {
   (options: {
-    baseStyle?: SystemStyleObject
+    baseStyle?:
+      | SystemStyleObject
+      | ((props: StyleResolverProps) => SystemStyleObject)
   }): FunctionInterpolation<StyleResolverProps>
 }
 
@@ -39,7 +41,8 @@ interface GetStyleObject {
 export const toCSSObject: GetStyleObject = ({ baseStyle }) => (props) => {
   const { theme, css: cssProp, __css, sx, ...rest } = props
   const styleProps = objectFilter(rest, (_, prop) => isStyleProp(prop))
-  const finalStyles = Object.assign({}, __css, baseStyle, styleProps, sx)
+  const finalBaseStyle = runIfFn(baseStyle, props)
+  const finalStyles = Object.assign({}, __css, finalBaseStyle, styleProps, sx)
   const computedCSS = css(finalStyles)(props.theme)
   return cssProp ? [computedCSS, cssProp] : computedCSS
 }
@@ -47,7 +50,9 @@ export const toCSSObject: GetStyleObject = ({ baseStyle }) => (props) => {
 interface StyledOptions {
   shouldForwardProp?(prop: string): boolean
   label?: string
-  baseStyle?: SystemStyleObject
+  baseStyle?:
+    | SystemStyleObject
+    | ((props: StyleResolverProps) => SystemStyleObject)
 }
 
 export function styled<T extends As, P = {}>(

--- a/packages/system/tests/style-resolver.test.ts
+++ b/packages/system/tests/style-resolver.test.ts
@@ -97,6 +97,19 @@ test("should resolve styles correctly", () => {
     ]
   `)
 })
+test("should resolve styles correctly", () => {
+  const result = toCSSObject({ baseStyle: (props) => ({ bg: props.color }) })({
+    theme,
+    color: "pink.300",
+  })
+
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "background": "var(--chakra-colors-pink-300)",
+      "color": "var(--chakra-colors-pink-300)",
+    }
+  `)
+})
 
 test("should override padding correctly", () => {
   const result = toCSSObject({})({


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

This PR append  `chakra` factory function enable functional `baseStyle` and use props.

```js
const CustomButton = chakra(Button, {
  baseStyle:  (props) => {
    bg: `${props.colorScheme}.200`,
    p: 10
  }
})
```

```js
<CustomButton colorScheme="red" />
```

I'm not very confident about the implementation. If this PR have any problems(implementations, design, or etc), please close this PR.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

`chakra` factory is not accept baseStyle as a function and we can't treat `props`.


## 🚀 New behavior

> Please describe the behavior or changes this PR adds

`chakra` factory can resolve functional baseStyle.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information

We can create custom component as normally, but sometimes those need `forwardRef`...

```js
// this component occur error when use refs.
const CustomButton: FC<ButtonProps> = (props) => <Button color={`${props.colorScheme}.100` {...props} />
```
```js
// and we need use forwardRef
const CustomButton: FC<ButtonProps> = forwardRef<ButtonProps, "button">((props, ref)  => <Button color={`${props.colorScheme}.100` {...props} /> )
```

Related discussion: https://github.com/chakra-ui/chakra-ui/discussions/3585
