### PR TITLE
(fix) useSystemColorMode behavior between system and app choices

### DIFF
--- a/packages/color-mode/src/color-mode.utils.ts
+++ b/packages/color-mode/src/color-mode.utils.ts
@@ -64,11 +64,10 @@ export function addListener(fn: Function) {
     fn(mediaQueryList.matches ? "dark" : "light")
   }
 
-  listener()
-  mediaQueryList.addListener(listener)
+  mediaQueryList.addEventListener('change', listener)
 
   return () => {
-    mediaQueryList.removeListener(listener)
+    mediaQueryList.removeEventListener('change', listener)
   }
 }
 


### PR DESCRIPTION
remove initial call of "listener()"
and change addListener (deprecated) to addEventListener
and change removeListener (deprecated) to removeEventListener
[I couldn't make all the necessary changes]

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
> Add a brief description
if use <code>useSystemColorMode=true</code> and change color mode inside de application, when refresh the application, the color mode will be reset to the system option.


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying
if:
* system: light
* app: changed to dark
* if refresh page, will be light.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds
preference is always the last option (either in the system or in the app)

## 💣 Is this a breaking change (Yes/No):
Actually, I do not know
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

I recorded a video to demonstrate this, and my solution.
https://www.youtube.com/watch?v=tjVQwK97hGk
But I couldn't implement everything directly in the chakra code

I hope to help
