### PR TITLE
docs: Replaced `Lorem` with `Text` component

### DIFF
--- a/website/pages/docs/overlay/modal.mdx
+++ b/website/pages/docs/overlay/modal.mdx
@@ -64,7 +64,7 @@ function BasicUsage() {
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem count={2} />
+            <Text>Example text</Text>
           </ModalBody>
 
           <ModalFooter>
@@ -106,7 +106,7 @@ function ReturnFocus() {
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem count={2} />
+            <<Text>Example text</Text>
           </ModalBody>
 
           <ModalFooter>
@@ -145,7 +145,7 @@ function BasicUsage() {
             <Text fontWeight="bold" mb="1rem">
               You can scroll the content behind the modal
             </Text>
-            <Lorem count={2} />
+            <Text>Example text</Text>
           </ModalBody>
 
           <ModalFooter>
@@ -245,7 +245,7 @@ function ManualClose() {
           <ModalHeader>Create your account</ModalHeader>
           <ModalCloseButton />
           <ModalBody pb={6}>
-            <Lorem count={2} />
+            <Text>Example text</Text>
           </ModalBody>
 
           <ModalFooter>
@@ -284,7 +284,7 @@ function VerticallyCenter() {
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem count={2} />
+            <Text>Example text</Text>
           </ModalBody>
           <ModalFooter>
             <Button onClick={onClose}>Close</Button>
@@ -319,7 +319,7 @@ function TransitionExample() {
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem count={2} />
+            <Text>Example text</Text>
           </ModalBody>
           <ModalFooter>
             <Button colorScheme="blue" mr={3} onClick={onClose}>
@@ -373,7 +373,7 @@ function ScrollingExample() {
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem count={15} />
+            <Text>Example text</Text>
           </ModalBody>
           <ModalFooter>
             <Button onClick={onClose}>Close</Button>
@@ -418,7 +418,7 @@ function SizeExample() {
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Lorem count={2} />
+            <Text>Example text</Text>
           </ModalBody>
           <ModalFooter>
             <Button onClick={onClose}>Close</Button>


### PR DESCRIPTION
<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> In the examples for Modal, the Lorem component is used, which, as far as I see, isn't part of the Chakra-UI. I'm proposing it gets replaced with an existing Chakra-UI component (such as Text) so the examples use only the Chakra-UI components.

## ⛳️ Current behavior (updates)

> Lorem doesn't exist in Chakra-UI as a component so it might lead to dumb issues when trying to debug an invalid export

## 🚀 New behavior

> Edits to docs so it uses a Chakra-UI component

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
