### PR TITLE
Fix/toast centering

### DIFF
--- a/.changeset/itchy-mangos-hunt.md
+++ b/.changeset/itchy-mangos-hunt.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Toasts have been updated to fix centering when the width of the toast exceeds
+560 pixels

--- a/packages/toast/src/toast-manager.tsx
+++ b/packages/toast/src/toast-manager.tsx
@@ -28,7 +28,7 @@ type State = { [K in ToastPosition]: ToastOptions[] }
 type CreateToastOptions = Partial<
   Pick<
     ToastOptions,
-    "status" | "duration" | "position" | "id" | "onCloseComplete"
+    "status" | "duration" | "position" | "id" | "onCloseComplete" | "maxWidth"
   >
 >
 
@@ -168,6 +168,7 @@ export class ToastManager extends React.Component<Props, State> {
       onRequestRemove: () => this.removeToast(String(id), position),
       status: options.status,
       requestClose: false,
+      maxWidth: options.maxWidth, 
     }
   }
 

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -65,6 +65,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
     message,
     onCloseComplete,
     onRequestRemove,
+    maxWidth = 560, 
     requestClose = false,
     position = "bottom",
     duration = 5000,
@@ -118,7 +119,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
         className="chakra-toast__inner"
         style={{
           pointerEvents: "auto",
-          maxWidth: 560,
+          maxWidth,
           minWidth: 300,
           margin: "0.5rem",
         }}

--- a/packages/toast/src/toast.types.ts
+++ b/packages/toast/src/toast.types.ts
@@ -63,6 +63,13 @@ export interface ToastOptions {
    * anyone else, but documented regardless.
    */
   requestClose?: boolean
+
+  /**
+   * The maximum width of the toast. 
+   * The toast will wrap if its width is bigger than this. 
+   * Defaults to 560px if not set.
+   */
+  maxWidth?: number | string
 }
 
 export type ToastState = { [K in ToastPosition]: ToastOptions[] }

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -69,6 +69,13 @@ export interface UseToastOptions {
    * Callback function to run side effects after the toast has closed.
    */
   onCloseComplete?: () => void
+
+  /**
+   * The maximum width of the toast. 
+   * The toast will wrap if its width is bigger than this. 
+   * Defaults to 560px if not set.
+   */
+  maxWidth?: number | string
 }
 
 export type IToast = UseToastOptions
@@ -112,6 +119,7 @@ const defaults = {
   duration: 5000,
   position: "bottom",
   variant: "solid",
+  maxWidth: 560, 
 } as const
 
 export type CreateStandAloneToastParam = Partial<

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Button, ButtonGroup } from "@chakra-ui/button"
 import { chakra, useColorMode } from "@chakra-ui/system"
 import { Alert } from "@chakra-ui/alert"
-import { Text } from "@chakra-ui/layout"
+import { Box, Text } from "@chakra-ui/layout"
 import { createStandaloneToast, useToast } from "../src"
 import theme from "../../../website/theme"
 
@@ -89,6 +89,38 @@ export function CustomRender() {
       >
         Show Toastify
       </Button>
+      <Button
+      onClick={() =>
+        toast({
+          position: "top",
+          maxWidth: '100%', 
+          render: () => (
+            <Box color="white" p={3} w="800px" bg="blue.500">
+              Test for alignment
+            </Box>
+          ),
+        })
+      }
+    >
+      Show Huge Toast
+    </Button>
+    <Button
+    colorScheme = 'pink'
+      onClick={() =>
+        toast({
+          position: "top",
+          maxWidth: '600px', 
+          render: () => (
+            <Box color="white" p={3} bg="blue.500">
+              Test for alignment when the toast is extremely small.
+              Look at this toast. It is so small. How can it be so ridiculously small.
+            </Box>
+          ),
+        })
+      }
+    >
+      Show small Toast
+    </Button>
     </>
   )
 }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4387 

## 📝 Description

When users set a fixed-width on their custom toast, this causes their toast to not be centered. This is because we set a fixed `maxWidth` property on the wrapper component around the toast, which results in the invisible wrapper being centered correctly, but the visible custom component overflowing the parent (the wrapper), making it seem off-centered. 

A more detailed explanation of why this arises can be found [here](https://github.com/chakra-ui/chakra-ui/issues/4387#issuecomment-884419618)
## ⛳️ Current behavior (updates)

Fixes the centering issue so that when the `maxWidth` property is set on the hook, the invisible wrapper has the correct `maxWidth`, allowing correct alignment of the visible component.

## 🚀 New behavior

Visible toast component is centered correctly when parent component has enough space to accommodate the component. This can now be done through using the exposed `maxWidth` property on the hook

## 💣 Is this a breaking change (Yes/No):
No.
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
Inbuild chakra toast does not have this issue as we set the `maxWidth` to be 100%, allowing for automatic wrapping. The choice was made to expose the property on the hook rather than changing the maxWidth on the `ReachAlert` itself so that users are able to customize for their use case (eg: accommodate for mobile view so that maxWidth should be ~400 px etc). 