### PR TITLE
Better handling of `system` as initial color mode

### DIFF
--- a/.changeset/khaki-toes-repair.md
+++ b/.changeset/khaki-toes-repair.md
@@ -1,0 +1,13 @@
+---
+"@chakra-ui/color-mode": minor
+---
+
+Added possibility to use the system preferred color scheme as value for
+`initialColorMode`, while still respecting a user's previous choice.
+
+As long as the user does not manually select a color mode through a website
+interaction, the theme will change when the system preference changes.
+
+This would easily allow for an implementation where the user can choose between
+`light`, `dark` and `system` by simply setting the `initialColorMode` setting to
+`system` and presenting the user with the three options.

--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -108,11 +108,11 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
     (value: ColorMode, isListenerEvent = false) => {
       if (!isListenerEvent) {
         colorModeManager.set(value)
-      } else if (colorModeManager.get()) return
+      } else if (colorModeManager.get() && !useSystemColorMode) return
 
       rawSetColorMode(value)
     },
-    [colorModeManager],
+    [colorModeManager, useSystemColorMode],
   )
 
   const toggleColorMode = React.useCallback(() => {

--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -1,16 +1,16 @@
 import * as React from "react"
-import { ColorMode } from "./color-mode-provider"
+import { ConfigColorMode } from "./color-mode-provider"
 
-type Mode = ColorMode | "system" | undefined
-
-function setScript(initialValue: Mode) {
+function setScript(initialValue: ConfigColorMode) {
   const mql = window.matchMedia("(prefers-color-scheme: dark)")
   const systemPreference = mql.matches ? "dark" : "light"
 
-  let persistedPreference: Mode
+  let persistedPreference: ConfigColorMode
 
   try {
-    persistedPreference = localStorage.getItem("chakra-ui-color-mode") as Mode
+    persistedPreference = localStorage.getItem(
+      "chakra-ui-color-mode",
+    ) as ConfigColorMode
   } catch (error) {
     console.log(
       "Chakra UI: localStorage is not available. Color mode persistence might not work as expected",
@@ -19,7 +19,7 @@ function setScript(initialValue: Mode) {
 
   const isInStorage = typeof persistedPreference === "string"
 
-  let colorMode: Mode
+  let colorMode: ConfigColorMode
 
   if (isInStorage) {
     colorMode = persistedPreference
@@ -34,7 +34,7 @@ function setScript(initialValue: Mode) {
 }
 
 interface ColorModeScriptProps {
-  initialColorMode?: Mode
+  initialColorMode?: ConfigColorMode
   /**
    * Optional nonce that will be passed to the created `<script>` tag.
    */

--- a/packages/color-mode/src/color-mode.utils.ts
+++ b/packages/color-mode/src/color-mode.utils.ts
@@ -53,7 +53,9 @@ export function getColorScheme(fallback?: ColorMode) {
  * Adds system os color mode listener, and run the callback
  * once preference changes
  */
-export function addListener(fn: Function) {
+export function addListener(
+  fn: (cm: ColorMode, isListenerEvent: true) => unknown,
+) {
   if (!("matchMedia" in window)) {
     return noop
   }
@@ -61,14 +63,13 @@ export function addListener(fn: Function) {
   const mediaQueryList = window.matchMedia(queries.dark)
 
   const listener = () => {
-    fn(mediaQueryList.matches ? "dark" : "light")
+    fn(mediaQueryList.matches ? "dark" : "light", true)
   }
 
-  listener()
-  mediaQueryList.addListener(listener)
+  mediaQueryList.addEventListener("change", listener)
 
   return () => {
-    mediaQueryList.removeListener(listener)
+    mediaQueryList.removeEventListener("change", listener)
   }
 }
 

--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -23,6 +23,12 @@ To get dark mode working correctly, you need to do two things:
    your application should start with to either `light`, `dark` or `system`. It
    is `light` by default.
 
+> **Note:** When using `system` as initial color mode, the theme will change
+> with the system preference. However, if another theme is manually selected by
+> the user then that theme will be used on the next page load. To reset it to
+> system preference, simply remove the `chakra-ui-color-mode` entry from
+> localStorage.
+
 ### Updating the theme config
 
 The theme config for color mode has 2 options:
@@ -74,7 +80,7 @@ export default theme
 
 ### Adding the `ColorModeScript`
 
-The color mode script needs to added before the `body` tag for local storage
+The color mode script needs to be added before the content inside the `body` tag for local storage
 syncing to work correctly.
 
 > When setting the initial color mode, we recommend adding it as a config to


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Sort of similar to #4224, but with a somewhat different approach

## 📝 Description

I wanted to add the possibility to use the system preferred color scheme as a value for
`initialColorMode`, while still respecting a user's previous choice.

## ⛳️ Current behavior (updates)

When the `system` value is used for the `<ColorModeScript />`s `initialColorMode` prop, the color mode will _always_ initially be set to the color mode that matches the system preference. 

However, this may not be what a user expects after manually selecting a color mode through the UI. A user is more likely to expect the color mode to remain in the configuration that he/she left it in.

Additionally, while I am not 100% sure if intended or not (or if I missed something), there seemed to be a mismatch of the types between the `ColorModeProvider` and `ColorModeScript`  components,  where the latter would allow the `system` option while the first did not (at least not explicitly).

## 🚀 New behavior

As long as a user does not manually select a color mode through a website interaction, the color mode will change when the system preference changes (in real-time). When the page is reloaded, it will default to the system preference just like before.

However, if the color mode is manipulated during the visit, localStorage would be updated and upon the next visit/page reload, the color mode would no longer default to the system preference, but instead use the previously selected mode.

In order to revert back to using the system preference as default, one just needs to remove the localStorage entry.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

While reading #4224, and before trying my own approach, I thought a lot about whether this change is wanted by a majority (and thus is motivated as is), or if the change should be mapped to a standalone configuration property.

As it currently stands, the changes that this PR brings to the `system` option would make it _partially_ incompatible with the `useSystemColorMode` option, as setting it to `true` would **not** cause the website to **load** using the system's preference if the color mode was manually updated before. It would still cause the application to listen for and adapt to changes in the preference, though.

I thought about the `useSystemColorMode` option as a directive for the application to "listen for updates to the color preference and update the color mode when it is changed", making the `initialColorMode` option feel like a better fit for this implementation.

With all this said, I'd be more than happy to discuss this new usage of the `initialColorMode` option. There might of course be factors that I failed to take into account, and perhaps this could be made more intuitive with another option in the theme config.


