### PR TITLE
fix(menu): scroll menu list with maxHeight on keyboard navigation

### DIFF
--- a/.changeset/lucky-mirrors-sleep.md
+++ b/.changeset/lucky-mirrors-sleep.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+MenuList scroll to next MenuItem on KeyboardNavigation when there is a defined maxHeight on MenuList

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -240,7 +240,7 @@ export function useMenu(props: UseMenuProps = {}) {
 
     const node = descendants.item(focusedIndex)?.node
     if (node) {
-      focus(node, { selectTextIfInput: false })
+      focus(node, { selectTextIfInput: false, preventScroll: false })
     }
   }, [isOpen, focusedIndex, descendants])
 
@@ -607,9 +607,13 @@ export function useMenuItem(
   useUpdateEffect(() => {
     if (!isOpen) return
     if (isFocused && !trulyDisabled && ref.current) {
-      focus(ref.current, { nextTick: true, selectTextIfInput: false })
+      focus(ref.current, {
+        nextTick: true,
+        selectTextIfInput: false,
+        preventScroll: false,
+      })
     } else if (menuRef.current && !isActiveElement(menuRef.current)) {
-      focus(menuRef.current)
+      focus(menuRef.current, { preventScroll: false })
     }
   }, [isFocused, trulyDisabled, menuRef, isOpen])
 

--- a/packages/menu/stories/menu.stories.tsx
+++ b/packages/menu/stories/menu.stories.tsx
@@ -447,3 +447,25 @@ export const MenuWithInput = () => {
     </Menu>
   )
 }
+
+export const MenuWithOverflowingContent = () => {
+  return (
+    <Menu>
+      <MenuButton>Welcome</MenuButton>
+      <MenuList maxHeight="200px" overflowY="hidden">
+        <MenuItem>Menu 1</MenuItem>
+        <MenuItem>Menu 2</MenuItem>
+        <MenuItem>Menu 3</MenuItem>
+        <MenuItem>Menu 4</MenuItem>
+        <MenuItem>Menu 5</MenuItem>
+        <MenuItem>Menu 6</MenuItem>
+        <MenuItem>Menu 7</MenuItem>
+        <MenuItem>Menu 8</MenuItem>
+        <MenuItem>Menu 9</MenuItem>
+        <MenuItem>Menu 10</MenuItem>
+        <MenuItem>Menu 11</MenuItem>
+        <MenuItem>Menu 12</MenuItem>
+      </MenuList>
+    </Menu>
+  )
+}


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4510

## 📝 Description

Added `preventScroll:false` to `focus`-calls in `use-menu`

## ⛳️ Current behavior (updates)

If `MenuList` has a `maxHeight` and overflowing items and the User navigates it via Keyboard the `MenuList` doesn't scroll to the focused `MenuItem`  which is inside the "overflow-area".

## 🚀 New behavior

`preventScroll` is set to `false` in `use-menu` and now the focused item is scrolled into view when selected.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
