### PR TITLE
fix: add correct variant type to UseToastOptions

### DIFF
--- a/.changeset/plenty-avocados-drop.md
+++ b/.changeset/plenty-avocados-drop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Add correct variant type to `UseToastOptions`

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -53,7 +53,7 @@ export interface UseToastOptions {
   /**
    * The alert component `variant` to use
    */
-  variant?: string
+  variant?: "subtle"| "solid"| "left-accent" | "top-accent"
   /**
    * The status of the toast.
    */

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -53,7 +53,7 @@ export interface UseToastOptions {
   /**
    * The alert component `variant` to use
    */
-  variant?: "subtle"| "solid"| "left-accent" | "top-accent"
+  variant?: "subtle"| "solid"| "left-accent" | "top-accent" | (string & {})
   /**
    * The status of the toast.
    */


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Corrected the TS type for the useToast hook options according to the [docs](https://chakra-ui.com/docs/feedback/toast#variants)

## ⛳️ Current behavior (updates)

`UseToastOptions.variant?: string | undefined`

## 🚀 New behavior

`UseToastOptions.variant?: "subtle" | "solid" | "left-accent" | "top-accent" | undefined`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
