### PR TITLE
fix(textarea): bottom gap space 

### DIFF
--- a/.changeset/nasty-hairs-invent.md
+++ b/.changeset/nasty-hairs-invent.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Fix an issue where the distance to the next element below a textarea was too large in some browsers.

--- a/packages/theme/src/components/textarea.ts
+++ b/packages/theme/src/components/textarea.ts
@@ -7,6 +7,7 @@ const baseStyle = {
   paddingY: "8px",
   minHeight: "80px",
   lineHeight: "short",
+  verticalAlign: "top",
 }
 
 const variants = {


### PR DESCRIPTION
## 📝 Description

Firefox and Chome set the display property of TextAreas to Inline-Block by default, that causes a gap at the bottom of the component, can be fixed by changing the display to block or if we want to keep it inline, we can also set the vertical align of the component to top, bottom, middle, just not base line, also fixes issue I think is a better solution.
check discussion on https://github.com/chakra-ui/chakra-ui/discussions/4087

## ⛳️ Current behavior (updates)

no vertical alignment set by default on the textarea component, firefox and chrome set this to baseline

## 🚀 New behavior

set the vertical align of the textarea component to `top` by default, fixes an issue of a 7px gap on the bottom of the component 
![image](https://user-images.githubusercontent.com/17008138/120571429-efdf4c00-c3ce-11eb-8117-92f47f6d4c75.png)

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
