### PR TITLE
feat(modal): replace react-remove-scroll-bar with tua-body-scroll-lock

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -68,7 +68,9 @@
     "@chakra-ui/transition": "1.3.3",
     "@chakra-ui/utils": "1.8.1",
     "aria-hidden": "^1.1.1",
-    "react-remove-scroll": "2.4.1"
+    "react-remove-scroll": "2.4.1",
+    "react-remove-scroll-bar": "^2.2.0",
+    "tua-body-scroll-lock": "^1.2.1"
   },
   "devDependencies": {
     "@chakra-ui/system": "1.7.1",

--- a/packages/modal/stories/modal.stories.tsx
+++ b/packages/modal/stories/modal.stories.tsx
@@ -196,3 +196,32 @@ export const FullWithLongContent = () => {
     </>
   )
 }
+
+export const BlockScrollOnMount = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  return (
+    <>
+      <button onClick={onOpen}>Open</button>
+      <Lorem count={50} />
+      <Modal
+        onClose={onClose}
+        isOpen={isOpen}
+        withTua={true}
+        blockScrollOnMount={true}
+        preserveScrollBarGap={true}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal Title2</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Lorem count={20} />
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={onClose}>Close</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4779,10 +4779,15 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@popperjs/core@2.4.4", "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
+"@popperjs/core@2.4.4":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
+
+"@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.3.tgz#8b68da1ebd7fc603999cf6ebee34a4899a14b88e"
+  integrity sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ==
 
 "@reach/alert@0.13.2":
   version "0.13.2"
@@ -22401,7 +22406,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@17.0.1, react-dom@^17.0.1:
+react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
   integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
@@ -22594,6 +22599,14 @@ react-remove-scroll-bar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.1.1.tgz#5876428dfd546f2f63a4d277aea2197925505c1e"
   integrity sha512-IZbfQPSozIr8ylHE9MFcQeb2TTzj4abfE7OBXjmtUeXQ5h6ColGKDNo5h7OmzrJRilAx3YIKBf3jb0yrb31BJQ==
+  dependencies:
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+
+react-remove-scroll-bar@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz#d4d545a7df024f75d67e151499a6ab5ac97c8cdd"
+  integrity sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==
   dependencies:
     react-style-singleton "^2.1.0"
     tslib "^1.0.0"
@@ -22807,7 +22820,7 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@17.0.1, react@^17.0.1:
+react@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
@@ -26148,6 +26161,11 @@ tty-table@^2.8.10:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
     yargs "^15.1.0"
+
+tua-body-scroll-lock@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/tua-body-scroll-lock/-/tua-body-scroll-lock-1.2.1.tgz#a45b428a61ff41e7cccded11c2095d44ac02536e"
+  integrity sha512-DuGbQxIBSbz7/aAwh0oMThOwCwDdYzsU8nF5XQPAvoeOBWp/qhjrZfOtc84gj6CQLZu5L1+TgMNX6fW3OuafHA==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Fiddled around with `tua-body-scroll-lock` to check if it is possible to migrate from `react-remove-scroll-bar` to it.

Currently added a flag to `modal.ts` which decides which lib is used for scroll locking. 

Added `react-remove-scroll-bar` to keep the possibility to remove the scroll bar if we want to change to `tua-body-scroll-lock`

Didn't found an easy way to reimplement `allowPinchZoom` but didn't even get how a change in this property changes the behavior.

### Current drawback why we shouldn't use `tua-body-scroll-lock`:

- Added a Story `BlockScrollOnMount` to the modal stories. When you open the modal and scroll down to the bottom with the mouse wheel without moving your mouse and then try to scroll up again the modal content does not change. Scrolling the modal content only works after moving your mouse again. 

Didn't get why this happens.

This behavior doesn't occur with `react-remove-scroll-bar`


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

Yes for now, since there ain't an alternative for `allowPinchZoom` yet in here.

## 📝 Additional Information
