### PR TITLE
fix(icon-button): update IconButton to use theme borderRadius

### DIFF
--- a/.changeset/wet-spoons-play.md
+++ b/.changeset/wet-spoons-play.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/button": patch
+---
+
+fix(icon-button): update IconButton to use theme borderRadius

--- a/packages/button/src/icon-button.tsx
+++ b/packages/button/src/icon-button.tsx
@@ -47,7 +47,7 @@ export const IconButton = forwardRef<IconButtonProps, "button">(
     return (
       <Button
         padding="0"
-        borderRadius={isRound ? "full" : "md"}
+        borderRadius={isRound ? "full" : undefined}
         ref={ref}
         aria-label={ariaLabel}
         {...rest}


### PR DESCRIPTION
Closes #4244

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Makes the IconButton component use the themed borderRadius, not set to md.

## ⛳️ Current behavior (updates)

> IconButton always has borderRadius: 'md' unless directly set or using the isRound prop.

## 🚀 New behavior

> IconButton uses the themed default for the Button borderRadius.

## 💣 Is this a breaking change (Yes/No):

No
