### PR TITLE
docs: update tabs doc by passing the ref to <StyledTab>.

### DIFF
--- a/website/pages/docs/disclosure/tabs.mdx
+++ b/website/pages/docs/disclosure/tabs.mdx
@@ -410,7 +410,7 @@ function CustomTabs() {
     const styles = useStyles()
 
     return (
-      <StyledTab __css={styles.tab} {...tabProps}>
+      <StyledTab ref={ref} __css={styles.tab} {...tabProps}>
         <Box as="span" mr="2">
           {isSelected ? "😎" : "😐"}
         </Box>

--- a/website/pages/docs/disclosure/tabs.mdx
+++ b/website/pages/docs/disclosure/tabs.mdx
@@ -403,14 +403,14 @@ function CustomTabs() {
 
   const CustomTab = React.forwardRef((props, ref) => {
     // 2. Reuse the `useTab` hook
-    const tabProps = useTab(props)
+    const tabProps = useTab({...props, ref})
     const isSelected = !!tabProps["aria-selected"]
 
     // 3. Hook into the Tabs `size`, `variant`, props
     const styles = useStyles()
 
     return (
-      <StyledTab ref={ref} __css={styles.tab} {...tabProps}>
+      <StyledTab __css={styles.tab} {...tabProps}>
         <Box as="span" mr="2">
           {isSelected ? "😎" : "😐"}
         </Box>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
@segunadebayo  The explanation of the section says "Because TabList needs to know the order of the children, we use cloneElement to pass state internally.", but the ref is not passed to any component in the example <CustomTab>.