### PR TITLE
feat: multi-thumb slider

### DIFF
--- a/packages/multi-slider/README.md
+++ b/packages/multi-slider/README.md
@@ -1,0 +1,75 @@
+# @chakra-ui/multi-slider
+
+The Multi-Thumb Slider is used to allow users to make selections from a range of
+values.
+
+Multi-THumb Sliders reflect a range of values along a bar, from which users may
+select varius values. They are ideal for picking price filters or other type of
+filters.
+
+## Installation
+
+```sh
+yarn add @chakra-ui/multi-slider
+
+# or
+
+npm i @chakra-ui/multi-slider
+```
+
+## Import components
+
+```js
+import {
+  MultiSlider,
+  MultiSliderTrack,
+  MultiSliderFilledTrack,
+  MultiSliderThumb,
+} from "@chakra-ui/react"
+```
+
+## Usage
+
+```jsx
+<MultiSlider>
+  <MultiSliderTrack>
+    <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+  </MultiSliderTrack>
+  <MultiSliderThumb thumbKey={0} aria-label="slider 0" defaultValue={10} />
+  <MultiSliderThumb thumbKey={1} aria-label="slider 1" defaultValue={15} />
+</MultiSlider>
+```
+
+### Changing the slider color
+
+```jsx
+<MultiSlider colorScheme="red">
+  <MultiSliderTrack>
+    <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+  </MultiSliderTrack>
+  <MultiSliderThumb thumbKey={0} aria-label="slider 0" defaultValue={10} />
+  <MultiSliderThumb thumbKey={1} aria-label="slider 1" defaultValue={15} />
+</MultiSlider>
+```
+
+### Use local maximim and minimum
+
+```jsx
+<MultiSlider colorScheme="red" min={0} max={100} step={5}>
+  <MultiSliderTrack>
+    <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+  </MultiSliderTrack>
+  <MultiSliderThumb
+    thumbKey={0}
+    aria-label="slider 0"
+    defaultValue={10}
+    max={10}
+  />
+  <MultiSliderThumb
+    thumbKey={1}
+    aria-label="slider 1"
+    defaultValue={15}
+    min={10}
+  />
+</MultiSlider>
+```

--- a/packages/multi-slider/index.ts
+++ b/packages/multi-slider/index.ts
@@ -1,0 +1,1 @@
+export * from "./src"

--- a/packages/multi-slider/jest.config.js
+++ b/packages/multi-slider/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require("../../jest.config")
+
+module.exports = {
+  ...baseConfig,
+}

--- a/packages/multi-slider/package.json
+++ b/packages/multi-slider/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@chakra-ui/multi-slider",
+  "version": "0.0.0",
+  "description": "Accessible multi thumb slider component for React that implements multiple <input type=range>",
+  "keywords": [
+    "react",
+    "chakra ui",
+    "chakra",
+    "component",
+    "multi thomb slider",
+    "accessible",
+    "a11y slider",
+    "react a11y slider",
+    "react accessible multi thomb slider",
+    "react multi thomb slider",
+    "a11y",
+    "input range",
+    "react aria slider",
+    "aria",
+    "aria slider"
+  ],
+  "sideEffects": false,
+  "author": "luigiminardim <luigiminardim@gmail.com>",
+  "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
+  "license": "MIT",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/chakra-ui.git",
+    "directory": "packages/multi-slider"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/chakra-ui/issues"
+  },
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "start": "nodemon --watch src --exec yarn build -e ts,tsx",
+    "build": "concurrently yarn:build:*",
+    "test": "jest --env=jsdom --passWithNoTests",
+    "lint": "concurrently yarn:lint:*",
+    "version": "yarn build",
+    "build:esm": "cross-env BABEL_ENV=esm babel src --root-mode upward --extensions .ts,.tsx -d dist/esm --source-maps",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --root-mode upward --extensions .ts,.tsx -d dist/cjs --source-maps",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types",
+    "test:cov": "yarn test --coverage",
+    "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
+    "lint:types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@chakra-ui/hooks": "1.6.0",
+    "@chakra-ui/react-utils": "1.1.2",
+    "@chakra-ui/utils": "1.8.2"
+  },
+  "devDependencies": {
+    "@chakra-ui/system": "1.7.3",
+    "react": "^17.0.1"
+  },
+  "peerDependencies": {
+    "@chakra-ui/system": ">=1.0.0",
+    "react": ">=16.8.6"
+  }
+}

--- a/packages/multi-slider/src/index.ts
+++ b/packages/multi-slider/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./multi-slider"

