### PR TITLE
fix(select): background bars in select menu - firefox #4194

### DIFF
--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -9,6 +9,7 @@ import {
   ThemingProps,
   useMultiStyleConfig,
   HTMLChakraProps,
+  useColorModeValue,
 } from "@chakra-ui/system"
 import { cx, mergeWith, split, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -30,6 +31,7 @@ export const SelectField = forwardRef<SelectFieldProps, "select">(
         {...ownProps}
         ref={ref}
         className={cx("chakra-select", className)}
+        bg={useColorModeValue("white", "gray.700")}
       >
         {placeholder && <option value="">{placeholder}</option>}
         {children}


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4194

## 📝 Description

Fixes issue with select dropdowns having a white bar in dark mode, I wasn't sure where to put prop so I put it in the select file, but if you tell me where to set this I can change it. Thanks1

## ⛳️ Current behavior (updates)
white bar in background of dropdown (windows 10 firefox latest)

## 🚀 New behavior

Adds set background color for select instead of default inherit attribute.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
