### PR TITLE
docs: fix minor numeric typo

### DIFF
--- a/website/pages/docs/features/responsive-styles.mdx
+++ b/website/pages/docs/features/responsive-styles.mdx
@@ -44,7 +44,7 @@ To make the `width` or `w` responsive using the array syntax, here's what you
 need to do:
 
 ```jsx live=false
-<Box bg="red.200" w={[300, 400, 560]}>
+<Box bg="red.200" w={[300, 400, 500]}>
   This is a box
 </Box>
 ```


### PR DESCRIPTION
## 📝 Description

> Fixes minor numeric typo 

## ⛳️ Current behavior (updates)

> From the docs -
Here's how to interpret this syntax:
500px: From 48em upwards

but the `w={[300, 400, 560]}`