--- a/packages/multi-slider/src/multi-slider-context.tsx
+++ b/packages/multi-slider/src/multi-slider-context.tsx
@@ -1,0 +1,96 @@
+import * as React from "react"
+import { __DEV__ } from "@chakra-ui/utils"
+import { createContext } from "@chakra-ui/react-utils"
+
+export interface MultiSliderContextValue {
+  /**
+   * The values of all thumbs in the slider context.
+   */
+  values: { [key: number]: number | undefined }
+  /**
+   * Function to update a thumb value in the multi thumb slider context.
+   */
+  setThumbValue: (thumbKey: number, value: number | undefined) => void
+  /**
+   * TrackReference
+   */
+  trackRef: React.RefObject<HTMLElement>
+  /**
+   * The minimum allowed value of the slider thumb. Cannot be greater than max.
+   * @default 0
+   */
+  min: number
+  /**
+   * The maximum allowed value of the slider thumb. Cannot be less than min.
+   * @default 100
+   */
+  max: number
+  /**
+   * The step in which increments/decrements have to be made
+   * @default 1
+   */
+  step: number
+  /**
+   * orientation of the slider
+   * @default "horizontal"
+   */
+  orientation: "horizontal" | "vertical"
+  /**
+   * If `true`, the value will be incremented or decremented in reverse.
+   */
+  isReversed: boolean
+  /**
+   * If `true`, the slider will be disabled
+   */
+  isDisabled: boolean
+  /**
+   * If `true`, the slider will be in `read-only` state
+   */
+  isReadOnly: boolean
+}
+
+export const [
+  MultiSliderContextProvider,
+  useMultiSliderContext,
+] = createContext<MultiSliderContextValue>({
+  name: "SliderContext",
+  errorMessage:
+    "useMultiSliderContext: `context` is undefined. Seems you forgot to wrap all slider components within <MultiSlider />",
+})
+
+export interface MultiSliderProviderProps
+  extends Omit<
+    MultiSliderContextValue,
+    "values" | "setThumbValue" | "trackRef"
+  > {}
+
+export const MultiSliderProvider: React.FC<MultiSliderProviderProps> = ({
+  children,
+  ...props
+}) => {
+  const [values, setValues] = React.useState<MultiSliderContextValue["values"]>(
+    {},
+  )
+  const setThumbValue = React.useCallback(
+    (thumbKey: number, value: number | undefined) =>
+      setValues({ ...values, [thumbKey]: value }),
+    [values],
+  )
+  const trackRef = React.useRef<HTMLElement>(null)
+  const contextValue = {
+    ...props,
+    orientation: props.orientation,
+    values,
+    setThumbValue,
+    trackRef,
+  }
+
+  return (
+    <MultiSliderContextProvider value={contextValue}>
+      {children}
+    </MultiSliderContextProvider>
+  )
+}
+if (__DEV__) {
+  MultiSliderProvider.displayName = "MultiSliderProvider"
+}

--- a/packages/multi-slider/src/multi-slider-utils.ts
+++ b/packages/multi-slider/src/multi-slider-utils.ts
@@ -1,0 +1,25 @@
+import { valueToPercent } from "@chakra-ui/utils"
+import { CSSProperties } from "react"
+
+export type Orientation = "vertical" | "horizontal"
+
+export function orient(options: {
+  orientation: Orientation
+  vertical: CSSProperties
+  horizontal: CSSProperties
+}) {
+  const { orientation, vertical, horizontal } = options
+  return orientation === "vertical" ? vertical : horizontal
+}
+
+export function getTrackPercent(
+  value: number,
+  min: number,
+  max: number,
+  isReversed: boolean,
+) {
+  const reversedValue = max - value + min
+  const trackValue = isReversed ? reversedValue : value
+  const trackPercent = valueToPercent(trackValue, min, max)
+  return trackPercent
+}

