### PR TITLE
docs: fix typo in tabs docs

### DIFF
--- a/website/pages/docs/disclosure/tabs.mdx
+++ b/website/pages/docs/disclosure/tabs.mdx
@@ -486,7 +486,7 @@ function Example() {
 | Key                | Action                                                                     |
 | ------------------ | -------------------------------------------------------------------------- |
 | `ArrowLeft`        | Moves focus to the next tab                                                |
-| `ArrowUp`          | Moves focus to the previous tab                                            |
+| `ArrowRight`       | Moves focus to the previous tab                                            |
 | `Tab`              | When focus moves into the tab list, places focus on the active tab element |
 | `Space` or `Enter` | Activates the tab if it was not activated automatically on focus           |
 | `Home`             | Moves focus to the first tab                                               |


### PR DESCRIPTION
Closes N/A

## 📝 Description

I saw a small typo in the keyboard section under the accessibility paragraph. This PR fixes it.

## ⛳️ Current behavior (updates)

Docs display the wrong key (`ArrowUp`) for the 'Moves focus to the previous tab' action.

## 🚀 New behavior

Docs display the correct key (`ArrowRight`) for the 'Moves focus to the previous tab' action.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A
