### PR TITLE
fix(menu): isChecked on MenuItemOption is considered when inside Menu…

### DIFF
--- a/.changeset/old-dryers-change.md
+++ b/.changeset/old-dryers-change.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fixed a Bug where the `isChecked`-Prop on `MenuItemOption` inside
+`MenuOptionGroup` wasn't considered

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -36,6 +36,7 @@ import {
   removeItem,
 } from "@chakra-ui/utils"
 import * as React from "react"
+import { UseOutsideClickProps } from "@chakra-ui/hooks/src"
 
 /* -------------------------------------------------------------------------------------------------
  * Create context to track descendants and their indices
@@ -157,7 +158,7 @@ export function useMenu(props: UseMenuProps = {}) {
         onClose()
       }
     },
-  })
+  } as UseOutsideClickProps)
 
   /**
    * Add some popper.js for dynamic positioning
@@ -727,10 +728,12 @@ export function useMenuOptionGroup(props: UseMenuOptionGroupProps = {}) {
       child.props.onClick?.(event)
     }
 
-    const isChecked =
+    const isCheckedBasedOnMenuOptionGroup =
       type === "radio"
         ? child.props.value === value
         : value.includes(child.props.value)
+
+    const isChecked = isCheckedBasedOnMenuOptionGroup || child.props.isChecked
 
     return React.cloneElement(child, {
       type,

--- a/packages/menu/tests/menu.test.tsx
+++ b/packages/menu/tests/menu.test.tsx
@@ -443,3 +443,21 @@ test("MenuItem can override its parent menu's `closeOnSelect` and close the menu
   fireEvent.click(menuItemThatCloses)
   expect(onClose).toHaveBeenCalled()
 })
+
+test("MenuItemOption can be manually checked", () => {
+  const { getByRole } = render(
+    <Menu closeOnSelect={false}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuOptionGroup>
+        <MenuItemOption isChecked>Option 1</MenuItemOption>
+        <MenuItemOption>Option 2</MenuItemOption>
+      </MenuOptionGroup>
+    </Menu>,
+  )
+
+  const openMenuButton = getByRole("button")
+  fireEvent.click(openMenuButton)
+
+  expect(screen.getByText("Option 1").closest("button")).toBeChecked()
+  expect(screen.getByText("Option 2").closest("button")).not.toBeChecked()
+})


### PR DESCRIPTION
Closes #4666 

## 📝 Description

> Add a brief description

`MenuOptionGroup` didn't took the `isChecked`-property of a `MenuItemOption` into account when calculating the `isChecked` prop


## 🚀 New behavior

the `isChecked` property of a `MenuItemOption` is taken into account when using `MenuOptionGroup`

## 💣 Is this a breaking change (Yes/No):

No

