### PR TITLE
fix: menu keyboard navigation consistency

### DIFF
--- a/.changeset/spicy-chairs-build.md
+++ b/.changeset/spicy-chairs-build.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fix issue where keyboard navigation doesnt work when menu button isn't rendered

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -241,6 +241,12 @@ export function useMenu(props: UseMenuProps = {}) {
     }
   }, [isOpen, focusedIndex, descendants])
 
+  React.useEffect(() => {
+    if (!isOpen) return
+    if (autoSelect) openAndFocusFirstItem()
+    else openAndFocusMenu()
+  }, [isOpen, autoSelect, openAndFocusFirstItem, openAndFocusMenu])
+
   return {
     openAndFocusMenu,
     openAndFocusFirstItem,
@@ -289,24 +295,7 @@ export function useMenuButton(
 ) {
   const menu = useMenuContext()
 
-  const {
-    isOpen,
-    onClose,
-    autoSelect,
-    popper,
-    openAndFocusFirstItem,
-    openAndFocusLastItem,
-    openAndFocusMenu,
-  } = menu
-
-  const onClick = React.useCallback(() => {
-    if (isOpen) {
-      onClose()
-    } else {
-      const action = autoSelect ? openAndFocusFirstItem : openAndFocusMenu
-      action()
-    }
-  }, [autoSelect, isOpen, onClose, openAndFocusFirstItem, openAndFocusMenu])
+  const { onToggle, popper, openAndFocusFirstItem, openAndFocusLastItem } = menu
 
   const onKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
@@ -336,7 +325,7 @@ export function useMenuButton(
     "aria-expanded": menu.isOpen,
     "aria-haspopup": "menu" as React.AriaAttributes["aria-haspopup"],
     "aria-controls": menu.menuId,
-    onClick: callAllHandlers(props.onClick, onClick),
+    onClick: callAllHandlers(props.onClick, onToggle),
     onKeyDown: callAllHandlers(props.onKeyDown, onKeyDown),
   }
 }

--- a/packages/menu/stories/menu.stories.tsx
+++ b/packages/menu/stories/menu.stories.tsx
@@ -2,6 +2,7 @@ import { Button } from "@chakra-ui/button"
 import { Image } from "@chakra-ui/image"
 import { Portal } from "@chakra-ui/portal"
 import { chakra } from "@chakra-ui/system"
+import { Modal, ModalBody, ModalContent, ModalOverlay } from "@chakra-ui/modal"
 import * as React from "react"
 import {
   FaChevronDown,
@@ -483,4 +484,47 @@ export const MenuPerformanceTest = () => {
       </Menu>
     </div>
   ))
+}
+
+export const WithoutMenuButton = () => {
+  const [isOpen, setOpen] = React.useState(false)
+  const open = () => setOpen(true)
+  const close = () => setOpen(false)
+
+  React.useEffect(() => {
+    const listener = (ev) => {
+      if ((ev.metaKey || ev.ctrlKey) && ev.code === "KeyK") {
+        ev.preventDefault()
+        open()
+      }
+    }
+    window.addEventListener("keydown", listener)
+    return () => window.removeEventListener("keydown", listener)
+  }, [])
+
+  return (
+    <>
+      <Modal
+        onClose={close}
+        isOpen={isOpen}
+        isCentered
+        motionPreset="slideInBottom"
+      >
+        <ModalOverlay />
+        <ModalContent minHeight={100} background="none" boxShadow="none">
+          <ModalBody display="flex" justifyContent="center" alignItems="center">
+            <Menu isOpen closeOnSelect onClose={close}>
+              <MenuList paddingY={5}>
+                <MenuItem>
+                  Saves or updates the code in Stately Registry
+                </MenuItem>
+                <MenuItem>Visualizes the current editor code</MenuItem>
+              </MenuList>
+            </Menu>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+      <p>Press Cmd + K to open</p>
+    </>
+  )
 }


### PR DESCRIPTION
Closes #4688

## 📝 Description

The menu should be always focused when opened and arrow navigation should work without rendering the menu button. This is useful for context menus.

## ⛳️ Current behavior (updates)

The first item is not auto-selected and pressing arrows doesn't select any items

## 🚀 New behavior

The first item is auto-selected and arrow navigation works


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
