### PR TITLE
docs: update tooltip docs with arrow styling information

### DIFF
--- a/website/pages/docs/overlay/tooltip.mdx
+++ b/website/pages/docs/overlay/tooltip.mdx
@@ -160,6 +160,25 @@ Using the `placement` prop you can adjust where your tooltip will be displayed.
 </VStack>
 ```
 
+## Styling arrow
+
+The API for changing the background of an arrow is:
+
+> Note ⚠️: If you're styling the arrow element, it does not accept Chakra UI 
+> color values. You have to put the color as an explicit css value.
+
+```jsx
+export default {
+  // Styles for the base style
+  baseStyle: {
+     bg: '"purple.500"', // Chakra UI color value
+     "--popper-arrow-bg": "#805AD5", // explicit css color value
+  },
+}
+
+```
+
+
 ## More examples
 
 ```jsx


### PR DESCRIPTION
Update tooltip docs with arrow styling information.

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
NO.

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

@segunadebayo When I was trying to customize the Tooltip - the information about styling up the arrow was missing. No info on docs, stackoverflow etc. It was hard to figure out how to change the color of an arrow. Then I found the way to do it by digging into the code of the component,  which is not so obvious to every other developer. I think it would be super nice to add this information to the docs as some other people may struggle with it while extending the default tooltip styles. 
