### PR TITLE
docs: tooltip forward ref

### DIFF
--- a/.changeset/ten-goats-eat.md
+++ b/.changeset/ten-goats-eat.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/docs": major
+"@chakra-ui/docs": minor
 ---
 
 Included the example in Tooltip for forwardref

--- a/.changeset/ten-goats-eat.md
+++ b/.changeset/ten-goats-eat.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": major
+---
+
+Included the example in Tooltip for forwardref

--- a/website/pages/docs/overlay/tooltip.mdx
+++ b/website/pages/docs/overlay/tooltip.mdx
@@ -36,20 +36,20 @@ If the `children` of Tooltip is a `string`, we wrap with in a `span` with
 > Note 🚨: If the `Tooltip` is wrapping a functional component, ensure that the
 > functional component accepts a `ref` using `forwardRef`.
 
-### With a forwardRef
+### Using custom components
 
 ```jsx manual=true
-const CustomCard = React.forwardRef(({ text, ...rest }, ref) => (
+const CustomCard = React.forwardRef(({ children, ...rest }, ref) => (
   <Box p="1">
     <Tag ref={ref} {...rest}>
-      {text}
+      {children}
     </Tag>
   </Box>
 ))
 
 const CustomToolTip = () => (
-  <Tooltip label="Hover me" fontSize="md">
-    <CustomCard text="Tag here" />
+  <Tooltip label="Hover me">
+    <CustomCard>Tag Here</CustomCard>
   </Tooltip>
 )
 

--- a/website/pages/docs/overlay/tooltip.mdx
+++ b/website/pages/docs/overlay/tooltip.mdx
@@ -36,6 +36,26 @@ If the `children` of Tooltip is a `string`, we wrap with in a `span` with
 > Note 🚨: If the `Tooltip` is wrapping a functional component, ensure that the
 > functional component accepts a `ref` using `forwardRef`.
 
+### With a forwardRef
+
+```jsx manual=true
+const CustomCard = React.forwardRef(({ text, ...rest }, ref) => (
+  <Box p="1">
+    <Tag ref={ref} {...rest}>
+      {text}
+    </Tag>
+  </Box>
+))
+
+const CustomToolTip = () => (
+  <Tooltip label="Hover me" fontSize="md">
+    <CustomCard text="Tag here" />
+  </Tooltip>
+)
+
+render(<CustomToolTip />)
+```
+
 ```jsx
 <Tooltip label="Hey, I'm here!" aria-label="A tooltip">
   Hover me


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4555 

## 📝 Description

This PR adds the example for the use of `forwardRef` in the tooltip in the docs



## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

