### PR TITLE
fix: make grid props type definitions reflect current implementation

### DIFF
--- a/.changeset/rare-experts-beg.md
+++ b/.changeset/rare-experts-beg.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Grid props type definitions now correclty reflect the implemented behavior in
+regard to tokens.

--- a/packages/styled-system/src/config/grid.ts
+++ b/packages/styled-system/src/config/grid.ts
@@ -130,7 +130,7 @@ export interface GridProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-columns)
    */
-  gridAutoColumns?: Token<CSS.Property.GridAutoColumns | number, "sizes">
+  gridAutoColumns?: Token<CSS.Property.GridAutoColumns>
   /**
    * The CSS `grid-auto-rows` property.
    *
@@ -138,7 +138,7 @@ export interface GridProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows)
    */
-  gridAutoRows?: Token<CSS.Property.GridAutoRows | number, "sizes">
+  gridAutoRows?: Token<CSS.Property.GridAutoRows>
   /**
    * The CSS `grid-template-columns` property
    *
@@ -146,10 +146,7 @@ export interface GridProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
    */
-  gridTemplateColumns?: Token<
-    CSS.Property.GridTemplateColumns | number,
-    "sizes"
-  >
+  gridTemplateColumns?: Token<CSS.Property.GridTemplateColumns>
   /**
    * The CSS `grid-template-rows` property.
    *
@@ -157,7 +154,7 @@ export interface GridProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows)
    */
-  gridTemplateRows?: Token<CSS.Property.GridTemplateRows | number, "sizes">
+  gridTemplateRows?: Token<CSS.Property.GridTemplateRows>
   /**
    * The CSS `grid-template-areas` property.
    *

--- a/packages/styled-system/src/config/grid.ts
+++ b/packages/styled-system/src/config/grid.ts
@@ -30,7 +30,7 @@ export interface GridProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-gap)
    */
-  gridGap?: Token<CSS.Property.GridGap | number, "sizes">
+  gridGap?: Token<CSS.Property.GridGap | number, "space">
   /**
    * The CSS `grid-column-gap` property.
    *
@@ -38,7 +38,7 @@ export interface GridProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap)
    */
-  gridColumnGap?: Token<CSS.Property.GridColumnGap | number, "sizes">
+  gridColumnGap?: Token<CSS.Property.GridColumnGap | number, "space">
   /**
    * The CSS `grid-row-gap` property.
    *
@@ -46,7 +46,7 @@ export interface GridProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap)
    */
-  gridRowGap?: Token<CSS.Property.GridRowGap | number, "sizes">
+  gridRowGap?: Token<CSS.Property.GridRowGap | number, "space">
   /**
    * The CSS `grid-column` property.
    *


### PR DESCRIPTION
## 📝 Description

This PR makes grid props type definitions reflect the currently implemented behavior of the components.

## ⛳️ Current behavior (updates)

Gap props incorrectly specify that sizes tokens are applicable to the css properties, which is not the case, only space tokens are taken into consideration (which is also the expected and documented behavior). Other changed properties don't support token values at the moment.

## 🚀 New behavior

Type definitions are adjusted to the currently implemented behavior. Types for gap properties either specify the correct token (space) or no token at all if inapplicable.

## 💣 Is this a breaking change (Yes/No):

No, the behavior was never supported in first place.
