### PR TITLE
fix(form-control): provided `aria-describedby` isnt ignored anymore

### DIFF
--- a/.changeset/eight-socks-invent.md
+++ b/.changeset/eight-socks-invent.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/form-control": patch
+---
+
+if an `aria-describedby` property is passed it will be joined with the id's from
+helper-text and error-message instead of being overwritten.

--- a/packages/form-control/src/use-form-control.ts
+++ b/packages/form-control/src/use-form-control.ts
@@ -60,7 +60,9 @@ export function useFormControlProps<T extends HTMLElement>(
     ...rest
   } = props
 
-  const labelIds: string[] = []
+  const labelIds: string[] = props["aria-describedby"]
+    ? [props["aria-describedby"]]
+    : []
 
   // Error message must be described first in all scenarios.
   if (field?.hasFeedbackText && field?.isInvalid) {

--- a/packages/form-control/tests/form-control.test.tsx
+++ b/packages/form-control/tests/form-control.test.tsx
@@ -222,3 +222,26 @@ test("has the correct data attributes", async () => {
   expect(label).toHaveAttribute("data-invalid")
   expect(label).toHaveAttribute("data-readonly")
 })
+
+test("can provide a custom aria-describedby reference", () => {
+  const { rerender } = render(<Input aria-describedby="reference" />)
+  expect(screen.getByRole("textbox")).toHaveAttribute(
+    "aria-describedby",
+    "reference",
+  )
+
+  rerender(
+    <FormControl id="name">
+      <Input aria-describedby="name-expanded-helptext" />
+      <FormHelperText>Please enter your name!</FormHelperText>
+      <p id="name-expanded-helptext">
+        Sometimes it can be really helpfull to enter a name, trust me.
+      </p>
+    </FormControl>,
+  )
+
+  expect(screen.getByRole("textbox")).toHaveAttribute(
+    "aria-describedby",
+    "name-expanded-helptext name-helptext",
+  )
+})


### PR DESCRIPTION
Closes #4522 


## ⛳️ Current behavior (updates)

If the user provides an `aria-describedby` property to any form element this value isn't taken into account and will be overwritten.

## 🚀 New behavior

if the user provides a value for `aria-describedby` this value will be attached to the other labels like `feedbackText` and `helperText`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
