### PR TITLE
docs: removed extra dot in checkbox onChange desc

### DIFF
--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -67,7 +67,7 @@ export interface UseCheckboxProps {
    */
   defaultChecked?: boolean
   /**
-   * The callback invoked when the checked state of the `Checkbox` changes..
+   * The callback invoked when the checked state of the `Checkbox` changes.
    */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   /**


### PR DESCRIPTION
## 📝 Description
The `onChange` prop's description in Checkbox has an extra dot