### PR TITLE
docs(tabs): fixed meta tag

### DIFF
--- a/website/pages/docs/disclosure/tabs.mdx
+++ b/website/pages/docs/disclosure/tabs.mdx
@@ -2,7 +2,7 @@
 title: Tabs
 package: "@chakra-ui/tabs"
 image: "components/tabs.svg"
-decription:
+description:
   A React component that helps you build accessible tabs, by providing keyboard
   interactions and ARIA attributes described in the WAI-ARIA Tab Panel Design
   Pattern.


### PR DESCRIPTION
## 📝 Description

Fixed SEO `description` tag.

## ⛳️ Current behavior (updates)

Mistyped `description` won't be rendered

## 🚀 New behavior

Get's properly rendered.

## 💣 Is this a breaking change (Yes/No):

No
