### PR TITLE
Put sandbox example on wiki page

### DIFF
--- a/website/pages/guides/integrations/with-hook-form.mdx
+++ b/website/pages/guides/integrations/with-hook-form.mdx
@@ -6,6 +6,82 @@ author: abheist
 ---
 
 This example shows how to build a simple form with Chakra UI's form components
-and the [React Hook Form](https://react-hook-form.com) form library.
+and the [React Hook Form](https://react-hook-form.com) form library:
+
+```
+import { useForm } from "react-hook-form";
+import React from "react";
+import {
+  FormErrorMessage,
+  FormLabel,
+  FormControl,
+  Input,
+  Button
+} from "@chakra-ui/react";
+
+export default function HookForm() {
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting }
+  } = useForm();
+
+  function onSubmit(values) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        alert(JSON.stringify(values, null, 2));
+        resolve();
+      }, 3000);
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <FormControl isInvalid={errors.name}>
+        <FormLabel htmlFor="name">First name</FormLabel>
+        <Input
+          id="name"
+          placeholder="name"
+          {...register("name", {
+            required: "This is required",
+            minLength: { value: 4, message: "Minimum length should be 4" }
+          })}
+        />
+        <FormErrorMessage>
+          {errors.name && errors.name.message}
+        </FormErrorMessage>
+      </FormControl>
+      <Button mt={4} colorScheme="teal" isLoading={isSubmitting} type="submit">
+        Submit
+      </Button>
+    </form>
+  );
+}
+```
+
+Wiring up to the rest of your app:
+
+```
+import React from "react";
+import ReactDOM from "react-dom";
+import HookForm from "./HookForm";
+import { ChakraProvider, CSSReset, Box } from "@chakra-ui/react";
+
+function App() {
+  return (
+    <ChakraProvider>
+      <CSSReset />
+      <Box p={4}>
+        <HookForm />
+      </Box>
+    </ChakraProvider>
+  );
+}
+
+const rootElement = document.getElementById("root");
+ReactDOM.render(<App />, rootElement);
+```
+
+credit: Abhishek Kumar Singh - https://abheist.com/
 
 [Explore on Code Sandbox](https://codesandbox.io/s/chakra-ui-react-hook-form-t3l69)

--- a/website/pages/guides/integrations/with-hook-form.mdx
+++ b/website/pages/guides/integrations/with-hook-form.mdx
@@ -8,7 +8,7 @@ author: abheist
 This example shows how to build a simple form with Chakra UI's form components
 and the [React Hook Form](https://react-hook-form.com) form library:
 
-```
+```jsx live=false
 import { useForm } from "react-hook-form";
 import React from "react";
 import {

--- a/website/pages/guides/integrations/with-hook-form.mdx
+++ b/website/pages/guides/integrations/with-hook-form.mdx
@@ -61,7 +61,7 @@ export default function HookForm() {
 
 Wiring up to the rest of your app:
 
-```
+```jsx live=false
 import React from "react";
 import ReactDOM from "react-dom";
 import HookForm from "./HookForm";


### PR DESCRIPTION
so people can see it without having to open codesandbox...

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

There was no example displayed on the react-hook-form page of Chakra-UI wiki, so I pulled the example out of CodeSandBox and put it on the page

## ⛳️ Current behavior (updates)

No example displayed on react-hook-form page of Chakra-UI wiki 

## 🚀 New behavior

PR displays example from provided CodeSandBox on the page

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Credited author of CodeSandBox example