### PR TITLE
Fix/tooltip close

### DIFF
--- a/.changeset/grumpy-dodos-turn.md
+++ b/.changeset/grumpy-dodos-turn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tooltip": patch
+---
+
+Fix tooltips not closing when openDelay is set

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -159,7 +159,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
    * React regarding the onMouseLeave polyfill.
    * @see https://github.com/facebook/react/issues/11972
    */
-  useEventListener("mouseleave", closeWithDelay, ref.current)
+  useEventListener("mouseleave", closeWithDelay, () => ref.current)
 
   const getTriggerProps: PropGetter = React.useCallback(
     (props = {}, _ref = null) => {

--- a/packages/tooltip/tests/tooltip.test.tsx
+++ b/packages/tooltip/tests/tooltip.test.tsx
@@ -68,6 +68,35 @@ test("should not show on mouseover if isDisabled is true", async () => {
   jest.useRealTimers()
 })
 
+test("should close on mouseleave if openDelay is set", async () => {
+  jest.useFakeTimers()
+
+  render(<DummyComponent openDelay={500} />)
+
+  act(() => {
+    fireEvent.mouseOver(screen.getByText(buttonLabel))
+    jest.advanceTimersByTime(200)
+  })
+
+  expect(screen.queryByText(tooltipLabel)).not.toBeInTheDocument()
+
+  act(() => {
+    jest.advanceTimersByTime(500)
+    fireEvent.mouseLeave(screen.getByText(buttonLabel))
+  })
+
+  expect(screen.getByText(buttonLabel)).toBeInTheDocument()
+  expect(screen.getByRole("tooltip")).toBeInTheDocument()
+
+  act(() => {
+    jest.advanceTimersByTime(1000)
+  })
+
+  await waitForElementToBeRemoved(() => screen.getByText(tooltipLabel))
+
+  jest.useRealTimers()
+})
+
 test("should show on mouseover if isDisabled has a falsy value", async () => {
   render(<DummyComponent isDisabled={false} />)
 


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3659 

## 📝 Description

When tooltips are used with `openDelay` they behave inconsistent and sometimes don't disappear until you hover them a second time.

## ⛳️ Current behavior (updates)

Currently the element inside the trigger ref is directly passed to `useEventListener` which is null on initial render.
As a result, the event listener for `mouseleave` is not being applied on first render.

## 🚀 New behavior

With the changes in this PR, the element inside the trigger ref is not directly passed, but passed inside a callback that still points to the trigger ref.

Tooltips should now close as intended.

## 💣 Is this a breaking change (Yes/No):

No.
