### PR TITLE
docs: fixed a typo in theme docs

### DIFF
--- a/website/pages/docs/theming/theme.mdx
+++ b/website/pages/docs/theming/theme.mdx
@@ -362,7 +362,7 @@ We recommend trying to solve stacking issues without `z-index`. You can read our
 recommendations and learn more about
 [stacking contexts and z-index here](/guides/z-index).
 
-Chakra provides a minimal set of z-indeces out of the box to help control the
+Chakra provides a minimal set of z-Indices out of the box to help control the
 stacking order of components.
 
 ```js


### PR DESCRIPTION
## 📝 Description

> Fixes a minor word typo in default theme section of the documentation website.

## ⛳️ Current behavior (updates)

> Chakra provides a minimal set of ***z-indeces*** out of the box to help control the stacking order of components.
## 🚀 New behavior

> Changed "*z-indeces*" to "*z-indices*" .
> Chakra provides a minimal set of ***z-indices*** out of the box to help control the stacking order of components.

