### PR TITLE
fix(docs): default action key works

### DIFF
--- a/website/src/components/algolia-search.tsx
+++ b/website/src/components/algolia-search.tsx
@@ -77,7 +77,7 @@ export const SearchButton = React.forwardRef(function SearchButton(
               title={actionKey[1]}
               textDecoration="none !important"
             >
-              {ACTION_KEY_APPLE[0]}
+              {actionKey[0]}
             </chakra.div>
           </Kbd>
           <VisuallyHidden> and </VisuallyHidden>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description
The action key in search button always shows Mac's action key,  "⌘".


## ⛳️ Current behavior (updates)
The action key in search button shows  "⌘" when I use Ubuntu.


## 🚀 New behavior
Using a OS other than Mac,  the action key shows "Ctrl" as follows.

![chakra-website2](https://user-images.githubusercontent.com/17586662/123529494-a4009800-d72b-11eb-9004-3d37427c6c77.png)
