### PR TITLE
feat(input): add new input parts

### DIFF
--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -30,12 +30,14 @@ const InputElement = forwardRef<InputElementProps, "div">((props, ref) => {
   const input: any = styles.field
 
   const attr = placement === "left" ? "insetStart" : "insetEnd"
+  const part = placement === "left" ? "leftelement" : "rightelement"
 
   const elementStyles: SystemStyleObject = {
     [attr]: "0",
     width: input?.height ?? input?.h,
     height: input?.height ?? input?.h,
     fontSize: input?.fontSize,
+    ...styles[part],
   }
 
   return <StyledElement ref={ref} __css={elementStyles} {...rest} />

--- a/packages/input/src/input-group.tsx
+++ b/packages/input/src/input-group.tsx
@@ -71,6 +71,7 @@ export const InputGroup = forwardRef<InputGroupProps, "div">((props, ref) => {
         width: "100%",
         display: "flex",
         position: "relative",
+        ...styles.group,
       }}
       {...rest}
     >

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -1,6 +1,6 @@
 import { getColor, mode } from "@chakra-ui/theme-tools"
 
-const parts = ["field", "addon"]
+const parts = ["field", "addon", "leftelement", "rightelement", "group"]
 
 const baseStyle = {
   field: {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> I've added input parts to support theming for `InputGroup`, `InputLeftElement` and `InputRightElement`.

## ⛳️ Current behavior (updates)

> Currently, we can't customize the theme of `InputGroup`, `InputLeftElement` and `InputRightElement` because the parts is unavailable.

## 🚀 New behavior

> We able to customize the theme of `InputGroup`, `InputLeftElement` and `InputRightElement`.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
