### PR TITLE
Feat/expand aria current pseudos

### DIFF
--- a/packages/styled-system/src/pseudos.ts
+++ b/packages/styled-system/src/pseudos.ts
@@ -164,6 +164,11 @@ export const pseudoSelectors = {
    */
   _activeLink: "&[aria-current=page]",
   /**
+   * Used to style the active link in a navigation
+   * Styles for CSS Selector `&[aria-current=step]`
+   */
+  _activeStep: "&[aria-current=step]",
+  /**
    * Styles to apply when the ARIA attribute `aria-checked` is `mixed`
    * - CSS selector `&[aria-checked=mixed]`
    */

--- a/website/pages/docs/features/style-props.mdx
+++ b/website/pages/docs/features/style-props.mdx
@@ -489,6 +489,7 @@ import { Button } from "@chakra-ui/react"
 | `_notLast`       | `:not(:last-of-type)`                                                    | none        |
 | `_visited`       | `:visited`                                                               | none        |
 | `_activeLink`    | `[aria-current=page]`                                                    | none        |
+| `_activeStep`    | `[aria-current=step]`                                                    | none        |
 | `_indeterminate` | `:indeterminate`,<br/>`[aria-checked=mixed]`,<br/>`[data-indeterminate]` | none        |
 | `_groupHover`    | `[role=group]:hover &`, <br/> `[role=group][data-hover] &`               | none        |
 | `_groupFocus`    | `[role=group]:focus &`, <br/> `[role=group][data-focus] &`               | none        |


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

I added new pseudo prop that can be used for selecting element set as `aria-current="step"`.

## ⛳️ Current behavior (updates)

To select that element you need to do this `&[aria-current="step"]`.

## 🚀 New behavior

It would be awesome if this can be achievable same as current page: `_activePage`.

New pseudo selector would be `_activeStep`

## 💣 Is this a breaking change (Yes/No):

No, not a breaking change.

## 📝 Additional Information

I updated the docs as well 😄 