### PR TITLE
docs: fixed SidebarLink's active state check

### DIFF
--- a/.changeset/chatty-emus-relate.md
+++ b/.changeset/chatty-emus-relate.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": patch
+---
+
+Fixed the sidebar links' active state

--- a/website/src/components/sidebar/sidebar-link.tsx
+++ b/website/src/components/sidebar/sidebar-link.tsx
@@ -39,8 +39,8 @@ type SidebarLinkProps = PropsOf<typeof chakra.div> & {
 const SidebarLink = (props: SidebarLinkProps) => {
   const { href, icon, children, ...rest } = props
 
-  const { pathname } = useRouter()
-  const isActive = pathname === href
+  const { asPath } = useRouter()
+  const isActive = asPath === href
 
   return (
     <chakra.div


### PR DESCRIPTION
## 📝 Description

This PR fixes the docsite's `SidebarLink` active state checking.

## ⛳️ Current behavior (updates)

Some of the pages don't highlight their corresponding `SidebarLink` when active

## 🚀 New behavior

Now they all do

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
