### PR TITLE
Fix/popover arrowshadowcolor

### DIFF
--- a/.changeset/afraid-clouds-hunt.md
+++ b/.changeset/afraid-clouds-hunt.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popover": patch
+---
+
+Fix: arrowShadowColor being overridden by default styles.

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -197,6 +197,9 @@ export function usePopover(props: UsePopoverProps = {}) {
         style: {
           ...props.style,
           transformOrigin: popperCSSVars.transformOrigin.varRef,
+          [popperCSSVars.arrowSize.var]: arrowSize ? px(arrowSize) : undefined,
+          [popperCSSVars.arrowShadowColor.var]: arrowShadowColor,
+          visibility: isOpen ? "visible" : "hidden",
         },
         ref: mergeRefs(popoverRef, _ref),
         children: shouldRenderChildren ? props.children : null,
@@ -248,26 +251,14 @@ export function usePopover(props: UsePopoverProps = {}) {
       isOpen,
       closeOnBlur,
       closeDelay,
+      arrowShadowColor,
+      arrowSize,
     ],
   )
 
   const getPopoverPositionerProps: PropGetter = useCallback(
-    (props = {}, forwardedRef = null) =>
-      getPopperProps(
-        {
-          ...props,
-          style: {
-            [popperCSSVars.arrowSize.var]: arrowSize
-              ? px(arrowSize)
-              : undefined,
-            [popperCSSVars.arrowShadowColor.var]: arrowShadowColor,
-            visibility: isOpen ? "visible" : "hidden",
-            ...props.style,
-          },
-        },
-        forwardedRef,
-      ),
-    [arrowShadowColor, arrowSize, isOpen, getPopperProps],
+    (props = {}, forwardedRef = null) => getPopperProps(props, forwardedRef),
+    [getPopperProps],
   )
 
   const openTimeout = useRef<number>()

--- a/packages/popover/stories/popover.stories.tsx
+++ b/packages/popover/stories/popover.stories.tsx
@@ -94,6 +94,24 @@ export const basic = () => (
   </>
 )
 
+export const Arrow = () => (
+  <>
+    <Popover placement="top" arrowShadowColor="red" arrowSize={40}>
+      <PopoverTrigger>
+        <chakra.button>Welcome home</chakra.button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverHeader>Submit now</PopoverHeader>
+        <PopoverBody>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  </>
+)
+
 export function ControlledUsage() {
   const [isOpen, setIsOpen] = React.useState(false)
   const open = () => setIsOpen(!isOpen)

--- a/packages/stat/src/stat.tsx
+++ b/packages/stat/src/stat.tsx
@@ -151,7 +151,7 @@ if (__DEV__) {
   Stat.displayName = "Stat"
 }
 
-interface StatGroupProps extends HTMLChakraProps<"div"> {}
+export interface StatGroupProps extends HTMLChakraProps<"div"> {}
 
 export const StatGroup = forwardRef<StatGroupProps, "div">((props, ref) => (
   <chakra.div


### PR DESCRIPTION
Closes #4127

## 📝 Description

Fixes arrowShadowColor being overridden by default styles

## Working Codesandbox Test
https://codesandbox.io/s/chakra-ui-header-forked-wp32e

## 💣 Is this a breaking change (Yes/No):

No