### PR TITLE
docs: fixed a typo in responsive styles docs

### DIFF
--- a/website/pages/docs/features/responsive-styles.mdx
+++ b/website/pages/docs/features/responsive-styles.mdx
@@ -29,7 +29,7 @@ To make styles responsive, you can use either the array or object syntax.
 
 ## The Array syntax
 
-All style props that arrays as values for mobile-first responsive styles. This
+All style props accept arrays as values for mobile-first responsive styles. This
 is the recommended method.
 
 Let's say you have a `Box` with the following properties:


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->
## 📝 Description

> Fixes a minor word typo in responsive styles section of the documentation website

## ⛳️ Current behavior (updates)

> From the docs of responsive styles under the section "The Array Syntax":
> _"All style props **that** arrays as values for mobile-first responsive styles."_

## 🚀 New behavior

> Changed _"that"_ to _"accept"_
> _"All style props **accept** arrays as values for mobile-first responsive styles."_