### PR TITLE
doc(website): @see doc links

### DIFF
--- a/.changeset/poor-games-yell.md
+++ b/.changeset/poor-games-yell.md
@@ -1,0 +1,19 @@
+---
+"@chakra-ui/accordion": patch
+"@chakra-ui/breadcrumb": patch
+"@chakra-ui/checkbox": patch
+"@chakra-ui/editable": patch
+"@chakra-ui/image": patch
+"@chakra-ui/layout": patch
+"@chakra-ui/modal": patch
+"@chakra-ui/portal": patch
+"@chakra-ui/progress": patch
+"@chakra-ui/radio": patch
+"@chakra-ui/slider": patch
+"@chakra-ui/spinner": patch
+"@chakra-ui/tag": patch
+"@chakra-ui/textarea": patch
+"@chakra-ui/docs": patch
+---
+
+updated @see doc links to point to shorthand see PR #4046 comment

--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -44,7 +44,7 @@ export interface AccordionProps
  * for all accordion items.
  *
  * It wraps all accordion items in a `div` for better grouping.
- * @see Docs https://chakra-ui.com/docs/components/accordion
+ * @see Docs https://chakra-ui.com/accordion
  */
 export const Accordion = forwardRef<AccordionProps, "div">(
   ({ children, reduceMotion, ...props }, ref) => {

--- a/packages/breadcrumb/src/breadcrumb.tsx
+++ b/packages/breadcrumb/src/breadcrumb.tsx
@@ -98,7 +98,7 @@ export interface BreadcrumbItemProps
  * BreadcrumbItem is used to group a breadcrumb link.
  * It renders a `li` element to denote it belongs to an order list of links.
  *
- * @see Docs https://chakra-ui.com/docs/components/breadcrumbs
+ * @see Docs https://chakra-ui.com/breadcrumb
  */
 export const BreadcrumbItem = forwardRef<BreadcrumbItemProps, "li">(
   (props, ref) => {
@@ -179,7 +179,7 @@ export interface BreadcrumbProps
  * Breadcrumb is used to render a breadcrumb navigation landmark.
  * It renders a `nav` element with `aria-label` set to `Breadcrumb`
  *
- * @see Docs https://chakra-ui.com/docs/components/breadcrumbs
+ * @see Docs https://chakra-ui.com/breadcrumbs
  */
 export const Breadcrumb = forwardRef<BreadcrumbProps, "nav">((props, ref) => {
   const styles = useMultiStyleConfig("Breadcrumb", props)

--- a/packages/breadcrumb/src/breadcrumb.tsx
+++ b/packages/breadcrumb/src/breadcrumb.tsx
@@ -179,7 +179,7 @@ export interface BreadcrumbProps
  * Breadcrumb is used to render a breadcrumb navigation landmark.
  * It renders a `nav` element with `aria-label` set to `Breadcrumb`
  *
- * @see Docs https://chakra-ui.com/breadcrumbs
+ * @see Docs https://chakra-ui.com/breadcrumb
  */
 export const Breadcrumb = forwardRef<BreadcrumbProps, "nav">((props, ref) => {
   const styles = useMultiStyleConfig("Breadcrumb", props)

--- a/packages/checkbox/src/checkbox-group.tsx
+++ b/packages/checkbox/src/checkbox-group.tsx
@@ -32,7 +32,7 @@ export { useCheckboxGroupContext }
  * Used for multiple checkboxes which are bound in one group,
  * and it indicates whether one or more options are selected.
  *
- * @see Docs https://chakra-ui.com/docs/form/checkbox
+ * @see Docs https://chakra-ui.com/checkbox
  */
 export const CheckboxGroup: React.FC<CheckboxGroupProps> = (props) => {
   const { colorScheme, size, variant, children, isDisabled } = props

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -80,7 +80,7 @@ export interface CheckboxProps
  * React component used in forms when a user needs to select
  * multiple values from several options.
  *
- * @see Docs https://chakra-ui.com/docs/form/checkbox
+ * @see Docs https://chakra-ui.com/checkbox
  */
 export const Checkbox = forwardRef<CheckboxProps, "input">((props, ref) => {
   const group = useCheckboxGroupContext()

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -108,7 +108,7 @@ export interface UseCheckboxProps {
  * useCheckbox that provides all the state and focus management logic
  * for a checkbox. It is consumed by the `Checkbox` component
  *
- * @see Docs https://chakra-ui.com/docs/form/checkbox#hooks
+ * @see Docs https://chakra-ui.com/checkbox#hooks
  */
 export function useCheckbox(props: UseCheckboxProps = {}) {
   const {

--- a/packages/editable/src/use-editable.ts
+++ b/packages/editable/src/use-editable.ts
@@ -74,7 +74,7 @@ export interface UseEditableProps {
 /**
  * React hook for managing the inline renaming of some text.
  *
- * @see Docs https://chakra-ui.com/docs/editable
+ * @see Docs https://chakra-ui.com/editable
  */
 export function useEditable(props: UseEditableProps = {}) {
   const {

--- a/packages/image/src/image.tsx
+++ b/packages/image/src/image.tsx
@@ -80,7 +80,7 @@ export interface ImageProps
  * React component that renders an image with support
  * for fallbacks
  *
- * @see Docs https://chakra-ui.com/docs/data-display/image
+ * @see Docs https://chakra-ui.com/image
  */
 export const Image = forwardRef<ImageProps, "img">((props, ref) => {
   const {

--- a/packages/layout/src/aspect-ratio.tsx
+++ b/packages/layout/src/aspect-ratio.tsx
@@ -24,7 +24,7 @@ export interface AspectRatioProps
  * React component used to cropping media (videos, images and maps)
  * to a desired aspect ratio.
  *
- * @see Docs https://chakra-ui.com/docs/layout/aspect-ratio
+ * @see Docs https://chakra-ui.com/aspectratiobox
  */
 export const AspectRatio = forwardRef<AspectRatioProps, "div">((props, ref) => {
   const { ratio = 4 / 3, children, className, ...rest } = props

--- a/packages/layout/src/badge.tsx
+++ b/packages/layout/src/badge.tsx
@@ -17,7 +17,7 @@ export interface BadgeProps
  * React component used to display notifications, messages, or
  * statuses in different shapes and sizes.
  *
- * @see Docs https://chakra-ui.com/docs/data-display/badge
+ * @see Docs https://chakra-ui.com/badge
  */
 export const Badge = forwardRef<BadgeProps, "span">((props, ref) => {
   const styles = useStyleConfig("Badge", props)

--- a/packages/layout/src/box.tsx
+++ b/packages/layout/src/box.tsx
@@ -13,7 +13,7 @@ export interface BoxProps extends HTMLChakraProps<"div"> {}
  * Box is the most abstract component on top of which other chakra
  * components are built. It renders a `div` element by default.
  *
- * @see Docs https://chakra-ui.com/docs/layout/box
+ * @see Docs https://chakra-ui.com/box
  */
 export const Box = chakra("div")
 

--- a/packages/layout/src/center.tsx
+++ b/packages/layout/src/center.tsx
@@ -8,7 +8,7 @@ export interface CenterProps extends HTMLChakraProps<"div"> {}
  * React component used to horizontally and vertically center its child.
  * It uses the popular `display: flex` centering technique.
  *
- * @see Docs https://chakra-ui.com/docs/layout/center
+ * @see Docs https://chakra-ui.com/center
  */
 export const Center = chakra("div", {
   baseStyle: {
@@ -48,7 +48,7 @@ const centerStyles = {
  *
  * It uses the `position: absolute` strategy.
  *
- * @see Docs https://chakra-ui.com/docs/layout/center
+ * @see Docs https://chakra-ui.com/center
  * @see WebDev https://web.dev/centering-in-css/#5.-pop-and-plop
  */
 export const AbsoluteCenter = forwardRef<AbsoluteCenterProps, "div">(

--- a/packages/layout/src/code.tsx
+++ b/packages/layout/src/code.tsx
@@ -16,7 +16,7 @@ export interface CodeProps
 /**
  * React component to render inline code snippets.
  *
- * @see Docs https://chakra-ui.com/docs/data-display/code
+ * @see Docs https://chakra-ui.com/code
  */
 export const Code = forwardRef<CodeProps, "code">((props, ref) => {
   const styles = useStyleConfig("Code", props)

--- a/packages/layout/src/divider.tsx
+++ b/packages/layout/src/divider.tsx
@@ -13,7 +13,7 @@ import * as React from "react"
  * Layout component used to visually separate content in a list or group.
  * It display a thin horizontal or vertical line, and renders a `hr` tag.
  *
- * @see Docs https://chakra-ui.com/docs/data-display/divider
+ * @see Docs https://chakra-ui.com/divider
  */
 export const Divider = forwardRef<DividerProps, "hr">((props, ref) => {
   const {

--- a/packages/layout/src/flex.tsx
+++ b/packages/layout/src/flex.tsx
@@ -59,7 +59,7 @@ export interface FlexProps extends HTMLChakraProps<"div">, FlexOptions {}
  * It renders a `div` with `display: flex` and
  * comes with helpful style shorthand.
  *
- * @see Docs https://chakra-ui.com/docs/layout/flex
+ * @see Docs https://chakra-ui.com/flex
  */
 export const Flex = forwardRef<FlexProps, "div">((props, ref) => {
   const {

--- a/packages/layout/src/grid.tsx
+++ b/packages/layout/src/grid.tsx
@@ -17,7 +17,7 @@ export interface GridProps extends HTMLChakraProps<"div">, GridOptions {}
  * It renders a `div` with `display: grid` and
  * comes with helpful style shorthand.
  *
- * @see Docs https://chakra-ui.com/docs/layout/grid
+ * @see Docs https://chakra-ui.com/grid
  */
 export const Grid = forwardRef<GridProps, "div">((props, ref) => {
   const {

--- a/packages/layout/src/kbd.tsx
+++ b/packages/layout/src/kbd.tsx
@@ -21,7 +21,7 @@ export interface KbdProps extends HTMLChakraProps<"kbd">, ThemingProps<"Kbd"> {}
  * <Kbd>⌘ + T</Kbd>
  * ```
  *
- * @see Docs https://chakra-ui.com/docs/data-display/kbd
+ * @see Docs https://chakra-ui.com/kbd
  */
 export const Kbd = forwardRef<KbdProps, "kbd">((props, ref) => {
   const styles = useStyleConfig("Kbd", props)

--- a/packages/layout/src/link.tsx
+++ b/packages/layout/src/link.tsx
@@ -28,7 +28,7 @@ export interface LinkProps extends HTMLChakraProps<"a">, ThemingProps<"Link"> {
  * <Link as={ReactRouterLink} to="/home">Home</Link>
  * ```
  *
- * @see Docs https://chakra-ui.com/docs/layout/link
+ * @see Docs https://chakra-ui.com/link
  */
 export const Link = forwardRef<LinkProps, "a">((props, ref) => {
   const styles = useStyleConfig("Link", props)

--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -40,7 +40,7 @@ export interface ListProps
 /**
  * List is used to display list items, it renders a `<ul>` by default.
  *
- * @see Docs https://chakra-ui.com/docs/data-display/list
+ * @see Docs https://chakra-ui.com/list
  */
 export const List = forwardRef<ListProps, "ul">((props, ref) => {
   const styles = useMultiStyleConfig("List", props)

--- a/packages/layout/src/simple-grid.tsx
+++ b/packages/layout/src/simple-grid.tsx
@@ -34,7 +34,7 @@ export interface SimpleGridProps extends GridProps, SimpleGridOptions {}
  * React component make that providers a simpler interface, and
  * make its easy to create responsive grid layouts.
  *
- * @see Docs https://chakra-ui.com/docs/layout/simple-grid
+ * @see Docs https://chakra-ui.com/simplegrid
  */
 export const SimpleGrid = forwardRef<SimpleGridProps, "div">((props, ref) => {
   const { columns, spacingX, spacingY, spacing, minChildWidth, ...rest } = props

--- a/packages/layout/src/spacer.tsx
+++ b/packages/layout/src/spacer.tsx
@@ -7,7 +7,7 @@ export interface SpacerProps extends HTMLChakraProps<"div"> {}
  * A flexible flex spacer that expands along the major axis of its containing flex layout.
  * It renders a `div` by default, and takes up any available space.
  *
- * @see Docs https://chakra-ui.com/docs/layout/flex#using-the-spacer
+ * @see Docs https://chakra-ui.com/flex#using-the-spacer
  */
 export const Spacer = chakra("div", {
   baseStyle: {

--- a/packages/layout/src/stack.tsx
+++ b/packages/layout/src/stack.tsx
@@ -94,7 +94,7 @@ export interface StackProps extends HTMLChakraProps<"div">, StackOptions {}
  *
  * It uses `display: flex` internally and renders a `div`.
  *
- * @see Docs https://chakra-ui.com/docs/layout/stack
+ * @see Docs https://chakra-ui.com/stack
  *
  */
 export const Stack = forwardRef<StackProps, "div">((props, ref) => {

--- a/packages/layout/src/text.tsx
+++ b/packages/layout/src/text.tsx
@@ -31,7 +31,7 @@ export interface TextProps extends HTMLChakraProps<"p">, ThemingProps<"Text"> {
 /**
  * Used to render texts or paragraphs.
  *
- * @see Docs https://chakra-ui.com/docs/typography/text
+ * @see Docs https://chakra-ui.com/text
  */
 export const Text = forwardRef<TextProps, "p">((props, ref) => {
   const styles = useStyleConfig("Text", props)

--- a/packages/layout/src/wrap.tsx
+++ b/packages/layout/src/wrap.tsx
@@ -43,7 +43,7 @@ export interface WrapProps extends HTMLChakraProps<"div"> {
  * - Buttons that appear together at the end of forms
  * - Lists of tags and chips
  *
- * @see Docs https://chakra-ui.com/docs/layout/wrap
+ * @see Docs https://chakra-ui.com/wrap
  */
 export const Wrap = forwardRef<WrapProps, "div">((props, ref) => {
   const {

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -334,7 +334,7 @@ export interface ModalOverlayProps
  * ModalOverlay renders a backdrop behind the modal. It is
  * also used as a wrapper for the modal content for better positioning.
  *
- * @see Docs https://chakra-ui.com/docs/overlay/modal
+ * @see Docs https://chakra-ui.com/modal
  */
 export const ModalOverlay = forwardRef<ModalOverlayProps, "div">(
   (props, ref) => {
@@ -377,7 +377,7 @@ export interface ModalHeaderProps extends HTMLChakraProps<"header"> {}
  *
  * React component that houses the title of the modal.
  *
- * @see Docs https://chakra-ui.com/docs/overlay/modal
+ * @see Docs https://chakra-ui.com/modal
  */
 export const ModalHeader = forwardRef<ModalHeaderProps, "header">(
   (props, ref) => {
@@ -425,7 +425,7 @@ export interface ModalBodyProps extends HTMLChakraProps<"div"> {}
  *
  * React component that houses the main content of the modal.
  *
- * @see Docs https://chakra-ui.com/docs/overlay/modal
+ * @see Docs https://chakra-ui.com/modal
  */
 export const ModalBody = forwardRef<ModalBodyProps, "div">((props, ref) => {
   const { className, ...rest } = props
@@ -462,7 +462,7 @@ export interface ModalFooterProps extends HTMLChakraProps<"footer"> {}
 
 /**
  * ModalFooter houses the action buttons of the modal.
- * @see Docs https://chakra-ui.com/docs/overlay/modal
+ * @see Docs https://chakra-ui.com/modal
  */
 export const ModalFooter = forwardRef<ModalFooterProps, "footer">(
   (props, ref) => {

--- a/packages/portal/src/portal.tsx
+++ b/packages/portal/src/portal.tsx
@@ -157,7 +157,7 @@ export interface PortalProps {
  * Declarative component used to render children into a DOM node
  * that exists outside the DOM hierarchy of the parent component.
  *
- * @see Docs https://chakra-ui.com/docs/components/portal
+ * @see Docs https://chakra-ui.com/portal
  */
 
 export function Portal(props: PortalProps) {

--- a/packages/progress/src/circular-progress.tsx
+++ b/packages/progress/src/circular-progress.tsx
@@ -98,7 +98,7 @@ export interface CircularProgressProps
  * It is built using `svg` and `circle` components with support for
  * theming and `indeterminate` state
  *
- * @see Docs https://chakra-ui.com/docs/feedback/circular-progress
+ * @see Docs https://chakra-ui.com/circularprogress
  * @todo add theming support for circular progress
  */
 export const CircularProgress: React.FC<CircularProgressProps> = (props) => {

--- a/packages/progress/src/progress.tsx
+++ b/packages/progress/src/progress.tsx
@@ -22,7 +22,7 @@ export interface ProgressLabelProps extends HTMLChakraProps<"div"> {}
 
 /**
  * ProgressLabel is used to show the numeric value of the progress.
- * @see Docs https://chakra-ui.com/docs/feedback/progress
+ * @see Docs https://chakra-ui.com/progress
  */
 export const ProgressLabel: React.FC<ProgressLabelProps> = (props) => {
   const styles = useStyles()
@@ -52,7 +52,7 @@ export interface ProgressFilledTrackProps
  * The progress component that visually indicates the current level of the progress bar.
  * It applies `background-color` and changes its width.
  *
- * @see Docs https://chakra-ui.com/docs/components/progress
+ * @see Docs https://chakra-ui.com/progress
  */
 const ProgressFilledTrack: React.FC<ProgressFilledTrackProps> = (props) => {
   const { min, max, value, isIndeterminate, ...rest } = props
@@ -122,7 +122,7 @@ export interface ProgressProps
  * It includes accessible attributes to help assistive technologies understand
  * and speak the progress values.
  *
- * @see Docs https://chakra-ui.com/docs/components/progress
+ * @see Docs https://chakra-ui.com/progress
  */
 export const Progress: React.FC<ProgressProps> = (props) => {
   const {

--- a/packages/radio/src/radio-group.tsx
+++ b/packages/radio/src/radio-group.tsx
@@ -44,7 +44,7 @@ export interface RadioGroupProps
  * Used for multiple radios which are bound in one group,
  * and it indicates which option is selected.
  *
- * @see Docs https://chakra-ui.com/docs/form/radio
+ * @see Docs https://chakra-ui.com/radio
  */
 export const RadioGroup = forwardRef<RadioGroupProps, "div">((props, ref) => {
   const { colorScheme, size, variant, children, className, ...rest } = props

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -41,7 +41,7 @@ export interface RadioProps
  * Radio component is used in forms when a user needs to select a single value from
  * several options.
  *
- * @see Docs https://chakra-ui.com/docs/form/radio
+ * @see Docs https://chakra-ui.com/radio
  */
 export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
   const { onChange: onChangeProp, value: valueProp } = props

--- a/packages/slider/src/slider.tsx
+++ b/packages/slider/src/slider.tsx
@@ -172,7 +172,7 @@ export interface SliderMarkProps extends HTMLChakraProps<"div"> {
  * SliderMark is used to provide names for specific Slider
  * values by defining labels or markers along the track.
  *
- * @see Docs https://chakra-ui.com/docs/components/slider
+ * @see Docs https://chakra-ui.com/slider
  */
 export const SliderMark = forwardRef<SliderMarkProps, "div">((props, ref) => {
   const { getMarkerProps } = useSliderContext()

--- a/packages/spinner/src/spinner.tsx
+++ b/packages/spinner/src/spinner.tsx
@@ -61,7 +61,7 @@ export interface SpinnerProps
  * Spinner is used to indicate the loading state of a page or a component,
  * It renders a `div` by default.
  *
- * @see Docs https://chakra-ui.com/docs/feedback/spinner
+ * @see Docs https://chakra-ui.com/spinner
  */
 export const Spinner = forwardRef<SpinnerProps, "div">((props, ref) => {
   const styles = useStyleConfig("Spinner", props)

--- a/packages/tag/src/tag.tsx
+++ b/packages/tag/src/tag.tsx
@@ -20,7 +20,7 @@ export interface TagProps
 /**
  * The tag component is used to label or categorize UI elements.
  * To style the tag globally, change the styles in `theme.components.Tag`
- * @see Docs https://chakra-ui.com/docs/data-display/tag
+ * @see Docs https://chakra-ui.com/tag
  */
 export const Tag = forwardRef<TagProps, "span">((props, ref) => {
   const styles = useMultiStyleConfig("Tag", props)
@@ -92,7 +92,7 @@ export interface TagCloseButtonProps
 
 /**
  * TagCloseButton is used to close "remove" the tag
- * @see Docs https://chakra-ui.com/docs/components/tag
+ * @see Docs https://chakra-ui.com/tag
  */
 export const TagCloseButton: React.FC<TagCloseButtonProps> = (props) => {
   const { isDisabled, children, ...rest } = props

--- a/packages/textarea/src/textarea.tsx
+++ b/packages/textarea/src/textarea.tsx
@@ -43,7 +43,7 @@ export interface TextareaProps
 
 /**
  * Textarea is used to enter an amount of text that's longer than a single line
- * @see Docs https://chakra-ui.com/docs/form/textarea
+ * @see Docs https://chakra-ui.com/textarea
  */
 export const Textarea = forwardRef<TextareaProps, "textarea">((props, ref) => {
   const styles = useStyleConfig("Textarea", props)

--- a/website/next-redirect.js
+++ b/website/next-redirect.js
@@ -44,7 +44,7 @@ async function redirect() {
     // COMPONENTS
     {
       source: "/accordion",
-      destination: "/docs/components/accordion",
+      destination: "/docs/disclosure/accordion",
       permanent: true,
     },
     {
@@ -64,7 +64,7 @@ async function redirect() {
     },
     {
       source: "/avatar",
-      destination: "/docs/data-display/avatar",
+      destination: "/docs/media-and-icons/avatar",
       permanent: true,
     },
     {
@@ -78,8 +78,13 @@ async function redirect() {
       permanent: true,
     },
     {
+      source: "/wrap",
+      destination: "/docs/layout/wrap",
+      permanent: true,
+    },
+    {
       source: "/breadcrumb",
-      destination: "/docs/components/breadcrumb",
+      destination: "/docs/navigation/breadcrumb",
       permanent: true,
     },
     {
@@ -108,8 +113,18 @@ async function redirect() {
       permanent: true,
     },
     {
+      source: "/portal",
+      destination: "/docs/components/portal",
+      permanent: true,
+    },
+    {
       source: "/collapse",
       destination: "/docs/components/transition#collapse",
+      permanent: true,
+    },
+    {
+      source: "/center",
+      destination: "/docs/layout/center",
       permanent: true,
     },
     {
@@ -155,7 +170,7 @@ async function redirect() {
     },
     {
       source: "/icon",
-      destination: "/docs/components/icon",
+      destination: "/docs/media-and-icons/icon",
       permanent: true,
     },
     {
@@ -165,7 +180,7 @@ async function redirect() {
     },
     {
       source: "/image",
-      destination: "/docs/data-display/image",
+      destination: "/docs/media-and-icons/image",
       permanent: true,
     },
     {
@@ -175,7 +190,12 @@ async function redirect() {
     },
     {
       source: "/link",
-      destination: "/docs/components/link",
+      destination: "/docs/navigation/link",
+      permanent: true,
+    },
+    {
+      source: "/kbd",
+      destination: "/docs/data-display/kbd",
       permanent: true,
     },
     {
@@ -261,7 +281,7 @@ async function redirect() {
     },
     {
       source: "/tabs",
-      destination: "/docs/components/tabs",
+      destination: "/docs/disclosure/tabs",
       permanent: true,
     },
     {
@@ -290,43 +310,8 @@ async function redirect() {
       permanent: true,
     },
     {
-      source: "/docs/components/accordion",
-      destination: "/docs/disclosure/accordion",
-      permanent: true,
-    },
-    {
-      source: "/docs/components/tabs",
-      destination: "/docs/disclosure/tabs",
-      permanent: true,
-    },
-    {
       source: "/docs/components/visually-hidden",
       destination: "/docs/disclosure/visually-hidden",
-      permanent: true,
-    },
-    {
-      source: "/docs/components/breadcrumb",
-      destination: "/docs/navigation/breadcrumb",
-      permanent: true,
-    },
-    {
-      source: "/docs/components/link",
-      destination: "/docs/navigation/link",
-      permanent: true,
-    },
-    {
-      source: "/docs/data-display/avatar",
-      destination: "/docs/media-and-icons/avatar",
-      permanent: true,
-    },
-    {
-      source: "/docs/data-display/image",
-      destination: "/docs/media-and-icons/image",
-      permanent: true,
-    },
-    {
-      source: "/docs/components/icon",
-      destination: "/docs/media-and-icons/icon",
       permanent: true,
     },
   ]

--- a/website/pages/docs/data-display/stat.mdx
+++ b/website/pages/docs/data-display/stat.mdx
@@ -67,7 +67,7 @@ import {
 
 - `StatLabel`, `StatHelpText`, `StatNumber` composes
   [Text](/docs/typography/text) component.
-- `StatArrow` composes [Icon](/docs/components/icon) component.
+- `StatArrow` composes [Icon](/icon) component.
 - `Stat` and `StatGroup` composes [Box](/docs/layout/box) component.
 
 <PropsTable of="Stat" />

--- a/website/pages/docs/navigation/breadcrumb.mdx
+++ b/website/pages/docs/navigation/breadcrumb.mdx
@@ -173,7 +173,7 @@ It'll replace the rendered `a` tag with Reach's Link.
 
 ### BreadcrumbLink Props
 
-The BreadcrumbLink composes the [Link](/docs/components/link) component so you
+The BreadcrumbLink composes the [Link](/link) component so you
 can use all Link props.
 
 <PropsTable of="BreadcrumbLink" />


### PR DESCRIPTION
## 📝 Description
In reference to [comment](https://github.com/chakra-ui/chakra-ui/pull/4046#issuecomment-845164769)

This PR changes all documentation links in JS doc blocks to use shorter form so that future changes to the website/documentation structure (i.e. /components/radio -> /form/radio) won't require changing those links.


## ⛳️ Current behavior (updates)

It seems that this approach has been started already, this PR just builds on what's already there (plus removing some duplication in favor of recent links as well as adding new short redirects i.e. `/wrap` & `/center`)

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No

