### PR TITLE
Fix/parse gradient

### DIFF
--- a/.changeset/rare-cherries-rest.md
+++ b/.changeset/rare-cherries-rest.md
@@ -1,0 +1,29 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Corrected parseGradient function so that it checks for CSS functions.
+
+Previously, using the CSS `calc` function would result in invalid CSS being
+generated.
+
+The expectation is that
+
+```jsx
+<Heading bgGradient="linear(to-r, green.200, pink.500 calc(20px + 20px))">
+  Chakra-UI: Create accessible React apps with speed
+</Heading>
+```
+
+functions similar to `linear-gradient` which handles using a CSS function
+
+```jsx
+<Heading
+  bgImage="linear-gradient(
+    to right, 
+    var(--chakra-colors-green-200)), 
+    var(--chakra-colors-pink-500 calc(20px + 20px))"
+>
+  Chakra-UI: Create accessible React apps with speed
+</Heading>
+```

--- a/packages/styled-system/src/utils/transform-functions.ts
+++ b/packages/styled-system/src/utils/transform-functions.ts
@@ -7,7 +7,7 @@ import {
   getTransformTemplate,
   flexDirectionTemplate,
 } from "./templates"
-import { gradientTransform, globalSet } from "./parse-gradient"
+import { gradientTransform, globalSet, isCSSFunction } from "./parse-gradient"
 
 const analyzeCSSValue = (value: number | string) => {
   const num = parseFloat(value.toString())
@@ -83,8 +83,4 @@ export const transformFunctions = {
     if (divide) result[divide] = 1
     return result
   },
-}
-
-const isCSSFunction = (value: unknown) => {
-  return isString(value) && value.includes("(") && value.includes(")")
 }

--- a/packages/styled-system/tests/parse-gradient.test.ts
+++ b/packages/styled-system/tests/parse-gradient.test.ts
@@ -87,6 +87,14 @@ describe("linear gradient", () => {
     )
   })
 
+  test("should parse color stop with function", () => {
+    expect(
+      parseGradient("linear(to-r, green, pink.dark calc(20px + 20px))", theme),
+    ).toMatchInlineSnapshot(
+      `"linear-gradient(to right, var(--colors-green), var(--colors-pink-dark) calc(20px + 20px))"`,
+    )
+  })
+
   test("should parse colors in rgb", () => {
     expect(
       parseGradient("linear(to-l, rgb(0,0,0), rgb(255,255,255))", theme),


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->
Correct parseGradient function so that it correctly handles CSS functions.

Closes #4433

## 📝 Description

Using the `linear` function with a CSS function as a stop causes invalid CSS to be generated. Therefore, no gradient is applied to the element. If corresponding parameters are used in the `linear-gradient` CSS function, the gradient is correctly applied. The current `parseGradient` function only accounts for `stops` as values and not as functions.

## ⛳️ Current behavior (updates)

Applying a gradient using `linear` in the following JSX
```jsx
<Heading bgGradient="linear(to-r, green.200, pink.500 calc(20px + 20px))">
  Chakra-UI: Create accessible React apps with speed
</Heading>
```
results in the generation of invalid CSS 
```css 
background-image: linear-gradient(to right, var(--chakra-colors-green-200), var(--chakra-colors-pink-500) calc(20px);};};
```

While applying a gradient using `linear-gradient`
```jsx
<Heading
  bgImage="linear-gradient(
    to right, 
    var(--chakra-colors-green-200)), 
    var(--chakra-colors-pink-500 calc(20px + 20px))"
>
  Chakra-UI: Create accessible React apps with speed
</Heading>
```
results in CSS generation of 
```css
background-image: linear-gradient(to right, var(--chakra-colors-green-200), var(--chakra-colors-pink-500) calc(20px + 20px));
```

## 🚀 New behavior

Using the `linear` with the `calc` function will now produce the correct CSS output.
```css
background-image: linear-gradient(to right, var(--chakra-colors-green-200), var(--chakra-colors-pink-500) calc(20px + 20px));
```

## 💣 Is this a breaking change (Yes/No): No

