### PR TITLE
docs(visually-hidden): fixed description

### DIFF
--- a/website/pages/docs/disclosure/visually-hidden.mdx
+++ b/website/pages/docs/disclosure/visually-hidden.mdx
@@ -1,7 +1,7 @@
 ---
 title: VisuallyHidden
 package: "@chakra-ui/visually-hidden"
-descsription:
+description:
   VisuallyHidden is a common techinique used in web accessibility to hide
   content from the visual client
 ---


### PR DESCRIPTION
## 📝 Description

Fixed a type in `description` for SEO meta tags.

## ⛳️ Current behavior (updates)

The field name is ignored, as it's mistyped. 

## 🚀 New behavior

Renders now correct SEO description

## 💣 Is this a breaking change (Yes/No):

No.
