### PR TITLE
docs(react-live-dynamic): reduces 32.2% size of the docs website

### DIFF
--- a/website/src/components/codeblock/code-container.tsx
+++ b/website/src/components/codeblock/code-container.tsx
@@ -1,0 +1,8 @@
+import { Box, BoxProps } from "@chakra-ui/react"
+import React from "react"
+
+function CodeContainer(props: BoxProps) {
+  return <Box padding="5" rounded="8px" my="8" bg="#011627" {...props} />
+}
+
+export default CodeContainer

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -1,12 +1,22 @@
-import { Box } from "@chakra-ui/react"
+import { Box, useBoolean } from "@chakra-ui/react"
+import dynamic from "next/dynamic"
 import theme from "prism-react-renderer/themes/nightOwl"
-import React from "react"
+import React, { useEffect } from "react"
 import CodeContainer from "./code-container"
 import CopyButton from "./copy-button"
 import Highlight from "./highlight"
-import ReactLiveBlock from "./react-live-block"
+
+const ReactLiveBlock = dynamic(() => import("./react-live-block"))
 
 function CodeBlock(props) {
+  const [isMounted, { on }] = useBoolean()
+  useEffect(
+    /**
+     * Lazily-load <ReactLiveBlock /> to save bundle size.
+     */
+    on,
+    [],
+  )
   const {
     className,
     live = true,
@@ -30,11 +40,11 @@ function CodeBlock(props) {
     ...rest,
   }
 
-  if (language === "jsx" && live === true) {
+  if (isMounted && language === "jsx" && live === true) {
     return <ReactLiveBlock editable {...reactLiveBlockProps} />
   }
 
-  if (render) {
+  if (isMounted && render) {
     /**
      * @TODO Not sure if this is even used?
      */

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -1,14 +1,8 @@
-import {
-  Box,
-  BoxProps,
-  Button,
-  ButtonProps,
-  chakra,
-  useClipboard,
-} from "@chakra-ui/react"
+import { Box, BoxProps, chakra } from "@chakra-ui/react"
 import theme from "prism-react-renderer/themes/nightOwl"
 import React, { useState } from "react"
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from "react-live"
+import CopyButton from "./copy-button"
 import Highlight from "./highlight"
 import scope from "./react-live-scope"
 import { liveEditorStyle, liveErrorStyle } from "./styles"
@@ -22,21 +16,6 @@ const LiveCodePreview = chakra(LivePreview, {
     borderRadius: "12px",
   },
 })
-
-const CopyButton = (props: ButtonProps) => (
-  <Button
-    size="sm"
-    position="absolute"
-    textTransform="uppercase"
-    colorScheme="teal"
-    fontSize="xs"
-    height="24px"
-    top={0}
-    zIndex="1"
-    right="1.25em"
-    {...props}
-  />
-)
 
 const EditableNotice = (props: BoxProps) => {
   return (
@@ -80,7 +59,6 @@ function CodeBlock(props) {
   const [editorCode, setEditorCode] = useState(children.trim())
 
   const language = className?.replace(/language-/, "")
-  const { hasCopied, onCopy } = useClipboard(editorCode)
 
   const liveProviderProps = {
     theme,
@@ -101,9 +79,7 @@ function CodeBlock(props) {
           <CodeContainer>
             <LiveEditor onChange={onChange} style={liveEditorStyle} />
           </CodeContainer>
-          <CopyButton onClick={onCopy}>
-            {hasCopied ? "copied" : "copy"}
-          </CopyButton>
+          <CopyButton code={editorCode} />
           <EditableNotice />
         </Box>
         <LiveError style={liveErrorStyle} />
@@ -117,9 +93,7 @@ function CodeBlock(props) {
         <LiveProvider {...liveProviderProps}>
           <LiveCodePreview zIndex="1" />
           <Box position="relative" zIndex="0">
-            <CopyButton onClick={onCopy}>
-              {hasCopied ? "copied" : "copy"}
-            </CopyButton>
+            <CopyButton code={editorCode} />
           </Box>
         </LiveProvider>
       </div>
@@ -136,9 +110,7 @@ function CodeBlock(props) {
           showLines={viewlines}
         />
       </CodeContainer>
-      <CopyButton top="4" onClick={onCopy}>
-        {hasCopied ? "copied" : "copy"}
-      </CopyButton>
+      <CopyButton top="4" code={editorCode} />
     </Box>
   )
 }

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -54,6 +54,7 @@ function CodeBlock(props) {
     children,
     viewlines,
     ln,
+    mountStylesheet = false,
     ...rest
   } = props
   const [editorCode, setEditorCode] = useState(children.trim())
@@ -66,6 +67,7 @@ function CodeBlock(props) {
     code: editorCode,
     scope,
     noInline: manual,
+    mountStylesheet,
     ...rest,
   }
 
@@ -113,10 +115,6 @@ function CodeBlock(props) {
       <CopyButton top="4" code={editorCode} />
     </Box>
   )
-}
-
-CodeBlock.defaultProps = {
-  mountStylesheet: false,
 }
 
 export default CodeBlock

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -1,46 +1,10 @@
-import { Box, BoxProps, chakra } from "@chakra-ui/react"
+import { Box } from "@chakra-ui/react"
 import theme from "prism-react-renderer/themes/nightOwl"
-import React, { useState } from "react"
-import { LiveEditor, LiveError, LivePreview, LiveProvider } from "react-live"
+import React from "react"
 import CodeContainer from "./code-container"
 import CopyButton from "./copy-button"
 import Highlight from "./highlight"
-import scope from "./react-live-scope"
-import { liveEditorStyle, liveErrorStyle } from "./styles"
-
-const LiveCodePreview = chakra(LivePreview, {
-  baseStyle: {
-    fontFamily: "body",
-    mt: 5,
-    p: 3,
-    borderWidth: 1,
-    borderRadius: "12px",
-  },
-})
-
-const EditableNotice = (props: BoxProps) => {
-  return (
-    <Box
-      position="absolute"
-      width="full"
-      top="-1.25em"
-      roundedTop="8px"
-      bg="#011627"
-      py="2"
-      zIndex="0"
-      letterSpacing="wide"
-      color="gray.400"
-      fontSize="xs"
-      fontWeight="semibold"
-      textAlign="center"
-      textTransform="uppercase"
-      pointerEvents="none"
-      {...props}
-    >
-      Editable Example
-    </Box>
-  )
-}
+import ReactLiveBlock from "./react-live-block"
 
 function CodeBlock(props) {
   const {
@@ -54,47 +18,29 @@ function CodeBlock(props) {
     mountStylesheet = false,
     ...rest
   } = props
-  const [editorCode, setEditorCode] = useState(children.trim())
 
   const language = className?.replace(/language-/, "")
-
-  const liveProviderProps = {
-    theme,
+  const rawCode = children.trim()
+  const reactLiveBlockProps = {
+    rawCode,
     language,
-    code: editorCode,
-    scope,
+    theme,
     noInline: manual,
     mountStylesheet,
     ...rest,
   }
 
-  const onChange = (newCode) => setEditorCode(newCode.trim())
-
   if (language === "jsx" && live === true) {
-    return (
-      <LiveProvider {...liveProviderProps}>
-        <LiveCodePreview zIndex="1" />
-        <Box position="relative" zIndex="0">
-          <CodeContainer>
-            <LiveEditor onChange={onChange} style={liveEditorStyle} />
-          </CodeContainer>
-          <CopyButton code={editorCode} />
-          <EditableNotice />
-        </Box>
-        <LiveError style={liveErrorStyle} />
-      </LiveProvider>
-    )
+    return <ReactLiveBlock editable {...reactLiveBlockProps} />
   }
 
   if (render) {
+    /**
+     * @TODO Not sure if this is even used?
+     */
     return (
       <div style={{ marginTop: 32 }}>
-        <LiveProvider {...liveProviderProps}>
-          <LiveCodePreview zIndex="1" />
-          <Box position="relative" zIndex="0">
-            <CopyButton code={editorCode} />
-          </Box>
-        </LiveProvider>
+        <ReactLiveBlock editable={false} {...reactLiveBlockProps} />
       </div>
     )
   }
@@ -103,14 +49,14 @@ function CodeBlock(props) {
     <Box position="relative" zIndex="0">
       <CodeContainer px="0" overflow="hidden">
         <Highlight
-          codeString={editorCode}
+          codeString={rawCode}
           language={language}
           theme={theme}
           metastring={ln}
           showLines={viewlines}
         />
       </CodeContainer>
-      <CopyButton top="4" code={editorCode} />
+      <CopyButton top="4" code={rawCode} />
     </Box>
   )
 }

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -2,6 +2,7 @@ import { Box, BoxProps, chakra } from "@chakra-ui/react"
 import theme from "prism-react-renderer/themes/nightOwl"
 import React, { useState } from "react"
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from "react-live"
+import CodeContainer from "./code-container"
 import CopyButton from "./copy-button"
 import Highlight from "./highlight"
 import scope from "./react-live-scope"
@@ -40,10 +41,6 @@ const EditableNotice = (props: BoxProps) => {
     </Box>
   )
 }
-
-const CodeContainer = (props: BoxProps) => (
-  <Box padding="5" rounded="8px" my="8" bg="#011627" {...props} />
-)
 
 function CodeBlock(props) {
   const {

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -105,6 +105,7 @@ function CodeBlock(props) {
         <Highlight
           codeString={editorCode}
           language={language}
+          theme={theme}
           metastring={ln}
           showLines={viewlines}
         />

--- a/website/src/components/codeblock/codeblock.tsx
+++ b/website/src/components/codeblock/codeblock.tsx
@@ -11,21 +11,7 @@ import React, { useState } from "react"
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from "react-live"
 import Highlight from "./highlight"
 import scope from "./react-live-scope"
-
-export const liveEditorStyle: React.CSSProperties = {
-  fontSize: 14,
-  overflowX: "auto",
-  fontFamily: "SF Mono, Menlo, monospace",
-}
-
-export const liveErrorStyle: React.CSSProperties = {
-  fontFamily: "SF Mono, Menlo, monospace",
-  fontSize: 14,
-  padding: "1em",
-  overflowX: "auto",
-  color: "white",
-  backgroundColor: "red",
-}
+import { liveEditorStyle, liveErrorStyle } from "./styles"
 
 const LiveCodePreview = chakra(LivePreview, {
   baseStyle: {

--- a/website/src/components/codeblock/copy-button.tsx
+++ b/website/src/components/codeblock/copy-button.tsx
@@ -1,0 +1,30 @@
+import { Button, ButtonProps, useClipboard } from "@chakra-ui/react"
+import React from "react"
+
+interface CopyButtonProps extends ButtonProps {
+  code: string
+}
+
+function CopyButton({ code, ...props }: CopyButtonProps) {
+  const { hasCopied, onCopy } = useClipboard(code)
+
+  return (
+    <Button
+      size="sm"
+      position="absolute"
+      textTransform="uppercase"
+      colorScheme="teal"
+      fontSize="xs"
+      height="24px"
+      top={0}
+      zIndex="1"
+      right="1.25em"
+      {...props}
+      onClick={onCopy}
+    >
+      {hasCopied ? "copied" : "copy"}
+    </Button>
+  )
+}
+
+export default CopyButton

--- a/website/src/components/codeblock/highlight.tsx
+++ b/website/src/components/codeblock/highlight.tsx
@@ -1,6 +1,9 @@
 import { chakra } from "@chakra-ui/react"
-import BaseHighlight, { defaultProps, Language } from "prism-react-renderer"
-import theme from "prism-react-renderer/themes/nightOwl"
+import BaseHighlight, {
+  defaultProps,
+  Language,
+  PrismTheme,
+} from "prism-react-renderer"
 import React from "react"
 import { liveEditorStyle } from "./styles"
 
@@ -26,6 +29,7 @@ const calculateLinesToHighlight = (meta: string) => {
 interface HighlightProps {
   codeString: string
   language: Language
+  theme: PrismTheme
   metastring?: string
   showLines?: boolean
 }
@@ -44,7 +48,6 @@ function Highlight({
       {...defaultProps}
       code={codeString}
       language={language}
-      theme={theme}
       {...props}
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => (

--- a/website/src/components/codeblock/highlight.tsx
+++ b/website/src/components/codeblock/highlight.tsx
@@ -2,7 +2,7 @@ import { chakra } from "@chakra-ui/react"
 import BaseHighlight, { defaultProps, Language } from "prism-react-renderer"
 import theme from "prism-react-renderer/themes/nightOwl"
 import React from "react"
-import { liveEditorStyle } from "./codeblock"
+import { liveEditorStyle } from "./styles"
 
 const RE = /{([\d,-]+)}/
 

--- a/website/src/components/codeblock/react-live-block.tsx
+++ b/website/src/components/codeblock/react-live-block.tsx
@@ -1,0 +1,68 @@
+import { Box, BoxProps, chakra } from "@chakra-ui/react"
+import React, { useState } from "react"
+import { LiveEditor, LiveError, LivePreview, LiveProvider } from "react-live"
+import CodeContainer from "./code-container"
+import CopyButton from "./copy-button"
+import scope from "./react-live-scope"
+import { liveEditorStyle, liveErrorStyle } from "./styles"
+
+const LiveCodePreview = chakra(LivePreview, {
+  baseStyle: {
+    fontFamily: "body",
+    mt: 5,
+    p: 3,
+    borderWidth: 1,
+    borderRadius: "12px",
+  },
+})
+
+const EditableNotice = (props: BoxProps) => {
+  return (
+    <Box
+      position="absolute"
+      width="full"
+      top="-1.25em"
+      roundedTop="8px"
+      bg="#011627"
+      py="2"
+      zIndex="0"
+      letterSpacing="wide"
+      color="gray.400"
+      fontSize="xs"
+      fontWeight="semibold"
+      textAlign="center"
+      textTransform="uppercase"
+      pointerEvents="none"
+      {...props}
+    >
+      Editable Example
+    </Box>
+  )
+}
+
+function ReactLiveBlock({ editable, rawCode, ...rest }) {
+  const [editorCode, setEditorCode] = useState(rawCode.trim())
+  const onChange = (newCode) => setEditorCode(newCode.trim())
+  const liveProviderProps = {
+    code: editorCode,
+    scope,
+    ...rest,
+  }
+  return (
+    <LiveProvider {...liveProviderProps}>
+      <LiveCodePreview zIndex="1" />
+      <Box position="relative" zIndex="0">
+        {editable && (
+          <CodeContainer>
+            <LiveEditor onChange={onChange} style={liveEditorStyle} />
+          </CodeContainer>
+        )}
+        <CopyButton code={editorCode} />
+        {editable && <EditableNotice />}
+      </Box>
+      {editable && <LiveError style={liveErrorStyle} />}
+    </LiveProvider>
+  )
+}
+
+export default ReactLiveBlock

--- a/website/src/components/codeblock/styles.tsx
+++ b/website/src/components/codeblock/styles.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+
+export const liveEditorStyle: React.CSSProperties = {
+  fontSize: 14,
+  overflowX: "auto",
+  fontFamily: "SF Mono, Menlo, monospace",
+}
+
+export const liveErrorStyle: React.CSSProperties = {
+  fontFamily: "SF Mono, Menlo, monospace",
+  fontSize: 14,
+  padding: "1em",
+  overflowX: "auto",
+  color: "white",
+  backgroundColor: "red",
+}


### PR DESCRIPTION
## 📝 Description

> Load live-editor dynamically after page mount

Per page size reduction: 785kB -> 532kB. Reduced **32.2%** of the initial bytes.

![out](https://user-images.githubusercontent.com/922234/126858634-0067f35d-3077-4184-8b37-89a1ed3c096a.jpg)

## ⛳️ Current behavior (updates)

The current `<CodeBlock />` imports `react-live` everywhere. Even for those pages that are not even using the live-editor feature (`live=true` ). 

## 🚀 New behavior

Refactor `<CodeBlock />` and make the live-editor parts loadable via `next/dynamic`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The loadable information by `Nextjs`:

![loadable](https://user-images.githubusercontent.com/922234/126858594-8f9ca087-86ab-40bd-b01e-e5de6d5329b7.jpg)
