### PR TITLE
docs: add /apply-theme route with customizing theme feature

### DIFF
--- a/website/configs/docs-sidebar.json
+++ b/website/configs/docs-sidebar.json
@@ -87,6 +87,10 @@
               "path": "/docs/theming/customize-theme"
             },
             {
+              "title": "Apply Theme",
+              "path": "/apply-theme"
+            },
+            {
               "title": "Component Style",
               "path": "/docs/theming/component-style"
             },

--- a/website/package.json
+++ b/website/package.json
@@ -36,6 +36,7 @@
     "react-live": "^2.2.3",
     "react-multi-ref": "1.0.0",
     "react-player": "^2.9.0",
+    "react-use": "^17.2.4",
     "remark": "^13.0.0",
     "remark-autolink-headings": "^6.0.1",
     "remark-emoji": "^2.1.0",

--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -1,9 +1,9 @@
 import { ChakraProvider } from "@chakra-ui/react"
+import { CustomizableThemeProvider } from "components/customizable-theme"
 import FontFace from "components/font-face"
 import { DefaultSeo } from "next-seo"
 import Head from "next/head"
 import React from "react"
-import theme from "theme"
 import { getSeo } from "utils/seo"
 
 const App = ({ Component, pageProps }) => {
@@ -27,9 +27,9 @@ const App = ({ Component, pageProps }) => {
         )}
       </Head>
       <DefaultSeo {...seo} />
-      <ChakraProvider theme={theme}>
+      <CustomizableThemeProvider>
         <Component {...pageProps} />
-      </ChakraProvider>
+      </CustomizableThemeProvider>
       <FontFace />
     </>
   )

--- a/website/pages/apply-theme.tsx
+++ b/website/pages/apply-theme.tsx
@@ -18,7 +18,7 @@ import {
 import PageContainer from "components/page-container"
 import Sidebar from "components/sidebar/sidebar"
 import { getRoutes } from "layouts/mdx"
-import _ from "lodash"
+import { last, omit } from "lodash"
 import { extension } from "theme"
 import { useContext, useCallback, useEffect, useState } from "react"
 import {
@@ -47,7 +47,7 @@ function GistTheme({ onChangeGistId }) {
           url: { value },
         },
       } = event
-      const fromGistId: string = _.last(value.split("/"))
+      const fromGistId: string = last(value.split("/"))
       if (!isValidGistId(fromGistId)) {
         return
       }
@@ -182,7 +182,7 @@ function ApplyTheme() {
     })
     replace({
       pathname: route,
-      query: _.omit(query, ["fromGistId"]),
+      query: omit(query, ["fromGistId"]),
     })
   }, [code, replace, route, query])
 

