### PR TITLE
feat: component anatomy

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:ci": "jest --runInBand",
     "lint": "lerna run lint --no-private --stream",
     "lint:types": "lerna run lint:types --no-private --stream",
-    "prestorybook": "rimraf node_modules/.cache/storybook",
+    "prestorybook": "rimraf node_modules/.cache/storybook && yarn pkg babel-plugin build",
     "storybook": "start-storybook -p 6006",
     "clean": "lerna clean --yes && rimraf node_modules",
     "clean-dist": "yarn lerna exec -- rimraf dist",

--- a/packages/anatomy/README.md
+++ b/packages/anatomy/README.md
@@ -1,0 +1,27 @@
+# @chakra-ui/anatomy
+
+> This is an internal utility, not intended for public usage.
+
+This package declares the anatomy for common UI elements. It mimics the
+`::part()` selector from the
+[W3C CSS Shadow Parts Draft](https://www.w3.org/TR/css-shadow-parts-1/) with
+data-attributes.
+
+## Installation
+
+```sh
+yarn add @chakra-ui/anatomy
+# or
+npm i @chakra-ui/anatomy
+```
+
+## Contribution
+
+Yes please! See the
+[contributing guidelines](https://github.com/chakra-ui/core/blob/main/CONTRIBUTING.md)
+for details.
+
+## Licence
+
+This project is licensed under the terms of the
+[MIT license](https://github.com/chakra-ui/core/blob/main/LICENSE).

--- a/packages/anatomy/index.ts
+++ b/packages/anatomy/index.ts
@@ -1,0 +1,1 @@
+export * from "./src"

--- a/packages/anatomy/jest.config.js
+++ b/packages/anatomy/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
+  transform: {
+    ".(ts|tsx)$": "ts-jest/dist",
+  },
+  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+}

--- a/packages/anatomy/package.json
+++ b/packages/anatomy/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@chakra-ui/anatomy",
+  "version": "1.0.0",
+  "description": "The anatony of all chakra components",
+  "keywords": [
+    "theme",
+    "theming",
+    "ui mode",
+    "ui"
+  ],
+  "author": "Segun Adebayo <sage@adebayosegun.com>",
+  "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
+  "license": "MIT",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "typings": "dist/types/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/chakra-ui.git",
+    "directory": "packages/anatomy"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/chakra-ui/issues"
+  },
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "start": "nodemon --watch src --exec yarn build -e ts,tsx",
+    "build": "concurrently yarn:build:*",
+    "test": "jest --env=jsdom --passWithNoTests",
+    "lint": "concurrently yarn:lint:*",
+    "version": "yarn build",
+    "build:esm": "cross-env BABEL_ENV=esm babel src --root-mode upward --extensions .ts,.tsx -d dist/esm --source-maps",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --root-mode upward --extensions .ts,.tsx -d dist/cjs --source-maps",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types",
+    "test:cov": "yarn test --coverage",
+    "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
+    "lint:types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@chakra-ui/theme-tools": "^1.1.9"
+  }
+}

--- a/packages/anatomy/src/index.ts
+++ b/packages/anatomy/src/index.ts
@@ -1,0 +1,155 @@
+import { anatomy } from "@chakra-ui/theme-tools"
+
+/**
+ * **Accordion anatomy**
+ * - Item: the accordion item contains the button and panel
+ * - Button: the button is the trigger for the panel
+ * - Panel: the panel is the content of the accordion item
+ * - Icon: the expanded/collapsed icon
+ */
+export const accordionAnatomy = anatomy("accordion")
+  .parts("container", "item", "button", "panel")
+  .extend("icon")
+
+/**
+ * **Alert anatomy**
+ * - Title: the alert's title
+ * - Description: the alert's description
+ * - Icon: the alert's icon
+ */
+export const alertAnatomy = anatomy("alert")
+  .parts("title", "description", "container")
+  .extend("icon")
+
+/**
+ * **Avatar anatomy**
+ * - Container: the container for the avatar
+ * - Label: the avatar initials text
+ * - Excess Label: the label or text that represents excess avatar count.
+ * Typically used in avatar groups.
+ * - Group: the container for the avatar group
+ */
+export const avatarAnatomy = anatomy("avatar")
+  .parts("label", "badge", "container")
+  .extend("excessLabel", "group")
+
+/**
+ * **Breadcrumb anatomy**
+ * - Item: the container for a breadcrumb item
+ * - Link: the element that represents the breadcrumb link
+ * - Container: the container for the breadcrumb items
+ * - Separator: the separator between breadcrumb items
+ */
+export const breadcrumbAnatomy = anatomy("breadcrumb")
+  .parts("link", "item")
+  .extend("separator")
+
+export const buttonAnatomy = anatomy("button").parts()
+
+export const checkboxAnatomy = anatomy("checkbox")
+  .parts("control", "icon")
+  .extend("label")
+
+export const circularProgressAnatomy = anatomy("progress")
+  .parts("track", "filledTrack")
+  .extend("label")
+
+export const drawerAnatomy = anatomy("drawer")
+  .parts("overlay", "dialogContainer", "dialog")
+  .extend("header", "closeButton", "body", "footer")
+
+export const editableAnatomy = anatomy("editable").parts("preview", "input")
+
+export const formAnatomy = anatomy("form").parts(
+  "container",
+  "requiredIndicator",
+  "helperText",
+)
+
+export const formErrorAnatomy = anatomy("formError").parts("text", "icon")
+
+export const inputAnatomy = anatomy("input").parts("addon", "field", "element")
+
+export const listAnatomy = anatomy("list").parts("container", "item", "icon")
+
+export const menuAnatomy = anatomy("menu")
+  .parts("button", "list", "item")
+  .extend("groupTitle", "command", "divider")
+
+export const modalAnatomy = anatomy("modal")
+  .parts("overlay", "dialogContainer", "dialog")
+  .extend("header", "closeButton", "body", "footer")
+
+export const numberInputAnatomy = anatomy("numberinput").parts(
+  "root",
+  "field",
+  "stepperGroup",
+  "stepper",
+)
+
+export const pinInputAnatomy = anatomy("pininput").parts("field")
+
+export const popoverAnatomy = anatomy("popover")
+  .parts("content", "header", "body", "footer")
+  .extend("popper", "arrow")
+
+export const progressAnatomy = anatomy("progress").parts(
+  "label",
+  "filledTrack",
+  "track",
+)
+
+export const radioAnatomy = anatomy("radio").parts(
+  "container",
+  "control",
+  "label",
+)
+
+export const selectAnatomy = anatomy("select").parts("field", "icon")
+
+export const sliderAnatomy = anatomy("slider").parts(
+  "container",
+  "track",
+  "thumb",
+  "filledTrack",
+)
+
+export const statAnatomy = anatomy("stat").parts(
+  "container",
+  "label",
+  "helpText",
+  "number",
+  "icon",
+)
+
+export const switchAnatomy = anatomy("switch").parts(
+  "container",
+  "track",
+  "thumb",
+)
+
+export const tableAnatomy = anatomy("table").parts(
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  "tfoot",
+  "caption",
+)
+
+export const tabsAnatomy = anatomy("tabs").parts(
+  "root",
+  "tab",
+  "tablist",
+  "tabpanel",
+  "tabpanels",
+  "indicator",
+)
+
+export const tagAnatomy = anatomy("tag").parts(
+  "container",
+  "label",
+  "closeButton",
+)

