### PR TITLE
fix(gatsby-plugin): Pass pluginOptions correctly

### DIFF
--- a/.changeset/twelve-planes-brush.md
+++ b/.changeset/twelve-planes-brush.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/gatsby-plugin": patch
+---
+
+Pass `pluginOptions` correctly to the `ChakraProvider`. Fixes https://github.com/chakra-ui/chakra-ui/issues/4014

--- a/tooling/gatsby-plugin/gatsby-browser.js
+++ b/tooling/gatsby-plugin/gatsby-browser.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { WrapRootElement } from "./src/provider"
 
-export const wrapRootElement = (props) => {
-  return <WrapRootElement {...props} />
+export const wrapRootElement = ({ element }, pluginOptions) => {
+  return <WrapRootElement element={element} {...pluginOptions} />
 }

--- a/tooling/gatsby-plugin/gatsby-ssr.js
+++ b/tooling/gatsby-plugin/gatsby-ssr.js
@@ -12,6 +12,6 @@ export const onRenderBody = ({ setPreBodyComponents }) => {
   ])
 }
 
-export const wrapRootElement = (props) => {
-  return <WrapRootElement {...props} />
+export const wrapRootElement = ({ element }, pluginOptions) => {
+  return <WrapRootElement element={element} {...pluginOptions} />
 }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/4014

## 📝 Description

In the last major update I introduced a little error as I didn't pass the `pluginOptions` correctly. It's always the second arg and just spreading `props` won't pass that to the provider component.

## ⛳️ Current behavior (updates)

`pluginOptions` isn't passed to the `ChakraProvider`

## 🚀 New behavior

Accessing the second arg from the `wrapRootElement` API to pass `pluginOptions` to the provider component.

## 💣 Is this a breaking change (Yes/No):

No
