### PR TITLE
fix(modal): @see doc link

### DIFF
--- a/.changeset/lovely-houses-repair.md
+++ b/.changeset/lovely-houses-repair.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Fix link in @see doc

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -377,7 +377,7 @@ export interface ModalHeaderProps extends HTMLChakraProps<"header"> {}
  *
  * React component that houses the title of the modal.
  *
- * @see Docs https://chakra-ui.com/docs/components/modal
+ * @see Docs https://chakra-ui.com/docs/overlay/modal
  */
 export const ModalHeader = forwardRef<ModalHeaderProps, "header">(
   (props, ref) => {
@@ -425,7 +425,7 @@ export interface ModalBodyProps extends HTMLChakraProps<"div"> {}
  *
  * React component that houses the main content of the modal.
  *
- * @see Docs https://chakra-ui.com/docs/components/modal
+ * @see Docs https://chakra-ui.com/docs/overlay/modal
  */
 export const ModalBody = forwardRef<ModalBodyProps, "div">((props, ref) => {
   const { className, ...rest } = props
@@ -462,7 +462,7 @@ export interface ModalFooterProps extends HTMLChakraProps<"footer"> {}
 
 /**
  * ModalFooter houses the action buttons of the modal.
- * @see Docs https://chakra-ui.com/docs/components/modal
+ * @see Docs https://chakra-ui.com/docs/overlay/modal
  */
 export const ModalFooter = forwardRef<ModalFooterProps, "footer">(
   (props, ref) => {


### PR DESCRIPTION
Closes #4045

## 📝 Description
Fix link to modal documentation

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
I found some redirect duplication happening in `next-redirect.js`. For example `/avatar` 
```js
// ...
{
    source: "/avatar",
    destination: "/docs/data-display/avatar",
    permanent: true,
},
// ...
{
  source: "/docs/data-display/avatar",
  destination: "/docs/media-and-icons/avatar",
  permanent: true,
},
```
We can (should?) remove all the duplications and make shortpaths direct to current latest location (i.e. `/avatar` to `/docs/media-and-icons/avatar`) then update all `@see Doc [link]` comments to use the short format `/[target]` like

```js
/*
* @see Docs https://chakra-ui.com/avatar
*/
```
