### PR TITLE
fix(theme-tools): Add `parts` to MultiStyleConfig

### DIFF
--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -13,6 +13,7 @@ export interface StyleConfig {
 }
 
 export interface MultiStyleConfig {
+  parts?: string[]
   baseStyle?: { [part: string]: SystemStyleObject }
   sizes?: { [size: string]: { [part: string]: SystemStyleObject } }
   variants?: { [variants: string]: { [part: string]: SystemStyleObject } }


### PR DESCRIPTION
## 📝 Description

When using the `MultiStyleConfig` typing to cast a custom multipart component the `parts` key is missing on the typing.

I just changed this in the GitHub UI so tests will decide if I need to change something locally, too.

If we'd really want we maybe could be clever and read the `parts` so that on other keys like `baseStyle` it'll use the `keyof` for better autocompletion 🤷 

## ⛳️ Current behavior (updates)

TS error complaining about `parts` when doing something like:

```ts
import { MultiStyleConfig } from "@chakra-ui/theme-tools"

const CustomContainer: MultiStyleConfig = {
  parts: ["outer", "inner"]
}
```

## 🚀 New behavior

Add `parts` :)

## 💣 Is this a breaking change (Yes/No):

It's marked as optional, so no.

## 📝 Additional Information