--- a/packages/multi-slider/src/multi-slider.tsx
+++ b/packages/multi-slider/src/multi-slider.tsx
@@ -1,0 +1,225 @@
+import * as React from "react"
+import {
+  ThemingProps,
+  HTMLChakraProps,
+  useMultiStyleConfig,
+  forwardRef,
+  StylesProvider,
+  useStyles,
+  chakra,
+  omitThemingProps,
+} from "@chakra-ui/system"
+import { cx, __DEV__ } from "@chakra-ui/utils"
+import {
+  MultiSliderContextValue,
+  MultiSliderProvider,
+} from "./multi-slider-context"
+import { useMultiSliderRoot } from "./use-multi-slider-root"
+import { useMultiSliderTrack } from "./use-multi-slider-track"
+import {
+  useMultiSliderThumb,
+  UseMultiSliderThumbProps,
+} from "./use-multi-slider-thumb"
+import {
+  useMultiSliderInnerTrack,
+  UseMultiSliderInnerTrackProps,
+} from "./use-multi-slider-inner-track"
+
+export interface MultiSliderProps
+  extends Partial<Omit<MultiSliderContextValue, "values" | "setThumbValue">>,
+    ThemingProps<"Slider">,
+    HTMLChakraProps<"div"> {}
+
+export const MultiSlider = forwardRef<MultiSliderProps, "div">((props, ref) => {
+  const styles = useMultiStyleConfig("Slider", props)
+  const {
+    min,
+    max,
+    orientation,
+    step,
+    isDisabled,
+    isReadOnly,
+    isReversed,
+    ...otherProps
+  } = props
+  const containerProps = omitThemingProps(otherProps)
+
+  return (
+    <MultiSliderProvider
+      min={min ?? 0}
+      max={max ?? 100}
+      orientation={orientation ?? "horizontal"}
+      step={step ?? 1}
+      isDisabled={isDisabled ?? false}
+      isReadOnly={isReadOnly ?? false}
+      isReversed={isReversed ?? false}
+    >
+      <StylesProvider value={styles}>
+        <MultiSliderContainer ref={ref} {...containerProps} />
+      </StylesProvider>
+    </MultiSliderProvider>
+  )
+})
+MultiSlider.defaultProps = {
+  orientation: "horizontal",
+}
+if (__DEV__) {
+  MultiSlider.displayName = "MultiSlider"
+}
+
+const MultiSliderContainer = forwardRef<HTMLChakraProps<"div">, "div">(
+  (props, ref) => {
+    const styles = useStyles()
+    const { getRootProps } = useMultiSliderRoot()
+    const rootProps = getRootProps(props)
+
+    return (
+      <chakra.div
+        ref={ref}
+        {...rootProps}
+        className="chakra-multi-slider"
+        __css={{
+          display: "inline-block",
+          position: "relative",
+          ...styles.container,
+        }}
+      >
+        {props.children}
+      </chakra.div>
+    )
+  },
+)
+if (__DEV__) {
+  MultiSliderContainer.displayName = "MultiSliderContainer"
+}
+
+export interface MultiSliderTrackProps extends HTMLChakraProps<"div"> {}
+
+export const MultiSliderTrack = forwardRef<MultiSliderTrackProps, "div">(
+  (props, ref) => {
+    const { getTrackProps } = useMultiSliderTrack()
+    const trackProps = getTrackProps(props, ref)
+    const styles = useStyles()
+
+    return (
+      <chakra.div
+        {...trackProps}
+        className={cx("chakra-multi-slider__track", props.className)}
+        __css={{
+          overflow: "hidden",
+          ...styles.track,
+        }}
+      />
+    )
+  },
+)
+if (__DEV__) {
+  MultiSliderTrack.displayName = "MultiSliderTrack"
+}
+
+export interface MultiSliderThumbProps
+  extends Omit<HTMLChakraProps<"div">, "defaultValue">,
+    UseMultiSliderThumbProps {}
+
+/**
+ * Slider component that acts as the handle used to select predefined
+ * values by dragging its handle along the track
+ */
+export const MultiSliderThumb = forwardRef<MultiSliderThumbProps, "div">(
+  (
+    {
+      thumbKey,
+      min,
+      max,
+      value,
+      defaultValue,
+      onValueChangeStart,
+      onValueChangeEnd,
+      onValueChange,
+      id,
+      name,
+      getAriaValueText,
+      "aria-label": ariaLabel,
+      "aria-valuetext": ariaValueText,
+      "aria-labelledby": ariaLabelledby,
+      ...props
+    },
+    ref,
+  ) => {
+    const { getThumbProps, getInputProps } = useMultiSliderThumb({
+      thumbKey,
+      min,
+      max,
+      value,
+      defaultValue,
+      onValueChangeStart,
+      onValueChangeEnd,
+      onValueChange,
+      id,
+      name,
+      getAriaValueText,
+      "aria-label": ariaLabel,
+      "aria-valuetext": ariaValueText,
+      "aria-labelledby": ariaLabelledby,
+    })
+    const thumbProps = getThumbProps(props, ref)
+    const inputProps = getInputProps(props, ref)
+    const styles = useStyles()
+
+    return (
+      <>
+        <chakra.div
+          {...thumbProps}
+          className={cx("chakra-multi-slider__thumb", props.className)}
+          __css={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            outline: 0,
+            cursor: "pointer",
+            ...styles.thumb,
+          }}
+        />
+        <input {...inputProps} />
+      </>
+    )
+  },
+)
+
+if (__DEV__) {
+  MultiSliderThumb.displayName = "MultiSliderThumb"
+}
+
+export interface MultiSliderInnerTrackProps
+  extends HTMLChakraProps<"div">,
+    UseMultiSliderInnerTrackProps {}
+
+export const MultiSliderFilledTrack = forwardRef<
+  MultiSliderInnerTrackProps,
+  "div"
+>(({ startThumbKey, endThumbKey, ...props }, ref) => {
+  const { getInnerTrackProps } = useMultiSliderInnerTrack({
+    startThumbKey,
+    endThumbKey,
+  })
+
+  const styles = useStyles()
+  const trackStyles = {
+    width: "inherit",
+    height: "inherit",
+    ...styles.filledTrack,
+  }
+
+  const trackProps = getInnerTrackProps(props, ref)
+
+  return (
+    <chakra.div
+      {...trackProps}
+      className="chakra-slider__filled-track"
+      __css={trackStyles}
+    />
+  )
+})
+if (__DEV__) {
+  MultiSliderFilledTrack.displayName = "MultiSliderFilledTrack"
+}

