### PR TITLE
docs(with-framer): Simplify Typescript example for framer-motion

### DIFF
--- a/website/pages/guides/integrations/with-framer.mdx
+++ b/website/pages/guides/integrations/with-framer.mdx
@@ -71,13 +71,10 @@ For TypeScript users, here's what you need to do:
 
 ```jsx live=false
 import React from "react"
-import { HTMLChakraProps, chakra } from "@chakra-ui/react"
-import { motion, HTMLMotionProps } from "framer-motion"
+import { Box, BoxProps } from '@chakra-ui/layout';
+import { motion } from 'framer-motion';
 
-type Merge<P, T> = Omit<P, keyof T> & T;
-type MotionBoxProps = Merge<HTMLChakraProps<"div">, HTMLMotionProps<"div">>;
-
-export const MotionBox: React.FC<MotionBoxProps> = motion(chakra.div);
+export const MotionBox = motion<BoxProps>(Box);
 
 function Example() {
   return (


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The example for using framer-motion with Typescript seems unnecessarily complicated.

## 🚀 New behavior

New code is much less intimidating.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
I may be missing something that means it's necessary to have these types. It's also interesting we show the usage of chakra.div instead of Box.