### PR TITLE
feat(menu)!: add left and right icon props to MenuItemOption

### DIFF
--- a/.changeset/fast-stingrays-reply.md
+++ b/.changeset/fast-stingrays-reply.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/menu": major
+---
+
+adds leftIcon, leftIconSpacing, rightIcon, and rightIconSpacing props to
+MenuItemOption

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -298,7 +298,7 @@ if (__DEV__) {
   MenuItem.displayName = "MenuItem"
 }
 
-const CheckIcon: React.FC<PropsOf<"svg">> = (props) => (
+export const CheckIcon: React.FC<PropsOf<"svg">> = (props) => (
   <svg viewBox="0 0 14 14" width="1em" height="1em" {...props}>
     <polygon
       fill="currentColor"
@@ -313,16 +313,30 @@ export interface MenuItemOptionProps
   /**
    * @type React.ReactElement
    */
-  icon?: React.ReactElement
+  leftIcon?: React.ReactElement
   /**
    * @type SystemProps["mr"]
    */
-  iconSpacing?: SystemProps["mr"]
+  leftIconSpacing?: SystemProps["mr"]
+  /**
+   * @type React.ReactElement
+   */
+  rightIcon?: React.ReactElement
+  /**
+   * @type SystemProps["mr"]
+   */
+  rightIconSpacing?: SystemProps["mr"]
 }
 
 export const MenuItemOption = forwardRef<MenuItemOptionProps, "button">(
   (props, ref) => {
-    const { icon, iconSpacing = "0.75rem", ...rest } = props
+    const {
+      rightIcon,
+      rightIconSpacing = "0.75rem",
+      leftIcon = rightIcon ? null : <CheckIcon />,
+      leftIconSpacing = "0.75rem",
+      ...rest
+    } = props
 
     const optionProps = useMenuOption(rest, ref) as HTMLAttributes
 
@@ -331,14 +345,27 @@ export const MenuItemOption = forwardRef<MenuItemOptionProps, "button">(
         {...optionProps}
         className={cx("chakra-menu__menuitem-option", rest.className)}
       >
-        <MenuIcon
-          fontSize="0.8em"
-          marginEnd={iconSpacing}
-          opacity={props.isChecked ? 1 : 0}
-        >
-          {icon || <CheckIcon />}
-        </MenuIcon>
+        {leftIcon && (
+          <MenuIcon
+            fontSize="0.8em"
+            marginEnd={leftIconSpacing}
+            opacity={props.isChecked ? 1 : 0}
+          >
+            {leftIcon}
+          </MenuIcon>
+        )}
+
         <span style={{ flex: 1 }}>{optionProps.children}</span>
+
+        {rightIcon && (
+          <MenuIcon
+            fontSize="0.8em"
+            marginStart={leftIconSpacing}
+            opacity={props.isChecked ? 1 : 0}
+          >
+            {rightIcon}
+          </MenuIcon>
+        )}
       </StyledMenuItem>
     )
   },

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -360,7 +360,7 @@ export const MenuItemOption = forwardRef<MenuItemOptionProps, "button">(
         {rightIcon && (
           <MenuIcon
             fontSize="0.8em"
-            marginStart={leftIconSpacing}
+            marginStart={rightIconSpacing}
             opacity={props.isChecked ? 1 : 0}
           >
             {rightIcon}

--- a/packages/menu/stories/menu.stories.tsx
+++ b/packages/menu/stories/menu.stories.tsx
@@ -9,6 +9,7 @@ import {
   FaTruck,
   FaUndoAlt,
   FaUnlink,
+  FaCheck,
 } from "react-icons/fa"
 import {
   Menu,
@@ -255,6 +256,43 @@ export const withMenuRadio = () => (
         <MenuItemOption value="email">Email</MenuItemOption>
         <MenuItemOption value="phone">Phone</MenuItemOption>
         <MenuItemOption value="country">Country</MenuItemOption>
+      </MenuOptionGroup>
+    </MenuList>
+  </Menu>
+)
+
+export const withMenuRadioRightIcon = () => (
+  <Menu closeOnSelect={false}>
+    <MenuButton as={Button} variant="solid" colorScheme="green" size="sm">
+      Open menu
+    </MenuButton>
+
+    <MenuList minWidth="240px">
+      <MenuItem icon={<FaUndoAlt />}>Undo</MenuItem>
+
+      <MenuDivider />
+
+      <MenuOptionGroup defaultValue="val-1" title="Order" type="radio">
+        <MenuItemOption rightIcon={<FaCheck />} value="val-1">
+          Option 1
+        </MenuItemOption>
+        <MenuItemOption rightIcon={<FaCheck />} value="val-2">
+          Option 2
+        </MenuItemOption>
+      </MenuOptionGroup>
+
+      <MenuDivider />
+
+      <MenuOptionGroup title="Country" type="checkbox">
+        <MenuItemOption rightIcon={<FaCheck />} value="email">
+          Email
+        </MenuItemOption>
+        <MenuItemOption rightIcon={<FaCheck />} value="phone">
+          Phone
+        </MenuItemOption>
+        <MenuItemOption rightIcon={<FaCheck />} value="country">
+          Country
+        </MenuItemOption>
       </MenuOptionGroup>
     </MenuList>
   </Menu>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2037

## 📝 Description

adds `leftIcon`, `leftIconSpacing`, `rightIcon`, and `rightIconSpacing` props to `MenuItemOption`

## ⛳️ Current behavior (updates)

Currently, there wasn't a way to add a right icon to `MenuItemOption`
You could only modify the left icon via
```jsx
<MenuItemOption icon={<CheckIcon />} />
```

## 🚀 New behavior

Now you can pass left and right icons to `MenuItemOption` via
```jsx
<MenuItemOption 
	leftIcon={<CheckIcon />}
	leftIconSpacing="0.75em"
	rightIcon={<CheckIcon />}
	rightIconSpacing="0.75em"
/>
```

## 💣 Is this a breaking change (Yes/No): Yes

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

`icon` and `iconSpacing` props will need to be migrated to `leftIcon` and `leftIconSpacing` props in `<MenuItemOption />`

### Example
from
```jsx
<MenuItemOption icon={<CheckIcon />} iconSpacing="0.75em" />
```
to
```jsx
<MenuItemOption leftIcon={<CheckIcon />} leftIconSpacing="0.75em" />
```
