### PR TITLE
fix(Stack): When cloning children, prefer each childs provided key 

### DIFF
--- a/.changeset/rotten-cobras-smash.md
+++ b/.changeset/rotten-cobras-smash.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/layout": patch
+---
+
+fix(Stack): Ensure that when cloning children, their provided keys are preferred
+over index. This prevents them from being destroyed and recreated when a child's
+position in the list changes.

--- a/packages/layout/src/stack.tsx
+++ b/packages/layout/src/stack.tsx
@@ -132,8 +132,10 @@ export const Stack = forwardRef<StackProps, "div">((props, ref) => {
   const clones = shouldUseChildren
     ? validChildren
     : validChildren.map((child, index) => {
+        // Prefer provided child key, fallback to index
+        const key = typeof child.key !== "undefined" ? child.key : index
         const isLast = index + 1 === validChildren.length
-        const wrappedChild = <StackItem key={index}>{child}</StackItem>
+        const wrappedChild = <StackItem key={key}>{child}</StackItem>
         const _child = shouldWrapChildren ? wrappedChild : child
 
         if (!hasDivider) return _child
@@ -146,7 +148,7 @@ export const Stack = forwardRef<StackProps, "div">((props, ref) => {
         const _divider = isLast ? null : clonedDivider
 
         return (
-          <React.Fragment key={index}>
+          <React.Fragment key={key}>
             {_child}
             {_divider}
           </React.Fragment>


### PR DESCRIPTION
Closes #4447

## 📝 Description

Ensures that, when cloning children, their original `key` is used if provided.

## ⛳️ Current behavior (updates)

Stack currently clones its children if `props.divider` is set or `props. shouldWrapChildren` is true. When cloning the children, the index of the children in the array is used as the key.

This results in children being unexpectedly/unnecessarily destroyed and re-created.

Using indexes as keys is described [in the React docs](https://reactjs.org/docs/lists-and-keys.html#keys) as a last resort.

## 🚀 New behavior

Prefers the child's provided `key` if it exists, falling back to index.

## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information

Regression test added to assert this fix.
