### PR TITLE
feat(popover): manual trigger mode

### DIFF
--- a/.changeset/sharp-mirrors-jog.md
+++ b/.changeset/sharp-mirrors-jog.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/popover": minor
+---
+
+The `trigger` can now be set to `manual` in order to not bind any mouse/keyboard
+to the trigger for fully controlled usage.

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -21,6 +21,7 @@ import { RefObject, useCallback, useEffect, useRef, useState } from "react"
 const TRIGGER = {
   click: "click",
   hover: "hover",
+  manual: "manual",
 } as const
 
 export interface UsePopoverProps extends UsePopperProps {
@@ -87,6 +88,9 @@ export interface UsePopoverProps extends UsePopperProps {
    *
    * `click` - means the popover will open on click or
    * press `Enter` to `Space` on keyboard
+   *
+   * `manual` - means the popover won't automatically open or close
+   * on any trigger interaction.
    */
   trigger?: keyof typeof TRIGGER
   openDelay?: number

--- a/website/pages/docs/overlay/popover.mdx
+++ b/website/pages/docs/overlay/popover.mdx
@@ -229,7 +229,11 @@ You can control the opening and closing of the popover by passing the `isOpen`,
 and `onClose` props.
 
 Sometimes you might need to set the `returnFocusOnClose` prop to `false` to
-prevent popver from returning focus to `PopoverTrigger`'s children.
+prevent popover from returning focus to `PopoverTrigger`'s children.
+
+Setting the `trigger` to `manual` is useful in case you don't want the
+`PopoverTrigger` to close the popover on click, but rather serve just as an
+reference point for positioning.
 
 ```jsx
 function ControlledUsage() {
@@ -247,6 +251,7 @@ function ControlledUsage() {
         onClose={close}
         placement="right"
         closeOnBlur={false}
+        trigger="manual"
       >
         <PopoverTrigger>
           <Button colorScheme="pink">Popover Target</Button>


### PR DESCRIPTION
Closes #4733

## 📝 Description

The `trigger` can now be set to `manual` in case you don't want the `PopoverTrigger` to close the popover on click, but rather serve just as an reference point for positioning.

## ⛳️ Current behavior (updates)

No way to disable hover/click triggering the popover.

## 🚀 New behavior

The `trigger` can now be set to `manual` in order to not bind any mouse/keyboard to the trigger for fully controlled usage.

## 💣 Is this a breaking change (Yes/No):

No
