### PR TITLE
fix(menu): fixes menu typeahead

### DIFF
--- a/.changeset/brown-radios-rhyme.md
+++ b/.changeset/brown-radios-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fixed menu typeahead

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -334,11 +334,11 @@ export function useMenuButton(
   }
 }
 
-function isTargetMenuItem(event: Pick<MouseEvent, "currentTarget">) {
+function isTargetMenuItem(target: EventTarget | null) {
   // this will catch `menuitem`, `menuitemradio`, `menuitemcheckbox`
   return (
-    event.currentTarget instanceof HTMLElement &&
-    !!event.currentTarget.getAttribute("role")?.startsWith("menuitem")
+    target instanceof HTMLElement &&
+    !!target.getAttribute("role")?.startsWith("menuitem")
   )
 }
 
@@ -386,7 +386,8 @@ export function useMenuList(
    * to printable keyboard character press
    */
   const createTypeaheadHandler = useShortcut({
-    preventDefault: (event) => event.key !== " " && isTargetMenuItem(event),
+    preventDefault: (event) =>
+      event.key !== " " && isTargetMenuItem(event.target),
   })
 
   const onKeyDown = React.useCallback(
@@ -431,7 +432,7 @@ export function useMenuList(
         }
       })
 
-      if (isTargetMenuItem(event)) {
+      if (isTargetMenuItem(event.target)) {
         onTypeahead(event)
       }
     },
@@ -577,7 +578,7 @@ export function useMenuItem(
   const onClick = React.useCallback(
     (event: React.MouseEvent) => {
       onClickProp?.(event)
-      if (!isTargetMenuItem(event)) return
+      if (!isTargetMenuItem(event.currentTarget)) return
       /**
        * Close menu and parent menus, allowing the MenuItem
        * to override its parent menu's `closeOnSelect` prop.


### PR DESCRIPTION
## 📝 Description

While not yet released, 245a164 introduced a bug that breaks the Menu components typeahead search functionality. This change adds a fix that also [presumably] keeps true to the original intent of 245a164.

## ⛳️ Current behavior (updates)

The Menu typeahead does not work at all.

## 🚀 New behavior

Reintroduces the pre-[245a164](https://github.com/chakra-ui/chakra-ui/commit/245a164f6058e96986b2354017d96816b5d336e9) behaviour for Menu typeahead.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

No issue was created or associates with this PR because 245a164 hasn't been released yet. Please inform if doing so before merging the PR is preferred.