### PR TITLE
test(tooltip): fixed type import

### DIFF
--- a/packages/tooltip/tests/tooltip.test.tsx
+++ b/packages/tooltip/tests/tooltip.test.tsx
@@ -7,7 +7,7 @@ import {
   waitForElementToBeRemoved,
 } from "@chakra-ui/test-utils"
 import * as React from "react"
-import { TooltipProps } from "../dist/types"
+import type { TooltipProps } from "../src"
 import { Tooltip } from "../src"
 
 const buttonLabel = "Hover me"


### PR DESCRIPTION


Closes # <!-- Github issue # here -->

## 📝 Description

Fixed the `TooltipProps` import in Tooltip tests.

## ⛳️ Current behavior (updates)

`TooltipProps` get imported from `dist` and not `src`

```js
import { TooltipProps } from "../dist/types"
```

## 🚀 New behavior

`TooltipProps` is now properly imported from `src`

## 💣 Is this a breaking change (Yes/No):

**NO**
