### PR TITLE
fix: consistent id generation

### DIFF
--- a/.changeset/red-hotels-raise.md
+++ b/.changeset/red-hotels-raise.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/hooks": patch
+"@chakra-ui/react": patch
+---
+
+Fix inconsisent id generation between client and server

--- a/examples/next-js/package.json
+++ b/examples/next-js/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "rm -rf .next && next dev",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/next-js/pages/_app.js
+++ b/examples/next-js/pages/_app.js
@@ -1,0 +1,9 @@
+import { ChakraProvider, IdProvider } from "@chakra-ui/react"
+
+export default function App({ Component, pageProps }) {
+  return (
+    <ChakraProvider>
+      <Component {...pageProps} />
+    </ChakraProvider>
+  )
+}

--- a/examples/next-js/pages/accordion.js
+++ b/examples/next-js/pages/accordion.js
@@ -1,0 +1,48 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionIcon,
+  AccordionPanel,
+  Box,
+} from "@chakra-ui/react"
+
+export default function Page() {
+  return (
+    <Accordion>
+      <AccordionItem>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">
+              Section 1
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={4}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">
+              Section 2
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={4}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/examples/next-js/pages/auto-id.js
+++ b/examples/next-js/pages/auto-id.js
@@ -1,0 +1,25 @@
+import { useId, useOptionalPart, useBoolean } from "@chakra-ui/hooks"
+
+export default function Page() {
+  const [error, setError] = useBoolean()
+  const id = useId()
+
+  const labelId = `label-${id}`
+  const inputId = `input-${id}`
+  const feedback = useOptionalPart(`feedback-${id}`)
+
+  return (
+    <>
+      <div id={id}>
+        <label id={labelId} htmlFor={inputId} />
+        <input id={inputId} aria-labelledby={feedback.id} />
+        {error && (
+          <div ref={feedback.ref} id={feedback.id} data-input={inputId}>
+            Feedback
+          </div>
+        )}
+      </div>
+      <button onClick={setError.toggle}>Toggle</button>
+    </>
+  )
+}

--- a/packages/hooks/src/use-id.ts
+++ b/packages/hooks/src/use-id.ts
@@ -71,7 +71,7 @@ export function useIds(idProp?: string, ...prefixes: string[]) {
  * const { ref, id } = useOptionalPart<HTMLInputElement>(`${id}-label`)
  */
 export function useOptionalPart<T = any>(partId: string) {
-  const [id, setId] = React.useState<string | null>()
+  const [id, setId] = React.useState<string | null>(null)
   const ref = React.useCallback(
     (node: T) => {
       setId(node ? partId : null)

--- a/packages/react/src/chakra-provider.tsx
+++ b/packages/react/src/chakra-provider.tsx
@@ -14,6 +14,7 @@ import {
   EnvironmentProviderProps,
 } from "@chakra-ui/react-env"
 import * as React from "react"
+import { IdProvider } from "@chakra-ui/hooks"
 
 export interface ChakraProviderProps
   extends Pick<ThemeProviderProps, "cssVarsRoot"> {
@@ -72,8 +73,14 @@ export const ChakraProvider = (props: ChakraProviderProps) => {
     cssVarsRoot,
   } = props
 
-  return (
+  const _children = (
     <EnvironmentProvider environment={environment}>
+      {children}
+    </EnvironmentProvider>
+  )
+
+  return (
+    <IdProvider>
       <ThemeProvider theme={theme} cssVarsRoot={cssVarsRoot}>
         <ColorModeProvider
           colorModeManager={colorModeManager}
@@ -82,12 +89,12 @@ export const ChakraProvider = (props: ChakraProviderProps) => {
           {resetCSS && <CSSReset />}
           <GlobalStyle />
           {portalZIndex ? (
-            <PortalManager zIndex={portalZIndex}>{children}</PortalManager>
+            <PortalManager zIndex={portalZIndex}>{_children}</PortalManager>
           ) : (
-            children
+            _children
           )}
         </ColorModeProvider>
       </ThemeProvider>
-    </EnvironmentProvider>
+    </IdProvider>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,6 +2159,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.12.6":
   version "7.12.12"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.12.tgz#f858ab1c76d9c4c23fe0783a0330ad37755f0176"
@@ -4799,6 +4806,13 @@
   dependencies:
     prop-types "^15.7.2"
     tslib "^2.1.0"
+
+"@react-aria/ssr@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.0.2.tgz#f96a41a7314a60324b6de871cb872039b63be5c0"
+  integrity sha512-+M0wrUlc2eTuMiwTfd0iFZJGu2hvMeYBLE8gRdbPJCDjLhrNWOQLKR/y6ntxQ9u8zjrNl/YPOdRtcqkA2EBnAQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"


### PR DESCRIPTION
Closes #4044

## 📝 Description

This PR introduces a consistent API to generate isomorphic Ids on the client and server.

Our current approach (with reach/auto-id) generates an `undefined` id on the server and resolves to an `id` on the client. The only way to get a consistent id is by telling the consumer to specify an `id`.

## 🚀 New behavior

Consistent id on server and client. Big thanks to the work done by the React Aria team, I basically leveraged their SSRProvider model.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

To get this working, I had to render an `IdProvider` to the set of providers in `ChakraProvider`