--- a/packages/multi-slider/src/use-multi-slider-inner-track.ts
+++ b/packages/multi-slider/src/use-multi-slider-inner-track.ts
@@ -1,0 +1,60 @@
+import { PropGetter } from "@chakra-ui/react-utils"
+import { useCallback, useMemo } from "react"
+import { useMultiSliderContext } from "./multi-slider-context"
+import { orient, getTrackPercent } from "./multi-slider-utils"
+
+export type UseMultiSliderInnerTrackProps = {
+  startThumbKey?: number
+  endThumbKey?: number
+}
+
+export function useMultiSliderInnerTrack(props: UseMultiSliderInnerTrackProps) {
+  const { startThumbKey, endThumbKey } = props
+  const { values, min, max, orientation, isReversed } = useMultiSliderContext()
+  const startValueContext = isReversed ? max : min
+  const endValueContext = isReversed ? min : max
+  const startValue =
+    (startThumbKey !== undefined ? values[startThumbKey] : startValueContext) ??
+    startValueContext
+  const endValue =
+    (endThumbKey !== undefined ? values[endThumbKey] : endValueContext) ??
+    endValueContext
+  const startTrackPercent = getTrackPercent(startValue, min, max, isReversed)
+  const endTrackPercent = getTrackPercent(endValue, min, max, isReversed)
+
+  const innerTrackStyle: React.CSSProperties = useMemo(
+    () => ({
+      position: "absolute",
+      ...orient({
+        orientation,
+        vertical: {
+          top: `${startTrackPercent}%`,
+          height: `${endTrackPercent - startTrackPercent}%`,
+          left: "50%",
+          transform: "translateX(-50%)",
+        },
+        horizontal: {
+          left: `${startTrackPercent}%`,
+          width: `${endTrackPercent - startTrackPercent}%`,
+        },
+      }),
+    }),
+    [endTrackPercent, orientation, startTrackPercent],
+  )
+
+  const getInnerTrackProps: PropGetter = useCallback(
+    (props = {}, ref = null) => ({
+      ...props,
+      ref,
+      style: {
+        ...props.style,
+        ...innerTrackStyle,
+      },
+    }),
+    [innerTrackStyle],
+  )
+
+  return {
+    getInnerTrackProps,
+  }
+}

--- a/packages/multi-slider/src/use-multi-slider-root.ts
+++ b/packages/multi-slider/src/use-multi-slider-root.ts
@@ -1,0 +1,39 @@
+import { PropGetter } from "@chakra-ui/react-utils"
+import { ariaAttr } from "@chakra-ui/utils"
+import { CSSProperties, useCallback, useMemo } from "react"
+import { useMultiSliderContext } from "./multi-slider-context"
+
+export function useMultiSliderRoot() {
+  const { isDisabled } = useMultiSliderContext()
+
+  const rootStyle = useMemo<CSSProperties>(
+    () => ({
+      position: "relative",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      touchAction: "none",
+      WebkitTapHighlightColor: "rgba(0,0,0,0)",
+      userSelect: "none",
+      outline: 0,
+    }),
+    [],
+  )
+
+  const getRootProps: PropGetter = useCallback(
+    (props = {}, ref = null) => ({
+      ...props,
+      ref,
+      tabIndex: -1,
+      "aria-disabled": ariaAttr(isDisabled),
+      style: {
+        ...props.style,
+        ...rootStyle,
+      },
+    }),
+    [isDisabled, rootStyle],
+  )
+  return {
+    getRootProps,
+  }
+}

