### PR TITLE
fix(popper): perf regression for lazy init

### DIFF
--- a/.changeset/warm-llamas-trade.md
+++ b/.changeset/warm-llamas-trade.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/popper": minor
+"@chakra-ui/menu": patch
+"@chakra-ui/popover": patch
+"@chakra-ui/tooltip": patch
+---
+
+Add `isEnabled` option to `usePopper` hook. The `popper.js` instance will not be
+created until this option is true. `Menu`, `Popover` and `Tooltip` components
+now use this option, so the `popper.js` instance is created only once the popper
+is open. This should significantly improve render and scroll performance.

--- a/.changeset/warm-llamas-trade.md
+++ b/.changeset/warm-llamas-trade.md
@@ -5,7 +5,10 @@
 "@chakra-ui/tooltip": patch
 ---
 
-Add `isOpen` option to `usePopper` hook. The `popper.js` instance will not be
-created until this option is true. `Menu`, `Popover` and `Tooltip` components
-now use this option, so the `popper.js` instance is created only once the popper
-is open. This should significantly improve render and scroll performance.
+Add `enabled` option to `usePopper` hook.
+
+The `popper.js` instance will not be created until this option is `true`.
+
+`Menu`, `Popover` and `Tooltip` components now use this option, so the
+`popper.js` instance is created only once the popper is open. This should
+significantly improve render and scroll performance.

--- a/.changeset/warm-llamas-trade.md
+++ b/.changeset/warm-llamas-trade.md
@@ -5,7 +5,7 @@
 "@chakra-ui/tooltip": patch
 ---
 
