### PR TITLE
Remove erroneous note about <Tabs> not rendering to DOM

### DIFF
--- a/.changeset/rotten-timers-promise.md
+++ b/.changeset/rotten-timers-promise.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tabs": patch
+---
+
+Remove erroneous note about <Tabs> not rendering to DOM

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -47,8 +47,7 @@ export interface TabsProps
 /**
  * Tabs
  *
- * Provides context and logic for all tabs components. It doesn't render
- * any DOM node.
+ * Provides context and logic for all tabs components.
  */
 export const Tabs = forwardRef<TabsProps, "div">((props, ref) => {
   const styles = useMultiStyleConfig("Tabs", props)


### PR DESCRIPTION
## 📝 Description

The `<Tabs>` component _does_ render a DOM element: a `div`. I've removed the comment that says otherwise.

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
