### PR TITLE
Fix document Page"edit this page" link

### DIFF
--- a/website/configs/site-config.ts
+++ b/website/configs/site-config.ts
@@ -16,7 +16,7 @@ const siteConfig = {
   },
   repo: {
     url: baseUrl,
-    editUrl: `${baseUrl}/edit/main/website`,
+    editUrl: `${baseUrl}/tree/main/website/pages`,
     blobUrl: `${baseUrl}/blob/main`,
   },
   openCollective: {

--- a/website/configs/site-config.ts
+++ b/website/configs/site-config.ts
@@ -16,7 +16,7 @@ const siteConfig = {
   },
   repo: {
     url: baseUrl,
-    editUrl: `${baseUrl}/tree/main/website/pages`,
+    editUrl: `${baseUrl}/edit/main/website/pages`,
     blobUrl: `${baseUrl}/blob/main`,
   },
   openCollective: {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

fix #4532  <!-- Github issue # here -->

## 📝 Description
Changed so that clicking `Edit this page` takes you to the correct page instead of the 404 page of GitHub.

## ⛳️ Current behavior (updates)

When I clicked the "Edit this Page" link on the documentation page, I was sent to a 404 page on GitHub.

For example, clicking the link on the Getting Started page took me to https://github.com/chakra-ui/chakra-ui/edit/main/website/docs/getting-started.mdx, That's it.

## 🚀 New behavior
Clicking the "Edit this Page" link on the documentation page now takes you to the correct GitHub editing page.
For example, clicking the link on the Getting Started page took me to "https://github.com/chakra-ui/chakra-ui/edit/main/website/pages/docs/getting-started.mdx ".
> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
