### PR TITLE
Support defaultBreakpoint for useBreakpiontValue()

### DIFF
--- a/.changeset/loud-radios-travel.md
+++ b/.changeset/loud-radios-travel.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/media-query": minor
+---
+
+`useBreakpointValue()` now supports receiving a `defaultBreakpoint` as the
+second argument to support SSR/SSG.

--- a/packages/media-query/src/use-breakpoint-value.ts
+++ b/packages/media-query/src/use-breakpoint-value.ts
@@ -7,13 +7,21 @@ import { useBreakpoint } from "./use-breakpoint"
  * React hook for getting the value for the current breakpoint from the
  * provided responsive values object.
  *
+ * @param values
+ * @param defaultBreakpoint default breakpoint name
+ * (in non-window environments like SSR)
+ *
+ * For SSR, you can use a package like [is-mobile](https://github.com/kaimallea/isMobile)
+ * to get the default breakpoint value from the user-agent
+ *
  * @example
  * const width = useBreakpointValue({ base: '150px', md: '250px' })
  */
 export function useBreakpointValue<T = any>(
   values: Record<string, T> | T[],
+  defaultBreakpoint?: string,
 ): T | undefined {
-  const breakpoint = useBreakpoint()
+  const breakpoint = useBreakpoint(defaultBreakpoint)
   const theme = useTheme()
 
   if (!breakpoint) return undefined

--- a/packages/media-query/tests/use-breakpoint-value.test.tsx
+++ b/packages/media-query/tests/use-breakpoint-value.test.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
 import { ThemeProvider } from "@chakra-ui/system"
 import { render, screen } from "@chakra-ui/test-utils"
 import MatchMediaMock from "jest-matchmedia-mock"
@@ -7,15 +8,15 @@ import { useBreakpointValue } from "../src"
 
 let matchMedia: any
 
-beforeAll(() => {
-  matchMedia = new MatchMediaMock()
-})
-
-afterEach(() => {
-  matchMedia.clear()
-})
-
 describe("with object", () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock()
+  })
+
+  afterEach(() => {
+    matchMedia.clear()
+  })
+
   const values = {
     base: "base",
     sm: "sm",
@@ -105,6 +106,14 @@ describe("with object", () => {
 })
 
 describe("with array", () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock()
+  })
+
+  afterEach(() => {
+    matchMedia.clear()
+  })
+
   const values = [
     "baseValue",
     "value2",
@@ -185,6 +194,97 @@ describe("with array", () => {
   })
 })
 
+describe("with defaultBreakpoint", () => {
+  // To clean up erroneous console warnings from react, we temporarliy force
+  // useLayoutEffect to behave like useEffect. Since neither can run in our SSR
+  // tests, it has no functional impact, but stops the huge console dumps that
+  // React causes.
+  let useLayoutEffect: typeof React.useLayoutEffect
+  beforeAll(() => {
+    useLayoutEffect = React.useLayoutEffect
+    React.useLayoutEffect = React.useEffect
+  })
+  afterAll(() => {
+    React.useLayoutEffect = useLayoutEffect
+  })
+
+  // NOTE: We do not setup matchMedia as we wish to simulate an SSR environment
+  const values = {
+    base: "base",
+    sm: "sm",
+    md: "md",
+    lg: "lg",
+    xl: "xl",
+    customBreakpoint: "customBreakpoint",
+  }
+
+  test("sm", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "sm")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "sm") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("md", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "md")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "md") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("lg", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "lg")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "lg") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("xl", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "xl")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "xl") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("customBreakpoint", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "customBreakpoint")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "customBreakpoint") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("base value is used if no breakpoint matches", () => {
+    const values = { base: "base", md: "md" }
+    const html = ssrRenderWithDefaultBreakpoint(values, "sm")
+    expect(html).toContain("base")
+  })
+})
+
 function renderWithQuery(values: any, query: string) {
   matchMedia.useMediaQuery(query)
   return render(
@@ -194,7 +294,24 @@ function renderWithQuery(values: any, query: string) {
   )
 }
 
-const TestComponent = ({ values }: { values: any }) => {
-  const value = useBreakpointValue(values)
+function ssrRenderWithDefaultBreakpoint(
+  values: any,
+  defaultBreakpoint: string,
+) {
+  return renderToStaticMarkup(
+    <ThemeProvider theme={theme}>
+      <TestComponent values={values} defaultBreakpoint={defaultBreakpoint} />
+    </ThemeProvider>,
+  )
+}
+
+const TestComponent = ({
+  values,
+  defaultBreakpoint = undefined,
+}: {
+  values: any
+  defaultBreakpoint?: string
+}) => {
+  const value = useBreakpointValue(values, defaultBreakpoint)
   return <>{value}</>
 }


### PR DESCRIPTION
## 📝 Description

When using `useBreakpoint()`, it's possible to SSR by providing a `defaultBreakpoint` value. However, it's not possible to do the same with `useBreakpointValue()` because it is hard coded to call `useBreakpoint()` without a default.

## ⛳️ Current behavior (updates)

Calling `useBreakpointValue()` on the server will always return `undefined` due to the hard coded call to `useBreakpoint()` without a default.

## 🚀 New behavior

This addition allows calculating a useful value from `useBreakpointValue()` on the server by passing a `defaultBreakpoint` value.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
