### PR TITLE
fix(slider): onChangeStart/onChangeEnd are triggered onClick

### DIFF
--- a/.changeset/thin-pens-fetch.md
+++ b/.changeset/thin-pens-fetch.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/slider": patch
+---
+
+Also call `onChangeStart`/ `onChangeEnd` when clicking somewhere in the
+`SliderTrack` without dragging the `DragHandle`

--- a/packages/slider/src/use-slider.ts
+++ b/packages/slider/src/use-slider.ts
@@ -6,7 +6,6 @@ import {
   useIds,
   useLatestRef,
   usePanGesture,
-  usePrevious,
   useUpdateEffect,
 } from "@chakra-ui/hooks"
 import { EventKeyMap, mergeRefs, PropGetter } from "@chakra-ui/react-utils"
@@ -162,7 +161,6 @@ export function useSlider(props: UseSliderProps) {
   })
 
   const [isDragging, setDragging] = useBoolean()
-  const prevIsDragging = usePrevious(isDragging)
 
   const [isFocused, setFocused] = useBoolean()
   const eventSourceRef = useRef<"pointer" | "keyboard" | null>(null)
@@ -344,26 +342,17 @@ export function useSlider(props: UseSliderProps) {
       setDragging.on()
       focusThumb()
       setValueFromPointer(event)
+      onChangeStart?.(valueRef.current)
     },
     onPanSessionEnd() {
       if (!isInteractive) return
       setDragging.off()
-      if (!prevIsDragging && prevRef.current !== valueRef.current) {
-        onChangeEnd?.(valueRef.current)
-        prevRef.current = valueRef.current
-      }
-    },
-    onPanStart() {
-      if (!isInteractive) return
-      onChangeStart?.(valueRef.current)
+      onChangeEnd?.(valueRef.current)
+      prevRef.current = valueRef.current
     },
     onPan(event) {
       if (!isInteractive) return
       setValueFromPointer(event)
-    },
-    onPanEnd() {
-      if (!isInteractive) return
-      onChangeEnd?.(valueRef.current)
     },
   })
 


### PR DESCRIPTION
Closes #4572 

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

`onChangeStart`/`onChangeEnd` aren't triggered on click see #4572 

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

made it possible to trigger `onChangeStart`/`onChangeEnd` onClick

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

Moved the call to `onChangeEnd` from `onPanEnd` to `onPanSessionEnd` - because `onPanEnd` is only called if there is a panning involved. 

❗  Also removed some logic in `onPanSessionEnd` - because this shouldn't break anything - or was there a cause why this was added @segunadebayo ?

Moved the call of `onChangeStart` from. `onPanStart` to `onPanSessionStart` - because `onPanStart` is only called if there is a panning involved. 
