### PR TITLE
fix(button): undefined style props not using default style 

### DIFF
--- a/.changeset/twelve-fishes-reflect.md
+++ b/.changeset/twelve-fishes-reflect.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/button": minor
+---
+
+Fixed an issue where undefined style props (such as `borderRadius`) would not
+fall back on using default styles

--- a/.changeset/twelve-fishes-reflect.md
+++ b/.changeset/twelve-fishes-reflect.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/button": minor
+"@chakra-ui/button": patch
 ---
 
 Fixed an issue where undefined style props (such as `borderRadius`) would not

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -10,7 +10,13 @@ import {
   useStyleConfig,
   HTMLChakraProps,
 } from "@chakra-ui/system"
-import { cx, dataAttr, mergeWith, __DEV__ } from "@chakra-ui/utils"
+import {
+  cx,
+  dataAttr,
+  filterUndefined,
+  mergeWith,
+  __DEV__,
+} from "@chakra-ui/utils"
 import * as React from "react"
 import { useButtonGroup } from "./button-group"
 
@@ -129,7 +135,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       data-loading={dataAttr(isLoading)}
       __css={buttonStyles}
       className={cx("chakra-button", className)}
-      {...rest}
+      {...filterUndefined(rest)}
     >
       {leftIcon && !isLoading && (
         <ButtonIcon marginEnd={iconSpacing}>{leftIcon}</ButtonIcon>


### PR DESCRIPTION
Closes #4255 

## 📝 Description

Fixed an issue where style props that are set to `undefined` won't use default theme styles. Now, undefined props are not passed to Chakra base button elements so that their `undefined` values won't override the styles.

## ⛳️ Current behavior (updates)

There was a recent PR (#4245) that fixed the icon button's border radius not using the themed border radius when `isRound` is false, [as intended](https://chakra-ui.com/docs/form/icon-button#props). That change meant setting `borderRadius` to `undefined`, but the issue was that undefined props were being passed to the Chakra base button element, thus overriding any **default** theme styles if no theme was set.
 
https://github.com/chakra-ui/chakra-ui/blob/bb0356f10e14886a19072b68f9e4999c6a3bfc1d/packages/button/src/icon-button.tsx#L50

I'd noticed that this was only an issue for props whose value was *explicitly* set to undefined, and not props that just weren't set/included in the component.

## 🚀 New behavior

Undefined props are **not** passed to base Chakra button elements, allowing default theme styles to be applied. And Icon Buttons are slightly round again if `isRound` is false.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