--- a/website/pages/apply-theme.tsx
+++ b/website/pages/apply-theme.tsx
@@ -169,7 +169,7 @@ function ApplyTheme() {
   )
   const setThemeConfig = useContext(ThemeConfigContext)
   useEffect(() => {
-    if (!isValidGistId(query.fromGistId)) {
+    if (!isValidGistId(query?.fromGistId)) {
       return
     }
     setThemeConfig({

--- a/website/pages/apply-theme.tsx
+++ b/website/pages/apply-theme.tsx
@@ -18,7 +18,8 @@ import {
 import PageContainer from "components/page-container"
 import Sidebar from "components/sidebar/sidebar"
 import { getRoutes } from "layouts/mdx"
-import { last, omit } from "lodash"
+import last from "lodash/last"
+import omit from "lodash/omit"
 import { extension } from "theme"
 import { useContext, useCallback, useEffect, useState } from "react"
 import {

--- a/website/pages/apply-theme.tsx
+++ b/website/pages/apply-theme.tsx
@@ -1,0 +1,239 @@
+import { useRouter } from "next/router"
+import {
+  Box,
+  Heading,
+  FormControl,
+  FormLabel,
+  Input,
+  FormHelperText,
+  Button,
+  HStack,
+  VStack,
+  Text,
+  Link,
+  extendTheme,
+  useClipboard,
+  useToast,
+} from "@chakra-ui/react"
+import PageContainer from "components/page-container"
+import Sidebar from "components/sidebar/sidebar"
+import { getRoutes } from "layouts/mdx"
+import _ from "lodash"
+import { extension } from "theme"
+import { useContext, useCallback, useEffect, useState } from "react"
+import {
+  CodeContainer,
+  liveEditorStyle,
+  CopyButton,
+  liveErrorStyle,
+} from "components/codeblock/codeblock"
+import theme from "prism-react-renderer/themes/nightOwl"
+import { LiveEditor, LiveError, LiveProvider } from "react-live"
+import {
+  getFromGistId,
+  isValidGistId,
+  ThemeConfigContext,
+} from "components/customizable-theme/helpers"
+import { Language } from "prism-react-renderer"
+
+function GistTheme({ onChangeGistId }) {
+  const onSubmit = useCallback(
+    (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      const {
+        target: {
+          url,
+          url: { value },
+        },
+      } = event
+      const fromGistId: string = _.last(value.split("/"))
+      if (!isValidGistId(fromGistId)) {
+        return
+      }
+      url.value = ""
+      onChangeGistId(fromGistId)
+    },
+    [onChangeGistId],
+  )
+
+  return (
+    <Box as="section" id="gist-theme" pt={12}>
+      <Box as="hr" pb={16} />
+      <Heading size="md">Import from a public gist URL</Heading>
+      <Text>
+        Your gist must contain one JavaScript file that is in Common-JS format.
+      </Text>
+      <Box as="form" p={4} onSubmit={onSubmit}>
+        <FormControl id="url">
+          <FormLabel>Gist URL</FormLabel>
+          <Input type="url" defaultValue="" />
+          <FormHelperText>
+            eg.
+            <Link
+              isExternal
+              href="https://gist.github.com/tomchentw/989ad340001061726bf2c0734d3739cf"
+            >
+              https://gist.github.com/tomchentw/989ad340001061726bf2c0734d3739cf
+            </Link>
+          </FormHelperText>
+        </FormControl>
+        <Button mt={4} colorScheme="teal" type="submit">
+          Import it!
+        </Button>
+      </Box>
+      <Text>The content will be editable in the LiveEditor below.</Text>
+    </Box>
+  )
+}
+
+function LiveTheme({ code, setCode, onApplyCode }) {
+  const { hasCopied, onCopy } = useClipboard(code)
+  const liveProviderProps = {
+    theme,
+    language: "javascript" as Language,
+    code,
+    scope: {
+      module: {
+        exports: {},
+      },
+    },
+  }
+  return (
+    <Box as="section" id="live-theme">
+      <Heading size="md">Or, try editing here</Heading>
+      <LiveProvider {...liveProviderProps}>
+        <Box position="relative" zIndex="0" p={4}>
+          <CodeContainer>
+            <LiveEditor onChange={setCode} style={liveEditorStyle} />
+          </CodeContainer>
+          <CopyButton onClick={onCopy}>
+            {hasCopied ? "copied" : "copy"}
+          </CopyButton>
+        </Box>
+        <LiveError style={liveErrorStyle} />
+      </LiveProvider>
+      <Button mt={4} colorScheme="teal" onClick={onApplyCode}>
+        Apply theme
+      </Button>
+    </Box>
+  )
+}
+
+const INITIAL_CODE = `
+module.exports = {
+  // Your theme here
+}
+`.trim()
+
+function ApplyTheme() {
+  /**
+   * Re-use the docs sidebar so it's easier for a visitors
+   * to reference components mentioned in the resource blog/video.
+   */
+  const routes = getRoutes("/docs/")
+  const [code, setCode] = useState(INITIAL_CODE)
+  const { route, query, replace } = useRouter()
+  const toast = useToast()
+  const onChangeGistId = useCallback(
+    (fromGistId) => {
+      getFromGistId(fromGistId).then(({ error, file, localModule }) => {
+        if (error) {
+          toast({
+            title: `Unknown error`,
+            description:
+              "Please provide a Gist with a CommonJS module, which exports the custom theme.",
+            status: "error",
+            duration: 3000,
+            isClosable: true,
+          })
+          return
+        }
+        toast({
+          title: `Gist (${fromGistId}) fetched`,
+          status: "info",
+          duration: 2000,
+          isClosable: true,
+        })
+        setCode(file.content)
+        replace({
+          pathname: route,
+          query: {
+            ...query,
+            fromGistId,
+          },
+        })
+      })
+    },
+    [route, query, replace, setCode],
+  )
+  const setThemeConfig = useContext(ThemeConfigContext)
+  useEffect(() => {
+    if (!isValidGistId(query.fromGistId)) {
+      return
+    }
+    setThemeConfig({
+      gistId: query.fromGistId,
+    })
+  }, [query.fromGistId, setThemeConfig])
+  const onApplyCode = useCallback(() => {
+    setThemeConfig({
+      code,
+    })
+    replace({
+      pathname: route,
+      query: _.omit(query, ["fromGistId"]),
+    })
+  }, [code, replace, route, query])
+
+  return (
+    <PageContainer
+      sidebar={<Sidebar routes={routes} />}
+      frontmatter={{
+        title: `Apply Theme`,
+        description: "Try a customized theme on this docs site.",
+      }}
+    >
+      <VStack mt={8} spacing={8} align="stretch">
+        <VStack spacing={4} align="stretch">
+          <Text>
+            In this page, you could play with a custom theme that applies
+            directly to this docs site.
+          </Text>
+          <Text>
+            This is fairly useful for the users to experiment with Chakra-UI. It
+            also provides a way for organization users to create a public Gist
+            that hosts their design system, saving their needs to create a
+            customized Chakra-UI documentation site.
+          </Text>
+          <HStack spacing={[2, 4]}>
+            <Button
+              as="a"
+              colorScheme="teal"
+              size="lg"
+              variant="solid"
+              href="#gist-theme"
+            >
+              Import from a public Gist
+            </Button>
+            <Text>or</Text>
+            <Button
+              as="a"
+              colorScheme="teal"
+              size="lg"
+              variant="outline"
+              href="#live-theme"
+            >
+              Try from a Live Editor
+            </Button>
+          </HStack>
+        </VStack>
+
+        <GistTheme onChangeGistId={onChangeGistId} />
+        <LiveTheme code={code} setCode={setCode} onApplyCode={onApplyCode} />
+      </VStack>
+    </PageContainer>
+  )
+}
+
+export default ApplyTheme

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -37,7 +37,7 @@ const LiveCodePreview = chakra(LivePreview, {
   },
 })
 
-const CopyButton = (props: ButtonProps) => (
+export const CopyButton = (props: ButtonProps) => (
   <Button
     size="sm"
     position="absolute"
@@ -76,7 +76,7 @@ const EditableNotice = (props: BoxProps) => {
   )
 }
 
-const CodeContainer = (props: BoxProps) => (
+export const CodeContainer = (props: BoxProps) => (
   <Box padding="5" rounded="8px" my="8" bg="#011627" {...props} />
 )
 

--- a/website/src/components/customizable-theme/helpers.ts
+++ b/website/src/components/customizable-theme/helpers.ts
@@ -29,11 +29,7 @@ export async function getFromGistId(gistId) {
   const rawTrimeedContent = rawContent.trim()
   // eval
   try {
-    const exports = {}
-    const localModule = { exports }
-    const execContent = new Function("module", "exports", rawTrimeedContent)
-    execContent(localModule, exports)
-
+    const localModule = execCode(rawTrimeedContent)
     return {
       file,
       localModule,
@@ -43,4 +39,13 @@ export async function getFromGistId(gistId) {
       error: true,
     }
   }
+}
+
+export function execCode(code) {
+  // eval
+  const exports = {}
+  const localModule = { exports }
+  const execContent = new Function("module", "exports", code)
+  execContent(localModule, exports)
+  return localModule
 }

--- a/website/src/components/customizable-theme/helpers.ts
+++ b/website/src/components/customizable-theme/helpers.ts
@@ -2,7 +2,7 @@ import { createContext } from "react"
 
 export const ThemeConfigContext = createContext(undefined)
 
-export function isValidGistId(gistId: string): boolean {
+export function isValidGistId(gistId: string | string[]): boolean {
   return !!gistId && gistId.length === 32
 }
 

--- a/website/src/components/customizable-theme/helpers.ts
+++ b/website/src/components/customizable-theme/helpers.ts
@@ -1,0 +1,46 @@
+import { createContext } from "react"
+
+export const ThemeConfigContext = createContext(undefined)
+
+export function isValidGistId(gistId: string): boolean {
+  return !!gistId && gistId.length === 32
+}
+
+export type File = {
+  filename: string
+  content: string
+}
+
+export async function getFromGistId(gistId) {
+  const response = await fetch(`https://api.github.com/gists/${gistId}`)
+  if (response.status !== 200) {
+    return {
+      error: true,
+    }
+  }
+  const { files } = await response.json()
+  const file: File = files[Object.keys(files)[0]]
+  const { filename, content: rawContent } = file
+  if (!rawContent) {
+    return {
+      error: true,
+    }
+  }
+  const rawTrimeedContent = rawContent.trim()
+  // eval
+  try {
+    const exports = {}
+    const localModule = { exports }
+    const execContent = new Function("module", "exports", rawTrimeedContent)
+    execContent(localModule, exports)
+
+    return {
+      file,
+      localModule,
+    }
+  } catch (e) {
+    return {
+      error: true,
+    }
+  }
+}

--- a/website/src/components/customizable-theme/index.tsx
+++ b/website/src/components/customizable-theme/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router"
-import _ from "lodash"
+import { omit } from "lodash"
 import {
   ChakraProvider,
   useToast,
@@ -51,7 +51,7 @@ function ThemeConfigProvider({ setTheme, children }) {
     setTheme(initialTheme)
     replace({
       pathname: route,
-      query: _.omit(query, ["fromGistId"]),
+      query: omit(query, ["fromGistId"]),
     })
   }, [removeThemeConfig, setTheme, route, query, replace])
 

--- a/website/src/components/customizable-theme/index.tsx
+++ b/website/src/components/customizable-theme/index.tsx
@@ -1,0 +1,6 @@
+import { ChakraProvider } from "@chakra-ui/react"
+import theme from "theme"
+
+export function CustomizableThemeProvider({ children }) {
+  return <ChakraProvider theme={theme}>{children}</ChakraProvider>
+}

--- a/website/src/components/customizable-theme/index.tsx
+++ b/website/src/components/customizable-theme/index.tsx
@@ -1,6 +1,144 @@
-import { ChakraProvider } from "@chakra-ui/react"
-import theme from "theme"
+import {
+  ChakraProvider,
+  useToast,
+  extendTheme,
+  Center,
+  Link,
+  Box,
+  Button,
+  Text,
+} from "@chakra-ui/react"
+import NextLink from "next/link"
+import { extension } from "theme"
+import { useState, useEffect, useCallback } from "react"
+import useLocalStorageExpired from "hooks/use-local-storage-expired"
+import {
+  ThemeConfigContext,
+  File,
+  isValidGistId,
+  getFromGistId,
+} from "./helpers"
+
+const initialTheme = extendTheme(extension)
 
 export function CustomizableThemeProvider({ children }) {
-  return <ChakraProvider theme={theme}>{children}</ChakraProvider>
+  const [theme, setTheme] = useState(initialTheme)
+
+  return (
+    <ChakraProvider theme={theme}>
+      <ThemeConfigProvider setTheme={setTheme}>{children}</ThemeConfigProvider>
+    </ChakraProvider>
+  )
+}
+
+type ThemeConfig = {
+  gistId?: string
+}
+
+function ThemeConfigProvider({ setTheme, children }) {
+  const [
+    themeConfig,
+    setThemeConfig,
+    removeThemeConfig,
+  ] = useLocalStorageExpired<ThemeConfig>("theme-config")
+  const onReset = useCallback(() => {
+    removeThemeConfig()
+    setTheme(initialTheme)
+  }, [removeThemeConfig, setTheme])
+
+  return (
+    <>
+      {themeConfig && isValidGistId(themeConfig?.gistId) && (
+        <FetchAndDisplayThemeConfig
+          themeConfig={themeConfig}
+          onReset={onReset}
+          setTheme={setTheme}
+        />
+      )}
+      <ThemeConfigContext.Provider value={setThemeConfig}>
+        {children}
+      </ThemeConfigContext.Provider>
+    </>
+  )
+}
+
+function FetchAndDisplayThemeConfig({ themeConfig, onReset, setTheme }) {
+  const toast = useToast()
+  const [file, setFile] = useState<File>()
+
+  useEffect(() => {
+    const description = file
+      ? false
+      : /* Only show on the first render from localStorage */ "The Gist Id is read from the localStored with 1 day expiration."
+
+    getFromGistId(themeConfig.gistId).then(({ error, file, localModule }) => {
+      if (error) {
+        return
+      }
+      setFile(file)
+      const finalTheme = extendTheme(extension, localModule.exports)
+      console.log(finalTheme)
+      setTheme(finalTheme)
+      toast({
+        title: `Applied theme from Gist (${themeConfig.gistId})`,
+        description,
+        status: "success",
+        duration: 9000,
+        isClosable: true,
+      })
+    })
+  }, [themeConfig])
+
+  if (!file) {
+    return <noscript />
+  }
+  return (
+    <Center py="4" px="6" bgColor="tomato" color="white" textAlign="center">
+      <Text
+        fontSize="lg"
+        fontWeight="medium"
+        maxW={{ base: "32ch", md: "unset" }}
+      >
+        Gist{" "}
+        {
+          <Link
+            href={`https://gists,github.com/${themeConfig.gistId}`}
+            ms="2"
+            color="whiteAlpha.900"
+            fontSize="md"
+            fontWeight="semibold"
+            fontStyle="italic"
+          >
+            {themeConfig.gistId}
+          </Link>
+        }
+        , {<Box as="i">{file.filename}</Box>} applied!
+      </Text>
+      <NextLink href="/apply-theme">
+        <Link
+          flexShrink={0}
+          ms="6"
+          bg="blackAlpha.300"
+          color="whiteAlpha.900"
+          fontWeight="semibold"
+          px="3"
+          py="1"
+          rounded="base"
+        >
+          Read how
+        </Link>
+      </NextLink>
+      <Button
+        variant="link"
+        flexShrink={0}
+        ms="6"
+        color="blackAlpha.900"
+        px="3"
+        py="1"
+        onClick={onReset}
+      >
+        Reset
+      </Button>
+    </Center>
+  )
 }

--- a/website/src/components/customizable-theme/index.tsx
+++ b/website/src/components/customizable-theme/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router"
-import { omit } from "lodash"
+import omit from "lodash/omit"
 import {
   ChakraProvider,
   useToast,

--- a/website/src/hooks/use-local-storage-expired.ts
+++ b/website/src/hooks/use-local-storage-expired.ts
@@ -1,0 +1,29 @@
+import { isPast, addDays } from "date-fns"
+import { useCallback } from "react"
+import { useLocalStorage } from "react-use"
+
+function useLocalStorageExpired<Type>(
+  key: string,
+): [Type, (value: Type) => void, () => void] {
+  type Storage = {
+    value?: Type
+    expiredAt?: number
+  }
+  const [storage, setStorage, removeStorage] = useLocalStorage<Storage>(key)
+  const setStorageWithExpired = useCallback(
+    (value: Type) => {
+      setStorage({
+        value,
+        expiredAt: addDays(new Date(), 1).valueOf(),
+      })
+    },
+    [setStorage],
+  )
+  if (storage?.expiredAt && !isPast(storage.expiredAt)) {
+    return [storage.value, setStorageWithExpired, removeStorage]
+  } else {
+    return [undefined, setStorageWithExpired, removeStorage]
+  }
+}
+
+export default useLocalStorageExpired

--- a/website/theme.ts
+++ b/website/theme.ts
@@ -1,7 +1,6 @@
-import { extendTheme } from "@chakra-ui/react"
 import { mode } from "@chakra-ui/theme-tools"
 
-const customTheme = extendTheme({
+export const extension = {
   fonts: {
     heading: "Inter, sans-serif",
     body: "Inter, sans-serif",
@@ -124,6 +123,4 @@ const customTheme = extendTheme({
       lineHeight: "normal",
     },
   },
-})
-
-export default customTheme
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6006,6 +6006,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/js-cookie@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
+  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+
 "@types/json-patch@0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/json-patch/-/json-patch-0.0.30.tgz#7c562173216c50529e70126ceb8e7a533f865e9b"
@@ -7014,6 +7019,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@xobotyi/scrollbar-width@^1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
+  integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
 
 "@xstate/react@1.0.0-rc.3":
   version "1.0.0-rc.3"
@@ -10384,6 +10394,14 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
+css-in-js-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+    isobject "^3.0.1"
+
 css-loader@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-4.3.0.tgz#c888af64b2a5b2e85462c72c0f4a85c7e2e0821e"
@@ -12881,10 +12899,20 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
+  integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
+
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
+
+fastest-stable-stringify@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz#3757a6774f6ec8de40c4e86ec28ea02417214c76"
+  integrity sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==
 
 fastq@^1.10.0:
   version "1.11.0"
@@ -15527,6 +15555,11 @@ husky@4.3.6:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -15816,6 +15849,13 @@ inline-style-parser@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
+
+inline-style-prefixer@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-6.0.0.tgz#f73d5dbf2855733d6b153a4d24b7b47a73e9770b"
+  integrity sha512-XTHvRUS4ZJNzC1GixJRmOlWSS45fSt+DJoyQC9ytj0WxQfcgofQtDtyKKYxHUqEsWCs+LIWftPF1ie7+i012Fg==
+  dependencies:
+    css-in-js-utils "^2.0.0"
 
 inquirer@6.5.2, inquirer@^6.2.0:
   version "6.5.2"
@@ -17239,6 +17279,11 @@ jpegtran-bin@^5.0.0:
     bin-build "^3.0.0"
     bin-wrapper "^4.0.0"
     logalot "^2.0.0"
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -19119,6 +19164,20 @@ nan@^2.12.1, nan@^2.14.0:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nano-css@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/nano-css/-/nano-css-5.3.1.tgz#b709383e07ad3be61f64edffacb9d98250b87a1f"
+  integrity sha512-ENPIyNzANQRyYVvb62ajDd7PAyIgS2LIUnT9ewih4yrXSZX4hKoUwssy8WjUH++kEOA5wUTMgNnV7ko5n34kUA==
+  dependencies:
+    css-tree "^1.1.2"
+    csstype "^3.0.6"
+    fastest-stable-stringify "^2.0.2"
+    inline-style-prefixer "^6.0.0"
+    rtl-css-js "^1.14.0"
+    sourcemap-codec "^1.4.8"
+    stacktrace-js "^2.0.2"
+    stylis "^4.0.6"
 
 nanoid@^3.1.16, nanoid@^3.1.20:
   version "3.1.20"
@@ -22765,6 +22824,31 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-universal-interface@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
+  integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
+
+react-use@^17.2.4:
+  version "17.2.4"
+  resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.2.4.tgz#1f89be3db0a8237c79253db0a15e12bbe3cfeff1"
+  integrity sha512-vQGpsAM0F5UIlshw5UI8ULGPS4yn5rm7/qvn3T1Gnkrz7YRMEEMh+ynKcmRloOyiIeLvKWiQjMiwRGtdbgs5qQ==
+  dependencies:
+    "@types/js-cookie" "^2.2.6"
+    "@xobotyi/scrollbar-width" "^1.9.5"
+    copy-to-clipboard "^3.3.1"
+    fast-deep-equal "^3.1.3"
+    fast-shallow-equal "^1.0.0"
+    js-cookie "^2.2.1"
+    nano-css "^5.3.1"
+    react-universal-interface "^0.6.2"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.1.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^3.0.1"
+    ts-easing "^0.2.0"
+    tslib "^2.1.0"
+
 react@17.0.1, react@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
@@ -23489,6 +23573,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -23741,6 +23830,13 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
+rtl-css-js@^1.14.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.1.tgz#f79781d6a0c510abe73fde60aa3cbe9dfd134a45"
+  integrity sha512-G9N1s/6329FpJr8k9e1U/Lg0IDWThv99sb7k0IrXHjSnubxe01h52/ajsPRafJK1/2Vqrhz3VKLe3E1dx6jS9Q==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -23889,6 +23985,11 @@ schema-utils@^3.0.0:
     "@types/json-schema" "^7.0.6"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+screenfull@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.1.0.tgz#85c13c70f4ead4c1b8a935c70010dfdcd2c0e5c8"
+  integrity sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA==
 
 scroll-into-view-if-needed@^2.2.26:
   version "2.2.26"
@@ -24086,6 +24187,11 @@ set-getter@^0.1.0:
   integrity sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=
   dependencies:
     to-object-path "^0.3.0"
+
+set-harmonic-interval@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
+  integrity sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -24555,6 +24661,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -24577,7 +24688,7 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.4.4, sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -24753,6 +24864,13 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stack-generator@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.5.tgz#fb00e5b4ee97de603e0773ea78ce944d81596c36"
+  integrity sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==
+  dependencies:
+    stackframe "^1.1.1"
+
 stack-trace@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
@@ -24776,6 +24894,23 @@ stackframe@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
+
+stacktrace-gps@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz#7688dc2fc09ffb3a13165ebe0dbcaf41bcf0c69a"
+  integrity sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.1.1"
+
+stacktrace-js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.2.tgz#4ca93ea9f494752d55709a081d400fdaebee897b"
+  integrity sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==
+  dependencies:
+    error-stack-parser "^2.0.6"
+    stack-generator "^2.0.5"
+    stacktrace-gps "^3.0.4"
 
 stacktrace-parser@0.1.10:
   version "0.1.10"
@@ -25318,6 +25453,11 @@ stylis@^4.0.3:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.6.tgz#0d8b97b6bc4748bea46f68602b6df27641b3c548"
   integrity sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg==
+
+stylis@^4.0.6:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
 sudo-prompt@^8.2.0:
   version "8.2.5"
@@ -26010,6 +26150,11 @@ ts-dedent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.0.0.tgz#47c5eb23d9096f3237cc413bc82d387d36dbe690"
   integrity sha512-DfxKjSFQfw9+uf7N9Cy8Ebx9fv5fquK4hZ6SD3Rzr+1jKP6AVA6H8+B5457ZpUs0JKsGpGqIevbpZ9DMQJDp1A==
+
+ts-easing@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
+  integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
 
 ts-essentials@^2.0.3:
   version "2.0.12"


### PR DESCRIPTION
## 📝 Description

This PR adds the `/apply-theme` route to the official v1 docs site. It allows user to try customizing theme directly on the v1 docs site.

## 🚀 New behavior

This is fairly useful for the users to experiment with Chakra-UI. It also provides a way for organization users to create a public Gist that hosts their design system, saving their needs to create a forked Chakra-UI documentation site.

![JPEG-1](https://user-images.githubusercontent.com/922234/123544098-3c2a6b80-d784-11eb-9333-bdad54f56e70.jpg)

To get started, the user has two different ways to interact with this route:

1. Import from a public gist URL:

![gist-import](https://user-images.githubusercontent.com/922234/123544227-e4d8cb00-d784-11eb-8220-f49b33933421.gif)

2. Try from a Live Editor

![live-editor](https://user-images.githubusercontent.com/922234/123544233-e904e880-d784-11eb-914f-33dce6115f77.gif)

Furthermore, it features storing the Gist Id or the code string in the `localStorage`, giving the flexibility of visiting the docs site.

3. Storing Gist Id in localStorage

![stored-gist](https://user-images.githubusercontent.com/922234/123544246-f7eb9b00-d784-11eb-8ec0-6a1c6e035ab5.gif)

4. Storing the code string in localStorage

![stored-code](https://user-images.githubusercontent.com/922234/123544260-05a12080-d785-11eb-849f-b16491e35ade.gif)

Last, when importing the Gist ID, it stores the Gist ID  to the query param so that you could share the URL to someone else directly:

```
https://chakra-ui.com/apply-theme?fromGistId=989ad340001061726bf2c0734d3739cf
```

5. Read from URL

![gits-from-url](https://user-images.githubusercontent.com/922234/123544300-3aad7300-d785-11eb-9b3c-9af7a0145f58.gif)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


