### PR TITLE
fix: initial position issue with popover or menu

### DIFF
--- a/.changeset/lucky-taxis-shave.md
+++ b/.changeset/lucky-taxis-shave.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/menu": minor
+"@chakra-ui/popover": minor
+---
+
+Added `computePositionOnMount` prop to allow positioning the popover or menu
+before initial open

--- a/.changeset/ten-turkeys-relax.md
+++ b/.changeset/ten-turkeys-relax.md
@@ -2,4 +2,6 @@
 "@chakra-ui/popper": patch
 ---
 
-Wrap force update within a function to prevent null scenarios
+- Wrap force update within a function to prevent null scenarios
+- Add default `inset` value to prevent overflow in scenarios where `enabled` is
+  `false` (i.e. when the popper is not visible)

--- a/.changeset/ten-turkeys-relax.md
+++ b/.changeset/ten-turkeys-relax.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popper": patch
+---
+
+Wrap force update within a function to prevent null scenarios

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -102,6 +102,13 @@ export interface UseMenuProps extends UsePopperProps, UseDisclosureProps {
    * @default "unmount"
    */
   lazyBehavior?: LazyBehavior
+  /**
+   * If `true`, the menu will be positioned when it mounts
+   * (even if it's not open)
+   *
+   * @default false
+   */
+  computePositionOnMount?: boolean
 }
 
 /**
@@ -123,6 +130,7 @@ export function useMenu(props: UseMenuProps = {}) {
     onOpen: onOpenProp,
     placement = "bottom-start",
     lazyBehavior = "unmount",
+    computePositionOnMount = false,
     ...popperProps
   } = props
 
@@ -157,7 +165,7 @@ export function useMenu(props: UseMenuProps = {}) {
    */
   const popper = usePopper({
     ...popperProps,
-    enabled: isOpen,
+    enabled: isOpen || computePositionOnMount,
     placement,
   })
 

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -106,7 +106,7 @@ export interface UseMenuProps extends UsePopperProps, UseDisclosureProps {
    * If `true`, the menu will be positioned when it mounts
    * (even if it's not open).
    *
-   * Note 🚨: We don't recommend using this in a menu intensive UI or page
+   * Note 🚨: We don't recommend using this in a menu/popover intensive UI or page
    * as it might affect scrolling performance.
    */
   computePositionOnMount?: boolean

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -104,9 +104,10 @@ export interface UseMenuProps extends UsePopperProps, UseDisclosureProps {
   lazyBehavior?: LazyBehavior
   /**
    * If `true`, the menu will be positioned when it mounts
-   * (even if it's not open)
+   * (even if it's not open).
    *
-   * @default false
+   * Note 🚨: We don't recommend using this in a menu intensive UI or page
+   * as it might affect scrolling performance.
    */
   computePositionOnMount?: boolean
 }
@@ -130,7 +131,7 @@ export function useMenu(props: UseMenuProps = {}) {
     onOpen: onOpenProp,
     placement = "bottom-start",
     lazyBehavior = "unmount",
-    computePositionOnMount = false,
+    computePositionOnMount,
     ...popperProps
   } = props
 

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -113,7 +113,8 @@ export interface UsePopoverProps extends UsePopperProps {
    * If `true`, the popover will be positioned when it mounts
    * (even if it's not open)
    *
-   * @default false
+   * Note 🚨: We don't recommend using this in a menu intensive UI or page
+   * as it might affect scrolling performance.
    */
   computePositionOnMount?: boolean
 }
@@ -136,7 +137,7 @@ export function usePopover(props: UsePopoverProps = {}) {
     closeDelay = 200,
     isLazy,
     lazyBehavior = "unmount",
-    computePositionOnMount = false,
+    computePositionOnMount,
     ...popperProps
   } = props
 

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -113,7 +113,7 @@ export interface UsePopoverProps extends UsePopperProps {
    * If `true`, the popover will be positioned when it mounts
    * (even if it's not open)
    *
-   * Note 🚨: We don't recommend using this in a menu intensive UI or page
+   * Note 🚨: We don't recommend using this in a popover/menu intensive UI or page
    * as it might affect scrolling performance.
    */
   computePositionOnMount?: boolean

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -109,6 +109,13 @@ export interface UsePopoverProps extends UsePopperProps {
    * @default "unmount"
    */
   lazyBehavior?: LazyBehavior
+  /**
+   * If `true`, the popover will be positioned when it mounts
+   * (even if it's not open)
+   *
+   * @default false
+   */
+  computePositionOnMount?: boolean
 }
 
 /**
@@ -129,6 +136,7 @@ export function usePopover(props: UsePopoverProps = {}) {
     closeDelay = 200,
     isLazy,
     lazyBehavior = "unmount",
+    computePositionOnMount = false,
     ...popperProps
   } = props
 
@@ -163,7 +171,7 @@ export function usePopover(props: UsePopoverProps = {}) {
     forceUpdate,
   } = usePopper({
     ...popperProps,
-    enabled: isOpen,
+    enabled: isOpen || computePositionOnMount,
   })
 
   useFocusOnPointerDown({

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -229,6 +229,7 @@ export function usePopper(props: UsePopperProps = {}) {
         ...props.style,
         position: strategy,
         minWidth: "max-content",
+        inset: "0 auto auto 0",
       },
     }),
     [strategy, popperRef],

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -13,6 +13,9 @@ import { cssVars, getEventListenerOptions } from "./utils"
 export type { Placement }
 
 export interface UsePopperProps {
+  /**
+   * Whether the popper.js should be enabled
+   */
   enabled?: boolean
   /**
    * The main and cross-axis offset to displace popper element
@@ -254,8 +257,12 @@ export function usePopper(props: UsePopperProps = {}) {
   )
 
   return {
-    update: instance.current?.update,
-    forceUpdate: instance.current?.forceUpdate,
+    update() {
+      instance.current?.update()
+    },
+    forceUpdate() {
+      instance.current?.forceUpdate()
+    },
     transformOrigin: cssVars.transformOrigin.varRef,
     referenceRef,
     popperRef,


### PR DESCRIPTION
Closes #4109
Closes #4186

## 📝 Description

This PR makes it possible for users to choose if they want to position the menu and popover components on mount or when it's open.

## ⛳️ Current behavior (updates)

We only position these components when it's open and it can cause an overflow on the page

## 💣 Is this a breaking change (Yes/No):

I'd consider the current behavior a breaking change from the previous release but now we're in a better place. It's up to the user to choose which strategy they want.