### PR TITLE
perf: remove useless useMemo

### DIFF
--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -7,7 +7,7 @@ import {
   omit,
   Dict,
 } from "@chakra-ui/utils"
-import { useMemo, useRef } from "react"
+import { useRef } from "react"
 import isEqual from "react-fast-compare"
 import { useChakra } from "./hooks"
 import { ThemingProps } from "./system.types"
@@ -43,37 +43,35 @@ export function useStyleConfig(themeKey: any, props: any = {}, opts: any = {}) {
   type StylesRef = SystemStyleObject | Record<string, SystemStyleObject>
   const stylesRef = useRef<StylesRef>({})
 
-  return useMemo(() => {
-    if (styleConfig) {
-      const baseStyles = runIfFn(styleConfig.baseStyle ?? {}, mergedProps)
+  if (styleConfig) {
+    const baseStyles = runIfFn(styleConfig.baseStyle ?? {}, mergedProps)
 
-      const variants = runIfFn(
-        styleConfig.variants?.[mergedProps.variant] ?? {},
-        mergedProps,
-      )
+    const variants = runIfFn(
+      styleConfig.variants?.[mergedProps.variant] ?? {},
+      mergedProps,
+    )
 
-      const sizes = runIfFn(
-        styleConfig.sizes?.[mergedProps.size] ?? {},
-        mergedProps,
-      )
+    const sizes = runIfFn(
+      styleConfig.sizes?.[mergedProps.size] ?? {},
+      mergedProps,
+    )
 
-      const styles = mergeWith({}, baseStyles, sizes, variants)
+    const styles = mergeWith({}, baseStyles, sizes, variants)
 
-      if (opts?.isMultiPart && styleConfig.parts) {
-        styleConfig.parts.forEach((part: string) => {
-          styles[part] = styles[part] ?? {}
-        })
-      }
-
-      const isStyleEqual = isEqual(stylesRef.current, styles)
-
-      if (!isStyleEqual) {
-        stylesRef.current = styles
-      }
+    if (opts?.isMultiPart && styleConfig.parts) {
+      styleConfig.parts.forEach((part: string) => {
+        styles[part] = styles[part] ?? {}
+      })
     }
 
-    return stylesRef.current
-  }, [styleConfig, mergedProps, opts?.isMultiPart])
+    const isStyleEqual = isEqual(stylesRef.current, styles)
+
+    if (!isStyleEqual) {
+      stylesRef.current = styles
+    }
+  }
+
+  return stylesRef.current
 }
 
 export function useMultiStyleConfig(themeKey: string, props: any) {


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The useMemo in useStyleConfig can't return any memoized result because of a dependancy on the locally created object `mergedProps`, so I figured it's better to just remove it as it is misleading (and can actually _cost_ a tiny bit of perf).

## 💣 Is this a breaking change (Yes/No):

No
