### PR TITLE
fix(statgroup): export statgroupprops interface

### DIFF
--- a/.changeset/red-dancers-know.md
+++ b/.changeset/red-dancers-know.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/stat": patch
+---
+
+export statgroupprops interface

--- a/.changeset/red-dancers-know.md
+++ b/.changeset/red-dancers-know.md
@@ -2,4 +2,4 @@
 "@chakra-ui/stat": patch
 ---
 
-export statgroupprops interface
+Export TypeScript interface `StatGroupProps`

--- a/packages/stat/src/stat.tsx
+++ b/packages/stat/src/stat.tsx
@@ -151,7 +151,7 @@ if (__DEV__) {
   Stat.displayName = "Stat"
 }
 
-interface StatGroupProps extends HTMLChakraProps<"div"> {}
+export interface StatGroupProps extends HTMLChakraProps<"div"> {}
 
 export const StatGroup = forwardRef<StatGroupProps, "div">((props, ref) => (
   <chakra.div


### PR DESCRIPTION

Closes #4123 

## 📝 Description

> Exported the `StatGroupProps` interface


## 💣 Is this a breaking change (Yes/No): No
