### PR TITLE
feat(editable): add editable textarea element

### DIFF
--- a/.changeset/beige-poems-fold.md
+++ b/.changeset/beige-poems-fold.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/anatomy": minor
+---
+
+Add `textarea` part to `editableAnatomy`

--- a/.changeset/modern-dryers-kiss.md
+++ b/.changeset/modern-dryers-kiss.md
@@ -1,0 +1,28 @@
+---
+"@chakra-ui/editable": minor
+---
+
+Add textarea element to handle multi line text input with editable context.
+
+1. Use union type
+
+```typescript
+// editable/src/use-editable.ts
+  ...
+  const [value, setValue] = useControllableState({
+    defaultValue: defaultValue || "",
+    value: valueProp,
+    onChange: onChangeProp,
+  })
+  ...
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
+```
+
+Because the editable context has one controllable state as default, use union
+type for input to make compatibility with the above condition.
+
+1. split test suite for editable textarea
+
+Despite of the similarity of `editable.test.tsx` and
+`editableTextarea.test.tsx`, which is the test file in `editable pakage`, I
+choose to split test suite to minimize lines of suite.

--- a/.changeset/modern-dryers-kiss.md
+++ b/.changeset/modern-dryers-kiss.md
@@ -2,27 +2,12 @@
 "@chakra-ui/editable": minor
 ---
 
-Add textarea element to handle multi line text input with editable context.
+Added the component `EditableTextarea` to `Editable`. Use the textarea element
+to handle multi line text input in an editable context.
 
