### PR TITLE
fix: radio styling

### DIFF
--- a/.changeset/long-rings-kiss.md
+++ b/.changeset/long-rings-kiss.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/radio": patch
+"@chakra-ui/styled-system": patch
+"@chakra-ui/utils": patch
+---
+
+Radio styling is now applied to the container element rather than the input
+element

--- a/packages/checkbox/stories/checkbox.stories.tsx
+++ b/packages/checkbox/stories/checkbox.stories.tsx
@@ -22,6 +22,18 @@ export const CheckboxWithHooks = () => {
 
 export const Basic = () => <Checkbox colorScheme="red">Hello</Checkbox>
 
+export const StyledCheckbox = () => (
+  <Checkbox
+    background="gray.100"
+    border="1px"
+    borderColor="gray.300"
+    colorScheme="gray"
+    padding={4}
+  >
+    Checkbox
+  </Checkbox>
+)
+
 export const BasicWithDisableFalse = () => (
   <Checkbox isDisabled={false} colorScheme="red">
     Hello

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -36,6 +36,7 @@
     "@chakra-ui/form-control": "1.5.1",
     "@chakra-ui/hooks": "1.7.1",
     "@chakra-ui/react-utils": "1.2.1",
+    "@chakra-ui/styled-system": "1.14.1",
     "@chakra-ui/utils": "1.9.1",
     "@chakra-ui/visually-hidden": "1.1.1"
   },

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -12,7 +12,7 @@ import { callAll, split, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useRadioGroupContext } from "./radio-group"
 import { useRadio, UseRadioProps } from "./use-radio"
-import { stylePropNames } from "../../styled-system/src/system"
+import { stylePropNames } from "@chakra-ui/styled-system"
 
 type Omitted = "onChange" | "defaultChecked" | "checked"
 interface BaseControlProps extends Omit<HTMLChakraProps<"div">, Omitted> {}
@@ -76,7 +76,6 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
     getInputProps,
     getCheckboxProps,
     getLabelProps,
-    getRootProps,
     htmlProps,
   } = useRadio({
     ...rest,
@@ -92,7 +91,6 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
   const checkboxProps = getCheckboxProps(otherProps)
   const inputProps = getInputProps({}, ref)
   const labelProps = getLabelProps()
-  const rootProps = Object.assign({}, layoutProps, getRootProps())
 
   const rootStyles = {
     width: isFullWidth ? "full" : undefined,

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -1,7 +1,6 @@
 import {
   chakra,
   forwardRef,
-  layoutPropNames,
   omitThemingProps,
   SystemProps,
   SystemStyleObject,
@@ -13,6 +12,7 @@ import { callAll, split, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useRadioGroupContext } from "./radio-group"
 import { useRadio, UseRadioProps } from "./use-radio"
+import { stylePropNames } from "../../styled-system/src/system"
 
 type Omitted = "onChange" | "defaultChecked" | "checked"
 interface BaseControlProps extends Omit<HTMLChakraProps<"div">, Omitted> {}
@@ -87,7 +87,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
     name,
   })
 
-  const [layoutProps, otherProps] = split(htmlProps, layoutPropNames as any)
+  const [styleProps, otherProps] = split(htmlProps, stylePropNames as any)
 
   const checkboxProps = getCheckboxProps(otherProps)
   const inputProps = getInputProps({}, ref)
@@ -118,7 +118,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
   }
 
   return (
-    <chakra.label className="chakra-radio" {...rootProps} __css={rootStyles}>
+    <chakra.label className="chakra-radio" {...styleProps} __css={rootStyles}>
       <input className="chakra-radio__input" {...inputProps} />
       <chakra.span
         className="chakra-radio__control"

--- a/packages/radio/stories/radio.stories.tsx
+++ b/packages/radio/stories/radio.stories.tsx
@@ -1,6 +1,13 @@
 import * as React from "react"
 import { chakra } from "@chakra-ui/system"
-import { Stack, Wrap, SimpleGrid, Container, WrapItem } from "@chakra-ui/layout"
+import {
+  Stack,
+  Wrap,
+  SimpleGrid,
+  Container,
+  WrapItem,
+  Box,
+} from "@chakra-ui/layout"
 import {
   useRadio,
   Radio,
@@ -23,7 +30,17 @@ export const Readonly = () => (
     I'm a readonly radio
   </Radio>
 )
-
+export const StyledRadio = () => (
+  <Radio
+    background="gray.100"
+    border="1px"
+    borderColor="gray.300"
+    colorScheme="gray"
+    padding={4}
+  >
+    Radio
+  </Radio>
+)
 export const WithSizes = () => {
   const sizes = ["sm", "md", "lg"]
 

--- a/packages/radio/stories/radio.stories.tsx
+++ b/packages/radio/stories/radio.stories.tsx
@@ -1,13 +1,6 @@
 import * as React from "react"
 import { chakra } from "@chakra-ui/system"
-import {
-  Stack,
-  Wrap,
-  SimpleGrid,
-  Container,
-  WrapItem,
-  Box,
-} from "@chakra-ui/layout"
+import { Stack, Wrap, SimpleGrid, Container, WrapItem } from "@chakra-ui/layout"
 import {
   useRadio,
   Radio,

--- a/packages/styled-system/src/system.ts
+++ b/packages/styled-system/src/system.ts
@@ -50,3 +50,4 @@ export const propNames = [...objectKeys(systemProps), ...pseudoPropNames]
 const styleProps = { ...systemProps, ...pseudoSelectors }
 
 export const isStyleProp = (prop: string) => prop in styleProps
+export const stylePropNames = objectKeys(styleProps)

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -25,11 +25,21 @@ export function pick<T extends Dict, K extends keyof T>(object: T, keys: K[]) {
   return result
 }
 
+/**
+ * Splits the property values of a dictionary like type.
+ * The values are split based on whether they are present within the keys.
+ * @param object The dictionary whose values we want to split
+ * @param keys The keys whose values we want to include
+ * @returns [picked, omitted] of the values of the dictionary
+ */
 export function split<T extends Dict, K extends keyof T>(object: T, keys: K[]) {
   const picked: Dict = {}
   const omitted: Dict = {}
 
   Object.keys(object).forEach((key) => {
+    // if key is within keys of the object
+    // then add it to picked
+    // otherwise omit it
     if (keys.includes(key as T[K])) {
       picked[key] = object[key]
     } else {


### PR DESCRIPTION
Closes #4295

## 📝 Description
`Radio` styling was being applied to the checkbox rather than the container. This behaviour was different from `Checkbox` (the chakra checkbox component), where the styling was applied to the container. 

As the radio is an extremely small element and its colours can be adjusted through usage of the `colorScheme` prop, it makes more sense for the behaviour to be brought in line with `Checkbox`, where styling is applied to the container as a whole.

This was done through making the props being applied to the container take `styleProps` (which is a strict superset of the old `layoutProps`). This still preserves behaviour where additional `htmlProps` is being applied to the checkbox (of the `Radio`)

## ⛳️ Current behavior (updates)

Styling for `Radio` is being applied onto the checkbox element rather than the container element, which is different from what `Checkbox` establishes and is also counter-intuitive. 

## 🚀 New behavior
This PR changes the internals of `Radio` so that `styleProps` are also applied rather than just `layoutProps`

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
- 