### PR TITLE
fix(cli): resolve custom tsconfig paths

### DIFF
--- a/.changeset/lemon-beers-relax.md
+++ b/.changeset/lemon-beers-relax.md
@@ -1,0 +1,22 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Fixed an issue where the CLI did not resolve custom tsconfig paths.
+
+🚨 Please note that only the first alias target from the string array will be
+resolved.
+
+```json5
+// tsconfig.json
+{
+  //...
+  compilerOptions: {
+    baseUrl: "src",
+    paths: {
+      "@alias/*": ["target/*"],
+      //           ^-- only the first target will be resolved
+    },
+  },
+}
+```

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -39,11 +39,10 @@
     "prebuild": "rimraf dist",
     "start": "nodemon --watch src --exec 'yarn build; yarn dev' -e ts,tsx",
     "dev": "node bin/index.js tokens ../../website/theme.ts",
-    "build": "concurrently yarn:build:*",
     "test": "jest --env=jsdom --passWithNoTests",
     "lint": "concurrently yarn:lint:*",
     "version": "yarn build",
-    "build:cjs": "cross-env BABEL_ENV=cjs babel src --root-mode upward --extensions .ts,.tsx -d dist --source-maps",
+    "build": "cross-env BABEL_ENV=cjs babel src --root-mode upward --extensions .ts,.tsx -d dist --source-maps",
     "test:cov": "yarn test --coverage",
     "lint:src": "eslint src --ext .ts,.tsx --config ../../.eslintrc",
     "lint:types": "tsc --noEmit"
@@ -54,12 +53,15 @@
     "cli-handle-unhandled": "^1.1.1",
     "cli-welcome": "^2.2.2",
     "commander": "^6.2.1",
+    "module-alias": "^2.2.2",
     "ora": "^5.3.0",
     "regenerator-runtime": "^0.13.7",
     "ts-node": "9.1.1",
+    "tsconfig-paths": "^3.11.0",
     "update-notifier": "^5.0.1"
   },
   "devDependencies": {
+    "@types/module-alias": "^2.0.1",
     "@types/ora": "^3.2.0",
     "@types/update-notifier": "5.0.0"
   }

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -1,7 +1,9 @@
 import "regenerator-runtime/runtime"
 import path from "path"
 import fs from "fs"
-import { register } from "ts-node"
+import * as tsNode from "ts-node"
+import * as tsConfigPaths from "tsconfig-paths"
+import moduleAlias from "module-alias"
 import { isObject } from "@chakra-ui/utils"
 import { createThemeTypingsInterface } from "../command/tokens/create-theme-typings-interface"
 import { themeKeyConfiguration } from "../command/tokens/config"
@@ -29,9 +31,49 @@ async function readTheme(themeFilePath: string) {
   const cwd = process.cwd()
   const absoluteThemePath = path.join(cwd, themeFilePath)
 
-  register({
-    project: path.join(__dirname, "..", "..", "bin", "tsconfig.json"),
-  })
+  const tsConfig = tsConfigPaths.loadConfig(absoluteThemePath)
+  if (tsConfig.resultType === "success") {
+    tsNode.register({
+      // use the TS projects own tsconfig file
+      project: tsConfig.configFileAbsolutePath,
+    })
+
+    /**
+     * Replace the module aliases in the transpiled code,
+     * because ts-node does not resolve them to relative require paths.
+     *
+     * 🚨 Note that only the first alias target will work
+     * @example tsconfig.json
+     * {
+     *   "baseUrl": "src",
+     *   "paths": {
+     *     "@alias/*": ["target/*"]
+     *   }
+     * }
+     */
+    const aliases = Object.keys(tsConfig.paths).reduce((acc, tsAlias) => {
+      // target/* -> target/
+      const firstTarget = tsConfig.paths[tsAlias][0].replace(/\*$/, "")
+      // @alias/* -> @alias
+      const jsAlias = tsAlias.replace(/\/\*$/, "")
+      // @alias = baseUrl/target/
+      acc[jsAlias] = path.join(tsConfig.absoluteBaseUrl, firstTarget)
+      return acc
+    }, {})
+    moduleAlias.addAliases(aliases)
+  } else {
+    // it is a JS project
+    const defaultProject = path.join(
+      __dirname,
+      "..",
+      "..",
+      "bin",
+      "tsconfig.json",
+    )
+    tsNode.register({
+      project: defaultProject,
+    })
+  }
 
   try {
     await fs.promises.stat(absoluteThemePath)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6141,6 +6141,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/module-alias@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/module-alias/-/module-alias-2.0.1.tgz#e5893236ce922152d57c5f3f978f764f4deeb45f"
+  integrity sha512-DN/CCT1HQG6HquBNJdLkvV+4v5l/oEuwOHUPLxI+Eub0NED+lk0YUfba04WGH90EINiUrNgClkNnwGmbICeWMQ==
+
 "@types/node-fetch@2":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -19082,6 +19087,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+module-alias@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
+  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
+
 moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
@@ -26132,6 +26142,16 @@ ts-pnp@1.2.0, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tsconfig-paths@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
+  integrity sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4652 

## 📝 Description

This PR allows the CLI to resolve custom TS config paths.

## ⛳️ Current behavior (updates)

The CLI uses currently its own `tsconfig.json` to transpile the userland theme file.

## 🚀 New behavior

The CLI reads the projects `tsconfig.json` and replaces the `compilerOptions.paths` during runtime of `ts-node`.
It uses the npm packages [tsconfig-paths](https://github.com/dividab/tsconfig-paths) to read the userland `tsconfig.json` and replaces the aliases with [module-alias](https://github.com/ilearnio/module-alias) while running.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

🚨 Please note that only the first alias target from the string array will be resolved.

```json5
// tsconfig.json
{
  //...
  compilerOptions: {
    baseUrl: "src",
    paths: {
      "@alias/*": ["target/*"],
      //           ^-- only the first target will be resolved
    },
  },
}
```