-1. Use union type
-
-```typescript
-// editable/src/use-editable.ts
-  ...
-  const [value, setValue] = useControllableState({
-    defaultValue: defaultValue || "",
-    value: valueProp,
-    onChange: onChangeProp,
-  })
-  ...
-  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
+```tsx live=false
+<Editable defaultValue="Change me" onChange={console.log}>
+  <EditablePreview />
+  <EditableTextarea />
+</Editable>
 ```
-
-Because the editable context has one controllable state as default, use union
-type for input to make compatibility with the above condition.
-
-1. split test suite for editable textarea
-
-Despite of the similarity of `editable.test.tsx` and
-`editableTextarea.test.tsx`, which is the test file in `editable pakage`, I
-choose to split test suite to minimize lines of suite.

--- a/.changeset/proud-camels-dream.md
+++ b/.changeset/proud-camels-dream.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": minor
+---
+
+Add styles for new `textarea` element in `Editable`

--- a/packages/anatomy/src/index.ts
+++ b/packages/anatomy/src/index.ts
@@ -59,7 +59,11 @@ export const drawerAnatomy = anatomy("drawer")
   .parts("overlay", "dialogContainer", "dialog")
   .extend("header", "closeButton", "body", "footer")
 
-export const editableAnatomy = anatomy("editable").parts("preview", "input")
+export const editableAnatomy = anatomy("editable").parts(
+  "preview",
+  "input",
+  "textarea",
+)
 
 export const formAnatomy = anatomy("form").parts(
   "container",

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -181,7 +181,7 @@ export const EditableTextarea = forwardRef<EditableTextareaProps, "textarea">(
         __css={{
           outline: 0,
           ...commonStyles,
-          ...styles,
+          ...styles.textarea,
         }}
         className={_className}
       />

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -8,6 +8,7 @@ import {
   useMultiStyleConfig,
   useStyles,
   HTMLChakraProps,
+  useStyleConfig,
 } from "@chakra-ui/system"
 import { cx, runIfFn, __DEV__ } from "@chakra-ui/utils"
 import { createContext, MaybeRenderProp } from "@chakra-ui/react-utils"
@@ -160,6 +161,41 @@ if (__DEV__) {
   EditableInput.displayName = "EditableInput"
 }
 
+export interface EditableTextareaProps extends HTMLChakraProps<"textarea"> {}
+
+/**
+ * EditableTextarea
+ *
+ * The textarea used in the `edit` mode
+ */
+export const EditableTextarea = forwardRef<EditableTextareaProps, "textarea">(
+  (props, ref) => {
+    const { getTextareaProps } = useEditableContext()
+    const styles = useStyleConfig("Textarea", props)
+
+    const textareaProps = getTextareaProps(
+      props,
+      ref,
+    ) as HTMLChakraProps<"textarea">
+    const _className = cx("chakra-editable__textarea", props.className)
+
+    return (
+      <chakra.textarea
+        {...textareaProps}
+        __css={{
+          outline: 0,
+          ...commonStyles,
+          ...styles,
+        }}
+        className={_className}
+      />
+    )
+  },
+)
+
+if (__DEV__) {
+  EditableTextarea.displayName = "EditableTextarea"
+}
 /**
  * React hook use to gain access to the editable state and actions.
  */

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -140,7 +140,7 @@ export const EditableInput = forwardRef<EditableInputProps, "input">(
     const { getInputProps } = useEditableContext()
     const styles = useStyles()
 
-    const inputProps = getInputProps(props, ref) as HTMLChakraProps<"input">
+    const inputProps = getInputProps(props, ref)
     const _className = cx("chakra-editable__input", props.className)
 
     return (
@@ -173,10 +173,7 @@ export const EditableTextarea = forwardRef<EditableTextareaProps, "textarea">(
     const { getTextareaProps } = useEditableContext()
     const styles = useStyleConfig("Textarea", props)
 
-    const textareaProps = getTextareaProps(
-      props,
-      ref,
-    ) as HTMLChakraProps<"textarea">
+    const textareaProps = getTextareaProps(props, ref)
     const _className = cx("chakra-editable__textarea", props.className)
 
     return (
@@ -200,13 +197,8 @@ if (__DEV__) {
  * React hook use to gain access to the editable state and actions.
  */
 export function useEditableState() {
-  const {
-    isEditing,
-    onSubmit,
-    onCancel,
-    onEdit,
-    isDisabled,
-  } = useEditableContext()
+  const { isEditing, onSubmit, onCancel, onEdit, isDisabled } =
+    useEditableContext()
 
   return {
     isEditing,

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -8,7 +8,6 @@ import {
   useMultiStyleConfig,
   useStyles,
   HTMLChakraProps,
-  useStyleConfig,
 } from "@chakra-ui/system"
 import { cx, runIfFn, __DEV__ } from "@chakra-ui/utils"
 import { createContext, MaybeRenderProp } from "@chakra-ui/react-utils"
@@ -171,7 +170,7 @@ export interface EditableTextareaProps extends HTMLChakraProps<"textarea"> {}
 export const EditableTextarea = forwardRef<EditableTextareaProps, "textarea">(
   (props, ref) => {
     const { getTextareaProps } = useEditableContext()
-    const styles = useStyleConfig("Textarea", props)
+    const styles = useStyles()
 
     const textareaProps = getTextareaProps(props, ref)
     const _className = cx("chakra-editable__textarea", props.className)

--- a/packages/editable/src/use-editable.ts
+++ b/packages/editable/src/use-editable.ts
@@ -5,6 +5,7 @@ import {
   useSafeLayoutEffect,
 } from "@chakra-ui/hooks"
 import { EventKeyMap, mergeRefs, PropGetter } from "@chakra-ui/react-utils"
+import { HTMLChakraProps } from "@chakra-ui/system"
 import {
   ariaAttr,
   callAllHandlers,
@@ -256,7 +257,10 @@ export function useEditable(props: UseEditableProps = {}) {
     ],
   )
 
-  const getInputProps: PropGetter = useCallback(
+  const getInputProps: PropGetter<
+    HTMLInputElement,
+    HTMLChakraProps<"input">
+  > = useCallback(
     (props = {}, ref = null) => ({
       ...props,
       hidden: !isEditing,
@@ -272,7 +276,10 @@ export function useEditable(props: UseEditableProps = {}) {
     [isDisabled, isEditing, onBlur, onChange, onKeyDown, placeholder, value],
   )
 
-  const getTextareaProps: PropGetter = useCallback(
+  const getTextareaProps: PropGetter<
+    HTMLTextAreaElement,
+    HTMLChakraProps<"textarea">
+  > = useCallback(
     (props = {}, ref = null) => ({
       ...props,
       hidden: !isEditing,

--- a/packages/editable/src/use-editable.ts
+++ b/packages/editable/src/use-editable.ts
@@ -4,7 +4,12 @@ import {
   useUpdateEffect,
   useSafeLayoutEffect,
 } from "@chakra-ui/hooks"
-import { EventKeyMap, mergeRefs, PropGetter } from "@chakra-ui/react-utils"
+import {
+  EventKeyMap,
+  mergeRefs,
+  PropGetter,
+  PropGetterV2,
+} from "@chakra-ui/react-utils"
 import { HTMLChakraProps } from "@chakra-ui/system"
 import {
   ariaAttr,
@@ -257,8 +262,8 @@ export function useEditable(props: UseEditableProps = {}) {
     ],
   )
 
-  const getInputProps: PropGetter<
-    HTMLInputElement,
+  const getInputProps: PropGetterV2<
+    "input",
     HTMLChakraProps<"input">
   > = useCallback(
     (props = {}, ref = null) => ({
@@ -276,8 +281,8 @@ export function useEditable(props: UseEditableProps = {}) {
     [isDisabled, isEditing, onBlur, onChange, onKeyDown, placeholder, value],
   )
 
-  const getTextareaProps: PropGetter<
-    HTMLTextAreaElement,
+  const getTextareaProps: PropGetterV2<
+    "textarea",
     HTMLChakraProps<"textarea">
   > = useCallback(
     (props = {}, ref = null) => ({

--- a/packages/editable/src/use-editable.ts
+++ b/packages/editable/src/use-editable.ts
@@ -113,7 +113,7 @@ export function useEditable(props: UseEditableProps = {}) {
   /**
    * Ref to help focus the input in edit mode
    */
-  const inputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
   const previewRef = useRef<any>(null)
 
   const editButtonRef = useRef<HTMLButtonElement>(null)
@@ -168,7 +168,7 @@ export function useEditable(props: UseEditableProps = {}) {
   }, [value, onSubmitProp])
 
   const onChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement & HTMLTextAreaElement>) => {
       setValue(event.target.value)
     },
     [setValue],
@@ -195,6 +195,24 @@ export function useEditable(props: UseEditableProps = {}) {
       }
     },
     [onCancel, onSubmit],
+  )
+
+  const onKeyDownWithoutSubmit = useCallback(
+    (event: React.KeyboardEvent) => {
+      const eventKey = normalizeEventKey(event)
+
+      const keyMap: EventKeyMap = {
+        Escape: onCancel,
+      }
+
+      const action = keyMap[eventKey]
+
+      if (action) {
+        event.preventDefault()
+        action(event)
+      }
+    },
+    [onCancel],
   )
 
   const isValueEmpty = isEmpty(value)
@@ -254,6 +272,30 @@ export function useEditable(props: UseEditableProps = {}) {
     [isDisabled, isEditing, onBlur, onChange, onKeyDown, placeholder, value],
   )
 
+  const getTextareaProps: PropGetter = useCallback(
+    (props = {}, ref = null) => ({
+      ...props,
+      hidden: !isEditing,
+      placeholder,
+      ref: mergeRefs(ref, inputRef),
+      disabled: isDisabled,
+      "aria-disabled": ariaAttr(isDisabled),
+      value,
+      onBlur: callAllHandlers(props.onBlur, onBlur),
+      onChange: callAllHandlers(props.onChange, onChange),
+      onKeyDown: callAllHandlers(props.onKeyDown, onKeyDownWithoutSubmit),
+    }),
+    [
+      isDisabled,
+      isEditing,
+      onBlur,
+      onChange,
+      onKeyDownWithoutSubmit,
+      placeholder,
+      value,
+    ],
+  )
+
   const getEditButtonProps: PropGetter = useCallback(
     (props = {}, ref = null) => ({
       "aria-label": "Edit",
@@ -298,6 +340,7 @@ export function useEditable(props: UseEditableProps = {}) {
     onSubmit,
     getPreviewProps,
     getInputProps,
+    getTextareaProps,
     getEditButtonProps,
     getSubmitButtonProps,
     getCancelButtonProps,

--- a/packages/editable/src/use-editable.ts
+++ b/packages/editable/src/use-editable.ts
@@ -168,8 +168,8 @@ export function useEditable(props: UseEditableProps = {}) {
   }, [value, onSubmitProp])
 
   const onChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement & HTMLTextAreaElement>) => {
-      setValue(event.target.value)
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setValue(event.currentTarget.value)
     },
     [setValue],
   )

--- a/packages/editable/stories/editable.stories.tsx
+++ b/packages/editable/stories/editable.stories.tsx
@@ -5,6 +5,7 @@ import {
   Editable,
   EditableInput,
   EditablePreview,
+  EditableTextarea,
   useEditableControls,
 } from "../src"
 
@@ -105,5 +106,22 @@ export const CodeSandboxTopbar = () => {
         <EditablePreview />
       </Editable>
     </chakra.div>
+  )
+}
+
+export const TextareaAsInput = () => {
+  return (
+    <Editable
+      defaultValue="Hello!!"
+      fontSize="xl"
+      textAlign="center"
+      isPreviewFocusable={false}
+      submitOnBlur={false}
+      onChange={console.log}
+    >
+      <EditablePreview />
+      <EditableTextarea />
+      <EditableControls />
+    </Editable>
   )
 }

--- a/packages/editable/tests/editableTextarea.test.tsx
+++ b/packages/editable/tests/editableTextarea.test.tsx
@@ -1,0 +1,211 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  testA11y,
+  userEvent,
+} from "@chakra-ui/test-utils"
+import * as React from "react"
+import { Editable, EditablePreview, EditableTextarea } from "../src"
+
+test("matches snapshot", () => {
+  render(
+    <Editable defaultValue="testing">
+      <EditableTextarea data-testid="textarea" />
+    </Editable>,
+  )
+
+  const textarea = screen.getByTestId("textarea")
+
+  expect(textarea).toHaveAttribute("hidden")
+})
+
+it("passes a11y test", async () => {
+  await testA11y(
+    <Editable defaultValue="testing">
+      <EditableTextarea data-testid="textarea" />
+    </Editable>,
+  )
+})
+
+test("uncontrolled: handles callbacks correctly", async () => {
+  const onChange = jest.fn()
+  const onCancel = jest.fn()
+  const onSubmit = jest.fn()
+  const onEdit = jest.fn()
+
+  render(
+    <Editable
+      onChange={onChange}
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+      onEdit={onEdit}
+      defaultValue="Hello "
+    >
+      <EditablePreview data-testid="preview" />
+      <EditableTextarea data-testid="textarea" />
+    </Editable>,
+  )
+  const preview = screen.getByTestId("preview")
+  const textarea = screen.getByTestId("textarea")
+
+  // calls `onEdit` when preview is focused
+  fireEvent.focus(preview)
+  expect(onEdit).toHaveBeenCalled()
+
+  // calls `onChange` with input on change
+  userEvent.type(textarea, "World")
+  expect(onChange).toHaveBeenCalledWith("Hello World")
+
+  // get new line on user press "Enter"
+  userEvent.type(
+    textarea,
+    `
+  textarea`,
+  )
+  expect(onChange).toHaveBeenLastCalledWith(`Hello World
+  textarea`)
+
+  // calls `onCancel` with previous value when "esc" pressed
+  fireEvent.keyDown(textarea, { key: "Escape" })
+  expect(onCancel).toHaveBeenCalledWith("Hello ")
+
+  fireEvent.focus(preview)
+
+  // do not calls `onSubmit` with previous value when "enter" pressed after cancelling
+  fireEvent.keyDown(textarea, { key: "Enter" })
+  expect(onSubmit).not.toHaveBeenCalled()
+})
+
+test("controlled: handles callbacks correctly", () => {
+  const onChange = jest.fn()
+  const onCancel = jest.fn()
+  const onSubmit = jest.fn()
+  const onEdit = jest.fn()
+
+  const Component = () => {
+    const [value, setValue] = React.useState("Hello ")
+    return (
+      <Editable
+        onChange={(val) => {
+          setValue(val)
+          onChange(val)
+        }}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        onEdit={onEdit}
+        value={value}
+      >
+        <EditablePreview data-testid="preview" />
+        <EditableTextarea data-testid="textarea" />
+      </Editable>
+    )
+  }
+
+  render(<Component />)
+  const preview = screen.getByTestId("preview")
+  const textarea = screen.getByTestId("textarea")
+
+  // calls `onEdit` when preview is focused
+  fireEvent.focus(preview)
+  expect(onEdit).toHaveBeenCalled()
+
+  // calls `onChange` with input on change
+  userEvent.type(textarea, "World")
+  expect(onChange).toHaveBeenCalledWith("Hello World")
+
+  // do not calls `onSubmit`
+  fireEvent.keyDown(textarea, { key: "Enter" })
+  expect(onSubmit).not.toHaveBeenCalledWith("World")
+
+  expect(textarea).toBeVisible()
+
+  // update the input value with new line
+  userEvent.type(
+    textarea,
+    `
+  textarea`,
+  )
+  expect(onChange).toHaveBeenCalledWith(`Hello World
+  textarea`)
+
+  // press `Escape`
+  fireEvent.keyDown(textarea, { key: "Escape" })
+
+  // calls `onCancel` with previous `value`
+  expect(onCancel).toHaveBeenCalledWith(`Hello `)
+})
+
+test("handles preview and textarea callbacks", () => {
+  const onFocus = jest.fn()
+  const onBlur = jest.fn()
+  const onChange = jest.fn()
+  const onKeyDown = jest.fn()
+
+  render(
+    <Editable defaultValue="Hello ">
+      <EditablePreview onFocus={onFocus} data-testid="preview" />
+      <EditableTextarea
+        onBlur={onBlur}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        data-testid="textarea"
+      />
+    </Editable>,
+  )
+  const preview = screen.getByTestId("preview")
+  const textarea = screen.getByTestId("textarea")
+
+  // calls `onFocus` when preview is focused
+  fireEvent.focus(preview)
+  expect(onFocus).toHaveBeenCalled()
+
+  // calls `onChange` when input is changed
+  userEvent.type(textarea, "World")
+  expect(onChange).toHaveBeenCalled()
+
+  // calls `onKeyDown` when key is pressed in input
+  fireEvent.keyDown(textarea, { key: "Escape" })
+  expect(onKeyDown).toHaveBeenCalled()
+
+  expect(textarea).not.toBeVisible()
+})
+
+test("has the proper aria attributes", () => {
+  const { rerender } = render(
+    <Editable defaultValue="">
+      <EditableTextarea data-testid="textarea" />
+    </Editable>,
+  )
+  let textarea = screen.getByTestId("textarea")
+
+  // preview and input do not have aria-disabled when `Editable` is not disabled
+  expect(textarea).not.toHaveAttribute("aria-disabled")
+
+  rerender(
+    <Editable isDisabled defaultValue="">
+      <EditableTextarea data-testid="textarea" />
+    </Editable>,
+  )
+
+  textarea = screen.getByTestId("textarea")
+
+  // preview and input have aria-disabled when `Editable` is disabled
+  expect(textarea).toHaveAttribute("aria-disabled", "true")
+})
+
+test("editable textarea can submit on blur", () => {
+  const onSubmit = jest.fn()
+
+  render(
+    <Editable submitOnBlur onSubmit={onSubmit} defaultValue="testing">
+      <EditablePreview data-testid="preview" />
+      <EditableTextarea data-testid="textarea" />
+    </Editable>,
+  )
+
+  const textarea = screen.getByTestId("textarea")
+
+  fireEvent.blur(textarea)
+  expect(onSubmit).toHaveBeenCalledWith("testing")
+})

--- a/packages/theme/src/components/editable.ts
+++ b/packages/theme/src/components/editable.ts
@@ -21,9 +21,20 @@ const baseStyleInput: SystemStyleObject = {
   _placeholder: { opacity: 0.6 },
 }
 
+const baseStyleTextarea: SystemStyleObject = {
+  borderRadius: "md",
+  py: "3px",
+  transitionProperty: "common",
+  transitionDuration: "normal",
+  width: "full",
+  _focus: { boxShadow: "outline" },
+  _placeholder: { opacity: 0.6 },
+}
+
 const baseStyle: PartsStyleObject<typeof parts> = {
   preview: baseStylePreview,
   input: baseStyleInput,
+  textarea: baseStyleTextarea,
 }
 
 export default {


### PR DESCRIPTION
Editable textarea element to handle multi-line input within editable context. 

Closes #1622 <!-- Github issue # here -->

## 📝 Description

>  Add EditableTextare element to handle multiline input with editable context

## 🚀 New behavior

> new line input is possible with editable context.

## 📝 Additional Information

 ### Use union type for inputRef

  ```typescript
// editable/src/use-editable.ts
  ...
  const [value, setValue] = useControllableState({
    defaultValue: defaultValue || "",
    value: valueProp,
    onChange: onChangeProp,
  })
  ...
  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
```
  Because the editable context has one controllable state as default, 
  use union type for input to maintain compatibility with the above condition.

### split test suite for editable textarea

  Despite of the similarity of `editable.test.tsx` and `editableTextarea.test.tsx`, which is the test file in `editable pakage`,
  I choose to split test suite to minimize lines of suite.