### PR TITLE
feat(stat): add `container` style to `Stat`-component

### DIFF
--- a/.changeset/early-meals-impress.md
+++ b/.changeset/early-meals-impress.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/stat": patch
+"@chakra-ui/theme": patch
+---
+
+Add `container`-part to Stat styleConfig

--- a/packages/stat/src/stat.tsx
+++ b/packages/stat/src/stat.tsx
@@ -8,6 +8,7 @@ import {
   useMultiStyleConfig,
   useStyles,
   HTMLChakraProps,
+  SystemStyleObject,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
@@ -130,16 +131,21 @@ export interface StatProps
 
 export const Stat = forwardRef<StatProps, "div">((props, ref) => {
   const styles = useMultiStyleConfig("Stat", props)
+  const statStyles: SystemStyleObject = {
+    position: "relative",
+    flex: "1 1 0%",
+    ...styles.container,
+  }
+
   const { className, children, ...rest } = omitThemingProps(props)
 
   return (
     <StylesProvider value={styles}>
       <chakra.div
-        className={cx("chakra-stat", className)}
         ref={ref}
-        position="relative"
-        flex="1 1 0%"
         {...rest}
+        className={cx("chakra-stat", className)}
+        __css={statStyles}
       >
         <dl>{children}</dl>
       </chakra.div>

--- a/packages/theme/src/components/stat.ts
+++ b/packages/theme/src/components/stat.ts
@@ -1,5 +1,6 @@
-const parts = ["label", "number", "icon", "helpText"]
+const parts = ["label", "number", "icon", "helpText", "container"]
 
+const baseStyleContainer = {}
 const baseStyleLabel = {
   fontWeight: "medium",
 }
@@ -22,6 +23,7 @@ const baseStyleIcon = {
 }
 
 const baseStyle = {
+  container: baseStyleContainer,
   label: baseStyleLabel,
   helpText: baseStyleHelpText,
   number: baseStyleNumber,


### PR DESCRIPTION
Closes #4537 

## 📝 Description

Add `container` style to`Stat`-component.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Currently, it isn't possible to overwrite the container style in the theme (see #4537)

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Added a `container` prop in the `Stat`-theme and used the `container`-style inside the Stat component so that the container style can be overwritten inside the theme.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
