### PR TITLE
fix(use-breakpoint): avoid re-rendering when using `useBreakpoint`

### DIFF
--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -42,18 +42,18 @@ export function useBreakpoint(defaultBreakpoint?: string) {
     )
 
     if (mediaQuery) {
-      const { query, ...breakpoint } = mediaQuery
+      const { breakpoint } = mediaQuery
       return breakpoint
     }
 
     return undefined
   })
 
-  const current = currentBreakpoint?.breakpoint
+  const current = currentBreakpoint
 
   const update = React.useCallback(
-    (query: MediaQueryList, breakpoint: Breakpoint) => {
-      if (query.matches && current !== breakpoint.breakpoint) {
+    (query: MediaQueryList, { breakpoint }: Breakpoint) => {
+      if (query.matches && current !== breakpoint) {
         setCurrentBreakpoint(breakpoint)
       }
     },


### PR DESCRIPTION
Closes #4267 

## 📝 Description

Avoids re-rendering when using `useBreakpoint` together with `defaultBreakpoint`.

## ⛳️ Current behavior (updates)

Since we were storing an object in `useState`, React could not see the new value as identical, and triggered a re-render.

## 🚀 New behavior

We're now only storing the actual `string`, which React can see as identical, and will avoid re-render. We were not using the other values on the object anyway.

## 💣 Is this a breaking change (Yes/No):

No, I wouldn't say so. It will of course change the behavior, but should not do so in any breaking way.

## 📝 Additional Information

**Note:** I could not get the development mode working, so I haven't been able to try this locally. I want to be able to link my project to my local Chakra UI, but I couldn't find any links after running `yarn boot`. This is why I chose a "Draft" PR.