### PR TITLE
fix(button): take left and right icons into consideration for button loading state

### DIFF
--- a/.changeset/cold-guests-hug.md
+++ b/.changeset/cold-guests-hug.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/button": patch
+---
+
+Resolved an issue where a `Button` in loading state didn't consider the width of
+`leftIcon` and `rightIcon`, resulting in layout shifts when the button leaves
+the loading state. Buttons now render with the same width regardless of state.

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -81,7 +81,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     isLoading,
     isActive,
     isFullWidth,
-    children,
+    children: _children,
     leftIcon,
     rightIcon,
     loadingText,
@@ -119,6 +119,16 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
 
   const { ref: _ref, type: defaultType } = useButtonType(as)
 
+  const children = (
+    <>
+      {leftIcon && <ButtonIcon marginEnd={iconSpacing}>{leftIcon}</ButtonIcon>}
+      {_children}
+      {rightIcon && (
+        <ButtonIcon marginStart={iconSpacing}>{rightIcon}</ButtonIcon>
+      )}
+    </>
+  )
+
   return (
     <chakra.button
       disabled={isDisabled || isLoading}
@@ -131,10 +141,6 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       className={cx("chakra-button", className)}
       {...rest}
     >
-      {leftIcon && !isLoading && (
-        <ButtonIcon marginEnd={iconSpacing}>{leftIcon}</ButtonIcon>
-      )}
-
       {isLoading && spinnerPlacement === "start" && (
         <ButtonSpinner
           className="chakra-button__spinner--start"
@@ -157,9 +163,6 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
         >
           {spinner}
         </ButtonSpinner>
-      )}
-      {rightIcon && !isLoading && (
-        <ButtonIcon marginStart={iconSpacing}>{rightIcon}</ButtonIcon>
       )}
     </chakra.button>
   )


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This is a fix so that the left and right icon of a button also stay in the DOM while the button isLoading to avoid jumping button elements.

## ⛳️ Current behavior (updates)

Currently, the left and right icons of a button don't get rendered when the button is in the loading state, which leads to less width of the button, leading to unwanted layout shifts.

## 🚀 New behavior

The left and right icons also get rendered when the button is in the loading state and will be hidden with opacity 0 like the rest of the children.

## 💣 Is this a breaking change (Yes/No):

No