### PR TITLE
fix(slider): don't use onChangeEndProp as dep

### DIFF
--- a/.changeset/angry-knives-sniff.md
+++ b/.changeset/angry-knives-sniff.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/slider": patch
+---
+
+Fix issue where slider thumb gets focus when onChangeEnd changes.

--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -327,9 +327,9 @@ export function useSlider(props: UseSliderProps) {
   useUpdateEffect(() => {
     focusThumb()
     if (eventSourceRef.current === "keyboard") {
-      onChangeEndProp?.(valueRef.current)
+      onChangeEnd?.(valueRef.current)
     }
-  }, [value, onChangeEndProp])
+  }, [value, onChangeEnd])
 
   const setValueFromPointer = (event: AnyPointerEvent) => {
     const nextValue = getValueFromPointer(event)


### PR DESCRIPTION
Closes #4563

## 📝 Description

When supplying an onChangeEnd callback to the slider component it will receive focus on every rerender.

## ⛳️ Current behavior (updates)

The onChangeEndProp is not stable between renders and hence the following [lines](https://github.com/chakra-ui/chakra-ui/blob/main/packages/slider/src/use-slider.ts#L327-L332) causes the slider thumb to be focused on every render:
```
  useUpdateEffect(() => {
    focusThumb()
    if (eventSourceRef.current === "keyboard") {
      onChangeEndProp?.(valueRef.current)
    }
  }, [value, onChangeEndProp])
```

## 🚀 New behavior

Instead use the onChangeEnd callbackRef that is stable between renders and therefore not causing the slider to receive focus.

## 💣 Is this a breaking change (Yes/No):

No (unless someone depends on this behavior)

## 📝 Additional Information
