### PR TITLE
feat: add `/docs` redirect to getting started page

### DIFF
--- a/website/next-redirect.js
+++ b/website/next-redirect.js
@@ -7,6 +7,11 @@ async function redirect() {
     },
     // GENERAL
     {
+      source: "/docs",
+      destination: "/docs/getting-started",
+      permanent: true,
+    },
+    {
       source: "/getting-started",
       destination: "/docs/getting-started",
       permanent: true,


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This very minor PR adds a redirect rule to navigate `/docs` to `/docs/getting-started` since there is no index page for `/docs`.

## ⛳️ Current behavior (updates)

`/docs` shows the 404 page.

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/8220954/119396866-a4a6a880-bcff-11eb-9b08-54ad50f27e08.png">

## 🚀 New behavior

`/docs` should redirect to `/docs/getting-started`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Merge is optional. ✌🏻 