### PR TITLE
fix(modal): preventing drawer from disappearing on placement change

### DIFF
--- a/.changeset/khaki-feet-count.md
+++ b/.changeset/khaki-feet-count.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/transition": patch
+---
+
+Updated transition variants for drawer animations to prevent it from
+disappearing when placement conditionally changes

--- a/packages/transition/src/transition-utils.ts
+++ b/packages/transition/src/transition-utils.ts
@@ -83,7 +83,6 @@ export type SlideDirection = "top" | "left" | "bottom" | "right"
 
 export function slideTransition(options?: { direction?: SlideDirection }) {
   const side = options?.direction ?? "right"
-  // console.log(side)
   switch (side) {
     case "right":
       return TransitionVariants.slideRight

--- a/packages/transition/src/transition-utils.ts
+++ b/packages/transition/src/transition-utils.ts
@@ -59,23 +59,23 @@ export const TransitionVariants = {
   },
   slideLeft: {
     position: { left: 0, top: 0, bottom: 0, width: "100%" },
-    enter: { x: 0 },
-    exit: { x: "-100%" },
+    enter: { x: 0, y: 0 },
+    exit: { x: "-100%", y: 0 },
   },
   slideRight: {
     position: { right: 0, top: 0, bottom: 0, width: "100%" },
-    enter: { x: 0 },
-    exit: { x: "100%" },
+    enter: { x: 0, y: 0 },
+    exit: { x: "100%", y: 0 },
   },
   slideUp: {
     position: { top: 0, left: 0, right: 0, maxWidth: "100vw" },
-    enter: { y: 0 },
-    exit: { y: "-100%" },
+    enter: { x: 0, y: 0 },
+    exit: { x: 0, y: "-100%" },
   },
   slideDown: {
     position: { bottom: 0, left: 0, right: 0, maxWidth: "100vw" },
-    enter: { y: 0 },
-    exit: { y: "100%" },
+    enter: { x: 0, y: 0 },
+    exit: { x: 0, y: "100%" },
   },
 }
 
@@ -83,6 +83,7 @@ export type SlideDirection = "top" | "left" | "bottom" | "right"
 
 export function slideTransition(options?: { direction?: SlideDirection }) {
   const side = options?.direction ?? "right"
+  // console.log(side)
   switch (side) {
     case "right":
       return TransitionVariants.slideRight


### PR DESCRIPTION
Closes #4729 

## 📝 Description

> Preventing drawer modal from disappearing on changing the placement value

## ⛳️ Current behavior (updates)

> Drawer gets hidden if placement prop changes

## 🚀 New behavior

> Now drawer doesn't get hidden and placement is changed accordingly

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Explicitly mentioning x and y values of enter and exit states for slide transition variants
