### PR TITLE
fix: add missing breadcrumb part

### DIFF
--- a/.changeset/gentle-icons-smell.md
+++ b/.changeset/gentle-icons-smell.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/anatomy": patch
+---
+
+Add missing breadcrumb part

--- a/packages/anatomy/src/index.ts
+++ b/packages/anatomy/src/index.ts
@@ -41,7 +41,7 @@ export const avatarAnatomy = anatomy("avatar")
  * - Separator: the separator between breadcrumb items
  */
 export const breadcrumbAnatomy = anatomy("breadcrumb")
-  .parts("link", "item")
+  .parts("link", "item", "container")
   .extend("separator")
 
 export const buttonAnatomy = anatomy("button").parts()


### PR DESCRIPTION

Closes https://github.com/chakra-ui/chakra-ui/issues/4720

## 📝 Description

Breadcrumb anatomy was missing the "container" part.

## 💣 Is this a breaking change (Yes/No): No
