### PR TITLE
fix: issue with slider thumb and firefox

### DIFF
--- a/.changeset/itchy-planes-confess.md
+++ b/.changeset/itchy-planes-confess.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/slider": patch
+---
+
+Fix issue where slider thumb doesn't show active state in firefox

--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -341,10 +341,13 @@ export function useSlider(props: UseSliderProps) {
   usePanGesture(rootRef, {
     onPanSessionStart(event) {
       if (!isInteractive) return
+      setDragging.on()
+      focusThumb()
       setValueFromPointer(event)
     },
     onPanSessionEnd() {
       if (!isInteractive) return
+      setDragging.off()
       if (!prevIsDragging && prevRef.current !== valueRef.current) {
         onChangeEnd?.(valueRef.current)
         prevRef.current = valueRef.current
@@ -352,7 +355,6 @@ export function useSlider(props: UseSliderProps) {
     },
     onPanStart() {
       if (!isInteractive) return
-      setDragging.on()
       onChangeStart?.(valueRef.current)
     },
     onPan(event) {
@@ -361,7 +363,6 @@ export function useSlider(props: UseSliderProps) {
     },
     onPanEnd() {
       if (!isInteractive) return
-      setDragging.off()
       onChangeEnd?.(valueRef.current)
     },
   })


### PR DESCRIPTION
Closes #4367

## 📝 Description

Fix issue where slider's thumb active state doesn't work properly on Firefox

## ⛳️ Current behavior (updates)

If you click the slider thumb without dragging, it doesn't show its active state

## 🚀 New behavior

The slider thumb now shows its active state

## 💣 Is this a breaking change (Yes/No):

No.