### PR TITLE
fix: 'on this page' links to use lighter hover color in dark mode

### DIFF
--- a/website/src/components/table-of-content.tsx
+++ b/website/src/components/table-of-content.tsx
@@ -59,11 +59,13 @@ function TableOfContent(props: TableOfContentProps) {
             <chakra.a
               py="1"
               display="block"
-              _hover={{ color: "gray.900" }}
               fontWeight={id === activeId ? "bold" : "medium"}
               href={`#${id}`}
               aria-current={id === activeId ? "location" : undefined}
               color={useColorModeValue("gray.600", "gray.400")}
+              _hover={{
+                color: useColorModeValue("gray.900", "gray.600"),
+              }}
             >
               {text}
             </chakra.a>


### PR DESCRIPTION
## 📝 Description

Closes #3999.

Changed hover color to use a lighter color in dark mode, the color used is the same as in Header icons.

## ⛳️ Current behavior (updates)

Hover links in dark mode are too darker to read:

![ezgif-2-77814720b07b](https://user-images.githubusercontent.com/44916285/118213084-a3de5e80-b443-11eb-98c5-68dcfb692bf6.gif)

## 🚀 New behavior

Updated to use lighter color in dark mode:

![after](https://user-images.githubusercontent.com/44916285/118213161-c83a3b00-b443-11eb-9722-0526a6ed31ef.gif)

## 💣 Is this a breaking change (Yes/No): No