-Add `isEnabled` option to `usePopper` hook. The `popper.js` instance will not be
+Add `isOpen` option to `usePopper` hook. The `popper.js` instance will not be
 created until this option is true. `Menu`, `Popover` and `Tooltip` components
 now use this option, so the `popper.js` instance is created only once the popper
 is open. This should significantly improve render and scroll performance.

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -157,7 +157,7 @@ export function useMenu(props: UseMenuProps = {}) {
    */
   const popper = usePopper({
     ...popperProps,
-    isEnabled: isOpen,
+    isOpen,
     placement,
   })
 

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -157,6 +157,7 @@ export function useMenu(props: UseMenuProps = {}) {
    */
   const popper = usePopper({
     ...popperProps,
+    isEnabled: isOpen,
     placement,
   })
 

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -157,7 +157,7 @@ export function useMenu(props: UseMenuProps = {}) {
    */
   const popper = usePopper({
     ...popperProps,
-    isOpen,
+    enabled: isOpen,
     placement,
   })
 

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -163,7 +163,7 @@ export function usePopover(props: UsePopoverProps = {}) {
     forceUpdate,
   } = usePopper({
     ...popperProps,
-    isEnabled: isOpen,
+    isOpen,
   })
 
   useFocusOnPointerDown({

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -163,7 +163,7 @@ export function usePopover(props: UsePopoverProps = {}) {
     forceUpdate,
   } = usePopper({
     ...popperProps,
-    isOpen,
+    enabled: isOpen,
   })
 
   useFocusOnPointerDown({

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -161,7 +161,10 @@ export function usePopover(props: UsePopoverProps = {}) {
     getPopperProps,
     getArrowInnerProps,
     forceUpdate,
-  } = usePopper(popperProps)
+  } = usePopper({
+    ...popperProps,
+    isEnabled: isOpen,
+  })
 
   useFocusOnPointerDown({
     enabled: isOpen,

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -13,7 +13,7 @@ import { cssVars, getEventListenerOptions } from "./utils"
 export type { Placement }
 
 export interface UsePopperProps {
-  isOpen?: boolean
+  enabled?: boolean
   /**
    * The main and cross-axis offset to displace popper element
    * from its reference element.
@@ -99,7 +99,7 @@ export type ArrowCSSVarProps = {
 
 export function usePopper(props: UsePopperProps = {}) {
   const {
-    isOpen = true,
+    enabled = true,
     modifiers = [],
     placement: placementProp = "bottom",
     strategy = "absolute",
@@ -120,7 +120,7 @@ export function usePopper(props: UsePopperProps = {}) {
   const cleanup = useRef(() => {})
 
   const setupPopper = useCallback(() => {
-    if (!isOpen || !reference.current || !popper.current) return
+    if (!enabled || !reference.current || !popper.current) return
 
     // If popper instance exists, destroy it so we can create a new one
     cleanup.current?.()
@@ -167,7 +167,7 @@ export function usePopper(props: UsePopperProps = {}) {
 
     cleanup.current = instance.current.destroy
   }, [
-    isOpen,
+    enabled,
     placementProp,
     modifiers,
     matchWidth,

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -13,7 +13,7 @@ import { cssVars, getEventListenerOptions } from "./utils"
 export type { Placement }
 
 export interface UsePopperProps {
-  isEnabled?: boolean
+  isOpen?: boolean
   /**
    * The main and cross-axis offset to displace popper element
    * from its reference element.
@@ -99,7 +99,7 @@ export type ArrowCSSVarProps = {
 
 export function usePopper(props: UsePopperProps = {}) {
   const {
-    isEnabled = true,
+    isOpen = true,
     modifiers = [],
     placement: placementProp = "bottom",
     strategy = "absolute",
@@ -120,7 +120,7 @@ export function usePopper(props: UsePopperProps = {}) {
   const cleanup = useRef(() => {})
 
   const setupPopper = useCallback(() => {
-    if (!isEnabled || !reference.current || !popper.current) return
+    if (!isOpen || !reference.current || !popper.current) return
 
     // If popper instance exists, destroy it so we can create a new one
     cleanup.current?.()
@@ -167,7 +167,7 @@ export function usePopper(props: UsePopperProps = {}) {
 
     cleanup.current = instance.current.destroy
   }, [
-    isEnabled,
+    isOpen,
     placementProp,
     modifiers,
     matchWidth,

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -13,6 +13,7 @@ import { cssVars, getEventListenerOptions } from "./utils"
 export type { Placement }
 
 export interface UsePopperProps {
+  isEnabled?: boolean
   /**
    * The main and cross-axis offset to displace popper element
    * from its reference element.
@@ -98,6 +99,7 @@ export type ArrowCSSVarProps = {
 
 export function usePopper(props: UsePopperProps = {}) {
   const {
+    isEnabled = true,
     modifiers = [],
     placement: placementProp = "bottom",
     strategy = "absolute",
@@ -118,7 +120,7 @@ export function usePopper(props: UsePopperProps = {}) {
   const cleanup = useRef(() => {})
 
   const setupPopper = useCallback(() => {
-    if (!reference.current || !popper.current) return
+    if (!isEnabled || !reference.current || !popper.current) return
 
     // If popper instance exists, destroy it so we can create a new one
     cleanup.current?.()
@@ -165,6 +167,7 @@ export function usePopper(props: UsePopperProps = {}) {
 
     cleanup.current = instance.current.destroy
   }, [
+    isEnabled,
     placementProp,
     modifiers,
     matchWidth,

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -97,7 +97,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
     getArrowInnerProps,
     getArrowProps,
   } = usePopper({
-    isOpen,
+    enabled: isOpen,
     placement,
     arrowPadding,
     modifiers,

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -97,6 +97,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
     getArrowInnerProps,
     getArrowProps,
   } = usePopper({
+    isEnabled: isOpen,
     placement,
     arrowPadding,
     modifiers,

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -97,7 +97,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
     getArrowInnerProps,
     getArrowProps,
   } = usePopper({
-    isEnabled: isOpen,
+    isOpen,
     placement,
     arrowPadding,
     modifiers,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes regression of https://github.com/chakra-ui/chakra-ui/pull/3343

Add `isOpen` option to `usePopper` hook. 
The `popper.js` instance will not be created until this option is true.
`Menu`, `Popover` and `Tooltip` components now use this option,
so the `popper.js` instance is created only once the popper is open.
This should significantly improve render and scroll performance.

## ⛳️ Current behavior (updates)

`popper.js` instance is created for every `Menu`/`Popper`/`Tooltip` instance, regardless of whether it is open.

## 🚀 New behavior

`popper.js` instance is only created once the popper is actually needed for positioning.

## 💣 Is this a breaking change (Yes/No):

No
