### PR TITLE
Update color-mode.mdx

### DIFF
--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -49,6 +49,26 @@ const theme = extendTheme({ config })
 export default theme
 ```
 
+For typescript, you need to explicitly describe the theme config type as `ThemeConfig` object.
+
+```jsx live=false
+// theme.tsx
+
+// 1. import `extendTheme` function
+import { extendTheme, ThemeConfig } from "@chakra-ui/react"
+
+// 2. Add your color mode config
+const config : ThemeConfig = {
+  initialColorMode: "light",
+  useSystemColorMode: false,
+}
+
+// 3. extend the theme
+const theme = extendTheme({ config })
+
+export default theme
+```
+
 > Remember to pass your custom `theme` to the `ChakraProvider`, otherwise your
 > color mode config won't be taken into consideration.
 

--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -52,7 +52,7 @@ export default theme
 For typescript, you need to explicitly describe the theme config type as `ThemeConfig` object.
 
 ```jsx live=false
-// theme.tsx
+// theme.ts
 
 // 1. import `extendTheme` function
 import { extendTheme, ThemeConfig } from "@chakra-ui/react"


### PR DESCRIPTION
Add a typescript  explanation for changing the theme config in color mode page.

## 📝 Description

Add an explanation in the color-mode docs page for extending the theme config in typescript

## ⛳️ Current behavior (updates)

If no type for the config object is described, then an error is thrown in typescript

## 🚀 New behavior

No error after specifying the type

## 💣 Is this a breaking change (Yes/No):
No
