### PR TITLE
docs: drawer remove redundant closing tag

### DIFF
--- a/website/pages/docs/overlay/drawer.mdx
+++ b/website/pages/docs/overlay/drawer.mdx
@@ -108,7 +108,7 @@ function PlacementExample() {
             <p>Some contents...</p>
             <p>Some contents...</p>
           </DrawerBody>
-        </DrawerContent>>
+        </DrawerContent>
       </Drawer>
     </>
   )


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->
## 📝 Description

Removes redundant closing tag for `DrawerContent` in the [drawer-placement example](https://chakra-ui.com/docs/overlay/drawer#drawer-placement).

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No