--- a/packages/multi-slider/src/use-multi-slider-thumb.ts
+++ b/packages/multi-slider/src/use-multi-slider-thumb.ts
@@ -1,0 +1,340 @@
+import { useBoolean } from "@chakra-ui/react"
+
+import { useMemo, CSSProperties, useCallback, useRef, useEffect } from "react"
+import { PropGetter, mergeRefs } from "@chakra-ui/react-utils"
+import {
+  ariaAttr,
+  dataAttr,
+  clampValue,
+  normalizeEventKey,
+  roundValueToStep,
+  callAllHandlers,
+  EventKeys,
+  focus,
+  getBox,
+  PanEventInfo,
+  percentToValue,
+} from "@chakra-ui/utils"
+import { usePanGesture } from "@chakra-ui/hooks"
+import { getTrackPercent, orient } from "./multi-slider-utils"
+import { useMultiSliderContext } from "./multi-slider-context"
+
+export interface UseMultiSliderThumbProps {
+  /**
+   * Unique key of the thumb in the multi thumb slider.
+   */
+  thumbKey: number
+  /**
+   * The minimum allowed value of the slider thumb. Cannot be greater than max.
+   * @default 0
+   */
+  min?: number
+  /**
+   * The maximum allowed value of the slider thumb. Cannot be less than min.
+   * @default 100
+   */
+  max?: number
+  /**
+   * The value of the slider in controlled mode
+   */
+  value?: number
+  /**
+   * The initial value of the slider in uncontrolled mode
+   */
+  defaultValue?: number
+  /**
+   * Function called when the user starts selecting a new value (by dragging or clicking)
+   */
+  onValueChangeStart?(value: number): void
+  /**
+   * Function called when the user is done selecting a new value (by dragging or clicking)
+   */
+  onValueChangeEnd?(value: number): void
+  /**
+   * Function called whenever the slider value changes  (by dragging or clicking)
+   */
+  onValueChange?(value: number): void
+  /**
+   * The base `id` to use for the slider and its components
+   */
+  id?: string
+  /**
+   * The name attribute of the hidden `input` field.
+   * This is particularly useful in forms
+   */
+  name?: string
+  /**
+   * Function that returns the `aria-valuetext` for screen readers.
+   * It is mostly used to generate a more human-readable
+   * representation of the value for assistive technologies
+   */
+  getAriaValueText?(value: number): string
+  /**
+   * The static string to use used for `aria-valuetext`
+   */
+  "aria-valuetext"?: string
+  /**
+   * The static string to use used for `aria-label`
+   * if no visible label is used.
+   */
+  "aria-label"?: string
+  /**
+   * The static string `aria-labelledby` that points to the
+   * ID of the element that serves as label for the slider
+   */
+  "aria-labelledby"?: string
+}
+
+export function useMultiSliderThumb(props: UseMultiSliderThumbProps) {
+  const {
+    thumbKey,
+    min: minProp = -Infinity,
+    max: maxProp = Infinity,
+    onValueChange,
+    value: valueProp,
+    defaultValue: defaultValueProp,
+    id,
+    onValueChangeStart,
+    onValueChangeEnd,
+    getAriaValueText,
+    "aria-valuetext": ariaValueText,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledBy,
+    name,
+  } = props
+  const {
+    values,
+    setThumbValue,
+    trackRef,
+    min: minContext,
+    max: maxContext,
+    step = 1,
+    orientation,
+    isReversed,
+    isDisabled,
+    isReadOnly,
+  } = useMultiSliderContext()
+
+  const minNeighbor =
+    (isReversed ? values[thumbKey + 1] : values[thumbKey - 1]) ?? -Infinity
+  const maxNeighbor =
+    (isReversed ? values[thumbKey - 1] : values[thumbKey + 1]) ?? Infinity
+  const min = Math.max(minProp, minNeighbor, minContext)
+  const max = Math.min(maxProp, maxNeighbor, maxContext)
+
+  const defaultValue =
+    defaultValueProp ?? getDefaultValue(thumbKey, min, max, step)
+  const value = valueProp ?? values[thumbKey] ?? defaultValue
+  const setValue = useCallback(
+    (value: number) => {
+      const next = constrainValue(value, min, max, step)
+      setThumbValue(thumbKey, next) // Update value in the global context.
+      onValueChange?.(next)
+    },
+    [min, max, step, setThumbValue, thumbKey, onValueChange],
+  )
+  useEffect(() => {
+    // Update the context thumb value.
+    if (values[thumbKey] === undefined) {
+      setThumbValue(thumbKey, value)
+    }
+  }, [setThumbValue, thumbKey, value, values])
+  const trackPercent = getTrackPercent(
+    value,
+    minContext,
+    maxContext,
+    isReversed,
+  )
+  const isInteractive = !(isDisabled || isReadOnly)
+
+  /**
+   * Keyboard interaction to ensure users can operate
+   * the slider using only their keyboard.
+   */
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const eventKey = normalizeEventKey(event)
+      const nextValueMap = {
+        stepUp: isReversed ? value - step : value + step,
+        stepUp10: isReversed ? value - 10 * step : value + 10 * step,
+        stepDown: isReversed ? value + step : value - step,
+        stepDown10: isReversed ? value + 10 * step : value - 10 * step,
+        stepStart: min,
+        stepEnd: max,
+      }
+      const keyMap: Partial<Record<EventKeys, number>> = {
+        ArrowRight: nextValueMap.stepUp,
+        ArrowUp: nextValueMap.stepUp,
+        ArrowLeft: nextValueMap.stepDown,
+        ArrowDown: nextValueMap.stepDown,
+        PageUp: nextValueMap.stepUp10,
+        PageDown: nextValueMap.stepDown10,
+        Home: nextValueMap.stepStart,
+        End: nextValueMap.stepEnd,
+      }
+      const next = keyMap[eventKey]
+      if (next !== undefined) {
+        event.preventDefault()
+        event.stopPropagation()
+        onValueChangeStart?.(next)
+        setValue(next)
+        onValueChangeEnd?.(next)
+      }
+    },
+    [
+      isReversed,
+      max,
+      min,
+      onValueChangeEnd,
+      onValueChangeStart,
+      setValue,
+      step,
+      value,
+    ],
+  )
+
+  const thumbRef = useRef<HTMLElement>(null)
+  const [isDragging, setIsDragging] = useBoolean(false)
+  const getValueFromPointer = (eventInfo: PanEventInfo) => {
+    if (!trackRef.current) return value
+    const trackRect = getBox(trackRef.current).borderBox
+    const {
+      point: { x, y },
+    } = eventInfo
+    const diff =
+      orientation === "vertical" ? y - trackRect.top : x - trackRect.left
+    const length =
+      orientation === "vertical" ? trackRect.height : trackRect.width
+    const percent = diff / length
+    const next = percentToValue(
+      isReversed ? 1 - percent : percent,
+      minContext,
+      maxContext,
+    )
+    return next
+  }
+  usePanGesture(thumbRef, {
+    onPanStart() {
+      if (!isInteractive) return
+      setIsDragging.on()
+      if (thumbRef.current) {
+        focus(thumbRef.current)
+      }
+      onValueChangeStart?.(value)
+    },
+    onPan(event, info) {
+      if (!isInteractive) return
+      const next = getValueFromPointer(info)
+      setValue(next)
+    },
+    onPanEnd(event, info) {
+      if (!isInteractive) return
+      setIsDragging.off()
+      const next = getValueFromPointer(info)
+      const constrainedNext = constrainValue(next, min, max, step)
+      onValueChangeEnd?.(constrainedNext)
+      setValue(constrainedNext)
+    },
+  })
+
+  const thumbStyle: CSSProperties = useMemo(
+    () => ({
+      position: "absolute",
+      userSelect: "none",
+      WebkitUserSelect: "none",
+      MozUserSelect: "none",
+      msUserSelect: "none",
+      touchAction: "none",
+      ...orient({
+        orientation,
+        vertical: {
+          top: `${trackPercent}%`,
+          left: "50%",
+          transform: "translateX(-50%) translateY(-50%)",
+        },
+        horizontal: {
+          left: `${trackPercent}%`,
+          top: `50%`,
+          transform: "translateY(-50%) translateX(-50%)",
+        },
+      }),
+    }),
+    [orientation, trackPercent],
+  )
+
+  const getThumbProps: PropGetter = useCallback(
+    (props = {}, ref = null) => ({
+      ...props,
+      ref: mergeRefs(ref, thumbRef),
+      role: "slider",
+      tabIndex: isInteractive ? 0 : undefined,
+      id,
+      "data-active": dataAttr(isDragging),
+      "aria-valuetext": getAriaValueText?.(value) ?? ariaValueText,
+      "aria-valuemin": min,
+      "aria-valuemax": max,
+      "aria-valuenow": value,
+      "aria-orientation": orientation,
+      "aria-disabled": ariaAttr(isDisabled),
+      "aria-readonly": ariaAttr(isReadOnly),
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabel ? undefined : ariaLabelledBy,
+      style: {
+        ...props.style,
+        ...thumbStyle,
+      },
+      onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),
+    }),
+    [
+      ariaLabel,
+      ariaLabelledBy,
+      ariaValueText,
+      getAriaValueText,
+      id,
+      isDisabled,
+      isDragging,
+      isInteractive,
+      isReadOnly,
+      max,
+      min,
+      onKeyDown,
+      orientation,
+      thumbStyle,
+      value,
+    ],
+  )
+
+  const getInputProps: PropGetter<HTMLInputElement> = useCallback(
+    (props = {}, ref = null) => ({
+      ...props,
+      ref,
+      type: "hidden",
+      value,
+      name,
+    }),
+    [name, value],
+  )
+
+  return {
+    getThumbProps,
+    getInputProps,
+  }
+}
+
+function constrainValue(value: number, min: number, max: number, step: number) {
+  return clampValue(parseFloat(roundValueToStep(value, min, step)), min, max)
+}
+
+function getDefaultValue(
+  thumbKey: number,
+  min: number,
+  max: number,
+  step: number,
+) {
+  return constrainValue(
+    ((max - min) * thumbKey) / (thumbKey + 1) + min,
+    min,
+    max,
+    step,
+  )
+}

