### PR TITLE
fix: Fix type export in styled-system package

### DIFF
--- a/packages/styled-system/src/index.ts
+++ b/packages/styled-system/src/index.ts
@@ -7,4 +7,4 @@ export * from "./create-theme-vars"
 export type { ResponsiveValue } from "./utils"
 export { tokenToCSSVar } from "./utils/create-transform"
 export type OmitSpaceXY<T> = Omit<T, "spaceX" | "spaceY">
-export { WithCSSVar } from "./utils/types"
+export type { WithCSSVar } from "./utils/types"


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> This fixes the esm build for the styled-system package; currently the esm build is trying to export `WithCSSVar` from an empty `types.js` file.

## ⛳️ Current behavior (updates)

> When including `@chakra-ui/styled-system` `rollup` is not able to build as the `WithCSSVar` `type` is trying to be re-exported in the esm build.

## 🚀 New behavior

> When including `@chakra-ui/styled-system` `rollup` is able to build.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
