### PR TITLE
fix(skeleton): don't animate when skeleton was previously loaded

### DIFF
--- a/.changeset/curly-frogs-kick.md
+++ b/.changeset/curly-frogs-kick.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/skeleton": patch
+---
+
+fix(skeleton): don't animate when skeleton was previously loaded

--- a/packages/skeleton/src/skeleton.tsx
+++ b/packages/skeleton/src/skeleton.tsx
@@ -8,6 +8,7 @@ import {
   useStyleConfig,
   HTMLChakraProps,
 } from "@chakra-ui/system"
+import { usePrevious } from "@chakra-ui/hooks"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
@@ -89,10 +90,13 @@ export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
     ...rest
   } = omitThemingProps(props)
 
+  const wasPreviouslyLoaded = usePrevious(isLoaded)
+
   const _className = cx("chakra-skeleton", className)
 
   if (isLoaded) {
-    const animation = isFirstRender ? "none" : `${fade} ${fadeDuration}s`
+    const animation =
+      isFirstRender || wasPreviouslyLoaded ? "none" : `${fade} ${fadeDuration}s`
 
     return (
       <chakra.div

--- a/packages/skeleton/tests/skeleton.test.tsx
+++ b/packages/skeleton/tests/skeleton.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { ThemeProvider } from "@chakra-ui/system"
 import { render } from "@chakra-ui/test-utils"
 import MatchMediaMock from "jest-matchmedia-mock"
-import { SkeletonText } from "../src"
+import { Skeleton, SkeletonText } from "../src"
 import { queries, theme } from "./test-data"
 
 let matchMedia: any
@@ -28,6 +28,27 @@ test("SkeletonText renders noOfLines respective to the responsive breakpoint", (
 
   expect(skeletonGroup).not.toBeNull()
   expect(skeletonGroup!.childElementCount).toBe(desiredNoOfLines)
+})
+
+test("Change in parent state does not cause animation if already loaded", () => {
+  const TestComponent = () => {
+    const [, setState] = React.useState(false)
+    React.useEffect(() => {
+      setState(true)
+    }, [])
+    return (
+      <ThemeProvider theme={theme}>
+        <Skeleton isLoaded />
+      </ThemeProvider>
+    )
+  }
+
+  const { container } = render(<TestComponent />)
+
+  const skeleton = container.querySelector(".chakra-skeleton")
+
+  expect(skeleton).not.toBeNull()
+  expect(skeleton).toHaveStyle({ animation: "none" })
 })
 
 function renderWithQuery(query: string, ui: React.ReactElement) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4394.

## 📝 Description

https://github.com/chakra-ui/chakra-ui/pull/2775 fixed one bug but introduced another. 

## ⛳️ Current behavior (updates)

If a component has a child Skeleton that's loaded (`<Skeleton isLoaded/>`) and the parent component re-renders, the Skeleton would animate because it was no longer the first render.

## 🚀 New behavior

It now needs to meet a stronger condition to animate when loaded. If `isLoaded=true` and it's the first render **or** the skeleton was already loaded in the previous render, no animation will happen.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Test was added. Was failing before my fix.
