### PR TITLE
docs(theming): remove obsolete zero space

### DIFF
--- a/website/pages/docs/theming/theme.mdx
+++ b/website/pages/docs/theming/theme.mdx
@@ -225,7 +225,6 @@ your project. By default these spacing value can be referenced by the `padding`,
 export default {
   space: {
     px: "1px",
-    0: "0",
     0.5: "0.125rem",
     1: "0.25rem",
     1.5: "0.375rem",
@@ -271,7 +270,6 @@ Tailwind CSS. The values are proportional, so 1 spacing unit is equal to
 
 | Name | Space    | Pixels |                                    |
 | ---- | -------- | ------ | ---------------------------------- |
-| 0    | 0        | 0px    | <Box bg="pink.200" h="4" w="0"/>   |
 | px   | 1px      | 1px    | <Box bg="pink.200" h="4" w="px"/>  |
 | 0.5  | 0.125rem | 2px    | <Box bg="pink.200" h="4" w="0.5"/> |
 | 1    | 0.25rem  | 4px    | <Box bg="pink.200" h="4" w="1"/>   |


### PR DESCRIPTION
## 📝 Description

Some time ago the `0` spacing was removed from the theme ([see this commit](https://github.com/chakra-ui/chakra-ui/commit/8c10423fb34a03d8cb5d4402ac3e592b3195108a#diff-5cd6a66aae12147b476dcb95669bb5435159f86cf037293de113e4cc5eca48f6)).
The docs still include the removed spacing though.
Referencing this value via indexer would lead to `undefined` and could cause unwanted default behavior where `0` is intended.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
