### PR TITLE
fix: typo in readme for `@chakra-ui/pin-input` package

### DIFF
--- a/packages/pin-input/README.md
+++ b/packages/pin-input/README.md
@@ -22,7 +22,7 @@ import {
   PinInputField,
   usePinInput,
   usePinInputField,
-} from "@chakra-ui/switch"
+} from "@chakra-ui/pin-input"
 ```
 
 ## Usage


### PR DESCRIPTION
## 📝 Description

> fixed typo in `@chakra-ui/pin-input` package, where the example code orginally said `@chakra-ui/pin-input`

## ⛳️ Current behavior (updates)

```javascript import {
  PinInput,
  PinInputField,
  usePinInput,
  usePinInputField,
} from "@chakra-ui/switch"
```

## 🚀 New behavior

```javascript import {
  PinInput,
  PinInputField,
  usePinInput,
  usePinInputField,
} from "@chakra-ui/pin-input"
```

## 💣 Is this a breaking change (Yes/No):

No, it's simply an update to the documentation.

## 📝 Additional Information