--- a/packages/multi-slider/src/use-multi-slider-track.ts
+++ b/packages/multi-slider/src/use-multi-slider-track.ts
@@ -1,0 +1,42 @@
+import { mergeRefs, PropGetter } from "@chakra-ui/react-utils"
+import { dataAttr } from "@chakra-ui/utils"
+import { useCallback, useMemo } from "react"
+import { useMultiSliderContext } from "./multi-slider-context"
+import { orient } from "./multi-slider-utils"
+
+export function useMultiSliderTrack() {
+  const { orientation, isDisabled, trackRef } = useMultiSliderContext()
+
+  const trackStyle: React.CSSProperties = useMemo(
+    () => ({
+      position: "relative",
+      ...orient({
+        orientation,
+        vertical: {
+          height: "100%",
+        },
+        horizontal: {
+          width: "100%",
+        },
+      }),
+    }),
+    [orientation],
+  )
+
+  const getTrackProps: PropGetter = useCallback(
+    (props = {}, ref = null) => ({
+      ...props,
+      ref: mergeRefs(ref, trackRef),
+      "data-disabled": dataAttr(isDisabled),
+      style: {
+        ...props.style,
+        ...trackStyle,
+      },
+    }),
+    [isDisabled, trackRef, trackStyle],
+  )
+
+  return {
+    getTrackProps,
+  }
+}

