### PR TITLE
fix(utils): Removed Circular dependency in @chakra-ui/utils

### DIFF
--- a/.changeset/polite-gifts-join.md
+++ b/.changeset/polite-gifts-join.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/utils": minor
+---
+
+fixed circular dependency

--- a/.changeset/polite-gifts-join.md
+++ b/.changeset/polite-gifts-join.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/utils": minor
+"@chakra-ui/utils": patch
 ---
 
 fixed circular dependency

--- a/.changeset/polite-gifts-join.md
+++ b/.changeset/polite-gifts-join.md
@@ -2,4 +2,5 @@
 "@chakra-ui/utils": patch
 ---
 
-fixed circular dependency
+Fixed a circular dependency which was causing warnings when bundling Chakra with
+`rollup`.

--- a/packages/utils/src/walk-object.ts
+++ b/packages/utils/src/walk-object.ts
@@ -1,4 +1,4 @@
-import { isArray, isObject } from "@chakra-ui/utils"
+import { isArray, isObject } from "./assertion";
 
 export type WalkObjectPredicate<Leaf = unknown> = (
   value: unknown,


### PR DESCRIPTION
## 📝 Description

If you bundle Chakra-UI yourself with rollup you get a warning about a Circular dependency.

## ⛳️ Current behavior (updates)

The Change fixed this warning, when bundling with rollup:
Circular dependency: ../../common/temp/node_modules/.pnpm/@chakra-ui+utils@1.8.0/node_modules/@chakra-ui/utils/dist/esm/index.js -> ../../common/temp/node_modules/.pnpm/@chakra-ui+utils@1.8.0/node_modules/@chakra-ui/utils/dist/esm/walk-object.js -> ../../common/temp/node_modules/.pnpm/@chakra-ui+utils@1.8.0/node_modules/@chakra-ui/utils/dist/esm/index.js

## 🚀 New behavior

No more Rollup warning

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
