### PR TITLE
docs(omni-search): link implementation on results boxes 

### DIFF
--- a/website/src/components/omni-search.tsx
+++ b/website/src/components/omni-search.tsx
@@ -263,68 +263,69 @@ function OmniSearch() {
                     const isLvl1 = item.type === "lvl1"
 
                     return (
-                      <Link key={item.id} href={item.url}>
-                        <Box
-                          id={`search-item-${index}`}
-                          as="li"
-                          aria-selected={selected ? true : undefined}
-                          cursor="pointer"
-                          onMouseEnter={() => {
-                            setActive(index)
-                            eventRef.current = "mouse"
-                          }}
-                          onClick={() => {
-                            modal.onClose()
-                          }}
-                          ref={menuNodes.ref(index)}
-                          role="option"
-                          key={item.id}
-                          sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            minH: 16,
-                            mt: 2,
-                            px: 4,
-                            py: 2,
-                            rounded: "lg",
-                            bg: "gray.100",
-                            ".chakra-ui-dark &": { bg: "gray.600" },
-                            _selected: {
-                              bg: "teal.500",
-                              color: "white",
-                              mark: {
+                      <Link key={item.id} href={item.url} passHref>
+                        <a>
+                          <Box
+                            id={`search-item-${index}`}
+                            as="li"
+                            aria-selected={selected ? true : undefined}
+                            onMouseEnter={() => {
+                              setActive(index)
+                              eventRef.current = "mouse"
+                            }}
+                            onClick={() => {
+                              modal.onClose()
+                            }}
+                            ref={menuNodes.ref(index)}
+                            role="option"
+                            key={item.id}
+                            sx={{
+                              display: "flex",
+                              alignItems: "center",
+                              minH: 16,
+                              mt: 2,
+                              px: 4,
+                              py: 2,
+                              rounded: "lg",
+                              bg: "gray.100",
+                              ".chakra-ui-dark &": { bg: "gray.600" },
+                              _selected: {
+                                bg: "teal.500",
                                 color: "white",
-                                textDecoration: "underline",
+                                mark: {
+                                  color: "white",
+                                  textDecoration: "underline",
+                                },
                               },
-                            },
-                          }}
-                        >
-                          {isLvl1 ? (
-                            <DocIcon opacity={0.4} />
-                          ) : (
-                            <HashIcon opacity={0.4} />
-                          )}
-
-                          <Box flex="1" ml="4">
-                            {!isLvl1 && (
-                              <Box
-                                fontWeight="medium"
-                                fontSize="xs"
-                                opacity={0.7}
-                              >
-                                {item.hierarchy.lvl1}
-                              </Box>
+                            }}
+                          >
+                            {isLvl1 ? (
+                              <DocIcon opacity={0.4} />
+                            ) : (
+                              <HashIcon opacity={0.4} />
                             )}
-                            <Box fontWeight="semibold">
-                              <OptionText
-                                searchWords={[query]}
-                                textToHighlight={item.content}
-                              />
-                            </Box>
-                          </Box>
 
-                          <EnterIcon opacity={0.5} />
-                        </Box>
+                            <Box flex="1" ml="4">
+                              {!isLvl1 && (
+                                <Box
+                                  fontWeight="medium"
+                                  fontSize="xs"
+                                  opacity={0.7}
+                                >
+                                  {item.hierarchy.lvl1}
+                                </Box>
+                              )}
+                              <Box fontWeight="semibold">
+                                <OptionText
+                                  searchWords={[query]}
+                                  textToHighlight={item.content}
+                                />
+                              </Box>
+                            </Box>
+
+                            <EnterIcon opacity={0.5} />
+                          </Box>
+                        </a>
                       </Link>
                     )
                   })}

--- a/website/src/components/omni-search.tsx
+++ b/website/src/components/omni-search.tsx
@@ -116,7 +116,7 @@ function OmniSearch() {
   const router = useRouter()
   const [query, setQuery] = React.useState("")
   const [active, setActive] = React.useState(0)
-  const [shouldCloseModal, setShouldCloseModal] = React.useState(false)
+  const [shouldCloseModal, setShouldCloseModal] = React.useState(true)
   const menu = useDisclosure()
   const modal = useDisclosure()
   const [menuNodes] = React.useState(() => new MultiRef<number, HTMLElement>())
@@ -295,7 +295,7 @@ function OmniSearch() {
                               eventRef.current = "mouse"
                             }}
                             onClick={() => {
-                              if (!shouldCloseModal) {
+                              if (shouldCloseModal) {
                                 modal.onClose()
                               }
                             }}

--- a/website/src/components/omni-search.tsx
+++ b/website/src/components/omni-search.tsx
@@ -116,6 +116,7 @@ function OmniSearch() {
   const router = useRouter()
   const [query, setQuery] = React.useState("")
   const [active, setActive] = React.useState(0)
+  const [shouldCloseModal, setShouldCloseModal] = React.useState(false)
   const menu = useDisclosure()
   const modal = useDisclosure()
   const [menuNodes] = React.useState(() => new MultiRef<number, HTMLElement>())
@@ -172,6 +173,13 @@ function OmniSearch() {
           }
           break
         }
+        case "Control":
+        case "Alt":
+        case "Shift": {
+          e.preventDefault()
+          setShouldCloseModal(true)
+          break
+        }
         case "Enter": {
           modal.onClose()
           router.push(results[active].url)
@@ -181,6 +189,18 @@ function OmniSearch() {
     },
     [active, results, router],
   )
+
+  const onKeyUp = React.useCallback((e: React.KeyboardEvent) => {
+    eventRef.current = "keyboard"
+    switch (e.key) {
+      case "Control":
+      case "Alt":
+      case "Shift": {
+        e.preventDefault()
+        setShouldCloseModal(false)
+      }
+    }
+  }, [])
 
   useUpdateEffect(() => {
     setActive(0)
@@ -243,6 +263,7 @@ function OmniSearch() {
                 menu.onOpen()
               }}
               onKeyDown={onKeyDown}
+              onKeyUp={onKeyUp}
             />
             <Center pos="absolute" left={7} h="68px">
               <SearchIcon color="teal.500" boxSize="20px" />
@@ -274,7 +295,9 @@ function OmniSearch() {
                               eventRef.current = "mouse"
                             }}
                             onClick={() => {
-                              modal.onClose()
+                              if (!shouldCloseModal) {
+                                modal.onClose()
+                              }
                             }}
                             ref={menuNodes.ref(index)}
                             role="option"


### PR DESCRIPTION
## 📝 Description

This commit aims to enhance the omni-search results so that you can open the results using gestures / shortcuts (right click => open new tab, middle click, ctrl + click, etc.)

## ⛳️ Current behavior (updates)

Users are not able to open the result of searches in omni-search on a new tab.

This is due to the results rendered with a `<NextLink>` (NextJS' Link) component but without an actual `<a>` tag which will, as far as I know, do nothing.

## 🚀 New behavior

Users are able to open the result of search in omni-search on a new tab using normal gestures / shortcuts. As an added bonus, when using modifier keys to click on a result, the modal does not close, increasing the ease of use.

## 💣 Is this a breaking change (Yes/No):

No. This only changes the documentation website.