--- a/packages/multi-slider/stories/multi-slider.stories.tsx
+++ b/packages/multi-slider/stories/multi-slider.stories.tsx
@@ -1,0 +1,90 @@
+import { chakra } from "@chakra-ui/system"
+import * as React from "react"
+import {
+  MultiSlider,
+  MultiSliderTrack,
+  MultiSliderThumb,
+  MultiSliderFilledTrack,
+} from "../src"
+
+export default {
+  title: "MultiSlider",
+  decorators: [
+    (story: Function) => (
+      <chakra.div maxWidth="400px" height="300px" mx="auto" mt="40px">
+        {story()}
+      </chakra.div>
+    ),
+  ],
+}
+
+export const Horizontal = () => {
+  return (
+    <MultiSlider min={0} max={20} step={5}>
+      <MultiSliderTrack>
+        <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+      </MultiSliderTrack>
+      <MultiSliderThumb
+        thumbKey={0}
+        aria-label="horizontal 0"
+        defaultValue={5}
+      />
+      <MultiSliderThumb
+        thumbKey={1}
+        aria-label="horizontal 1"
+        defaultValue={15}
+      />
+    </MultiSlider>
+  )
+}
+
+export const Vertical = () => {
+  return (
+    <MultiSlider min={0} max={20} step={5} orientation="vertical">
+      <MultiSliderTrack>
+        <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+      </MultiSliderTrack>
+      <MultiSliderThumb thumbKey={0} aria-label="slider 0" defaultValue={5} />
+      <MultiSliderThumb thumbKey={1} aria-label="slider 1" defaultValue={15} />
+    </MultiSlider>
+  )
+}
+
+export const ReverseHorizontal = () => {
+  return (
+    <MultiSlider min={0} max={20} step={5} isReversed>
+      <MultiSliderTrack>
+        <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+      </MultiSliderTrack>
+      <MultiSliderThumb thumbKey={0} aria-label="slider 0" defaultValue={15} />
+      <MultiSliderThumb thumbKey={1} aria-label="slider 1" defaultValue={5} />
+    </MultiSlider>
+  )
+}
+
+export const ReverseVertical = () => {
+  return (
+    <MultiSlider min={0} max={20} step={5} orientation="vertical" isReversed>
+      <MultiSliderTrack>
+        <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+      </MultiSliderTrack>
+      <MultiSliderThumb thumbKey={0} aria-label="slider 0" defaultValue={15} />
+      <MultiSliderThumb thumbKey={1} aria-label="slider 1" defaultValue={5} />
+    </MultiSlider>
+  )
+}
+
+export const FourThumbs = () => {
+  return (
+    <MultiSlider>
+      <MultiSliderTrack>
+        <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+        <MultiSliderFilledTrack startThumbKey={2} endThumbKey={3} />
+      </MultiSliderTrack>
+      <MultiSliderThumb thumbKey={0} aria-label="slider 0" defaultValue={0} />
+      <MultiSliderThumb thumbKey={1} aria-label="slider 1" defaultValue={25} />
+      <MultiSliderThumb thumbKey={2} aria-label="slider-2" defaultValue={50} />
+      <MultiSliderThumb thumbKey={3} aria-label="slider-3" defaultValue={75} />
+    </MultiSlider>
+  )
+}

