### PR TITLE
Fixed prop name to match source

### DIFF
--- a/packages/form-control/README.md
+++ b/packages/form-control/README.md
@@ -86,11 +86,11 @@ component to be fully accessible.
 ## Changing the required indicator
 
 To change the required indicator beside the `FormLabel`, simply pass the
-`indicator` prop and set it to your custom indicator components.
+`requiredIndicator` prop and set it to your custom indicator components.
 
 ```jsx
 <FormControl as="fieldset">
-  <FormLabel as="legend" indicator={CustomIndicator}>
+  <FormLabel as="legend" requiredIndicator={CustomIndicator}>
     Who is better:
   </FormLabel>
   <CheckboxGroup>


### PR DESCRIPTION
## 📝 Description

The source indicates the prop name is `requiredIndicator` but `chakra-ui/packages/form-control/README.md` says it's just `indicator`, which is incorrect

https://github.com/chakra-ui/chakra-ui/blob/main/packages/form-control/src/form-label.tsx#L20

## ⛳️ Current behavior (updates)

`chakra-ui/packages/form-control/README.md` says `indicator`

## 🚀 New behavior

`chakra-ui/packages/form-control/README.md` now says `requiredIndicator`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Just an update to `chakra-ui/packages/form-control/README.md`