### PR TITLE
fix(image): ignore fallback behavior when no fallback is set

### DIFF
--- a/.changeset/rare-chairs-whisper.md
+++ b/.changeset/rare-chairs-whisper.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/image": patch
+---
+
+If the user doesn't provide a `fallbackSrc` or a `fallback` `ignoreFallback` is
+applied by default

--- a/packages/image/src/image.tsx
+++ b/packages/image/src/image.tsx
@@ -99,7 +99,10 @@ export const Image = forwardRef<ImageProps, "img">((props, ref) => {
    * Defer to native `img` tag if `loading` prop is passed
    * @see https://github.com/chakra-ui/chakra-ui/issues/1027
    */
-  const shouldIgnore = loading != null || ignoreFallback
+  const shouldIgnore =
+    loading != null ||
+    ignoreFallback ||
+    (fallbackSrc === undefined && fallback === undefined) // if the user doesn't provide any kind of fallback we should ignore it
 
   const status = useImage({
     ...props,

--- a/packages/image/tests/image.test.tsx
+++ b/packages/image/tests/image.test.tsx
@@ -39,6 +39,12 @@ test("renders placeholder first, before image load", async () => {
   expect(screen.getByRole("img")).toHaveAttribute("src", fallbackSrc)
 })
 
+test("renders image if there is no fallback behavior defined", async () => {
+  render(<Image src={src} />)
+
+  expect(screen.getByRole("img")).toHaveAttribute("src", src)
+})
+
 /**
  * Not sure of the correctness of this test:
  * @see https://www.tfzx.net/article/4859040.html


### PR DESCRIPTION
Closes #4648

## 📝 Description

Currently, the user has to optIn into `ignoreFallback` in the `Image`-component. If the user doesn't provide any possibility to fall back to, the image flashes until the image source is loaded.

## 🚀 New behavior

If the user doesn't provide any sort of fallback (e.g. `fallbackSrc`/`fallback`) the component behaves equally as if the user would have set `ignoreFallback` on the Image

## 💣 Is this a breaking change (Yes/No):

No
