### PR TITLE
fix(tag): added overflow:visible to `TagLabel`

### DIFF
--- a/.changeset/twenty-candles-burn.md
+++ b/.changeset/twenty-candles-burn.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Added `overview:"visible"` to `baseStyle` of `TagLabel` to avoid clipped Text
+when rendering font-family `Segoe UI Semibold`

--- a/packages/theme/src/components/tag.ts
+++ b/packages/theme/src/components/tag.ts
@@ -15,6 +15,7 @@ const baseStyleContainer = {
 
 const baseStyleLabel = {
   lineHeight: 1.2,
+  overflow: "visible",
 }
 
 const baseStyleCloseButton = {


### PR DESCRIPTION
Closes #4565 

## 📝 Description

> Add a brief description

Added `overflow:visible` to `baseStyle` of `TagLabel` to render the label without any clipped Text when using font-family`Segoe UI Semibold`

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No 
