### PR TITLE
docs: apply custom theme from a Gist

### DIFF
--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -1,9 +1,9 @@
 import { ChakraProvider } from "@chakra-ui/react"
+import { CustomizableThemeProvider } from "components/customizable-theme"
 import FontFace from "components/font-face"
 import { DefaultSeo } from "next-seo"
 import Head from "next/head"
 import React from "react"
-import theme from "theme"
 import { getSeo } from "utils/seo"
 
 const App = ({ Component, pageProps }) => {
@@ -27,9 +27,9 @@ const App = ({ Component, pageProps }) => {
         )}
       </Head>
       <DefaultSeo {...seo} />
-      <ChakraProvider theme={theme}>
+      <CustomizableThemeProvider>
         <Component {...pageProps} />
-      </ChakraProvider>
+      </CustomizableThemeProvider>
       <FontFace />
     </>
   )

--- a/website/src/components/customizable-theme/gist-popover.tsx
+++ b/website/src/components/customizable-theme/gist-popover.tsx
@@ -17,10 +17,15 @@ import {
   Button,
   Text,
 } from "@chakra-ui/react"
-import { useState, ReactElement } from "react"
-import { getFromGistId, isValidGistId } from "./helpers"
+import { useState, useContext, ReactElement } from "react"
+import {
+  getFromGistId,
+  isValidGistId,
+  CustomizableThemeContext,
+} from "./helpers"
 
 function GistPopover({ icon }) {
+  const updateThemeFromFile = useContext(CustomizableThemeContext)
   const [state, setState] = useState({ isLoading: false, error: false })
   function onSubmit(event) {
     event.preventDefault()
@@ -38,7 +43,7 @@ function GistPopover({ icon }) {
     setState((it) => ({ ...it, isLoading: true }))
     getFromGistId(fromGistId).then(
       (it) => {
-        console.log("Success", it)
+        updateThemeFromFile(it)
         setState((it) => ({ ...it, isLoading: false }))
       },
       (error) => {

--- a/website/src/components/customizable-theme/gist-popover.tsx
+++ b/website/src/components/customizable-theme/gist-popover.tsx
@@ -1,0 +1,107 @@
+import {
+  Link,
+  Box,
+  Popover,
+  PopoverTrigger,
+  IconButton,
+  PopoverContent,
+  PopoverArrow,
+  PopoverCloseButton,
+  PopoverHeader,
+  PopoverBody,
+  FormControl,
+  FormLabel,
+  Input,
+  FormHelperText,
+  FormErrorMessage,
+  Button,
+  Text,
+} from "@chakra-ui/react"
+import { useState, ReactElement } from "react"
+import { getFromGistId, isValidGistId } from "./helpers"
+
+function GistPopover({ icon }) {
+  const [state, setState] = useState({ isLoading: false, error: false })
+  function onSubmit(event) {
+    event.preventDefault()
+    const {
+      target: {
+        url,
+        url: { value },
+      },
+    } = event
+    const fromGistId: string = value.split("/").pop()
+    if (!isValidGistId(fromGistId)) {
+      return
+    }
+    url.value = ""
+    setState((it) => ({ ...it, isLoading: true }))
+    getFromGistId(fromGistId).then(
+      (it) => {
+        console.log("Success", it)
+        setState((it) => ({ ...it, isLoading: false }))
+      },
+      (error) => {
+        setState((it) => ({ ...it, isLoading: false, error: error.message }))
+      },
+    )
+  }
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <IconButton
+          variant="link"
+          size="xs"
+          icon={icon as ReactElement}
+          aria-label="Gist"
+        />
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader color="gray.900" fontWeight="medium">
+          Apply Custom Theme
+        </PopoverHeader>
+        <PopoverBody color="gray.700">
+          <Text>
+            You may apply a custom theme to this docs site, directly from a
+            public Gist. <br />
+            Let's try it!
+          </Text>
+          <Box as="form" onSubmit={onSubmit}>
+            <FormControl
+              id="url"
+              isDisabled={state.isLoading}
+              isInvalid={!!state.error}
+            >
+              <FormLabel>Gist url</FormLabel>
+              <Input type="url" />
+              <FormHelperText>
+                eg.
+                <Link
+                  ms={2}
+                  isExternal
+                  href="https://gist.github.com/tomchentw/989ad340001061726bf2c0734d3739cf"
+                >
+                  https://gist.github.com/tomchentw/989ad340001061726bf2c0734d3739cf
+                </Link>
+              </FormHelperText>
+              <FormErrorMessage>{state.error}</FormErrorMessage>
+            </FormControl>
+
+            <Button
+              mt={4}
+              colorScheme="teal"
+              isLoading={state.isLoading}
+              type="submit"
+            >
+              Apply it!
+            </Button>
+          </Box>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default GistPopover

--- a/website/src/components/customizable-theme/helpers.ts
+++ b/website/src/components/customizable-theme/helpers.ts
@@ -1,8 +1,13 @@
+import { createContext } from "react"
+
+export const CustomizableThemeContext = createContext(undefined)
+
 export function isValidGistId(gistId: string | string[]): boolean {
   return !!gistId && gistId.length === 32
 }
 
 export type File = {
+  gistId: string
   filename: string
   content: string
   localModule: any
@@ -31,6 +36,7 @@ export async function getFromGistId(gistId): Promise<File> {
     execContent(localModule, exports)
 
     return {
+      gistId,
       filename,
       content,
       localModule,

--- a/website/src/components/customizable-theme/helpers.ts
+++ b/website/src/components/customizable-theme/helpers.ts
@@ -1,0 +1,43 @@
+export function isValidGistId(gistId: string | string[]): boolean {
+  return !!gistId && gistId.length === 32
+}
+
+export type File = {
+  filename: string
+  content: string
+  localModule: any
+}
+
+export async function getFromGistId(gistId): Promise<File> {
+  const response = await fetch(`https://api.github.com/gists/${gistId}`)
+  if (response.status !== 200) {
+    throw new Error("Fetching Gist failed! Please try again")
+  }
+  const { files } = await response.json()
+  if (!files || 0 === Object.keys(files).length) {
+    throw new Error("No file in the Gist!")
+  }
+  const file = files[Object.keys(files)[0]]
+  const { filename, content } = file
+  const rawTrimeedContent = content?.trim()
+  if (!rawTrimeedContent) {
+    throw new Error("No content in the file!")
+  }
+  // eval
+  try {
+    const exports = {}
+    const localModule = { exports }
+    const execContent = new Function("module", "exports", rawTrimeedContent)
+    execContent(localModule, exports)
+
+    return {
+      filename,
+      content,
+      localModule,
+    }
+  } catch (e) {
+    console.error(e)
+    throw new Error(`Error while evaulating the JavaScript module in your Gist.
+    Please define your custom theme in a Common-JS module.`)
+  }
+}

--- a/website/src/components/customizable-theme/index.tsx
+++ b/website/src/components/customizable-theme/index.tsx
@@ -1,0 +1,6 @@
+import { ChakraProvider } from "@chakra-ui/react"
+import theme from "theme"
+
+export function CustomizableThemeProvider({ children }) {
+  return <ChakraProvider theme={theme}>{children}</ChakraProvider>
+}

--- a/website/src/components/customizable-theme/index.tsx
+++ b/website/src/components/customizable-theme/index.tsx
@@ -1,6 +1,45 @@
-import { ChakraProvider } from "@chakra-ui/react"
-import theme from "theme"
+import { ChakraProvider, useToast, extendTheme } from "@chakra-ui/react"
+import { extension } from "theme"
+import { useState } from "react"
+import { CustomizableThemeContext, File } from "./helpers"
+
+const initialTheme = extendTheme(extension)
+console.log(initialTheme)
 
 export function CustomizableThemeProvider({ children }) {
-  return <ChakraProvider theme={theme}>{children}</ChakraProvider>
+  const [theme, setTheme] = useState(initialTheme)
+
+  return (
+    <ChakraProvider theme={theme}>
+      <CustomizableThemeContextProvider setTheme={setTheme}>
+        {children}
+      </CustomizableThemeContextProvider>
+    </ChakraProvider>
+  )
+}
+
+/**
+ * Render as a child of <ChakraProvider /> to get theme
+ */
+function CustomizableThemeContextProvider({ setTheme, children }) {
+  const toast = useToast()
+
+  function updateThemeFromFile(file: File) {
+    const finalTheme = extendTheme(extension, file.localModule.exports)
+    console.log(finalTheme)
+    setTheme(finalTheme)
+    toast({
+      title: `Custom Theme Applied`,
+      description: `From Gist ID (${file.gistId})`,
+      status: "success",
+      duration: 9000,
+      isClosable: true,
+    })
+  }
+
+  return (
+    <CustomizableThemeContext.Provider value={updateThemeFromFile}>
+      {children}
+    </CustomizableThemeContext.Provider>
+  )
 }

--- a/website/src/components/header.tsx
+++ b/website/src/components/header.tsx
@@ -127,8 +127,8 @@ function HeaderContent() {
                 <Icon
                   as={LinkIcon}
                   transition="color 0.2s"
-                  w="5"
-                  h="5"
+                  minW="5"
+                  minH="5"
                   _hover={{ color: "gray.600" }}
                 />
               }

--- a/website/src/components/header.tsx
+++ b/website/src/components/header.tsx
@@ -12,11 +12,13 @@ import {
   useUpdateEffect,
   HTMLChakraProps,
 } from "@chakra-ui/react"
+import { LinkIcon } from "@chakra-ui/icons"
 import siteConfig from "configs/site-config"
 import { useViewportScroll } from "framer-motion"
 import NextLink from "next/link"
 import React from "react"
 import { FaMoon, FaSun, FaYoutube } from "react-icons/fa"
+import GistPopover from "./customizable-theme/gist-popover"
 import Logo, { LogoIcon } from "./logo"
 import { MobileNavButton, MobileNavContent } from "./mobile-nav"
 import Search from "./omni-search"
@@ -120,6 +122,17 @@ function HeaderContent() {
                 _hover={{ color: "gray.600" }}
               />
             </Link>
+            <GistPopover
+              icon={
+                <Icon
+                  as={LinkIcon}
+                  transition="color 0.2s"
+                  w="5"
+                  h="5"
+                  _hover={{ color: "gray.600" }}
+                />
+              }
+            />
           </HStack>
           <IconButton
             size="md"

--- a/website/theme.ts
+++ b/website/theme.ts
@@ -1,7 +1,6 @@
-import { extendTheme } from "@chakra-ui/react"
 import { mode } from "@chakra-ui/theme-tools"
 
-const customTheme = extendTheme({
+export const extension = {
   fonts: {
     heading: "Inter, sans-serif",
     body: "Inter, sans-serif",
@@ -124,6 +123,4 @@ const customTheme = extendTheme({
       lineHeight: "normal",
     },
   },
-})
-
-export default customTheme
+}


### PR DESCRIPTION
## 📝 Description

I've extracted the key feature from #4292 : 

> Apply custom theme from a Gist

## 🚀 New behavior

It starts with the newly added icon on the header. It renders a `<Popover />` with an `<input />` asking for the Gist URL.

![JPEG-0](https://user-images.githubusercontent.com/922234/124795517-b2984c00-df82-11eb-9c90-5c014ac48fe9.jpg)

The user should provide a Gist URL. It should contain one CommonJS module defined the custom theme. For example,
https://gist.github.com/tomchentw/989ad340001061726bf2c0734d3739cf

![JPEG-1](https://user-images.githubusercontent.com/922234/124795916-29cde000-df83-11eb-8d98-c54925adf302.jpg)

## 🚀 New behavior

We could paste the Gist URL to the input and hit `Apply`. Since the custom theme above changes the `xs` size of the `<Button />`, It updates the icon size as expected:

![e449df7251828d00a1188f234a9c7180](https://user-images.githubusercontent.com/922234/124796091-5a157e80-df83-11eb-8fc4-3b4b8ac7ae85.gif)

A static image:

![JPEG-2](https://user-images.githubusercontent.com/922234/124796109-626db980-df83-11eb-8a3a-80b400cca47e.jpg)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Let me know if this is easier to review, @with-heart . We could ship the `localStorage` feature or `live editing feature later on with more thorough thinking.