### PR TITLE
docs: daily workflow create pr

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   daily:
+    if: ${{ 'chakra-ui/chakra-ui' == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Get Yarn cache path

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -59,7 +59,9 @@ jobs:
           git add .all-membersrc
           git commit -m "chore(.all-membersrc): $GITHUB_SHA"
 
-      - name: Deploy to main
-        run: |
-          git pull --rebase
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          delete-branch: true
+          title: Daily updates for sponsors, members and avatars
+          branch: chore/daily-updates


### PR DESCRIPTION
## 📝 Description

Fix issues mentioned in #4410.

## ⛳️ Current behavior (updates)

1. Runs on every forked repo
2. Commit and push to `main` branch

## 🚀 New behavior

1. Use [jobs.<job_id>.if](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif) with repository check
2. Use [create-pull-request](https://github.com/peter-evans/create-pull-request) for committing changes

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

@with-heart the workflow has been tested on my forked repo (with modified `daily.yml` pointed to my repo) and it created a PR:

* https://github.com/tomchentw/chakra-ui/runs/3148979339?check_suite_focus=true
* https://github.com/tomchentw/chakra-ui/pull/4

![JPEG-1](https://user-images.githubusercontent.com/922234/126856679-2b23d21c-ffa6-4aa8-a5a2-47dc467ac175.jpg)
