### PR TITLE
fix(website): fix kbd display in searchbar

### DIFF
--- a/website/src/components/algolia-search.tsx
+++ b/website/src/components/algolia-search.tsx
@@ -77,7 +77,7 @@ export const SearchButton = React.forwardRef(function SearchButton(
               title={actionKey[1]}
               textDecoration="none !important"
             >
-              {ACTION_KEY_APPLE[0]}
+              {actionKey[0]}
             </chakra.div>
           </Kbd>
           <VisuallyHidden> and </VisuallyHidden>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Display the correct `kbd`-actionKey `ctrl` on non-mac devices

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Right now macOs cmd key `⌘` is being displayed when on non-mac OS.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds


Correct display the `kbd`-actionKey `ctrl` on non-mac devices
## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