--- a/packages/multi-slider/tests/multi-slider.test.tsx
+++ b/packages/multi-slider/tests/multi-slider.test.tsx
@@ -1,0 +1,46 @@
+import { press, render, testA11y } from "@chakra-ui/test-utils"
+import * as React from "react"
+import {
+  MultiSlider,
+  MultiSliderFilledTrack,
+  MultiSliderThumb,
+  MultiSliderTrack,
+} from "../src"
+
+test("passes a11y test", async () => {
+  await testA11y(
+    <MultiSlider colorScheme="red">
+      <MultiSliderTrack>
+        <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+      </MultiSliderTrack>
+      <MultiSliderThumb thumbKey={0} aria-label="slider 0" />
+      <MultiSliderThumb thumbKey={1} aria-label="slider 1" />
+    </MultiSlider>,
+  )
+})
+
+test("should move the thumb", () => {
+  const { getByLabelText } = render(
+    <MultiSlider colorScheme="red">
+      <MultiSliderTrack>
+        <MultiSliderFilledTrack startThumbKey={0} endThumbKey={1} />
+      </MultiSliderTrack>
+      <MultiSliderThumb thumbKey={0} aria-label="slider 0" defaultValue={10} />
+      <MultiSliderThumb thumbKey={1} aria-label="slider 1" defaultValue={15} />
+    </MultiSlider>,
+  )
+
+  const thumb = getByLabelText("slider 0")
+
+  press.ArrowRight(thumb)
+  expect(thumb).toHaveAttribute("aria-valuenow", "11")
+
+  press.ArrowRight(thumb)
+  expect(thumb).toHaveAttribute("aria-valuenow", "12")
+
+  press.Home(thumb)
+  expect(thumb).toHaveAttribute("aria-valuenow", "0")
+
+  press.End(thumb)
+  expect(thumb).toHaveAttribute("aria-valuenow", "15")
+})

--- a/packages/multi-slider/tsconfig.json
+++ b/packages/multi-slider/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/theme/src/components/slider.ts
+++ b/packages/theme/src/components/slider.ts
@@ -93,6 +93,11 @@ const sizeLg: PartsStyleFunction<typeof parts> = (props) => {
       horizontal: { h: "4px" },
       vertical: { w: "4px" },
     }),
+    container: orient({
+      orientation: props.Orientation,
+      horizontal: { paddingX: "8px" },
+      vertical: { paddingY: "8px" },
+    }),
   }
 }
 
@@ -104,6 +109,11 @@ const sizeMd: PartsStyleFunction<typeof parts> = (props) => {
       horizontal: { h: "4px" },
       vertical: { w: "4px" },
     }),
+    container: orient({
+      orientation: props.Orientation,
+      horizontal: { paddingX: "7px" },
+      vertical: { paddingY: "7px" },
+    }),
   }
 }
 
@@ -114,6 +124,11 @@ const sizeSm: PartsStyleFunction<typeof parts> = (props) => {
       orientation: props.orientation,
       horizontal: { h: "2px" },
       vertical: { w: "2px" },
+    }),
+    container: orient({
+      orientation: props.Orientation,
+      horizontal: { paddingX: "5px" },
+      vertical: { paddingY: "5px" },
     }),
   }
 }


### PR DESCRIPTION
Closes #2642

Create a multi-thumb slider that can be a range slider.

> Add a brief description

## ⛳️ Current behavior (updates)

The current slider available by Chakra-UI has just one thumb that holds a single value.

## 🚀 New behavior

The multi-thumb slider has an API that allows the developers to use as many thumbs as needed. This behavior allows developers to create range sliders and other types of multi-thumb sliders. 

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This PR adds a new package in the Chakra-UI library.
