### PR TITLE
fix(number-input): spinner getting stuck in useNumberInput button props

### DIFF
--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -377,6 +377,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
         onMouseLeave: callAllHandlers(props.onMouseUp, spinner.stop),
         onTouchEnd: callAllHandlers(props.onTouchEnd, spinner.stop),
         onPointerLeave: callAllHandlers(props.onPointerLeave, spinner.stop),
+        onPointerUp: callAllHandlers(props.onPointerUp, spinner.stop),
         disabled,
         "aria-disabled": ariaAttr(disabled),
       }
@@ -404,6 +405,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
         onMouseUp: callAllHandlers(props.onMouseUp, spinner.stop),
         onTouchEnd: callAllHandlers(props.onTouchEnd, spinner.stop),
         onPointerLeave: callAllHandlers(props.onPointerLeave, spinner.stop),
+        onPointerUp: callAllHandlers(props.onPointerUp, spinner.stop),
         disabled,
         "aria-disabled": ariaAttr(disabled),
       }

--- a/packages/number-input/src/use-number-input.ts
+++ b/packages/number-input/src/use-number-input.ts
@@ -376,6 +376,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
         onMouseUp: callAllHandlers(props.onMouseUp, spinner.stop),
         onMouseLeave: callAllHandlers(props.onMouseUp, spinner.stop),
         onTouchEnd: callAllHandlers(props.onTouchEnd, spinner.stop),
+        onPointerLeave: callAllHandlers(props.onPointerLeave, spinner.stop),
         disabled,
         "aria-disabled": ariaAttr(disabled),
       }
@@ -402,6 +403,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
         onMouseLeave: callAllHandlers(props.onMouseLeave, spinner.stop),
         onMouseUp: callAllHandlers(props.onMouseUp, spinner.stop),
         onTouchEnd: callAllHandlers(props.onTouchEnd, spinner.stop),
+        onPointerLeave: callAllHandlers(props.onPointerLeave, spinner.stop),
         disabled,
         "aria-disabled": ariaAttr(disabled),
       }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4646 

## 📝 Description

Using `useNumberInput` and setting a `min` and/or `max` value and a chakra `<Button />` with `getIncrementButtonProps` or `getDecrementButtonProps` the spinner gets stuck if you reach the limit and move the mouse off the now disabled button while still holding left click in latest Chromium-based browsers. In Firefox it's fine.

## 🚀 New behavior

Adding an `onPointerLeave` event handler to the existing ones seems to fix the problem. This was also recommended [in this React issue](https://github.com/facebook/react/issues/18753) as a solution.

The `onPointerUp` handler is also needed if the mouse doesn't leave the button while editing the input field value.

## 💣 Is this a breaking change (Yes/No):

No
