### PR TITLE
fix(toast-accessible-name): allow toast to be discovered by name

### DIFF
--- a/.changeset/young-flowers-travel.md
+++ b/.changeset/young-flowers-travel.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Allow alerts rendered by useToast and createStandaloneToast to be discovered by
+role and accessible name (e.g. using Testing Library
+[ByRole](https://testing-library.com/docs/queries/byrole/)).

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -53,7 +53,7 @@ export interface UseToastOptions {
   /**
    * The alert component `variant` to use
    */
-  variant?: "subtle"| "solid"| "left-accent" | "top-accent" | (string & {})
+  variant?: "subtle" | "solid" | "left-accent" | "top-accent" | (string & {})
   /**
    * The status of the toast.
    */
@@ -76,6 +76,8 @@ export type IToast = UseToastOptions
 const Toast: React.FC<any> = (props) => {
   const { status, variant, id, title, isClosable, onClose, description } = props
 
+  const alertTitleId = typeof id !== "undefined" ? `${id}-title` : undefined
+
   return (
     <Alert
       status={status}
@@ -87,10 +89,11 @@ const Toast: React.FC<any> = (props) => {
       paddingEnd={8}
       textAlign="start"
       width="auto"
+      aria-labelledby={alertTitleId}
     >
       <AlertIcon />
       <chakra.div flex="1" maxWidth="100%">
-        {title && <AlertTitle>{title}</AlertTitle>}
+        {title && <AlertTitle id={alertTitleId}>{title}</AlertTitle>}
         {description && (
           <AlertDescription display="block">{description}</AlertDescription>
         )}

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -76,7 +76,7 @@ export type IToast = UseToastOptions
 const Toast: React.FC<any> = (props) => {
   const { status, variant, id, title, isClosable, onClose, description } = props
 
-  const alertTitleId = typeof id !== "undefined" ? `${id}-title` : undefined
+  const alertTitleId = typeof id !== "undefined" ? `toast-${id}-title` : undefined
 
   return (
     <Alert

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -14,7 +14,9 @@ test("Standalone toast renders correctly", async () => {
     isClosable: true,
   })
 
-  const allByTitle = await screen.findAllByText(title)
+  const allByTitle = await screen.findAllByRole("alert", {
+    name: new RegExp(title),
+  })
   const allByDescription = await screen.findAllByText(description)
 
   expect(allByTitle).toHaveLength(1)

--- a/packages/toast/test/standalone-toast.test.tsx
+++ b/packages/toast/test/standalone-toast.test.tsx
@@ -14,9 +14,7 @@ test("Standalone toast renders correctly", async () => {
     isClosable: true,
   })
 
-  const allByTitle = await screen.findAllByRole("alert", {
-    name: new RegExp(title),
-  })
+  const allByTitle = await screen.findAllByRole("alert", { name: title })
   const allByDescription = await screen.findAllByText(description)
 
   expect(allByTitle).toHaveLength(1)

--- a/packages/toast/test/use-toast.test.tsx
+++ b/packages/toast/test/use-toast.test.tsx
@@ -30,9 +30,7 @@ test("can accept default options", async () => {
     result.current()
   })
 
-  const allByTitle = await screen.findAllByRole("alert", {
-    name: new RegExp(title),
-  })
+  const allByTitle = await screen.findAllByRole("alert", { name: title })
   const allByDescription = await screen.findAllByText(description)
 
   expect(allByTitle).toHaveLength(1)
@@ -57,9 +55,7 @@ test("can override default options", async () => {
     result.current({ title, description })
   })
 
-  const allByTitle = await screen.findAllByRole("alert", {
-    name: new RegExp(title),
-  })
+  const allByTitle = await screen.findAllByRole("alert", { name: title })
   const allByDescription = await screen.findAllByText(description)
 
   expect(allByTitle).toHaveLength(1)

--- a/packages/toast/test/use-toast.test.tsx
+++ b/packages/toast/test/use-toast.test.tsx
@@ -30,7 +30,9 @@ test("can accept default options", async () => {
     result.current()
   })
 
-  const allByTitle = await screen.findAllByText(title)
+  const allByTitle = await screen.findAllByRole("alert", {
+    name: new RegExp(title),
+  })
   const allByDescription = await screen.findAllByText(description)
 
   expect(allByTitle).toHaveLength(1)
@@ -55,7 +57,9 @@ test("can override default options", async () => {
     result.current({ title, description })
   })
 
-  const allByTitle = await screen.findAllByText(title)
+  const allByTitle = await screen.findAllByRole("alert", {
+    name: new RegExp(title),
+  })
   const allByDescription = await screen.findAllByText(description)
 
   expect(allByTitle).toHaveLength(1)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4699 

## 📝 Description

* Adds an additional `id` attribute on the AlertTitle rendered by toast, and a matching `aria-labelledby` on the Alert.

* Behaviour of screen readers should be unchanged since the reader should announce either the title and then the content, or only the content. See https://github.com/chakra-ui/chakra-ui/issues/4699#issuecomment-916902517

* The alert div rendered by toast now has an [accessible name](https://knowledge.evinced.com/concepts/accessible-names/) which is the title of the toast.

* The alert div rendered by toast is discoverable using react-testing-library [ByRole](https://testing-library.com/docs/queries/byrole) methods by using the `name` option and providing the title of the toast.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

```js
const toast = useToast();

return (
  <Button
    onClick={() => {
      toast({
        title: 'My Toast Title',
      });
    }}
  >
    Show Toast
  </Button>
);
```

Renders this to the document:

```html
<div class="chakra-alert css-1kao88d" id="2" role="alert">
  <span class="chakra-alert__icon css-1c6vscd">
    <svg class="chakra-icon css-fi0ww0" focusable="false" viewBox="0 0 24 24">
      <path
        d="M12,0A12,12,0,1,0,24,12,12.013,12.013,0,0,0,12,0Zm.25,5a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,12.25,5ZM14.5,18.5h-4a1,1,0,0,1,0-2h.75a.25.25,0,0,0,.25-.25v-4.5a.25.25,0,0,0-.25-.25H10.5a1,1,0,0,1,0-2h1a2,2,0,0,1,2,2v4.75a.25.25,0,0,0,.25.25h.75a1,1,0,1,1,0,2Z"
        fill="currentColor" />
    </svg>
  </span>
  <div class="css-njbp03">
    <div class="chakra-alert__title css-0">
      My Toast Title
    </div>
  </div>
</div>
```

The parent `<div>` with `role="alert"` does not have `aria-labelledby`. The child div containing text `My Toast Title` does not have an `id` which can be referenced via `aria-labelledby` on the parent.

The [accessible name can be found using browser inspector](https://knowledge.evinced.com/concepts/accessible-names).

<img width="1552" alt="Google Chrome inspector screenshot, highlighting computer name is not specified" src="https://user-images.githubusercontent.com/18026180/132857190-44a3f571-2109-4f80-bc70-bc6e1d3214ee.png">

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

The same component above now should render this (I have edited the above code snippet by hand just for demonstration purposes):

```diff
- <div class="chakra-alert css-1kao88d" id="2" role="alert">
+ <div class="chakra-alert css-1kao88d" id="2" role="alert" aria-labelledby="2-title">
    <span class="chakra-alert__icon css-1c6vscd">
      <svg class="chakra-icon css-fi0ww0" focusable="false" viewBox="0 0 24 24">
        <path
          d="M12,0A12,12,0,1,0,24,12,12.013,12.013,0,0,0,12,0Zm.25,5a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,12.25,5ZM14.5,18.5h-4a1,1,0,0,1,0-2h.75a.25.25,0,0,0,.25-.25v-4.5a.25.25,0,0,0-.25-.25H10.5a1,1,0,0,1,0-2h1a2,2,0,0,1,2,2v4.75a.25.25,0,0,0,.25.25h.75a1,1,0,1,1,0,2Z"
          fill="currentColor" />
      </svg>
    </span>
    <div class="css-njbp03">
-     <div class="chakra-alert__title css-0">
+     <div class="chakra-alert__title css-0" id="2-title">
        My Toast Title
      </div>
    </div>
  </div>
```

You can now see the accessible name of the alert using inspector:

<img width="1421" alt="Screenshot of Google Chrome, highlighting accessible name is My Toast Title" src="https://user-images.githubusercontent.com/18026180/132874121-3b604a1e-78ab-407f-a7ae-5d173a9c08c0.png">

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information

See previous comments in https://github.com/chakra-ui/chakra-ui/issues/4699