### PR TITLE
fix(modal): remove vertical margin in full screen modal

### DIFF
--- a/.changeset/rude-geckos-build.md
+++ b/.changeset/rude-geckos-build.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Modals with `size:full` have no vertical margin

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -87,7 +87,7 @@ const baseStyle = (props: Dict) => ({
  */
 function getSize(value: string) {
   if (value === "full") {
-    return { dialog: { maxW: "100vw", minH: "100vh" } }
+    return { dialog: { maxW: "100vw", minH: "100vh", my: 0 } }
   }
   return { dialog: { maxW: value } }
 }


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4461 

## 📝 Description

Remove the vertical margin from the Modal with size `full` so the modal is displayed without scrollbars.

## ⛳️ Current behavior (updates)

The `modal` with `size:full` has a vertical margin.

## 🚀 New behavior

The vertical margin is set to `0` when `size===full`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
