### PR TITLE
feat(tokens-map): add tokens map to styled-system

### DIFF
--- a/packages/styled-system/src/create-theme-vars/create-theme-vars.ts
+++ b/packages/styled-system/src/create-theme-vars/create-theme-vars.ts
@@ -3,8 +3,11 @@ import { ThemeScale } from "./theme-tokens"
 import { calc, Operand } from "./calc"
 import { cssVar } from "./css-var"
 
+export interface Conditions extends Dict<string> {}
+
 export interface CreateThemeVarsOptions {
   cssVarPrefix?: string
+  conditions?: Conditions
 }
 
 export interface ThemeVars {
@@ -41,7 +44,9 @@ type TokenHandler = (
 /**
  * Define transformation handlers for ThemeScale
  */
-const tokenHandlerMap: Partial<Record<ThemeScale, TokenHandler>> & {
+const tokenHandlerMap: Partial<
+  Record<ThemeScale | "tokensMap", TokenHandler>
+> & {
   defaultHandler: TokenHandler
 } = {
   space: (keys, value, options) => {
@@ -67,6 +72,96 @@ const tokenHandlerMap: Partial<Record<ThemeScale, TokenHandler>> & {
           value: `${negativeValue}`,
           var: `${variable}`,
           varRef,
+        },
+      },
+    }
+  },
+  tokensMap: (keys, value, options) => {
+    const [, scale, ...tokenPath] = keys
+    const latestKey = tokenPath[tokenPath.length - 1]
+    const isConditionToken = Object.keys(options.conditions ?? {}).includes(
+      latestKey,
+    )
+
+    const varKey = [scale, ...tokenPath].join("-")
+    const lookupKey = [scale, ...tokenPath].join(".")
+
+    if (!isConditionToken) {
+      const { variable, reference } = cssVar(
+        varKey,
+        undefined,
+        options.cssVarPrefix,
+      )
+
+      const cssVars = {
+        [variable]: cssVar(
+          [scale, ...String(value).split(".")].join("-"),
+          undefined,
+          options.cssVarPrefix,
+        ).reference,
+      }
+
+      return {
+        cssVars,
+        cssMap: {
+          [lookupKey]: {
+            value,
+            variable,
+            reference,
+          },
+        },
+      }
+    }
+
+    /**
+     * @example ["colors", "text"]
+     */
+    const parentPath = [scale, ...tokenPath.slice(0, -1)]
+    const parentVarKey = parentPath.join("-")
+    const parentLookupKey = parentPath.join(".")
+
+    const { variable, reference } = cssVar(
+      parentVarKey,
+      undefined,
+      options.cssVarPrefix,
+    )
+
+    /**
+     * Resolves `_dark` to `[data-theme=dark] &`
+     */
+    const resolvedCondition = String(
+      options.conditions?.[latestKey] ?? latestKey,
+    )
+
+    /**
+     * Resolves for `scale="colors", value="gray.100"` to `--colors-gray-100`
+     */
+    const targetCssVar = cssVar(
+      [scale, ...String(value).split(".")].join("-"),
+      undefined,
+      options.cssVarPrefix,
+    )
+
+    const cssVarValue = cssVar(
+      [...parentPath, "DEFAULT"].join("-"),
+      "var(--chakra-empty,/*!*/ /*!*/)",
+      options.cssVarPrefix,
+    )
+
+    const cssVars = {
+      [variable]: cssVarValue.reference,
+      [resolvedCondition]: {
+        [variable]: targetCssVar.reference,
+      },
+    }
+
+    return {
+      cssVars,
+      cssMap: {
+        [parentLookupKey]: {
+          value: cssVarValue,
+          variable,
+          reference,
         },
       },
     }

--- a/packages/styled-system/src/create-theme-vars/theme-tokens.ts
+++ b/packages/styled-system/src/create-theme-vars/theme-tokens.ts
@@ -26,8 +26,7 @@ export type ThemeScale =
   | "transition.easing"
 
 export function extractTokens(theme: Dict) {
-  const _tokens = (tokens as unknown) as string[]
-  return pick(theme, _tokens)
+  return pick(theme, [...tokens, "tokensMap"])
 }
 
 export function omitVars(rawTheme: Dict) {

--- a/packages/styled-system/src/create-theme-vars/to-css-var.ts
+++ b/packages/styled-system/src/create-theme-vars/to-css-var.ts
@@ -1,7 +1,8 @@
 import { analyzeBreakpoints, Dict } from "@chakra-ui/utils"
-import type { WithCSSVar } from "../utils/types"
+import type { WithCSSVar } from "../utils"
 import { createThemeVars } from "./create-theme-vars"
 import { extractTokens, omitVars } from "./theme-tokens"
+import { pseudoSelectors } from "../pseudos"
 
 export function toCSSVar<T extends Dict>(rawTheme: T) {
   /**
@@ -15,6 +16,11 @@ export function toCSSVar<T extends Dict>(rawTheme: T) {
 
   const cssVarPrefix = theme.config?.cssVarPrefix
 
+  const conditions = {
+    ...pseudoSelectors,
+    ...theme.conditions,
+  }
+
   const {
     /**
      * This is more like a dictionary of tokens users will type `green.500`,
@@ -26,7 +32,7 @@ export function toCSSVar<T extends Dict>(rawTheme: T) {
      * the emotion's <Global/> component to attach variables to `:root`
      */
     cssVars,
-  } = createThemeVars(tokens, { cssVarPrefix })
+  } = createThemeVars(tokens, { cssVarPrefix, conditions })
 
   const defaultCssVars: Dict = {
     "--chakra-ring-inset": "var(--chakra-empty,/*!*/ /*!*/)",

--- a/packages/styled-system/src/pseudos.ts
+++ b/packages/styled-system/src/pseudos.ts
@@ -216,6 +216,11 @@ export const pseudoSelectors = {
    */
   _rtl: "[dir=rtl] &",
   /**
+   * Styles for CSS Selector `[dir=ltr] &`
+   * It is applied when any parent element has `dir="ltr"`
+   */
+  _ltr: "[dir=ltr] &",
+  /**
    * Styles for CSS Selector `@media (prefers-color-scheme: dark)`
    * used when the user has requested the system
    * use a light or dark color theme.

--- a/packages/styled-system/tests/css-var-token-map.test.ts
+++ b/packages/styled-system/tests/css-var-token-map.test.ts
@@ -1,0 +1,138 @@
+import { toCSSVar } from "../src"
+
+describe("Styled System: CSS variable token map", () => {
+  it("should create css vars with condition selectors", () => {
+    const theme = {
+      fonts: {
+        en: "Inter",
+        ar: "Tajawal",
+      },
+      colors: {
+        gray: {
+          100: "lightgray",
+          800: "darkgray",
+        },
+        red: {
+          500: "crimson",
+        },
+      },
+      tokensMap: {
+        colors: {
+          error: { DEFAULT: "red.500", _dark: "red.100" },
+          errorText: { DEFAULT: "white", _dark: "black" },
+          layerBg: "green.500",
+        },
+        fonts: {
+          body: { _ltr: "en", _rtl: "ar" },
+        },
+      },
+      config: {
+        cssVarPrefix: "chakra",
+      },
+    }
+
+    const result = toCSSVar(theme)
+
+    expect(result.__cssVars).toMatchInlineSnapshot(`
+      Object {
+        "--chakra-colors-error": "var(--chakra-colors-error-DEFAULT, var(--chakra-empty,/*!*/ /*!*/))",
+        "--chakra-colors-error-DEFAULT": "var(--chakra-colors-red-500)",
+        "--chakra-colors-errorText": "var(--chakra-colors-errorText-DEFAULT, var(--chakra-empty,/*!*/ /*!*/))",
+        "--chakra-colors-errorText-DEFAULT": "var(--chakra-colors-white)",
+        "--chakra-colors-gray-100": "lightgray",
+        "--chakra-colors-gray-800": "darkgray",
+        "--chakra-colors-layerBg": "var(--chakra-colors-green-500)",
+        "--chakra-colors-red-500": "crimson",
+        "--chakra-fonts-ar": "Tajawal",
+        "--chakra-fonts-body": "var(--chakra-fonts-body-DEFAULT, var(--chakra-empty,/*!*/ /*!*/))",
+        "--chakra-fonts-en": "Inter",
+        "--chakra-ring-color": "rgba(66, 153, 225, 0.6)",
+        "--chakra-ring-inset": "var(--chakra-empty,/*!*/ /*!*/)",
+        "--chakra-ring-offset-color": "#fff",
+        "--chakra-ring-offset-shadow": "0 0 #0000",
+        "--chakra-ring-offset-width": "0px",
+        "--chakra-ring-shadow": "0 0 #0000",
+        "--chakra-space-x-reverse": "0",
+        "--chakra-space-y-reverse": "0",
+        ".chakra-ui-dark &, [data-theme=dark] &, &[data-theme=dark]": Object {
+          "--chakra-colors-errorText": "var(--chakra-colors-black)",
+        },
+        "[dir=ltr] &": Object {
+          "--chakra-fonts-body": "var(--chakra-fonts-en)",
+        },
+        "[dir=rtl] &": Object {
+          "--chakra-fonts-body": "var(--chakra-fonts-ar)",
+        },
+      }
+    `)
+
+    expect(result.__cssMap).toMatchInlineSnapshot(`
+      Object {
+        "colors.error": Object {
+          "reference": "var(--chakra-colors-error)",
+          "value": Object {
+            "reference": "var(--chakra-colors-error-DEFAULT, var(--chakra-empty,/*!*/ /*!*/))",
+            "variable": "--chakra-colors-error-DEFAULT",
+          },
+          "variable": "--chakra-colors-error",
+        },
+        "colors.error.DEFAULT": Object {
+          "reference": "var(--chakra-colors-error-DEFAULT)",
+          "value": "red.500",
+          "variable": "--chakra-colors-error-DEFAULT",
+        },
+        "colors.errorText": Object {
+          "reference": "var(--chakra-colors-errorText)",
+          "value": Object {
+            "reference": "var(--chakra-colors-errorText-DEFAULT, var(--chakra-empty,/*!*/ /*!*/))",
+            "variable": "--chakra-colors-errorText-DEFAULT",
+          },
+          "variable": "--chakra-colors-errorText",
+        },
+        "colors.errorText.DEFAULT": Object {
+          "reference": "var(--chakra-colors-errorText-DEFAULT)",
+          "value": "white",
+          "variable": "--chakra-colors-errorText-DEFAULT",
+        },
+        "colors.gray.100": Object {
+          "value": "lightgray",
+          "var": "--chakra-colors-gray-100",
+          "varRef": "var(--chakra-colors-gray-100)",
+        },
+        "colors.gray.800": Object {
+          "value": "darkgray",
+          "var": "--chakra-colors-gray-800",
+          "varRef": "var(--chakra-colors-gray-800)",
+        },
+        "colors.layerBg": Object {
+          "reference": "var(--chakra-colors-layerBg)",
+          "value": "green.500",
+          "variable": "--chakra-colors-layerBg",
+        },
+        "colors.red.500": Object {
+          "value": "crimson",
+          "var": "--chakra-colors-red-500",
+          "varRef": "var(--chakra-colors-red-500)",
+        },
+        "fonts.ar": Object {
+          "value": "Tajawal",
+          "var": "--chakra-fonts-ar",
+          "varRef": "var(--chakra-fonts-ar)",
+        },
+        "fonts.body": Object {
+          "reference": "var(--chakra-fonts-body)",
+          "value": Object {
+            "reference": "var(--chakra-fonts-body-DEFAULT, var(--chakra-empty,/*!*/ /*!*/))",
+            "variable": "--chakra-fonts-body-DEFAULT",
+          },
+          "variable": "--chakra-fonts-body",
+        },
+        "fonts.en": Object {
+          "value": "Inter",
+          "var": "--chakra-fonts-en",
+          "varRef": "var(--chakra-fonts-en)",
+        },
+      }
+    `)
+  })
+})

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -2,6 +2,7 @@ import { ColorMode, ColorModeOptions, ThemingProps } from "@chakra-ui/system"
 import { Breakpoints, Styles } from "@chakra-ui/theme-tools"
 import { Dict } from "@chakra-ui/utils"
 import { StyleObjectOrFn, SystemStyleObject } from "@chakra-ui/styled-system"
+import { Pseudos } from "csstype"
 
 export type RecursiveProperty<Nested = string | number> =
   | RecursiveObject<Nested>
@@ -105,11 +106,25 @@ interface Foundations extends Typography {
   zIndices: RecursiveObject
 }
 
-export interface ChakraTheme extends Foundations {
+export type ConditionToken<
+  AdditionalConditions extends keyof any = string,
+  Condition extends keyof any = "DEFAULT" | keyof Pseudos | AdditionalConditions
+> = Partial<Record<string, string | Partial<Record<Condition, string>>>>
+
+export type TokensMap<
+  ThemeTokens extends Foundations,
+  ThemeConditions extends Breakpoints<any>
+> = Partial<Record<keyof ThemeTokens, ConditionToken<keyof ThemeConditions>>>
+
+export interface ChakraTheme<
+  ThemeTokens extends Foundations = Foundations,
+  ThemeBreakpoints extends Breakpoints<Dict> = Breakpoints<Dict>
+> extends Foundations {
   components: ThemeComponents
   config: ThemeConfig
   direction: ThemeDirection
   styles: Styles
   layerStyles?: SystemStyleObjectRecord
   textStyles?: SystemStyleObjectRecord
+  tokensMap?: TokensMap<ThemeTokens, ThemeBreakpoints>
 }


### PR DESCRIPTION
## 📝 Description

This PR introduces a new feature regarding design tokens.

## ⛳️ Current behavior (updates)

We need to use `useColorModeValue` or explicit `_dark`  styles to switch tokens based on environmental conditions.

## 🚀 New behavior

With the tokensMap we are able to define tokens which can change depending on CSS conditions like dark/light or ltr/rtl.

```ts
const customTheme = extendTheme({
  colors: {
    red: {
      100: "lightcoral",
      500: "crimson",
    },
  },
  tokensMap: {
    colors: {
      error: {
        DEFAULT: 'red.500',
        _dark: 'red.100',
      },
    },
  },
})

// Usage

<Box color="error" />
```

```ts
const customTheme = extendTheme({
  fonts: {
    en: "Inter",
    ar: "Tajawal",
  },
  tokensMap: {
    fonts: {
      content: { _ltr: 'en', _rtl: 'ar' },
    },
  },
})


// Usage

<Box fontFamily="content" />
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Todos:

- [ ] Changeset
- [ ] Documentation
