### PR TITLE
fix(utils): use correct window for instanceof checks

### DIFF
--- a/.changeset/strong-snakes-suffer.md
+++ b/.changeset/strong-snakes-suffer.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/menu": patch
+"@chakra-ui/utils": patch
+---
+
+Fix issues when rendering chakra components in different window

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -29,6 +29,7 @@ import {
   getOwnerDocument,
   isActiveElement,
   isArray,
+  isHTMLElement,
   isString,
   LazyBehavior,
   normalizeEventKey,
@@ -346,7 +347,7 @@ export function useMenuButton(
 function isTargetMenuItem(target: EventTarget | null) {
   // this will catch `menuitem`, `menuitemradio`, `menuitemcheckbox`
   return (
-    target instanceof HTMLElement &&
+    isHTMLElement(target) &&
     !!target.getAttribute("role")?.startsWith("menuitem")
   )
 }

--- a/packages/utils/src/dom-query.ts
+++ b/packages/utils/src/dom-query.ts
@@ -1,4 +1,5 @@
-import { isFocusable, isTabbable, isHTMLElement } from "./tabbable"
+import { isHTMLElement } from "./dom"
+import { isFocusable, isTabbable } from "./tabbable"
 
 const focusableElList = [
   "input:not([disabled])",

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -1,13 +1,35 @@
 import { Booleanish, EventKeys } from "./types"
 
-export function getOwnerWindow(node?: HTMLElement | null): Window {
-  return node instanceof Element
+export function isElement(el: any): el is Element {
+  return (
+    el != null &&
+    typeof el == "object" &&
+    "nodeType" in el &&
+    el.nodeType === Node.ELEMENT_NODE
+  )
+}
+
+export function isHTMLElement(el: any): el is HTMLElement {
+  if (!isElement(el)) {
+    return false
+  }
+
+  const win = el.ownerDocument.defaultView ?? window
+  return el instanceof win.HTMLElement
+}
+
+export function getOwnerWindow(node?: Element | null): typeof globalThis {
+  return isElement(node)
     ? getOwnerDocument(node)?.defaultView ?? window
     : window
 }
 
-export function getOwnerDocument(node?: HTMLElement | null): Document {
-  return node instanceof Element ? node.ownerDocument ?? document : document
+export function getOwnerDocument(node?: Element | null): Document {
+  return isElement(node) ? node.ownerDocument ?? document : document
+}
+
+export function getEventWindow(event: Event): typeof globalThis {
+  return (((event as UIEvent).view ?? window) as unknown) as typeof globalThis
 }
 
 export function canUseDOM(): boolean {

--- a/packages/utils/src/focus.ts
+++ b/packages/utils/src/focus.ts
@@ -95,11 +95,12 @@ interface ScrollableElement {
 
 function getScrollableElements(element: HTMLElement): ScrollableElement[] {
   const doc = getOwnerDocument(element)
+  const win = doc.defaultView ?? window
   let parent = element.parentNode
   const scrollableElements: ScrollableElement[] = []
   const rootScrollingElement = doc.scrollingElement || doc.documentElement
 
-  while (parent instanceof HTMLElement && parent !== rootScrollingElement) {
+  while (parent instanceof win.HTMLElement && parent !== rootScrollingElement) {
     if (
       parent.offsetHeight < parent.scrollHeight ||
       parent.offsetWidth < parent.scrollWidth
@@ -113,7 +114,7 @@ function getScrollableElements(element: HTMLElement): ScrollableElement[] {
     parent = parent.parentNode
   }
 
-  if (rootScrollingElement instanceof HTMLElement) {
+  if (rootScrollingElement instanceof win.HTMLElement) {
     scrollableElements.push({
       element: rootScrollingElement,
       scrollTop: rootScrollingElement.scrollTop,

--- a/packages/utils/src/pointer-event.ts
+++ b/packages/utils/src/pointer-event.ts
@@ -3,19 +3,24 @@
  * License can be found here: https://github.com/framer/motion
  */
 
-import { addDomEvent, isBrowser } from "./dom"
+import { addDomEvent, getEventWindow, isBrowser } from "./dom"
 
 export type AnyPointerEvent = MouseEvent | TouchEvent | PointerEvent
 
 type PointType = "page" | "client"
 
 export function isMouseEvent(event: AnyPointerEvent): event is MouseEvent {
+  const win = getEventWindow(event)
+
   // PointerEvent inherits from MouseEvent so we can't use a straight instanceof check.
-  if (typeof PointerEvent !== "undefined" && event instanceof PointerEvent) {
+  if (
+    typeof win.PointerEvent !== "undefined" &&
+    event instanceof win.PointerEvent
+  ) {
     return !!(event.pointerType === "mouse")
   }
 
-  return event instanceof MouseEvent
+  return event instanceof win.MouseEvent
 }
 
 export function isTouchEvent(event: AnyPointerEvent): event is TouchEvent {
@@ -43,7 +48,8 @@ export type EventHandler = (
  */
 function filterPrimaryPointer(eventHandler: EventListener): EventListener {
   return (event: Event) => {
-    const isMouseEvent = event instanceof MouseEvent
+    const win = getEventWindow(event)
+    const isMouseEvent = event instanceof win.MouseEvent
     const isPrimaryPointer =
       !isMouseEvent || (isMouseEvent && (event as MouseEvent).button === 0)
     if (isPrimaryPointer) {

--- a/packages/utils/src/tabbable.ts
+++ b/packages/utils/src/tabbable.ts
@@ -1,7 +1,7 @@
 // Really great work done by Diego Haz on this one
 // https://github.com/reakit/reakit/blob/master/packages/reakit-utils/src/tabbable.ts
 
-import { getOwnerDocument } from "./dom"
+import { getOwnerDocument, isHTMLElement } from "./dom"
 
 export const hasDisplayNone = (element: HTMLElement) =>
   window.getComputedStyle(element).display === "none"
@@ -34,18 +34,13 @@ export function isInputElement(
 }
 
 export function isActiveElement(element: FocusableElement) {
-  const doc =
-    element instanceof HTMLElement ? getOwnerDocument(element) : document
+  const doc = isHTMLElement(element) ? getOwnerDocument(element) : document
   return doc.activeElement === (element as HTMLElement)
 }
 
 export function hasFocusWithin(element: HTMLElement) {
   if (!document.activeElement) return false
   return element.contains(document.activeElement)
-}
-
-export function isHTMLElement(element: any): element is HTMLElement {
-  return element instanceof HTMLElement
 }
 
 export function isHidden(element: HTMLElement) {

--- a/packages/utils/tests/dom.test.ts
+++ b/packages/utils/tests/dom.test.ts
@@ -1,6 +1,7 @@
 import {
   ariaAttr,
   dataAttr,
+  getEventWindow,
   getOwnerDocument,
   getOwnerWindow,
   normalizeEventKey,
@@ -22,6 +23,11 @@ test("should return aria attribute value from boolean", () => {
 
 test("should get document object", () => {
   expect(getOwnerDocument()).toBe(document)
+})
+
+test("should get window object from event", () => {
+  const event = new UIEvent("change", { view: window })
+  expect(getEventWindow(event)).toBe(window)
 })
 
 test("should normalize keyboard events", () => {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4457

## 📝 Description

Use constructors like `Element` for `instanceof` checks from the `window` object that the current node belongs to.

## ⛳️ Current behavior (updates)

When rendered into a different window, some components currently misbehave (e.g. `<Menu>` doesn't close when clicking an item or clicking outside) because `instanceof Element` (and similar) checks fail, because the elements inherit the `Element` from a the other window object.

Also see #4457 .

## 🚀 New behavior

All `instanceof SomeContrusctor` checks now use `instanceof win.SomeConstructor` instead, where `win` is the window object that the current node or event belongs to.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Didn't add a lot of tests, since JSDOM doesn't support `window.open`, and also since most of the code wasn't explicitly tested. Let me know if you need more tests or have any ideas how to better test this.
