### PR TITLE
feat(radio-group): add isDisabled and isFocusable to RadioGroup

### DIFF
--- a/.changeset/great-parrots-guess.md
+++ b/.changeset/great-parrots-guess.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Add `isDisabled` to `RadioGroup` to make it possible to disable all `Radio`
+inside `RadioGroup`

--- a/.changeset/silver-hounds-shout.md
+++ b/.changeset/silver-hounds-shout.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Add `isFocusable` to `RadioGroup` to make it possible to define the
+`focusable`-state for all `Radio` inside a `RadioGroup`

--- a/packages/radio/src/radio-group.tsx
+++ b/packages/radio/src/radio-group.tsx
@@ -16,7 +16,7 @@ import {
 export interface RadioGroupContext
   extends Pick<
       UseRadioGroupReturn,
-      "onChange" | "value" | "name" | "isDisabled"
+      "onChange" | "value" | "name" | "isDisabled" | "isFocusable"
     >,
     Omit<ThemingProps<"Radio">, "orientation"> {}
 
@@ -57,6 +57,7 @@ export const RadioGroup = forwardRef<RadioGroupProps, "div">((props, ref) => {
     children,
     className,
     isDisabled,
+    isFocusable,
     ...rest
   } = props
 
@@ -71,8 +72,18 @@ export const RadioGroup = forwardRef<RadioGroupProps, "div">((props, ref) => {
       value,
       variant,
       isDisabled,
+      isFocusable,
     }),
-    [size, name, onChange, colorScheme, value, variant, isDisabled],
+    [
+      name,
+      size,
+      onChange,
+      colorScheme,
+      value,
+      variant,
+      isDisabled,
+      isFocusable,
+    ],
   )
 
   const groupProps = getRootProps(htmlProps, ref)

--- a/packages/radio/src/radio-group.tsx
+++ b/packages/radio/src/radio-group.tsx
@@ -14,7 +14,10 @@ import {
 } from "./use-radio-group"
 
 export interface RadioGroupContext
-  extends Pick<UseRadioGroupReturn, "onChange" | "value" | "name">,
+  extends Pick<
+      UseRadioGroupReturn,
+      "onChange" | "value" | "name" | "isDisabled"
+    >,
     Omit<ThemingProps<"Radio">, "orientation"> {}
 
 const [
@@ -47,7 +50,15 @@ export interface RadioGroupProps
  * @see Docs https://chakra-ui.com/radio
  */
 export const RadioGroup = forwardRef<RadioGroupProps, "div">((props, ref) => {
-  const { colorScheme, size, variant, children, className, ...rest } = props
+  const {
+    colorScheme,
+    size,
+    variant,
+    children,
+    className,
+    isDisabled,
+    ...rest
+  } = props
 
   const { value, onChange, getRootProps, name, htmlProps } = useRadioGroup(rest)
 
@@ -59,8 +70,9 @@ export const RadioGroup = forwardRef<RadioGroupProps, "div">((props, ref) => {
       colorScheme,
       value,
       variant,
+      isDisabled,
     }),
-    [size, name, onChange, colorScheme, value, variant],
+    [size, name, onChange, colorScheme, value, variant, isDisabled],
   )
 
   const groupProps = getRootProps(htmlProps, ref)

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -9,7 +9,7 @@ import {
   useMultiStyleConfig,
   HTMLChakraProps,
 } from "@chakra-ui/system"
-import { callAll, split, __DEV__, isDisabled } from "@chakra-ui/utils"
+import { callAll, split, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useRadioGroupContext } from "./radio-group"
 import { useRadio, UseRadioProps } from "./use-radio"
@@ -56,12 +56,10 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
     children,
     isFullWidth,
     isDisabled = group?.isDisabled,
+    isFocusable = group?.isFocusable,
     ...rest
   } = ownProps
 
-  // if `isFocusable` is defined on a `Radio` we take this value, if it's inside a `RadioGroup with `isDisabled===true` we use `false`
-  const isFocusable =
-    ownProps.isFocusable ?? group?.isDisabled ? false : undefined
   let isChecked = props.isChecked
   if (group?.value != null && valueProp != null) {
     isChecked = group.value === valueProp

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -9,7 +9,7 @@ import {
   useMultiStyleConfig,
   HTMLChakraProps,
 } from "@chakra-ui/system"
-import { callAll, split, __DEV__ } from "@chakra-ui/utils"
+import { callAll, split, __DEV__, isDisabled } from "@chakra-ui/utils"
 import * as React from "react"
 import { useRadioGroupContext } from "./radio-group"
 import { useRadio, UseRadioProps } from "./use-radio"
@@ -44,18 +44,24 @@ export interface RadioProps
  * @see Docs https://chakra-ui.com/radio
  */
 export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
+  const group = useRadioGroupContext()
   const { onChange: onChangeProp, value: valueProp } = props
 
-  const group = useRadioGroupContext()
   const styles = useMultiStyleConfig("Radio", { ...group, ...props })
+
+  const ownProps = omitThemingProps(props)
 
   const {
     spacing = "0.5rem",
     children,
     isFullWidth,
+    isDisabled = group?.isDisabled,
     ...rest
-  } = omitThemingProps(props)
+  } = ownProps
 
+  // if `isFocusable` is defined on a `Radio` we take this value, if it's inside a `RadioGroup with `isDisabled===true` we use `false`
+  const isFocusable =
+    ownProps.isFocusable ?? group?.isDisabled ? false : undefined
   let isChecked = props.isChecked
   if (group?.value != null && valueProp != null) {
     isChecked = group.value === valueProp
@@ -76,6 +82,8 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
   } = useRadio({
     ...rest,
     isChecked,
+    isFocusable,
+    isDisabled,
     onChange,
     name,
   })

--- a/packages/radio/src/use-radio-group.ts
+++ b/packages/radio/src/use-radio-group.ts
@@ -22,6 +22,10 @@ export interface UseRadioGroupProps {
    */
   onChange?(nextValue: string): void
   /**
+   * If `true`, all wrapped radio jinputs will be disabled
+   */
+  isDisabled?: boolean
+  /**
    * The `name` attribute forwarded to each `radio` element
    */
   name?: string
@@ -51,6 +55,7 @@ export function useRadioGroup(props: UseRadioGroupProps = {}) {
     value: valueProp,
     defaultValue,
     name: nameProp,
+    isDisabled,
     isNative,
     ...htmlProps
   } = props
@@ -137,6 +142,7 @@ export function useRadioGroup(props: UseRadioGroupProps = {}) {
     setValue,
     value,
     onChange,
+    isDisabled,
     htmlProps,
   }
 }

--- a/packages/radio/src/use-radio-group.ts
+++ b/packages/radio/src/use-radio-group.ts
@@ -22,9 +22,15 @@ export interface UseRadioGroupProps {
    */
   onChange?(nextValue: string): void
   /**
-   * If `true`, all wrapped radio jinputs will be disabled
+   * If `true`, all wrapped radio inputs will be disabled
    */
   isDisabled?: boolean
+
+  /**
+   * If `true` and `isDisabled` is true, all wrapped radio inputs will remain
+   * focusable but not interactive.
+   */
+  isFocusable?: boolean
   /**
    * The `name` attribute forwarded to each `radio` element
    */
@@ -56,6 +62,7 @@ export function useRadioGroup(props: UseRadioGroupProps = {}) {
     defaultValue,
     name: nameProp,
     isDisabled,
+    isFocusable,
     isNative,
     ...htmlProps
   } = props
@@ -143,6 +150,7 @@ export function useRadioGroup(props: UseRadioGroupProps = {}) {
     value,
     onChange,
     isDisabled,
+    isFocusable,
     htmlProps,
   }
 }

--- a/packages/radio/stories/radio.stories.tsx
+++ b/packages/radio/stories/radio.stories.tsx
@@ -161,3 +161,17 @@ export function CustomRadioCard() {
     </Stack>
   )
 }
+
+export function DisabledRadioGroup() {
+  return (
+    <RadioGroup isDisabled>
+      <Radio value="one">One</Radio>
+      <Radio value="two" isDisabled>
+        Two
+      </Radio>
+      <Radio value="three" isDisabled={false}>
+        Three
+      </Radio>
+    </RadioGroup>
+  )
+}

--- a/packages/radio/tests/radio-group.test.tsx
+++ b/packages/radio/tests/radio-group.test.tsx
@@ -43,10 +43,16 @@ test("uncontrolled: correctly manages state", () => {
 
 test("Uncontrolled RadioGroup - should not check if group disabled", () => {
   const Component = () => (
-    <RadioGroup isDisabled>
+    <RadioGroup isDisabled isFocusable={false}>
       <Radio value="one">One</Radio>
+      <Radio value="one-focus" isFocusable>
+        One Focusable
+      </Radio>
       <Radio value="two" isDisabled>
         Two
+      </Radio>
+      <Radio value="two-focus" isDisabled isFocusable>
+        Two Focusable
       </Radio>
       <Radio value="three" isDisabled={false}>
         Three
@@ -54,18 +60,44 @@ test("Uncontrolled RadioGroup - should not check if group disabled", () => {
     </RadioGroup>
   )
   const { container } = render(<Component />)
-  const [radioOne, radioTwo, radioThree] = Array.from(
-    container.querySelectorAll("input"),
-  )
+  const [
+    radioOne,
+    radioOneFocusable,
+    radioTwo,
+    radioTwoFocusable,
+    radioThree,
+  ] = Array.from(container.querySelectorAll("input"))
 
+  const [
+    radioOneSpan,
+    radioOneSpanFocusable,
+    radioTwoSpan,
+    radioTwoSpanFocusable,
+    radioThreeSpan,
+  ] = Array.from(container.querySelectorAll(".chakra-radio__control"))
+
+  // since `RadioGroup` has `isDisabled={true}` all radio spans should be disabled
+  expect(radioOneSpan).toHaveAttribute("data-disabled", "")
+  expect(radioOneSpanFocusable).toHaveAttribute("data-disabled", "")
+  expect(radioTwoSpan).toHaveAttribute("data-disabled", "")
+  expect(radioTwoSpanFocusable).toHaveAttribute("data-disabled", "")
+  expect(radioThreeSpan).not.toHaveAttribute("data-disabled") // radioThree isn't disabled at all
+
+  // to be truly disabled on the input field the condition `!isFocusable && isDisabled` has to be truthy
   expect(radioOne).toBeDisabled()
+  expect(radioOneFocusable).not.toBeDisabled() // because it is still focusable
   expect(radioTwo).toBeDisabled()
+  expect(radioTwoFocusable).not.toBeDisabled() // because it is still focusable
   expect(radioThree).not.toBeDisabled()
 
   fireEvent.click(radioOne)
   expect(radioOne).not.toBeChecked()
+  fireEvent.click(radioOneFocusable)
+  expect(radioOneFocusable).not.toBeChecked()
   fireEvent.click(radioTwo)
   expect(radioTwo).not.toBeChecked()
+  fireEvent.click(radioTwoFocusable)
+  expect(radioTwoFocusable).not.toBeChecked()
   fireEvent.click(radioThree)
   expect(radioThree).toBeChecked()
 })

--- a/packages/radio/tests/radio-group.test.tsx
+++ b/packages/radio/tests/radio-group.test.tsx
@@ -2,7 +2,7 @@
 import { FormControl } from "@chakra-ui/react"
 import { fireEvent, render } from "@chakra-ui/test-utils"
 import * as React from "react"
-import { Radio, useRadioGroup, UseRadioGroupProps } from "../src"
+import { Radio, useRadioGroup, UseRadioGroupProps, RadioGroup } from "../src"
 
 test("works with Radio component", () => {
   const Component = (props: UseRadioGroupProps = {}) => {
@@ -39,6 +39,35 @@ test("uncontrolled: correctly manages state", () => {
   // changes checked on click
   fireEvent.click(utils.getByLabelText("b"))
   expect(utils.getByLabelText("b")).toBeChecked()
+})
+
+test("Uncontrolled RadioGroup - should not check if group disabled", () => {
+  const Component = () => (
+    <RadioGroup isDisabled>
+      <Radio value="one">One</Radio>
+      <Radio value="two" isDisabled>
+        Two
+      </Radio>
+      <Radio value="three" isDisabled={false}>
+        Three
+      </Radio>
+    </RadioGroup>
+  )
+  const { container } = render(<Component />)
+  const [radioOne, radioTwo, radioThree] = Array.from(
+    container.querySelectorAll("input"),
+  )
+
+  expect(radioOne).toBeDisabled()
+  expect(radioTwo).toBeDisabled()
+  expect(radioThree).not.toBeDisabled()
+
+  fireEvent.click(radioOne)
+  expect(radioOne).not.toBeChecked()
+  fireEvent.click(radioTwo)
+  expect(radioTwo).not.toBeChecked()
+  fireEvent.click(radioThree)
+  expect(radioThree).toBeChecked()
 })
 
 test("controlled: correctly manages state", () => {


### PR DESCRIPTION
Closes #4551 

## 📝 Description

> Add a brief description

Add `isDisabled` to `RadioGroup` to match the behavior of `CheckboxGroup`

[feat(checkbox-group): add isDisabled prop to checkbox group](https://github.com/chakra-ui/chakra-ui/pull/3778/commits/8e24bfff938478311027f091d47d105489ccb8e3)

Also added `isFocusable` to `RadioGroup` so we can [trulyDisabled](https://github.com/chakra-ui/chakra-ui/blob/main/packages/radio/src/use-radio.ts#L205) all `Radio`'s inside a `RadioGroup`


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

It isn't possible to disable a whole `RadioGroup` on the `RadioGroup`-Level

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

It is possible to disable all `Radio` inside a `RadioGroup` by setting `isDisabled:false`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
