### PR TITLE
fix: type definition for apply style prop

### DIFF
--- a/.changeset/ninety-suits-camp.md
+++ b/.changeset/ninety-suits-camp.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/system": patch
+---
+
+Fix type definitions for `apply` prop.
+
+The `apply` prop supports responsive styles:
+```tsx
+// Before: type error, expects `string` for `apply`
+<Text apply={{ sm: 'styles.h3', lg: 'styles.h4' }}>
+
+// After: no type error, expects `ResponsiveValue<string>` for `apply`
+<Text apply={{ sm: 'styles.h3', lg: 'styles.h4' }}>
+```

--- a/packages/styled-system/src/config/others.ts
+++ b/packages/styled-system/src/config/others.ts
@@ -79,6 +79,13 @@ export interface OtherProps {
   textStyle?: Token<string & {}, "textStyles">
   /**
    * Apply theme-aware style objects in `theme`
+   *
+   * @example
+   * ```jsx
+   * <Box apply="styles.h3">This is a div</Box>
+   * ```
+   *
+   * This will apply styles defined in `theme.styles.h3`
    */
   apply?: ResponsiveValue<string>
 }

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -22,17 +22,6 @@ export interface ThemingProps<ThemeComponent extends string = string> {
 
 export interface ChakraProps extends SystemProps {
   /**
-   * Reference styles from any component or key in the theme.
-   *
-   * @example
-   * ```jsx
-   * <Box apply="styles.h3">This is a div</Box>
-   * ```
-   *
-   * This will apply styles defined in `theme.styles.h3`
-   */
-  apply?: string
-  /**
    * if `true`, it'll render an ellipsis when the text exceeds the width of the viewport or maxWidth set.
    */
   isTruncated?: boolean


### PR DESCRIPTION
## 📝 Description

Support for responsive values in the `apply` prop was added [here](https://github.com/chakra-ui/chakra-ui/pull/3245), however, overlapping type definitions prevent this from being accurately reflected in TypeScript.

## ⛳️ Current behavior (updates)

```tsx
// Type error, expects `string` for `apply`;
<Text apply={{ sm: 'styles.h3', lg: 'styles.h4' }}>
```

## 🚀 New behavior

```tsx
// No type error, expects `ResponsiveValue<string>`
<Text apply={{ sm: 'styles.h3', lg: 'styles.h4' }}>
```

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
