### PR TITLE
✨ Support generating token type definitions from theme packages

### DIFF
--- a/.changeset/soft-hairs-happen.md
+++ b/.changeset/soft-hairs-happen.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": minor
+---
+
+Support generating theme token type definitions from Chakra UI themes
+distributed as NPM modules

--- a/.changeset/soft-hairs-happen.md
+++ b/.changeset/soft-hairs-happen.md
@@ -2,5 +2,22 @@
 "@chakra-ui/cli": minor
 ---
 
-Support generating theme token type definitions from Chakra UI themes
-distributed as NPM modules
+The `tokens` command now supports generating theme token type definitions from a Chakra UI theme published as a package:
+
+```sh
+npx @chakra-ui/cli tokens <@your-org/chakra-theme-package>
+```
+
+A published theme package should export a theme object as either the `default` export or an export named `theme`.
+
+```jsx
+// chakra-theme-package/src/index.js
+import { extendTheme } from '@chakra-ui/react'
+
+const theme = extendTheme({})
+
+// as default export
+export default theme
+// as named export
+export { theme }
+```

--- a/tooling/cli/README.md
+++ b/tooling/cli/README.md
@@ -8,6 +8,12 @@ Generate TypeScript types to provide autocomplete for your custom theme.
 npx @chakra-ui/cli tokens <path/to/your/theme.(js|ts)>
 ```
 
+or
+
+```sh
+npx @chakra-ui/cli tokens <@your-org/chakra-theme-package>
+```
+
 ```sh
 $ npx @chakra-ui/cli --help
 

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -6,10 +6,23 @@ import { isObject } from "@chakra-ui/utils"
 import { createThemeTypingsInterface } from "../command/tokens/create-theme-typings-interface"
 import { themeKeyConfiguration } from "../command/tokens/config"
 
+const bold = (text: string) => `\x1b[1m${text}\x1b[22m`
+
 async function importTheme(path: string) {
   const module = await import(path)
+  const theme = module.default ?? module.theme
 
-  return module.default ?? module.theme
+  if (!theme)
+    throw new Error(`
+    Theme export not found in module: '${path}'.
+
+    A theme should have a ${bold("default")} export or a ${bold(
+      "theme",
+    )} named export.
+    Found the following exports: ${bold(Object.keys(module).join(", "))}
+  `)
+
+  return theme
 }
 
 async function readTheme(themeFilePath: string) {
@@ -24,8 +37,14 @@ async function readTheme(themeFilePath: string) {
     await fs.promises.stat(absoluteThemePath)
 
     return importTheme(absoluteThemePath)
-  } catch {
-    return importTheme(require.resolve(themeFilePath, { paths: [cwd] }))
+  } catch (statError) {
+    try {
+      return importTheme(require.resolve(themeFilePath, { paths: [cwd] }))
+    } catch (resolveError) {
+      throw new Error(
+        `Theme file or package not found \n${statError} \n${resolveError}`,
+      )
+    }
   }
 }
 

--- a/website/pages/docs/theming/advanced.mdx
+++ b/website/pages/docs/theming/advanced.mdx
@@ -98,6 +98,34 @@ interface StyleConfig {
 }
 ```
 
+## Distributing a Theme Package
+
+Publishing your theme to a package registry such as NPM is a great way to share
+your theme across multiple projects or applications.
+
+A published theme package should export a theme object as either the `default`
+export or an export named `theme`. For example, in
+`chakra-theme-package/src/index.js`:
+
+```js
+import { extendTheme } from "@chakra-ui/react"
+const theme = extendTheme({})
+
+// as default export
+export default theme
+
+// as named export
+export { theme }
+```
+
+See [this guide](/docs/theming/customize-theme#scaling-out-your-project) for
+more recommendations on how to structure your theme package.
+
+> Note ⚠️: If you're using TypeScript, you'll want to include some documentation guiding
+> consumers of your theme package to add a `postinstall` script to generate
+> typings for your theme. See the
+> [theme typings](/docs/theming/advanced#theme-typings) section for details.
+
 ## Theme Typings
 
 <Badge fontSize="sm" colorScheme="teal" letterSpacing="wider">
@@ -111,7 +139,7 @@ for your application theme.
 If you want to learn how to scale your custom theme you can
 [follow this guide](/docs/theming/customize-theme#scaling-out-your-project).
 
-### Install 
+### Install
 
 ```bash
 yarn add --dev @chakra-ui/cli
@@ -125,8 +153,16 @@ npm install -D @chakra-ui/cli
 
 ### Usage
 
+For a theme file:
+
 ```bash
 chakra-cli tokens <path/to/your/theme.(js|ts)>
+```
+
+or, for a [theme package](/docs/theming/advanced#distributing-a-theme-package):
+
+```bash
+chakra-cli tokens <@your-org/chakra-theme-package>
 ```
 
 The theme entrypoint file should export the theme object either as `default`


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I'm distributing a Chakra theme within my organization as a package on NPM and there's currently no good way to distribute the associated token type definitions.

## ⛳️ Current behavior (updates)

The Chakra CLI (**@chakra-ui/cli**) expects a theme to exist in a file within a project (e.g: `src/path/to/theme.ts`) with which to generate definitions from.

## 🚀 New behavior

Add support to **chakra-ui/cli** to consume themes distributed as NPM packages, e.g: `chakra-cli tokens @my-org/chakra-theme`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

I'm curious if this sort of use case has come up before. I did try to search around a bit in the issues and discussions on GitHub and didn't find anything. Ideally, it would be possible to define custom theme type definitions via declaration merging (similar to how [**styled-components** does it](https://styled-components.com/docs/api#create-a-declarations-file)), that way they could be distributed with the theme. That said, I understand the choice in distributing Chakra with the default theme's definitions as otherwise, it would take work for a user to get completion working with the default theme out of the box. With this change it's at least possible to add a simple step to the package's readme to add the `postinstall` hook.

### Implementation Notes

- I'm happy to add tests for this, but I didn't see any existing coverage for the functionality I updated. Perhaps an integration test makes sense for the CLI?
- I'm also happy to add additional documentation, but I wanted to get some guidance with regards to my question above first.

Thank you!