### PR TITLE
fix discrepancy in main theme entrypoint filename

### DIFF
--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -215,7 +215,7 @@ This way, you can structure your main theme entrypoint file to be much cleaner,
 like this:
 
 ```jsx live=false
-// theme.js
+// theme/index.js
 import { extendTheme } from "@chakra-ui/react"
 
 // Global style overrides


### PR DESCRIPTION
## 📝 Description
Fixes a small discrepancy in the docs. The directory structure recommends the main theme entrypoint be called index.js but the comment calls it theme.js.


## 💣 Is this a breaking change (Yes/No):
No. 
