### PR TITLE
Fix typos

### DIFF
--- a/website/configs/search-meta.json
+++ b/website/configs/search-meta.json
@@ -639,11 +639,11 @@
     "hierarchy": { "lvl1": "Keyboard Key", "lvl2": "Guideline", "lvl3": null }
   },
   {
-    "content": "Modifer",
+    "content": "Modifier",
     "id": "71a5eafc-282a-482a-815d-08ef1778b12a",
     "type": "lvl2",
-    "url": "/docs/data-display/kbd#modifer",
-    "hierarchy": { "lvl1": "Keyboard Key", "lvl2": "Modifer", "lvl3": null }
+    "url": "/docs/data-display/kbd#modifier",
+    "hierarchy": { "lvl1": "Keyboard Key", "lvl2": "Modifier", "lvl3": null }
   },
   {
     "content": "List",

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -134,7 +134,7 @@ const mdxConfig = {
       // get the slug
       const slug = frontmatter.slug || fileToPath(mdxPath)
 
-      // if frontmatter inclues author, add the author's data
+      // if frontmatter includes author, add the author's data
       const authorData = author ? await getUserData(author) : undefined
 
       return {

--- a/website/pages/docs/data-display/kbd.mdx
+++ b/website/pages/docs/data-display/kbd.mdx
@@ -38,7 +38,7 @@ All shortcuts should do their best to match what appears on the user’s keyboar
 - For non-letter keys such as enter, esc and shift, stick to lowercase.
 - Use the arrow symbol as opposed to spelling things out.
 
-## Modifer
+## Modifier
 
 The only punctuation you should need is the **+** to indicate that a combination
 of keys will activate the shortcut.

--- a/website/pages/docs/disclosure/tabs.mdx
+++ b/website/pages/docs/disclosure/tabs.mdx
@@ -287,7 +287,7 @@ arrow keys to change tabs, the tab is activated and focused.
 
 > The content of a `TabPanel` should ideally be preloaded. However, if switching
 > to a tab panel causes a network request and possibly a page refresh, there
-> might be some noticable latency and this might affect the experience for
+> might be some noticeable latency and this might affect the experience for
 > keyboard and screen reader users.
 
 In this scenario, you should use a manually activated tab, it moves focus

--- a/website/pages/docs/disclosure/visually-hidden.mdx
+++ b/website/pages/docs/disclosure/visually-hidden.mdx
@@ -2,11 +2,11 @@
 title: VisuallyHidden
 package: "@chakra-ui/visually-hidden"
 description:
-  VisuallyHidden is a common techinique used in web accessibility to hide
+  VisuallyHidden is a common technique used in web accessibility to hide
   content from the visual client
 ---
 
-VisuallyHidden is a common techinique used in web accessibility to hide content
+VisuallyHidden is a common technique used in web accessibility to hide content
 from the visual client, but keep it readable for screen readers.
 
 <ComponentLinks

--- a/website/pages/docs/form/button.mdx
+++ b/website/pages/docs/form/button.mdx
@@ -234,7 +234,7 @@ props. This means you can override any style of the Button via props.
 
 ```jsx
 // The size prop affects the height of the button
-// It can still be overriden by passing a custom height
+// It can still be overridden by passing a custom height
 <Button
   size="md"
   height="48px"

--- a/website/pages/docs/media-and-icons/icon.mdx
+++ b/website/pages/docs/media-and-icons/icon.mdx
@@ -204,7 +204,7 @@ When `children` is not provided, the `Icon` component renders a fallback icon.
 | `viewBox`   | `string`              | `0 0 24 24`    | The viewBox of the icon.                                                            |
 | `boxSize`   | `string`              | `1em`          | The size (width and height) of the icon.                                            |
 | `color`     | `string`              | `currentColor` | The color of the icon.                                                              |
-| `focusable` | `boolean`             | `false`        | Denotes that the icon is not an interative element, and only used for presentation. |
+| `focusable` | `boolean`             | `false`        | Denotes that the icon is not an interactive element, and only used for presentation. |
 | `role`      | `presentation`, `img` | `presentation` | The html role of the icon.                                                          |
 | `children`  | `React.ReactNode`     |                | The Path or Group of the icon                                                       |
 

--- a/website/pages/docs/migration.mdx
+++ b/website/pages/docs/migration.mdx
@@ -206,7 +206,7 @@ const overrides = {
 required.**
 
 You may of course add for example `xxl` or other breakpoints in between -
-`createBreakpoints` will sort in ascending order. It is adviseable to not mix
+`createBreakpoints` will sort in ascending order. It is advisable to not mix
 css units.
 
 > **Reason:** Previously, breakpoints on a theme had to be an array with your
@@ -522,7 +522,7 @@ prop instead.
 - Removed `preserveScrollBarGap` prop. We preserve scroll bar gap by default to
   prevent any layout shift.
 
-- `ModalCloseButton` now reads the `onClose` action from the `Modal` context - 
+- `ModalCloseButton` now reads the `onClose` action from the `Modal` context -
   you no longer need to pass the `onClick` to it. Conversely, the `onClose` prop
   on `Modal` is now a required prop if you specify `ModalCloseButton`.
 

--- a/website/pages/docs/principles.mdx
+++ b/website/pages/docs/principles.mdx
@@ -11,7 +11,7 @@ Our goal is to design simple, composable components that cater to real-life UI
 design problems. In order to do that, we developed a set of principles that help
 us always be on that path.
 
-- **Style Props:** All component styles can be overriden or extended via style
+- **Style Props:** All component styles can be overridden or extended via style
   props to reduce the use of `css` prop or `styled()`. Compose new components
   from `Box`.
 

--- a/website/src/types/github.ts
+++ b/website/src/types/github.ts
@@ -27,7 +27,7 @@ export interface Contributor {
 
 export interface Sponsor {
   MemberId: number
-  comapny: null
+  company: null
   createdAt: string
   description: string
   email: null

--- a/website/src/utils/mdx-utils.js
+++ b/website/src/utils/mdx-utils.js
@@ -26,7 +26,7 @@ async function processFrontmatter(options) {
   // get the slug
   const slug = fileToPath(mdxPath)
 
-  // if frontmatter inclues author, add the author's data
+  // if frontmatter includes author, add the author's data
   const authorData = author ? await getGithubUserData(author) : undefined
 
   return {


### PR DESCRIPTION
Fixes some typos found with [codespell](https://github.com/codespell-project/codespell).

I ignored the `packages` directory and any changelogs — if you'd like I can fix them though.