### PR TITLE
fix(layout): added flex gap property

### DIFF
--- a/.changeset/brown-rivers-switch.md
+++ b/.changeset/brown-rivers-switch.md
@@ -1,6 +1,6 @@
 ---
-"@chakra-ui/layout": patch
-"@chakra-ui/styled-system": patch
+"@chakra-ui/layout": minor
+"@chakra-ui/styled-system": minor
 ---
 
-Add support for `gap` CSS flexbox/grid gap property
+Add support for `gap` style prop. This maps to the CSS flexbox/grid gap property

--- a/.changeset/brown-rivers-switch.md
+++ b/.changeset/brown-rivers-switch.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/layout": patch
+"@chakra-ui/styled-system": patch
+---
+
+Add support for `gap` CSS flexbox/grid gap property

--- a/packages/layout/src/flex.tsx
+++ b/packages/layout/src/flex.tsx
@@ -70,6 +70,7 @@ export const Flex = forwardRef<FlexProps, "div">((props, ref) => {
     basis,
     grow,
     shrink,
+    gap,
     ...rest
   } = props
 
@@ -82,6 +83,7 @@ export const Flex = forwardRef<FlexProps, "div">((props, ref) => {
     flexBasis: basis,
     flexGrow: grow,
     flexShrink: shrink,
+    gap,
   }
 
   return <chakra.div ref={ref} __css={styles} {...rest} />

--- a/packages/layout/stories/flex.stories.tsx
+++ b/packages/layout/stories/flex.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { Box, Flex } from "../src"
+
+export default {
+  title: "Flex",
+}
+
+export const Vertical = () => (
+  <Flex gap={4} direction="column">
+    <span>ooooooo</span>
+    <span>ahhhhh</span>
+    <span>Woah!</span>
+  </Flex>
+)
+
+export const Horizontal = () => (
+  <Flex gap={4}>
+    <span>ooooooo</span>
+    <span>ahhhhh</span>
+    <span>Woah!</span>
+  </Flex>
+)
+
+export const VerticalWithMargin = () => (
+  <Flex gap={4} direction="column">
+    <Box boxSize="40px" bg="red" borderRadius="full" />
+    <Box boxSize="40px" bg="red" borderRadius="full" />
+    <Box boxSize="40px" bg="red" borderRadius="full" mt={4} />
+  </Flex>
+)

--- a/packages/styled-system/src/config/flexbox.ts
+++ b/packages/styled-system/src/config/flexbox.ts
@@ -38,6 +38,7 @@ export const flexbox: Config = {
   placeItems: true,
   placeContent: true,
   placeSelf: true,
+  gap: t.space("gap"),
 }
 
 Object.assign(flexbox, {
@@ -138,6 +139,15 @@ export interface FlexboxProps {
    * @see [Mozilla Docs](https://developer.mozilla.org/docs/Web/CSS/flex)
    */
   flex?: Token<CSS.Property.Flex<Length>>
+  /**
+   * The CSS `gap` property.
+   *
+   * It defines the gap between items in both flex and
+   * grid contexts.
+   *
+   * @see [Mozilla Docs](https://developer.mozilla.org/docs/Web/CSS/gap)
+   */
+  gap?: Token<CSS.Property.Gap<Length>>
   /**
    * The CSS `justify-self` property.
    *


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2720

## 📝 Description

> This change enables the `gap` property to be used in the Flex component. At the time of submitting this, browser support for this feature is at [87.3%](https://caniuse.com/flexbox-gap).

## ⛳️ Current behavior (updates)

> When applying the `gap` property to the Flex component, it merely appends the key and value as an attribute on the HTML element.

## 🚀 New behavior

> Now, when applying the `gap` property to the Flex component, it will be correctly applied as a CSS style. It also attempts to resolve values as tokens from the 'space' token set.

## 💣 Is this a breaking change (Yes/No):

> No, unless someone wants a gap attribute on their HTML elements for some reason.

## 📝 Additional Information

> Fingers crossed this gets added. This property is a lifesaver and deserves full support.