--- a/packages/anatomy/tsconfig.json
+++ b/packages/anatomy/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "../../types"],
+  "exclude": [
+    "src/tests",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*/*.stories.tsx"
+  ]
+}

--- a/packages/react/src/extend-theme.ts
+++ b/packages/react/src/extend-theme.ts
@@ -117,6 +117,19 @@ function mergeThemeCustomizer(
   key: string,
   object: any,
 ) {
+  // (backward compat) how the parts array should be merged
+  // The new Anatomy class returns an iterator instead of an array
+  // we need to convert it to an array using `Array.from`
+  if (key === "parts") {
+    //@ts-ignore
+    const _source = Array.from(source ?? []) as string[]
+    //@ts-ignore
+    const _override = Array.from(override ?? []) as string[]
+    const merged = _source.concat(_override)
+    // remove duplicates
+    return Array.from(new Set(merged))
+  }
+
   if (
     (isFunction(source) || isFunction(override)) &&
     Object.prototype.hasOwnProperty.call(object, key)

--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -59,8 +59,12 @@ export function useStyleConfig(themeKey: any, props: any = {}, opts: any = {}) {
 
       const styles = mergeWith({}, baseStyles, sizes, variants)
 
-      if (opts?.isMultiPart && styleConfig.parts) {
-        styleConfig.parts.forEach((part: string) => {
+      // parts could be a literal array (backward compat) or
+      // our parts iterable (new)
+      const parts = Array.from<string>(styleConfig.parts ?? [])
+
+      if (opts?.isMultiPart && parts) {
+        parts.forEach((part: string) => {
           styles[part] = styles[part] ?? {}
         })
       }

--- a/packages/theme-tools/src/anatomy.ts
+++ b/packages/theme-tools/src/anatomy.ts
@@ -1,0 +1,72 @@
+/**
+ * Used to define the anatomy/parts of a component in a way that provides
+ * a consistent API for `className`, css selector and `theming`.
+ */
+export class Anatomy<T extends string = string> {
+  private map: Record<T, Part> = {} as Record<T, Part>
+
+  constructor(private name: string) {}
+
+  public parts = <V extends string>(...values: V[]) => {
+    for (const part of values) {
+      ;(this.map as any)[part] = this.toPart(part)
+    }
+    return (this as unknown) as Anatomy<V>
+  }
+
+  public extend = <U extends string>(...parts: U[]) => {
+    for (const part of parts) {
+      if (part in this.map) continue
+      ;(this.map as any)[part] = this.toPart(part)
+    }
+    return (this as unknown) as Anatomy<T | U>
+  }
+
+  get selectors() {
+    const value = Object.fromEntries(
+      Object.entries(this.map).map(([key, part]) => [
+        key,
+        (part as any).selector,
+      ]),
+    )
+    return value as Record<T, string>
+  }
+
+  get keys() {
+    return Object.keys(this.map) as T[]
+  }
+
+  *[Symbol.iterator]() {
+    for (const val of this.keys) {
+      yield val as T
+    }
+  }
+
+  toPart = (part: string) => {
+    const el = ["container", "root"].includes(part ?? "")
+      ? [this.name]
+      : [this.name, part]
+    const attr = el.filter(Boolean).join("__")
+    const className = `chakra-${attr}`
+
+    const partObj = {
+      className,
+      selector: `.${className}`,
+      toString: () => part,
+    }
+
+    return partObj as typeof partObj & string
+  }
+
+  __type = {} as T
+}
+
+type Part = {
+  className: string
+  selector: string
+  toString: () => string
+}
+
+export function anatomy(name: string) {
+  return new Anatomy(name)
+}

--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -1,6 +1,10 @@
 import { SystemStyleObject } from "@chakra-ui/system"
 import { Dict, runIfFn } from "@chakra-ui/utils"
 
+/* -----------------------------------------------------------------------------
+ * Style Configuration definition for components
+ * -----------------------------------------------------------------------------*/
+
 export interface StyleConfig {
   baseStyle?: SystemStyleObject
   sizes?: { [size: string]: SystemStyleObject }
@@ -12,21 +16,54 @@ export interface StyleConfig {
   }
 }
 
-export interface MultiStyleConfig {
-  baseStyle?: { [part: string]: SystemStyleObject }
-  sizes?: { [size: string]: { [part: string]: SystemStyleObject } }
-  variants?: { [variants: string]: { [part: string]: SystemStyleObject } }
+// minimal represenation of the anatomy object
+type Anatomy = { __type: string }
+
+export interface MultiStyleConfig<T extends Anatomy = Anatomy> {
+  baseStyle?: PartsStyleObject<T>
+  sizes?: { [size: string]: PartsStyleObject<T> | PartsStyleFunction<T> }
+  variants?: { [variant: string]: PartsStyleObject<T> | PartsStyleFunction<T> }
   defaultProps?: StyleConfig["defaultProps"]
 }
 
-export interface GlobalStyleProps {
+/* -----------------------------------------------------------------------------
+ * [NEW] Style Functions used in the theme
+   - Single part components: use SystemStyleObject or SystemStyleFunction
+   - Multi part components: use PartsStyleObject or PartsStyleFunction
+ * -----------------------------------------------------------------------------*/
+
+export type { SystemStyleObject }
+
+export type StyleFunctionProps = {
   colorScheme: string
   colorMode: "light" | "dark"
+  orientation: "horizontal" | "vertical"
   theme: Dict
+  [key: string]: any
 }
 
+export type SystemStyleFunction = (
+  props: StyleFunctionProps,
+) => SystemStyleObject
+
+export type PartsStyleObject<T extends Anatomy> = Partial<
+  Record<T["__type"], SystemStyleObject>
+>
+
+export type PartsStyleFunction<T extends Anatomy> = (
+  props: StyleFunctionProps,
+) => PartsStyleObject<T>
+
+/* -----------------------------------------------------------------------------
+ * Global Style object definitions
+ * -----------------------------------------------------------------------------*/
+
+export type GlobalStyleProps = StyleFunctionProps
+
 export type GlobalStyles = {
-  global?: SystemStyleObject | ((props: GlobalStyleProps) => SystemStyleObject)
+  global?:
+    | SystemStyleObject
+    | ((props: StyleFunctionProps) => SystemStyleObject)
 }
 
 export type JSXElementStyles = {
@@ -38,7 +75,8 @@ export { runIfFn }
 export type Styles = GlobalStyles & JSXElementStyles
 
 export function mode(light: any, dark: any) {
-  return (props: Dict) => (props.colorMode === "dark" ? dark : light)
+  return (props: Dict | StyleFunctionProps) =>
+    props.colorMode === "dark" ? dark : light
 }
 
 export function orient(options: {

--- a/packages/theme-tools/src/css-calc.ts
+++ b/packages/theme-tools/src/css-calc.ts
@@ -1,0 +1,62 @@
+import { isObject } from "@chakra-ui/utils"
+import { CSSVar } from "./css-var"
+
+export type Operand = string | number | CSSVar
+type Operands = Operand[]
+
+type Operator = "+" | "-" | "*" | "/"
+
+function toRef(operand: Operand): string {
+  if (isObject(operand) && operand.reference) {
+    return operand.reference
+  }
+  return String(operand)
+}
+
+const toExpr = (operator: Operator, ...operands: Operands) =>
+  operands.map(toRef).join(` ${operator} `).replace(/calc/g, "")
+
+const add = (...operands: Operands) => `calc(${toExpr("+", ...operands)})`
+
+const subtract = (...operands: Operands) => `calc(${toExpr("-", ...operands)})`
+
+const multiply = (...operands: Operands) => `calc(${toExpr("*", ...operands)})`
+
+const divide = (...operands: Operands) => `calc(${toExpr("/", ...operands)})`
+
+const negate = (x: Operand) => {
+  const value = toRef(x)
+
+  if (value != null && !Number.isNaN(parseFloat(value))) {
+    return String(value).startsWith("-") ? String(value).slice(1) : `-${value}`
+  }
+
+  return multiply(value, -1)
+}
+
+export interface CalcChain {
+  add: (...operands: Operands) => CalcChain
+  subtract: (...operands: Operands) => CalcChain
+  multiply: (...operands: Operands) => CalcChain
+  divide: (...operands: Operands) => CalcChain
+  negate: () => CalcChain
+  toString: () => string
+}
+
+export const calc = Object.assign(
+  (x: Operand): CalcChain => ({
+    add: (...operands) => calc(add(x, ...operands)),
+    subtract: (...operands) => calc(subtract(x, ...operands)),
+    multiply: (...operands) => calc(multiply(x, ...operands)),
+    divide: (...operands) => calc(divide(x, ...operands)),
+    negate: () => calc(negate(x)),
+    toString: () => x.toString(),
+  }),
+  {
+    add,
+    subtract,
+    multiply,
+    divide,
+    negate,
+  },
+)

--- a/packages/theme-tools/src/css-var.ts
+++ b/packages/theme-tools/src/css-var.ts
@@ -1,4 +1,6 @@
-import { isDecimal } from "@chakra-ui/utils"
+export function isDecimal(value: any) {
+  return !Number.isInteger(parseFloat(value.toString()))
+}
 
 function replaceWhiteSpace(value: string, replaceValue = "-") {
   return value.replace(/\s+/g, replaceValue)

--- a/packages/theme-tools/src/css-var.ts
+++ b/packages/theme-tools/src/css-var.ts
@@ -1,0 +1,46 @@
+import { isDecimal } from "@chakra-ui/utils"
+
+function replaceWhiteSpace(value: string, replaceValue = "-") {
+  return value.replace(/\s+/g, replaceValue)
+}
+
+function escape(value: string | number) {
+  const valueStr = replaceWhiteSpace(value.toString())
+  if (valueStr.includes("\\.")) return value
+  return isDecimal(value) ? valueStr.replace(".", `\\.`) : value
+}
+
+export function addPrefix(value: string, prefix = "") {
+  return [prefix, escape(value)].filter(Boolean).join("-")
+}
+
+export function toVarRef(name: string, fallback?: string) {
+  return `var(${escape(name)}${fallback ? `, ${fallback}` : ""})`
+}
+
+export function toVar(value: string, prefix = "") {
+  return `--${addPrefix(value, prefix)}`
+}
+
+export type CSSVar = {
+  variable: string
+  reference: string
+}
+
+export type CSSVarOptions = {
+  fallback?: string | CSSVar
+  prefix?: string
+}
+
+export function cssVar(name: string, options?: CSSVarOptions) {
+  const cssVariable = toVar(name, options?.prefix)
+  return {
+    variable: cssVariable,
+    reference: toVarRef(cssVariable, getFallback(options?.fallback)),
+  }
+}
+
+function getFallback(fallback?: string | CSSVar) {
+  if (typeof fallback === "string") return fallback
+  return fallback?.reference
+}

--- a/packages/theme-tools/src/index.ts
+++ b/packages/theme-tools/src/index.ts
@@ -1,3 +1,6 @@
 export * from "./color"
 export * from "./component"
 export * from "./create-breakpoints"
+export * from "./anatomy"
+export * from "./css-calc"
+export * from "./css-var"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -52,6 +52,7 @@
     "lint:types": "tsc --noEmit"
   },
   "dependencies": {
+    "@chakra-ui/anatomy": "1.0.0",
     "@chakra-ui/theme-tools": "1.1.9",
     "@chakra-ui/utils": "1.8.2"
   },

--- a/packages/theme/src/components/accordion.ts
+++ b/packages/theme/src/components/accordion.ts
@@ -1,6 +1,10 @@
-const parts = ["container", "button", "panel", "icon"]
+import { accordionAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleObject,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const baseStyleContainer = {
+const baseStyleContainer: SystemStyleObject = {
   borderTopWidth: "1px",
   borderColor: "inherit",
   _last: {
@@ -8,7 +12,7 @@ const baseStyleContainer = {
   },
 }
 
-const baseStyleButton = {
+const baseStyleButton: SystemStyleObject = {
   transitionProperty: "common",
   transitionDuration: "normal",
   fontSize: "1rem",
@@ -26,17 +30,17 @@ const baseStyleButton = {
   py: 2,
 }
 
-const baseStylePanel = {
+const baseStylePanel: SystemStyleObject = {
   pt: 2,
   px: 4,
   pb: 5,
 }
 
-const baseStyleIcon = {
+const baseStyleIcon: SystemStyleObject = {
   fontSize: "1.25em",
 }
 
-const baseStyle = {
+const baseStyle: PartsStyleObject<typeof parts> = {
   container: baseStyleContainer,
   button: baseStyleButton,
   panel: baseStylePanel,

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -1,10 +1,12 @@
+import { alertAnatomy as parts } from "@chakra-ui/anatomy"
 import { getColor, mode, transparentize } from "@chakra-ui/theme-tools"
+import type {
+  PartsStyleObject,
+  PartsStyleFunction,
+  StyleFunctionProps,
+} from "@chakra-ui/theme-tools"
 
-type Dict = Record<string, any>
-
-const parts = ["container", "title", "description", "icon"]
-
-const baseStyle = {
+const baseStyle: PartsStyleObject<typeof parts> = {
   container: {
     px: 4,
     py: 3,
@@ -25,14 +27,14 @@ const baseStyle = {
   },
 }
 
-function getBg(props: Dict) {
+function getBg(props: StyleFunctionProps): string {
   const { theme, colorScheme: c } = props
   const lightBg = getColor(theme, `${c}.100`, c)
   const darkBg = transparentize(`${c}.200`, 0.16)(theme)
   return mode(lightBg, darkBg)(props)
 }
 
-function variantSubtle(props: Dict) {
+const variantSubtle: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     container: { bg: getBg(props) },
@@ -40,7 +42,7 @@ function variantSubtle(props: Dict) {
   }
 }
 
-function variantLeftAccent(props: Dict) {
+const variantLeftAccent: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     container: {
@@ -55,7 +57,7 @@ function variantLeftAccent(props: Dict) {
   }
 }
 
-function variantTopAccent(props: Dict) {
+const variantTopAccent: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     container: {
@@ -70,7 +72,7 @@ function variantTopAccent(props: Dict) {
   }
 }
 
-function variantSolid(props: Dict) {
+const variantSolid: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     container: {

--- a/packages/theme/src/components/avatar.ts
+++ b/packages/theme/src/components/avatar.ts
@@ -1,9 +1,13 @@
+import { avatarAnatomy as parts } from "@chakra-ui/anatomy"
 import { isDark, mode, randomColor } from "@chakra-ui/theme-tools"
+import type {
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+} from "@chakra-ui/theme-tools"
 import themeSizes from "../foundations/sizes"
 
-const parts = ["container", "excessLabel", "badge", "label"]
-
-function baseStyleBadge(props: Record<string, any>) {
+const baseStyleBadge: SystemStyleFunction = (props) => {
   return {
     transform: "translate(25%, 25%)",
     borderRadius: "full",
@@ -12,13 +16,13 @@ function baseStyleBadge(props: Record<string, any>) {
   }
 }
 
-function baseStyleExcessLabel(props: Record<string, any>) {
+const baseStyleExcessLabel: SystemStyleFunction = (props) => {
   return {
     bg: mode("gray.200", "whiteAlpha.400")(props),
   }
 }
 
-function baseStyleContainer(props: Record<string, any>) {
+const baseStyleContainer: SystemStyleFunction = (props) => {
   const { name, theme } = props
   const bg = name ? randomColor({ string: name }) : "gray.400"
   const isBgDark = isDark(bg)(theme)
@@ -36,13 +40,13 @@ function baseStyleContainer(props: Record<string, any>) {
   }
 }
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   badge: baseStyleBadge(props),
   excessLabel: baseStyleExcessLabel(props),
   container: baseStyleContainer(props),
 })
 
-function getSize(size: string) {
+function getSize(size: string): PartsStyleObject<typeof parts> {
   const themeSize = themeSizes[size]
   return {
     container: {

--- a/packages/theme/src/components/badge.ts
+++ b/packages/theme/src/components/badge.ts
@@ -1,6 +1,10 @@
 import { getColor, mode, transparentize } from "@chakra-ui/theme-tools"
+import type {
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const baseStyle = {
+const baseStyle: SystemStyleObject = {
   px: 1,
   textTransform: "uppercase",
   fontSize: "xs",
@@ -8,7 +12,7 @@ const baseStyle = {
   fontWeight: "bold",
 }
 
-function variantSolid(props: Record<string, any>) {
+const variantSolid: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
   const dark = transparentize(`${c}.500`, 0.6)(theme)
   return {
@@ -17,7 +21,7 @@ function variantSolid(props: Record<string, any>) {
   }
 }
 
-function variantSubtle(props: Record<string, any>) {
+const variantSubtle: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
   const darkBg = transparentize(`${c}.200`, 0.16)(theme)
   return {
@@ -26,7 +30,7 @@ function variantSubtle(props: Record<string, any>) {
   }
 }
 
-function variantOutline(props: Record<string, any>) {
+const variantOutline: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
   const darkColor = transparentize(`${c}.200`, 0.8)(theme)
   const lightColor = getColor(theme, `${c}.500`)

--- a/packages/theme/src/components/breadcrumb.ts
+++ b/packages/theme/src/components/breadcrumb.ts
@@ -1,6 +1,10 @@
-const parts = ["container", "item", "link", "separator"]
+import { breadcrumbAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleObject,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const baseStyleLink = {
+const baseStyleLink: SystemStyleObject = {
   transitionProperty: "common",
   transitionDuration: "fast",
   transitionTimingFunction: "ease-out",
@@ -16,7 +20,7 @@ const baseStyleLink = {
   },
 }
 
-const baseStyle = {
+const baseStyle: PartsStyleObject<typeof parts> = {
   link: baseStyleLink,
 }
 

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -1,8 +1,10 @@
 import { mode, transparentize } from "@chakra-ui/theme-tools"
+import type {
+  SystemStyleObject,
+  SystemStyleFunction,
+} from "@chakra-ui/theme-tools"
 
-type Dict = Record<string, any>
-
-const baseStyle = {
+const baseStyle: SystemStyleObject = {
   lineHeight: "1.2",
   borderRadius: "md",
   fontWeight: "semibold",
@@ -23,7 +25,7 @@ const baseStyle = {
   },
 }
 
-function variantGhost(props: Dict) {
+const variantGhost: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
 
   if (c === "gray") {
@@ -51,7 +53,7 @@ function variantGhost(props: Dict) {
   }
 }
 
-function variantOutline(props: Dict) {
+const variantOutline: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
   const borderColor = mode(`gray.200`, `whiteAlpha.300`)(props)
   return {
@@ -84,7 +86,7 @@ const accessibleColorMap: { [key: string]: AccessibleColor } = {
   },
 }
 
-function variantSolid(props: Dict) {
+const variantSolid: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
 
   if (c === "gray") {
@@ -124,7 +126,7 @@ function variantSolid(props: Dict) {
   }
 }
 
-function variantLink(props: Dict) {
+const variantLink: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
   return {
     padding: 0,
@@ -144,7 +146,7 @@ function variantLink(props: Dict) {
   }
 }
 
-const variantUnstyled = {
+const variantUnstyled: SystemStyleObject = {
   bg: "none",
   color: "inherit",
   display: "inline",
@@ -161,7 +163,7 @@ const variants = {
   unstyled: variantUnstyled,
 }
 
-const sizes = {
+const sizes: Record<string, SystemStyleObject> = {
   lg: {
     h: 12,
     minW: 12,

--- a/packages/theme/src/components/checkbox.ts
+++ b/packages/theme/src/components/checkbox.ts
@@ -1,8 +1,13 @@
+import { checkboxAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 import { mode } from "@chakra-ui/theme-tools"
 
-const parts = ["container", "control", "label", "icon"]
-
-function baseStyleControl(props: Record<string, any>) {
+const baseStyleControl: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
 
   return {
@@ -52,23 +57,23 @@ function baseStyleControl(props: Record<string, any>) {
   }
 }
 
-const baseStyleLabel = {
+const baseStyleLabel: SystemStyleObject = {
   userSelect: "none",
   _disabled: { opacity: 0.4 },
 }
 
-const baseStyleIcon = {
+const baseStyleIcon: SystemStyleObject = {
   transitionProperty: "transform",
   transitionDuration: "normal",
 }
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   icon: baseStyleIcon,
   control: baseStyleControl(props),
   label: baseStyleLabel,
 })
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   sm: {
     control: { h: 3, w: 3 },
     label: { fontSize: "sm" },

--- a/packages/theme/src/components/close-button.ts
+++ b/packages/theme/src/components/close-button.ts
@@ -1,10 +1,18 @@
-import { mode } from "@chakra-ui/theme-tools"
+import type {
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
+import { cssVar, mode } from "@chakra-ui/theme-tools"
 
-function baseStyle(props: Record<string, any>) {
+const btnSize = cssVar("close-button-size")
+
+const baseStyle: SystemStyleFunction = (props) => {
   const hoverBg = mode(`blackAlpha.100`, `whiteAlpha.100`)(props)
   const activeBg = mode(`blackAlpha.200`, `whiteAlpha.200`)(props)
 
   return {
+    w: [btnSize.reference],
+    h: [btnSize.reference],
     borderRadius: "md",
     transitionProperty: "common",
     transitionDuration: "normal",
@@ -21,20 +29,17 @@ function baseStyle(props: Record<string, any>) {
   }
 }
 
-const sizes = {
+const sizes: Record<string, SystemStyleObject> = {
   lg: {
-    w: "40px",
-    h: "40px",
+    [btnSize.variable]: "40px",
     fontSize: "16px",
   },
   md: {
-    w: "32px",
-    h: "32px",
+    [btnSize.variable]: "32px",
     fontSize: "12px",
   },
   sm: {
-    w: "24px",
-    h: "24px",
+    [btnSize.variable]: "24px",
     fontSize: "10px",
   },
 }

--- a/packages/theme/src/components/code.ts
+++ b/packages/theme/src/components/code.ts
@@ -1,8 +1,9 @@
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
 import Badge from "./badge"
 
 const { variants, defaultProps } = Badge
 
-const baseStyle = {
+const baseStyle: SystemStyleObject = {
   fontFamily: "mono",
   fontSize: "sm",
   px: "0.2em",

--- a/packages/theme/src/components/container.ts
+++ b/packages/theme/src/components/container.ts
@@ -1,4 +1,6 @@
-const baseStyle = {
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
+
+const baseStyle: SystemStyleObject = {
   w: "100%",
   mx: "auto",
   maxW: "60ch",

--- a/packages/theme/src/components/divider.ts
+++ b/packages/theme/src/components/divider.ts
@@ -1,13 +1,15 @@
-const baseStyle = {
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
+
+const baseStyle: SystemStyleObject = {
   opacity: 0.6,
   borderColor: "inherit",
 }
 
-const variantSolid = {
+const variantSolid: SystemStyleObject = {
   borderStyle: "solid",
 }
 
-const variantDashed = {
+const variantDashed: SystemStyleObject = {
   borderStyle: "dashed",
 }
 

--- a/packages/theme/src/components/drawer.ts
+++ b/packages/theme/src/components/drawer.ts
@@ -1,31 +1,39 @@
-import { mode } from "@chakra-ui/theme-tools"
-import Modal from "./modal"
-
-const parts = Modal.parts
+import { drawerAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  mode,
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
 /**
  * Since the `maxWidth` prop references theme.sizes internally,
  * we can leverage that to size our modals.
  */
-function getSize(value: string) {
+function getSize(value: string): PartsStyleObject<typeof parts> {
   if (value === "full") {
-    return { dialog: { maxW: "100vw", h: "100vh" } }
+    return {
+      dialog: { maxW: "100vw", h: "100vh" },
+    }
   }
-  return { dialog: { maxW: value } }
+  return {
+    dialog: { maxW: value },
+  }
 }
 
-const baseStyleOverlay = {
+const baseStyleOverlay: SystemStyleObject = {
   bg: "blackAlpha.600",
   zIndex: "overlay",
 }
 
-const baseStyleDialogContainer = {
+const baseStyleDialogContainer: SystemStyleObject = {
   display: "flex",
   zIndex: "modal",
   justifyContent: "center",
 }
 
-function baseStyleDialog(props: Record<string, any>) {
+const baseStyleDialog: SystemStyleFunction = (props) => {
   const { isFullHeight } = props
 
   return {
@@ -38,32 +46,32 @@ function baseStyleDialog(props: Record<string, any>) {
   }
 }
 
-const baseStyleHeader = {
+const baseStyleHeader: SystemStyleObject = {
   px: 6,
   py: 4,
   fontSize: "xl",
   fontWeight: "semibold",
 }
 
-const baseStyleCloseButton = {
+const baseStyleCloseButton: SystemStyleObject = {
   position: "absolute",
   top: 2,
   insetEnd: 3,
 }
 
-const baseStyleBody = {
+const baseStyleBody: SystemStyleObject = {
   px: 6,
   py: 2,
   flex: 1,
   overflow: "auto",
 }
 
-const baseStyleFooter = {
+const baseStyleFooter: SystemStyleObject = {
   px: 6,
   py: 4,
 }
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   overlay: baseStyleOverlay,
   dialogContainer: baseStyleDialogContainer,
   dialog: baseStyleDialog(props),

--- a/packages/theme/src/components/editable.ts
+++ b/packages/theme/src/components/editable.ts
@@ -1,13 +1,14 @@
-const parts = ["preview", "input"]
+import { editableAnatomy as parts } from "@chakra-ui/anatomy"
+import { PartsStyleObject, SystemStyleObject } from "@chakra-ui/theme-tools"
 
-const baseStylePreview = {
+const baseStylePreview: SystemStyleObject = {
   borderRadius: "md",
   py: "3px",
   transitionProperty: "common",
   transitionDuration: "normal",
 }
 
-const baseStyleInput = {
+const baseStyleInput: SystemStyleObject = {
   borderRadius: "md",
   py: "3px",
   transitionProperty: "common",
@@ -17,7 +18,7 @@ const baseStyleInput = {
   _placeholder: { opacity: 0.6 },
 }
 
-const baseStyle = {
+const baseStyle: PartsStyleObject<typeof parts> = {
   preview: baseStylePreview,
   input: baseStyleInput,
 }

--- a/packages/theme/src/components/form-error.ts
+++ b/packages/theme/src/components/form-error.ts
@@ -1,10 +1,11 @@
+import { formErrorAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleFunction,
+  SystemStyleFunction,
+} from "@chakra-ui/theme-tools"
 import { mode } from "@chakra-ui/theme-tools"
 
-type Dict = Record<string, any>
-
-const parts = ["text", "icon"]
-
-function baseStyleText(props: Dict) {
+const baseStyleText: SystemStyleFunction = (props) => {
   return {
     color: mode("red.500", "red.300")(props),
     mt: 2,
@@ -12,14 +13,14 @@ function baseStyleText(props: Dict) {
   }
 }
 
-function baseStyleIcon(props: Dict) {
+const baseStyleIcon: SystemStyleFunction = (props) => {
   return {
     marginEnd: "0.5em",
     color: mode("red.500", "red.300")(props),
   }
 }
 
-const baseStyle = (props: Dict) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   text: baseStyleText(props),
   icon: baseStyleIcon(props),
 })

--- a/packages/theme/src/components/form-label.ts
+++ b/packages/theme/src/components/form-label.ts
@@ -1,4 +1,6 @@
-const baseStyle = {
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
+
+const baseStyle: SystemStyleObject = {
   fontSize: "md",
   marginEnd: 3,
   mb: 2,

--- a/packages/theme/src/components/form.ts
+++ b/packages/theme/src/components/form.ts
@@ -1,17 +1,18 @@
+import { formAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleFunction,
+  SystemStyleFunction,
+} from "@chakra-ui/theme-tools"
 import { mode } from "@chakra-ui/theme-tools"
 
-type Dict = Record<string, any>
-
-const parts = ["container", "requiredIndicator", "helperText"]
-
-function baseStyleRequiredIndicator(props: Dict) {
+const baseStyleRequiredIndicator: SystemStyleFunction = (props) => {
   return {
     marginStart: 1,
     color: mode("red.500", "red.300")(props),
   }
 }
 
-function baseStyleHelperText(props: Dict) {
+const baseStyleHelperText: SystemStyleFunction = (props) => {
   return {
     mt: 2,
     color: mode("gray.500", "whiteAlpha.600")(props),
@@ -20,11 +21,8 @@ function baseStyleHelperText(props: Dict) {
   }
 }
 
-const baseStyle = (props: Dict) => ({
-  container: {
-    width: "100%",
-    position: "relative",
-  },
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+  container: { width: "100%", position: "relative" },
   requiredIndicator: baseStyleRequiredIndicator(props),
   helperText: baseStyleHelperText(props),
 })

--- a/packages/theme/src/components/heading.ts
+++ b/packages/theme/src/components/heading.ts
@@ -1,9 +1,11 @@
-const baseStyle = {
+import { SystemStyleObject } from "@chakra-ui/theme-tools"
+
+const baseStyle: SystemStyleObject = {
   fontFamily: "heading",
   fontWeight: "bold",
 }
 
-const sizes = {
+const sizes: Record<string, SystemStyleObject> = {
   "4xl": {
     fontSize: ["6xl", null, "7xl"],
     lineHeight: 1,

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -1,8 +1,12 @@
+import { inputAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 import { getColor, mode } from "@chakra-ui/theme-tools"
 
-const parts = ["field", "addon"]
-
-const baseStyle = {
+const baseStyle: PartsStyleObject<typeof parts> = {
   field: {
     width: "100%",
     minWidth: 0,
@@ -14,7 +18,7 @@ const baseStyle = {
   },
 }
 
-const size = {
+const size: Record<string, SystemStyleObject> = {
   lg: {
     fontSize: "lg",
     px: 4,
@@ -44,7 +48,7 @@ const size = {
   },
 }
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   lg: {
     field: size.lg,
     addon: size.lg,
@@ -71,7 +75,7 @@ function getDefaults(props: Record<string, any>) {
   }
 }
 
-function variantOutline(props: Record<string, any>) {
+const variantOutline: PartsStyleFunction<typeof parts> = (props) => {
   const { theme } = props
   const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props)
 
@@ -109,7 +113,7 @@ function variantOutline(props: Record<string, any>) {
   }
 }
 
-function variantFilled(props: Record<string, any>) {
+const variantFilled: PartsStyleFunction<typeof parts> = (props) => {
   const { theme } = props
   const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props)
 
@@ -145,7 +149,7 @@ function variantFilled(props: Record<string, any>) {
   }
 }
 
-function variantFlushed(props: Record<string, any>) {
+const variantFlushed: PartsStyleFunction<typeof parts> = (props) => {
   const { theme } = props
   const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props)
 
@@ -179,7 +183,7 @@ function variantFlushed(props: Record<string, any>) {
   }
 }
 
-const variantUnstyled = {
+const variantUnstyled: PartsStyleObject<typeof parts> = {
   field: {
     bg: "transparent",
     px: 0,

--- a/packages/theme/src/components/kbd.ts
+++ b/packages/theme/src/components/kbd.ts
@@ -1,6 +1,7 @@
+import type { SystemStyleFunction } from "@chakra-ui/theme-tools"
 import { mode } from "@chakra-ui/theme-tools"
 
-function baseStyle(props: Record<string, any>) {
+const baseStyle: SystemStyleFunction = (props) => {
   return {
     bg: mode("gray.100", "whiteAlpha")(props),
     borderRadius: "md",

--- a/packages/theme/src/components/link.ts
+++ b/packages/theme/src/components/link.ts
@@ -1,4 +1,6 @@
-const baseStyle = {
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
+
+const baseStyle: SystemStyleObject = {
   transitionProperty: "common",
   transitionDuration: "fast",
   transitionTimingFunction: "ease-out",

--- a/packages/theme/src/components/list.ts
+++ b/packages/theme/src/components/list.ts
@@ -1,18 +1,18 @@
-const parts = ["container", "item", "icon"]
+import { listAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleObject,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const baseStyleContainer = {}
-
-const baseStyleItem = {}
-
-const baseStyleIcon = {
+const baseStyleIcon: SystemStyleObject = {
   marginEnd: "0.5rem",
   display: "inline",
   verticalAlign: "text-bottom",
 }
 
-const baseStyle = {
-  container: baseStyleContainer,
-  item: baseStyleItem,
+const baseStyle: PartsStyleObject<typeof parts> = {
+  container: {},
+  item: {},
   icon: baseStyleIcon,
 }
 

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -1,8 +1,12 @@
-import { mode } from "@chakra-ui/theme-tools"
+import { menuAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  mode,
+  PartsStyleFunction,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const parts = ["item", "command", "list", "button", "groupTitle", "divider"]
-
-function baseStyleList(props: Record<string, any>) {
+const baseStyleList: SystemStyleFunction = (props) => {
   return {
     bg: mode(`#fff`, `gray.700`)(props),
     boxShadow: mode(`sm`, `dark-lg`)(props),
@@ -15,7 +19,7 @@ function baseStyleList(props: Record<string, any>) {
   }
 }
 
-function baseStyleItem(props: Record<string, any>) {
+const baseStyleItem: SystemStyleFunction = (props) => {
   return {
     py: "0.4rem",
     px: "0.8rem",
@@ -38,18 +42,18 @@ function baseStyleItem(props: Record<string, any>) {
   }
 }
 
-const baseStyleGroupTitle = {
+const baseStyleGroupTitle: SystemStyleObject = {
   mx: 4,
   my: 2,
   fontWeight: "semibold",
   fontSize: "sm",
 }
 
-const baseStyleCommand = {
+const baseStyleCommand: SystemStyleObject = {
   opacity: 0.6,
 }
 
-const baseStyleDivider = {
+const baseStyleDivider: SystemStyleObject = {
   border: 0,
   borderBottom: "1px solid",
   borderColor: "inherit",
@@ -57,12 +61,12 @@ const baseStyleDivider = {
   opacity: 0.6,
 }
 
-const baseStyleButton = {
+const baseStyleButton: SystemStyleObject = {
   transitionProperty: "common",
   transitionDuration: "normal",
 }
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   button: baseStyleButton,
   list: baseStyleList(props),
   item: baseStyleItem(props),

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -1,23 +1,18 @@
+import { modalAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 import { mode } from "@chakra-ui/theme-tools"
 
-const parts = [
-  "overlay",
-  "dialogContainer",
-  "dialog",
-  "header",
-  "closeButton",
-  "body",
-  "footer",
-]
-
-const baseStyleOverlay = {
+const baseStyleOverlay: SystemStyleObject = {
   bg: "blackAlpha.600",
   zIndex: "modal",
 }
 
-type Dict = Record<string, any>
-
-function baseStyleDialogContainer(props: Dict) {
+const baseStyleDialogContainer: SystemStyleFunction = (props) => {
   const { isCentered, scrollBehavior } = props
 
   return {
@@ -29,7 +24,7 @@ function baseStyleDialogContainer(props: Dict) {
   }
 }
 
-function baseStyleDialog(props: Dict) {
+const baseStyleDialog: SystemStyleFunction = (props) => {
   const { scrollBehavior } = props
 
   return {
@@ -43,20 +38,20 @@ function baseStyleDialog(props: Dict) {
   }
 }
 
-const baseStyleHeader = {
+const baseStyleHeader: SystemStyleObject = {
   px: 6,
   py: 4,
   fontSize: "xl",
   fontWeight: "semibold",
 }
 
-const baseStyleCloseButton = {
+const baseStyleCloseButton: SystemStyleObject = {
   position: "absolute",
   top: 2,
   insetEnd: 3,
 }
 
-function baseStyleBody(props: Dict) {
+const baseStyleBody: SystemStyleFunction = (props) => {
   const { scrollBehavior } = props
   return {
     px: 6,
@@ -66,12 +61,12 @@ function baseStyleBody(props: Dict) {
   }
 }
 
-const baseStyleFooter = {
+const baseStyleFooter: SystemStyleObject = {
   px: 6,
   py: 4,
 }
 
-const baseStyle = (props: Dict) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   overlay: baseStyleOverlay,
   dialogContainer: baseStyleDialogContainer(props),
   dialog: baseStyleDialog(props),
@@ -85,11 +80,15 @@ const baseStyle = (props: Dict) => ({
  * Since the `maxWidth` prop references theme.sizes internally,
  * we can leverage that to size our modals.
  */
-function getSize(value: string) {
+function getSize(value: string): PartsStyleObject<typeof parts> {
   if (value === "full") {
-    return { dialog: { maxW: "100vw", minH: "100vh", my: 0 } }
+    return {
+      dialog: { maxW: "100vw", minH: "100vh", my: 0 },
+    }
   }
-  return { dialog: { maxW: value } }
+  return {
+    dialog: { maxW: value },
+  }
 }
 
 const sizes = {

--- a/packages/theme/src/components/number-input.ts
+++ b/packages/theme/src/components/number-input.ts
@@ -1,24 +1,32 @@
-import { mode } from "@chakra-ui/theme-tools"
-import Input from "./input"
+import { numberInputAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  SystemStyleFunction,
+  SystemStyleObject,
+  PartsStyleFunction,
+  PartsStyleObject,
+} from "@chakra-ui/theme-tools"
+import { calc, cssVar, mode } from "@chakra-ui/theme-tools"
 import typography from "../foundations/typography"
-
-const parts = ["root", "field", "stepper", "stepperGroup"]
+import Input from "./input"
 
 const { variants, defaultProps } = Input
 
-const baseStyleRoot = {
-  "--number-input-stepper-width": "24px",
-  "--number-input-field-padding":
-    "calc(var(--number-input-stepper-width) + 0.5rem)",
+const stepperWidth = cssVar("number-input-stepper-width")
+const inputPadding = cssVar("number-input-input-padding")
+const inputPaddingValue = calc(stepperWidth).add("0.5rem").toString()
+
+const baseStyleRoot: SystemStyleObject = {
+  [stepperWidth.variable]: "24px",
+  [inputPadding.variable]: inputPaddingValue,
 }
 
-const baseStyleField = Input.baseStyle?.field
+const baseStyleField: SystemStyleObject = Input.baseStyle?.field ?? {}
 
-const baseStyleStepperGroup = {
-  width: "var(--number-input-stepper-width)",
+const baseStyleStepperGroup: SystemStyleObject = {
+  width: [stepperWidth.reference],
 }
 
-function baseStyleStepper(props: Record<string, any>) {
+const baseStyleStepper: SystemStyleFunction = (props) => {
   return {
     borderStart: "1px solid",
     borderStartColor: mode("inherit", "whiteAlpha.300")(props),
@@ -33,33 +41,36 @@ function baseStyleStepper(props: Record<string, any>) {
   }
 }
 
-const baseStyle = (props: Record<string, any>) => ({
-  root: baseStyleRoot,
-  field: baseStyleField,
-  stepperGroup: baseStyleStepperGroup,
-  stepper: baseStyleStepper(props),
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+  [parts.root]: baseStyleRoot,
+  [parts.field]: baseStyleField,
+  [parts.stepperGroup]: baseStyleStepperGroup,
+  [parts.stepper]: baseStyleStepper(props),
 })
 
-function getSize(size: "xs" | "sm" | "md" | "lg") {
+type Size = "xs" | "sm" | "md" | "lg"
+
+function getSize(size: Size): PartsStyleObject<typeof parts> {
   const sizeStyle = Input.sizes[size]
 
-  const radius = {
+  const radius: Record<Size, string> = {
     lg: "md",
     md: "md",
     sm: "sm",
     xs: "sm",
   }
 
-  const resolvedFontSize = typography.fontSizes[sizeStyle.field.fontSize]
+  const _fontSize = sizeStyle.field?.fontSize ?? "md"
+  const fontSize = typography.fontSizes[_fontSize.toString()]
 
   return {
     field: {
       ...sizeStyle.field,
-      paddingInlineEnd: "var(--number-input-field-padding)",
+      paddingInlineEnd: inputPadding.reference,
       verticalAlign: "top",
     },
     stepper: {
-      fontSize: `calc(${resolvedFontSize} * 0.75)`,
+      fontSize: calc(fontSize).multiply(0.75).toString(),
       _first: {
         borderTopEndRadius: radius[size],
       },

--- a/packages/theme/src/components/pin-input.ts
+++ b/packages/theme/src/components/pin-input.ts
@@ -1,43 +1,46 @@
+import type {
+  StyleFunctionProps,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
+import { cssVar } from "@chakra-ui/theme-tools"
 import Input from "./input"
 
-type Dict = Record<string, any>
+const inputSize = cssVar("pin-input-size")
 
-const baseStyle = {
+const baseStyle: SystemStyleObject = {
   ...Input.baseStyle.field,
   textAlign: "center",
+  w: inputSize.reference,
+  h: inputSize.reference,
 }
 
-const sizes = {
+const sizes: Record<string, SystemStyleObject> = {
   lg: {
     fontSize: "lg",
-    w: 12,
-    h: 12,
+    [inputSize.variable]: 12,
     borderRadius: "md",
   },
   md: {
     fontSize: "md",
-    w: 10,
-    h: 10,
+    [inputSize.variable]: 10,
     borderRadius: "md",
   },
   sm: {
     fontSize: "sm",
-    w: 8,
-    h: 8,
+    [inputSize.variable]: 8,
     borderRadius: "sm",
   },
   xs: {
     fontSize: "xs",
-    w: 6,
-    h: 6,
+    [inputSize.variable]: 6,
     borderRadius: "sm",
   },
 }
 
 const variants = {
-  outline: (props: Dict) => Input.variants.outline(props).field,
-  flushed: (props: Dict) => Input.variants.flushed(props).field,
-  filled: (props: Dict) => Input.variants.filled(props).field,
+  outline: (props: StyleFunctionProps) => Input.variants.outline(props).field,
+  flushed: (props: StyleFunctionProps) => Input.variants.flushed(props).field,
+  filled: (props: StyleFunctionProps) => Input.variants.filled(props).field,
   unstyled: Input.variants.unstyled.field,
 }
 

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -1,21 +1,28 @@
-import { mode } from "@chakra-ui/theme-tools"
+import { popoverAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleFunction,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
+import { cssVar, mode } from "@chakra-ui/theme-tools"
 
-const parts = ["popper", "content", "header", "body", "footer", "arrow"]
+const popperBg = cssVar("popper-bg")
+const popperArrowBg = cssVar("popper-arrow-bg")
+const popperArrowShadowColor = cssVar("popper-shadow-color")
 
-type Dict = Record<string, any>
-
-const baseStylePopper = {
+const baseStylePopper: SystemStyleObject = {
   zIndex: 10,
 }
 
-function baseStyleContent(props: Dict) {
+const baseStyleContent: SystemStyleFunction = (props) => {
   const bg = mode("white", "gray.700")(props)
   const shadowColor = mode("gray.200", "whiteAlpha.300")(props)
+
   return {
-    "--popover-bg": `colors.${bg}`,
-    bg: "var(--popover-bg)",
-    "--popper-arrow-bg": "var(--popover-bg)",
-    "--popper-arrow-shadow-color": `colors.${shadowColor}`,
+    [popperBg.variable]: `colors.${bg}`,
+    bg: popperBg.reference,
+    [popperArrowBg.variable]: popperBg.reference,
+    [popperArrowShadowColor.variable]: `colors.${shadowColor}`,
     width: "xs",
     border: "1px solid",
     borderColor: "inherit",
@@ -29,24 +36,24 @@ function baseStyleContent(props: Dict) {
   }
 }
 
-const baseStyleHeader = {
+const baseStyleHeader: SystemStyleObject = {
   px: 3,
   py: 2,
   borderBottomWidth: "1px",
 }
 
-const baseStyleBody = {
+const baseStyleBody: SystemStyleObject = {
   px: 3,
   py: 2,
 }
 
-const baseStyleFooter = {
+const baseStyleFooter: SystemStyleObject = {
   px: 3,
   py: 2,
   borderTopWidth: "1px",
 }
 
-const baseStyle = (props: Dict) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   popper: baseStylePopper,
   content: baseStyleContent(props),
   header: baseStyleHeader,

--- a/packages/theme/src/components/progress.ts
+++ b/packages/theme/src/components/progress.ts
@@ -1,10 +1,18 @@
-import { generateStripe, getColor, mode } from "@chakra-ui/theme-tools"
+import { progressAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  generateStripe,
+  getColor,
+  mode,
+  PartsStyleFunction,
+  PartsStyleObject,
+  StyleFunctionProps,
+} from "@chakra-ui/theme-tools"
+import type {
+  SystemStyleObject,
+  SystemStyleFunction,
+} from "@chakra-ui/theme-tools"
 
-type Dict = Record<string, any>
-
-const parts = ["track", "filledTrack", "label"]
-
-function filledStyle(props: Dict) {
+function filledStyle(props: StyleFunctionProps): SystemStyleObject {
   const { colorScheme: c, theme: t, isIndeterminate, hasStripe } = props
 
   const stripeStyle = mode(
@@ -29,20 +37,20 @@ function filledStyle(props: Dict) {
   }
 }
 
-const baseStyleLabel = {
+const baseStyleLabel: SystemStyleObject = {
   lineHeight: "1",
   fontSize: "0.25em",
   fontWeight: "bold",
   color: "white",
 }
 
-function baseStyleTrack(props: Dict) {
+const baseStyleTrack: SystemStyleFunction = (props) => {
   return {
     bg: mode(`gray.100`, `whiteAlpha.300`)(props),
   }
 }
 
-function baseStyleFilledTrack(props: Dict) {
+const baseStyleFilledTrack: SystemStyleFunction = (props) => {
   return {
     transitionProperty: "common",
     transitionDuration: "slow",
@@ -50,13 +58,13 @@ function baseStyleFilledTrack(props: Dict) {
   }
 }
 
-const baseStyle = (props: Dict) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   label: baseStyleLabel,
   filledTrack: baseStyleFilledTrack(props),
   track: baseStyleTrack(props),
 })
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   xs: {
     track: { h: "0.25rem" },
   },

--- a/packages/theme/src/components/radio.ts
+++ b/packages/theme/src/components/radio.ts
@@ -1,9 +1,13 @@
+import { radioAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+} from "@chakra-ui/theme-tools"
 import Checkbox from "./checkbox"
 
-const parts = ["container", "control", "label"]
-
-function baseStyleControl(props: Record<string, any>) {
-  const { control } = Checkbox.baseStyle(props)
+const baseStyleControl: SystemStyleFunction = (props) => {
+  const { control = {} } = Checkbox.baseStyle(props)
 
   return {
     ...control,
@@ -23,12 +27,12 @@ function baseStyleControl(props: Record<string, any>) {
   }
 }
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   label: Checkbox.baseStyle(props).label,
   control: baseStyleControl(props),
 })
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   md: {
     control: { w: 4, h: 4 },
     label: { fontSize: "md" },

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -1,10 +1,14 @@
-import { mode } from "@chakra-ui/theme-tools"
-import { mergeWith as merge } from "@chakra-ui/utils"
+import { selectAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  mode,
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 import Input from "./input"
 
-const parts = ["field", "icon"]
-
-function baseStyleField(props: Record<string, any>) {
+const baseStyleField: SystemStyleFunction = (props) => {
   return {
     ...Input.baseStyle.field,
     appearance: "none",
@@ -16,7 +20,7 @@ function baseStyleField(props: Record<string, any>) {
   }
 }
 
-const baseStyleIcon = {
+const baseStyleIcon: SystemStyleObject = {
   width: "1.5rem",
   height: "100%",
   insetEnd: "0.5rem",
@@ -28,18 +32,18 @@ const baseStyleIcon = {
   },
 }
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   field: baseStyleField(props),
   icon: baseStyleIcon,
 })
 
-const sizes = merge({}, Input.sizes, {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
+  ...Input.sizes,
   xs: {
-    icon: {
-      insetEnd: "0.25rem",
-    },
+    ...Input.sizes.xs,
+    icon: { insetEnd: "0.25rem" },
   },
-})
+}
 
 export default {
   parts,

--- a/packages/theme/src/components/skeleton.ts
+++ b/packages/theme/src/components/skeleton.ts
@@ -1,4 +1,5 @@
 import { keyframes } from "@chakra-ui/system"
+import type { SystemStyleFunction } from "@chakra-ui/theme-tools"
 import { getColor, mode } from "@chakra-ui/theme-tools"
 
 const fade = (startColor: string, endColor: string) =>
@@ -7,7 +8,7 @@ const fade = (startColor: string, endColor: string) =>
     to: { borderColor: endColor, background: endColor },
   })
 
-const baseStyle = (props: Record<string, any>) => {
+const baseStyle: SystemStyleFunction = (props) => {
   const defaultStartColor = mode("gray.100", "gray.800")(props)
   const defaultEndColor = mode("gray.400", "gray.600")(props)
 

--- a/packages/theme/src/components/skip-link.ts
+++ b/packages/theme/src/components/skip-link.ts
@@ -1,6 +1,6 @@
-import { mode } from "@chakra-ui/theme-tools"
+import { mode, SystemStyleFunction } from "@chakra-ui/theme-tools"
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: SystemStyleFunction = (props) => ({
   borderRadius: "md",
   fontWeight: "semibold",
   _focus: {

--- a/packages/theme/src/components/slider.ts
+++ b/packages/theme/src/components/slider.ts
@@ -1,10 +1,14 @@
-import { mode, orient } from "@chakra-ui/theme-tools"
+import { sliderAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  mode,
+  orient,
+  SystemStyleObject,
+  SystemStyleFunction,
+  StyleFunctionProps,
+  PartsStyleFunction,
+} from "@chakra-ui/theme-tools"
 
-const parts = ["container", "thumb", "track", "filledTrack"]
-
-type Dict = Record<string, any>
-
-function thumbOrientation(props: Dict) {
+function thumbOrientation(props: StyleFunctionProps): SystemStyleObject {
   return orient({
     orientation: props.orientation,
     vertical: {
@@ -24,7 +28,7 @@ function thumbOrientation(props: Dict) {
   })
 }
 
-const baseStyleContainer = (props: Dict) => {
+const baseStyleContainer: SystemStyleFunction = (props) => {
   const { orientation } = props
 
   return {
@@ -41,7 +45,7 @@ const baseStyleContainer = (props: Dict) => {
   }
 }
 
-function baseStyleTrack(props: Dict) {
+const baseStyleTrack: SystemStyleFunction = (props) => {
   return {
     borderRadius: "sm",
     bg: mode("gray.200", "whiteAlpha.200")(props),
@@ -51,7 +55,7 @@ function baseStyleTrack(props: Dict) {
   }
 }
 
-function baseStyleThumb(props: Dict) {
+const baseStyleThumb: SystemStyleFunction = (props) => {
   return {
     zIndex: 1,
     borderRadius: "full",
@@ -67,7 +71,7 @@ function baseStyleThumb(props: Dict) {
   }
 }
 
-function baseStyleFilledTrack(props: Dict) {
+const baseStyleFilledTrack: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
 
   return {
@@ -75,14 +79,14 @@ function baseStyleFilledTrack(props: Dict) {
   }
 }
 
-const baseStyle = (props: Dict) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   container: baseStyleContainer(props),
   track: baseStyleTrack(props),
   thumb: baseStyleThumb(props),
   filledTrack: baseStyleFilledTrack(props),
 })
 
-function sizeLg(props: Dict) {
+const sizeLg: PartsStyleFunction<typeof parts> = (props) => {
   return {
     thumb: { w: "16px", h: "16px" },
     track: orient({
@@ -93,7 +97,7 @@ function sizeLg(props: Dict) {
   }
 }
 
-function sizeMd(props: Dict) {
+const sizeMd: PartsStyleFunction<typeof parts> = (props) => {
   return {
     thumb: { w: "14px", h: "14px" },
     track: orient({
@@ -104,7 +108,7 @@ function sizeMd(props: Dict) {
   }
 }
 
-function sizeSm(props: Dict) {
+const sizeSm: PartsStyleFunction<typeof parts> = (props) => {
   return {
     thumb: { w: "10px", h: "10px" },
     track: orient({

--- a/packages/theme/src/components/spinner.ts
+++ b/packages/theme/src/components/spinner.ts
@@ -1,23 +1,27 @@
-const baseStyle = {
-  width: "var(--spinner-size)",
-  height: "var(--spinner-size)",
+import { cssVar, SystemStyleObject } from "@chakra-ui/theme-tools"
+
+const spinnerSize = cssVar("spinner-size")
+
+const baseStyle: SystemStyleObject = {
+  width: [spinnerSize.reference],
+  height: [spinnerSize.reference],
 }
 
-const sizes = {
+const sizes: Record<string, SystemStyleObject> = {
   xs: {
-    "--spinner-size": "0.75rem",
+    [spinnerSize.variable]: "0.75rem",
   },
   sm: {
-    "--spinner-size": "1rem",
+    [spinnerSize.variable]: "1rem",
   },
   md: {
-    "--spinner-size": "1.5rem",
+    [spinnerSize.variable]: "1.5rem",
   },
   lg: {
-    "--spinner-size": "2rem",
+    [spinnerSize.variable]: "2rem",
   },
   xl: {
-    "--spinner-size": "3rem",
+    [spinnerSize.variable]: "3rem",
   },
 }
 

--- a/packages/theme/src/components/stat.ts
+++ b/packages/theme/src/components/stat.ts
@@ -1,36 +1,39 @@
-const parts = ["label", "number", "icon", "helpText", "container"]
+import { statAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleObject,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const baseStyleContainer = {}
-const baseStyleLabel = {
+const baseStyleLabel: SystemStyleObject = {
   fontWeight: "medium",
 }
 
-const baseStyleHelpText = {
+const baseStyleHelpText: SystemStyleObject = {
   opacity: 0.8,
   marginBottom: 2,
 }
 
-const baseStyleNumber = {
+const baseStyleNumber: SystemStyleObject = {
   verticalAlign: "baseline",
   fontWeight: "semibold",
 }
 
-const baseStyleIcon = {
+const baseStyleIcon: SystemStyleObject = {
   marginEnd: 1,
   w: "14px",
   h: "14px",
   verticalAlign: "middle",
 }
 
-const baseStyle = {
-  container: baseStyleContainer,
+const baseStyle: PartsStyleObject<typeof parts> = {
+  container: {},
   label: baseStyleLabel,
   helpText: baseStyleHelpText,
   number: baseStyleNumber,
   icon: baseStyleIcon,
 }
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   md: {
     label: { fontSize: "sm" },
     helpText: { fontSize: "sm" },

--- a/packages/theme/src/components/switch.ts
+++ b/packages/theme/src/components/switch.ts
@@ -1,15 +1,30 @@
-import { mode } from "@chakra-ui/theme-tools"
+import { switchAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  calc,
+  cssVar,
+  mode,
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const parts = ["container", "track", "thumb"]
+const sliderWidth = cssVar("slider-track-width")
+const sliderHeight = cssVar("slider-track-height")
 
-function baseStyleTrack(props: Record<string, any>) {
+const sliderDiff = cssVar("slider-track-diff")
+const sliderDiffValue = calc(sliderWidth).subtract(sliderHeight).toString()
+
+const sliderX = cssVar("slider-thumb-x")
+
+const baseStyleTrack: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
 
   return {
     borderRadius: "full",
     p: "2px",
-    width: "var(--slider-track-width)",
-    height: "var(--slider-track-height)",
+    width: [sliderWidth.reference],
+    height: [sliderHeight.reference],
     transitionProperty: "common",
     transitionDuration: "fast",
     bg: mode("gray.300", "whiteAlpha.400")(props),
@@ -26,48 +41,47 @@ function baseStyleTrack(props: Record<string, any>) {
   }
 }
 
-const baseStyleThumb = {
+const baseStyleThumb: SystemStyleObject = {
   bg: "white",
   transitionProperty: "transform",
   transitionDuration: "normal",
   borderRadius: "inherit",
-  width: "var(--slider-track-height)",
-  height: "var(--slider-track-height)",
+  width: [sliderWidth.reference],
+  height: [sliderHeight.reference],
   _checked: {
-    transform: "translateX(var(--slider-thumb-x))",
+    transform: `translateX(${sliderX.reference})`,
   },
 }
 
-const baseStyle = (props: Record<string, any>) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   container: {
-    "--slider-track-diff":
-      "calc(var(--slider-track-width) - var(--slider-track-height))",
-    "--slider-thumb-x": "var(--slider-track-diff)",
+    [sliderDiff.variable]: sliderDiffValue,
+    [sliderX.variable]: sliderDiff.reference,
     _rtl: {
-      "--slider-thumb-x": "calc(-1 * var(--slider-track-diff))",
+      [sliderX.variable]: calc(sliderDiff).negate().toString(),
     },
   },
   track: baseStyleTrack(props),
   thumb: baseStyleThumb,
 })
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   sm: {
     container: {
-      "--slider-track-width": "1.375rem",
-      "--slider-track-height": "0.75rem",
+      [sliderWidth.variable]: "1.375rem",
+      [sliderHeight.variable]: "0.75rem",
     },
   },
   md: {
     container: {
-      "--slider-track-width": "1.875rem",
-      "--slider-track-height": "1rem",
+      [sliderWidth.variable]: "1.875rem",
+      [sliderHeight.variable]: "1rem",
     },
   },
   lg: {
     container: {
-      "--slider-track-width": "2.875rem",
-      "--slider-track-height": "1.5rem",
+      [sliderWidth.variable]: "2.875rem",
+      [sliderHeight.variable]: "1.5rem",
     },
   },
 }

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -1,10 +1,12 @@
+import { tableAnatomy as parts } from "@chakra-ui/anatomy"
 import { mode } from "@chakra-ui/theme-tools"
+import type {
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const parts = ["table", "thead", "tbody", "tr", "th", "td", "caption"]
-
-type Dict = Record<string, any>
-
-const baseStyle = {
+const baseStyle: PartsStyleObject<typeof parts> = {
   table: {
     fontVariantNumeric: "lining-nums tabular-nums",
     borderCollapse: "collapse",
@@ -28,13 +30,13 @@ const baseStyle = {
   },
 }
 
-const numericStyles = {
+const numericStyles: SystemStyleObject = {
   "&[data-is-numeric=true]": {
     textAlign: "end",
   },
 }
 
-const simpleVariant = (props: Dict) => {
+const variantSimple: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
 
   return {
@@ -62,7 +64,7 @@ const simpleVariant = (props: Dict) => {
   }
 }
 
-const stripedVariant = (props: Dict) => {
+const variantStripe: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
 
   return {
@@ -104,12 +106,12 @@ const stripedVariant = (props: Dict) => {
 }
 
 const variants = {
-  simple: simpleVariant,
-  striped: stripedVariant,
+  simple: variantSimple,
+  striped: variantStripe,
   unstyled: {},
 }
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   sm: {
     th: {
       px: "4",

--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -1,17 +1,21 @@
-import { getColor, mode } from "@chakra-ui/theme-tools"
+import { tabsAnatomy as parts } from "@chakra-ui/anatomy"
+import {
+  getColor,
+  mode,
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 
-const parts = ["root", "tablist", "tab", "tabpanels", "tabpanel", "indicator"]
-
-type Dict = Record<string, any>
-
-function baseStyleRoot(props: Dict) {
+const baseStyleRoot: SystemStyleFunction = (props) => {
   const { orientation } = props
   return {
     display: orientation === "vertical" ? "flex" : "block",
   }
 }
 
-function baseStyleTab(props: Dict) {
+const baseStyleTab: SystemStyleFunction = (props) => {
   const { isFitted } = props
 
   return {
@@ -25,7 +29,7 @@ function baseStyleTab(props: Dict) {
   }
 }
 
-function baseStyleTablist(props: Dict) {
+const baseStyleTablist: SystemStyleFunction = (props) => {
   const { align = "start", orientation } = props
 
   const alignments = {
@@ -40,16 +44,18 @@ function baseStyleTablist(props: Dict) {
   }
 }
 
-const baseStyleTabpanel = { p: 4 }
+const baseStyleTabpanel: SystemStyleObject = {
+  p: 4,
+}
 
-const baseStyle = (props: Dict) => ({
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   root: baseStyleRoot(props),
   tab: baseStyleTab(props),
   tablist: baseStyleTablist(props),
   tabpanel: baseStyleTabpanel,
 })
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   sm: {
     tab: {
       py: 1,
@@ -73,7 +79,7 @@ const sizes = {
   },
 }
 
-function variantLine(props: Dict) {
+const variantLine: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c, orientation } = props
   const isVertical = orientation === "vertical"
   const borderProp = orientation === "vertical" ? "borderStart" : "borderBottom"
@@ -103,7 +109,7 @@ function variantLine(props: Dict) {
   }
 }
 
-function variantEnclosed(props: Dict) {
+const variantEnclosed: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     tab: {
@@ -125,7 +131,7 @@ function variantEnclosed(props: Dict) {
   }
 }
 
-function variantEnclosedColored(props: Dict) {
+const variantEnclosedColored: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     tab: {
@@ -152,7 +158,7 @@ function variantEnclosedColored(props: Dict) {
   }
 }
 
-function variantSoftRounded(props: Dict) {
+const variantSoftRounded: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c, theme } = props
   return {
     tab: {
@@ -167,7 +173,7 @@ function variantSoftRounded(props: Dict) {
   }
 }
 
-function variantSolidRounded(props: Dict) {
+const variantSolidRounded: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     tab: {
@@ -182,7 +188,7 @@ function variantSolidRounded(props: Dict) {
   }
 }
 
-const variantUnstyled = {}
+const variantUnstyled: SystemStyleObject = {}
 
 const variants = {
   line: variantLine,

--- a/packages/theme/src/components/tag.ts
+++ b/packages/theme/src/components/tag.ts
@@ -1,10 +1,12 @@
+import { tagAnatomy as parts } from "@chakra-ui/anatomy"
+import type {
+  PartsStyleObject,
+  StyleFunctionProps,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 import Badge from "./badge"
 
-const parts = ["container", "label", "closeButton"]
-
-type Dict = Record<string, any>
-
-const baseStyleContainer = {
+const baseStyleContainer: SystemStyleObject = {
   fontWeight: "medium",
   lineHeight: 1.2,
   outline: 0,
@@ -13,12 +15,12 @@ const baseStyleContainer = {
   },
 }
 
-const baseStyleLabel = {
+const baseStyleLabel: SystemStyleObject = {
   lineHeight: 1.2,
   overflow: "visible",
 }
 
-const baseStyleCloseButton = {
+const baseStyleCloseButton: SystemStyleObject = {
   fontSize: "18px",
   w: "1.25rem",
   h: "1.25rem",
@@ -39,13 +41,13 @@ const baseStyleCloseButton = {
   _active: { opacity: 1 },
 }
 
-const baseStyle = {
+const baseStyle: PartsStyleObject<typeof parts> = {
   container: baseStyleContainer,
   label: baseStyleLabel,
   closeButton: baseStyleCloseButton,
 }
 
-const sizes = {
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   sm: {
     container: {
       minH: "1.25rem",
@@ -80,13 +82,13 @@ const sizes = {
 }
 
 const variants = {
-  subtle: (props: Dict) => ({
+  subtle: (props: StyleFunctionProps) => ({
     container: Badge.variants.subtle(props),
   }),
-  solid: (props: Dict) => ({
+  solid: (props: StyleFunctionProps) => ({
     container: Badge.variants.solid(props),
   }),
-  outline: (props: Dict) => ({
+  outline: (props: StyleFunctionProps) => ({
     container: Badge.variants.outline(props),
   }),
 }

--- a/packages/theme/src/components/textarea.ts
+++ b/packages/theme/src/components/textarea.ts
@@ -1,8 +1,10 @@
+import type {
+  StyleFunctionProps,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools"
 import Input from "./input"
 
-type Dict = Record<string, any>
-
-const baseStyle = {
+const baseStyle: SystemStyleObject = {
   ...Input.baseStyle.field,
   paddingY: "8px",
   minHeight: "80px",
@@ -11,9 +13,9 @@ const baseStyle = {
 }
 
 const variants = {
-  outline: (props: Dict) => Input.variants.outline(props).field,
-  flushed: (props: Dict) => Input.variants.flushed(props).field,
-  filled: (props: Dict) => Input.variants.filled(props).field,
+  outline: (props: StyleFunctionProps) => Input.variants.outline(props).field,
+  flushed: (props: StyleFunctionProps) => Input.variants.flushed(props).field,
+  filled: (props: StyleFunctionProps) => Input.variants.filled(props).field,
   unstyled: Input.variants.unstyled.field,
 }
 

--- a/packages/theme/src/components/tooltip.ts
+++ b/packages/theme/src/components/tooltip.ts
@@ -1,13 +1,16 @@
-import { mode } from "@chakra-ui/theme-tools"
+import { mode, cssVar, SystemStyleFunction } from "@chakra-ui/theme-tools"
 
-function baseStyle(props: Record<string, any>) {
+const tooltipBg = cssVar("tooltip-bg")
+const arrowBg = cssVar("popper-arrow-bg")
+
+const baseStyle: SystemStyleFunction = (props) => {
   const bg = mode("gray.700", "gray.300")(props)
   return {
-    "--tooltip-bg": `colors.${bg}`,
+    [tooltipBg.variable]: `colors.${bg}`,
     px: "8px",
     py: "2px",
-    bg: "var(--tooltip-bg)",
-    "--popper-arrow-bg": "var(--tooltip-bg)",
+    bg: [tooltipBg.reference],
+    [arrowBg.variable]: [tooltipBg.reference],
     color: mode("whiteAlpha.900", "gray.900")(props),
     borderRadius: "sm",
     fontWeight: "medium",


### PR DESCRIPTION
## 📝 Description

This PR adds some helper functions to the theme-tools package to make the process of creating component themes less cumbersome.

- cssVar - function to create css vars
- calc - function that makes it easy to create the css calc string
- anatomy- function to define and extend component parts
- Added `PartsStyleObject` and `PartStyleFunction` for easy creation of multipart component styles

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Creating a CSS variable in the theme

```jsx
import { cssVar, calc }  from "@chakra-ui/theme-tools"

const $width = cssVar("slider-width")
const $height = cssVar("slider-height")

const $diff = calc($width).subtract($height).toString()

$width.variable  // => '--slider-width'
$width.reference // => 'var(--slider-width)'
```

Create a component anatomy

```jsx
import { anatomy }  from "@chakra-ui/theme-tools"
import type { PartsStyle } from "@chakra-ui/theme-tools"

const btn = anatomy("button").parts("label", "container")

const newBtn = btn.extend("icon") //  extend button to include icon part

// Using the anatomy in component theme
const baseStyle: PartsStyle<typeof newBtn> = {
  // auto-complete for the component parts
  icon: {...},
  label: {...}
}
```