### PR TITLE
Docs/fix lodash import: saved 15kB of import size

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "lerna": "3.22.1",
     "lint-staged": "10.5.3",
     "listr": "0.14.3",
+    "lodash": "^4.17.21",
     "markdown-toc": "1.2.0",
     "mkdirp": "^1.0.4",
     "ncp": "2.0.0",

--- a/scripts/plopfile.ts
+++ b/scripts/plopfile.ts
@@ -1,6 +1,7 @@
 import nodePlop, { ActionType } from "node-plop"
 import shell from "shelljs"
-import _ from "lodash"
+import capitalize from "lodash/capitalize"
+import camelCase from "lodash/camelCase"
 
 const plop = nodePlop("plop-templates/plopfile.hbs")
 
@@ -21,7 +22,7 @@ interface Answers {
 
 async function createPackage() {
   plop.setHelper("capitalize", (text) => {
-    return _.capitalize(_.camelCase(text))
+    return capitalize(camelCase(text))
   })
 
   plop.setGenerator("component", {

--- a/website/package.json
+++ b/website/package.json
@@ -26,6 +26,7 @@
     "focus-visible": "5.2.0",
     "formik": "^2.2.5",
     "highlight-words-core": "^1.2.2",
+    "lodash": "^4.17.21",
     "match-sorter": "^6.1.0",
     "next": "^10.0.5",
     "next-mdx-enhanced": "^5.0.0",

--- a/website/pages/resources.tsx
+++ b/website/pages/resources.tsx
@@ -4,7 +4,7 @@ import ResourceCard, { Resource } from "components/resource-card"
 import Sidebar from "components/sidebar/sidebar"
 import resources from "configs/resources.json"
 import { getRoutes } from "layouts/mdx"
-import _ from "lodash"
+import groupBy from "lodash/groupBy"
 import * as React from "react"
 import { FaMicrophone, FaPenSquare, FaVideo } from "react-icons/fa"
 
@@ -15,7 +15,7 @@ function Resources() {
    */
   const routes = getRoutes("/docs/")
   const data = resources.data as Resource[]
-  const groups = _.groupBy(data, "type")
+  const groups = groupBy(data, "type")
 
   return (
     <PageContainer

--- a/website/src/components/blog-post-card.tsx
+++ b/website/src/components/blog-post-card.tsx
@@ -8,7 +8,7 @@ import {
 } from "@chakra-ui/react"
 import format from "date-fns/format"
 import parseISO from "date-fns/parseISO"
-import _ from "lodash"
+import capitalize from "lodash/capitalize"
 import Link from "next/link"
 import * as React from "react"
 import { BlogPost } from "utils/get-blog-posts"
@@ -46,7 +46,7 @@ export const BlogPostCard: React.FC<BlogPostCardProps> = ({ post }) => {
         </Heading>
         <Box fontSize="sm" color="gray.500" pt="2">
           <Text as="span" mb="3">
-            {post.tags.map((t) => _.capitalize(t)).join(",")}
+            {post.tags.map((t) => capitalize(t)).join(",")}
           </Text>
           <Box
             bg="gray.100"

--- a/website/src/components/sidebar/sidebar.tsx
+++ b/website/src/components/sidebar/sidebar.tsx
@@ -1,7 +1,7 @@
 import NextLink from "next/link"
 import { useRouter } from "next/router"
 import * as React from "react"
-import _ from "lodash"
+import sortBy from "lodash/sortBy"
 import {
   Badge,
   Box,
@@ -64,7 +64,7 @@ export function SidebarContent(props: SidebarContentProps) {
               const opened = selected || lvl2.open
 
               const sortedRoutes = !!lvl2.sort
-                ? _.sortBy(lvl2.routes, (i) => i.title)
+                ? sortBy(lvl2.routes, (i) => i.title)
                 : lvl2.routes
 
               return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,6 +2243,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@chakra-ui/machine@*":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/machine/-/machine-1.4.1.tgz#d0464bfa5e65d61f8e0fadd76be223245d9a5608"
+  integrity sha512-F+Tk5EeAonXIY2d/WRQUPrbABvWPtlmJ87NWhTpz7KJzwqBRgpXJnXmOC6czz11XcoJHnDW1mwg5ydTzQG6OHg==
+  dependencies:
+    nanoid "^3.1.22"
+    valtio "^1.0.3"
+
 "@changesets/apply-release-plan@^4.0.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-4.1.0.tgz#ec67c9a0f507c19740d9344766e37dd51fc981ee"


### PR DESCRIPTION
## 📝 Description

Change the `lodash` imports to import individual functions inside the package :)
This saves 15kB of not importing the whole `lodash` (since its index.js is CJS bundle.)

![out](https://user-images.githubusercontent.com/922234/124292699-729f2680-db88-11eb-84d9-4c8032744682.jpg)

*793kB -> 778kB (-1.9%)*

## ⛳️ Current behavior (updates)

```js
import _ from "lodash"
```

## 🚀 New behavior

```js
import capitalize from "lodash/capitalize"
```

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Originally from https://github.com/chakra-ui/chakra-ui/pull/4292#discussion_r659318653