### PR TITLE
feat: use outside click enable

### DIFF
--- a/.changeset/modern-garlics-taste.md
+++ b/.changeset/modern-garlics-taste.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/hooks": minor
+---
+
+Added an enabled prop to the useOutsideClick hook to conditionally attach event
+handlers and updated the useMenu hook to only enable the useOutsideClick hook
+when the menu is open

--- a/packages/hooks/src/use-outside-click.ts
+++ b/packages/hooks/src/use-outside-click.ts
@@ -4,6 +4,10 @@ import { useCallbackRef } from "./use-callback-ref"
 
 export interface UseOutsideClickProps {
   /**
+   * Whether the hook is enabled
+   */
+  enabled?: boolean
+  /**
    * The reference to a DOM element.
    */
   ref: RefObject<HTMLElement>
@@ -18,7 +22,7 @@ export interface UseOutsideClickProps {
  * when a user clicks outside them.
  */
 export function useOutsideClick(props: UseOutsideClickProps) {
-  const { ref, handler } = props
+  const { ref, handler, enabled = true } = props
   const savedHandler = useCallbackRef(handler)
 
   const stateRef = useRef({
@@ -29,6 +33,7 @@ export function useOutsideClick(props: UseOutsideClickProps) {
   const state = stateRef.current
 
   useEffect(() => {
+    if (!enabled) return
     const onPointerDown: any = (e: PointerEvent) => {
       if (isValidEvent(e, ref)) {
         state.isPointerDown = true
@@ -67,7 +72,7 @@ export function useOutsideClick(props: UseOutsideClickProps) {
       doc.removeEventListener("touchstart", onPointerDown, true)
       doc.removeEventListener("touchend", onTouchEnd, true)
     }
-  }, [handler, ref, savedHandler, state])
+  }, [handler, ref, savedHandler, state, enabled])
 }
 
 function isValidEvent(event: any, ref: React.RefObject<HTMLElement>) {

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -150,13 +150,10 @@ export function useMenu(props: UseMenuProps = {}) {
   const buttonRef = React.useRef<HTMLButtonElement>(null)
 
   useOutsideClick({
+    enabled: isOpen && closeOnBlur,
     ref: menuRef,
     handler: (event) => {
-      if (
-        isOpen &&
-        closeOnBlur &&
-        !buttonRef.current?.contains(event.target as HTMLElement)
-      ) {
+      if (!buttonRef.current?.contains(event.target as HTMLElement)) {
         onClose()
       }
     },

--- a/packages/menu/stories/menu.stories.tsx
+++ b/packages/menu/stories/menu.stories.tsx
@@ -469,3 +469,18 @@ export const MenuWithOverflowingContent = () => {
     </Menu>
   )
 }
+
+export const MenuPerformanceTest = () => {
+  return [...Array(100)].map((_, index) => (
+    <div key={index}>
+      <Menu eventListeners={false}>
+        <MenuButton>Menu {index + 1}</MenuButton>
+        <MenuList>
+          <MenuItem>Menu 1</MenuItem>
+          <MenuItem>Menu 2</MenuItem>
+          <MenuItem>Menu 3</MenuItem>
+        </MenuList>
+      </Menu>
+    </div>
+  ))
+}


### PR DESCRIPTION
## 📝 Description

This MR adds an `enabled` prop to the `useOutsideClick` hook so that we can conditionally apply the event listeners. We can use this prop in the `useMenu` hook to only apply the event listeners when the menu is open and `closeOnBlur`. 

This improves performance for pages with many menu items.

## ⛳️ Current behavior (updates)

Currently useOutsideClick attaches a new event listener for `mousedown`, `mouseup`, `touchstart` and `touchend` every time the `useOutsideClick` hook is used. Since this is attached to the document, the callback is fired for every click in the document.

Outside click is currently used in the `useMenu` hook with no way to disable it. For each Menu component that appears on the page an event listener is created:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/2268424/130155738-c874ef91-8bb7-44c3-ba8e-b5ceef6907b1.png">

## 🚀 New behavior

Adding an `enabled` prop to `useOutsideClick` enables us to control when to apply the event listeners and only add them when the menu is open and closeOnBlur is enabled:
<img width="665" alt="image" src="https://user-images.githubusercontent.com/2268424/130156530-4f779e5e-fd62-4759-ba8c-77e7a2e308ef.png">

<img width="665" alt="image" src="https://user-images.githubusercontent.com/2268424/130156474-9aa0a548-cde1-4a46-b04b-cb7f95dbc8f0.png">

## 💣 Is this a breaking change (Yes/No):
No, this is backwards compatible change with `enabled` true as the default.