### PR TITLE
feat: storybook theme selector, which stays persistent trough the stories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import {
   useColorMode,
   useColorModeValue,
   theme,
+  withDefaultColorScheme
 } from "@chakra-ui/react"
 import { StoryContext } from "@storybook/react"
 import * as React from "react"
@@ -23,6 +24,31 @@ export const globalTypes = {
     toolbar: {
       icon: "globe",
       items: ["LTR", "RTL"],
+    },
+  },
+  theme: {
+    name: 'Theme',
+    description: 'Theme selector',
+    toolbar: {
+      // https://storybook.js.org/docs/react/workflows/faq#what-icons-are-available-for-my-toolbar-or-my-addon
+      icon: 'component',
+      items: [
+
+        { value: 'black', title: 'Black' },
+        { value: 'white', title: 'White' },
+        { value: 'gray', title: 'Gray' },
+        { value: 'orange', title: 'orange' },
+        { value: 'yellow', title: 'yellow' },
+        { value: 'green', title: 'green' },
+        { value: 'teal', title: 'Teal', right: 'default' },
+        { value: 'blue', title: 'blue' },
+        { value: 'cyan', title: 'cyan' },
+        { value: 'purple', title: 'purple' },
+        { value: 'pink', title: 'pink' },
+        { value: 'telegram', title: 'Telegram' },
+        { value: 'messenger', title: 'Messenger' },
+        { value: 'facebook', title: 'Facebook' },
+      ],
     },
   },
 }
@@ -49,7 +75,7 @@ const ColorModeToggleBar = () => {
 }
 
 const withChakra = (StoryFn: Function, context: StoryContext) => {
-  const { direction } = context.globals
+  const { direction, theme } = context.globals;
   const dir = direction.toLowerCase()
 
   React.useEffect(() => {
@@ -57,7 +83,9 @@ const withChakra = (StoryFn: Function, context: StoryContext) => {
   }, [dir])
 
   return (
-    <ChakraProvider theme={extendTheme({ direction: dir })}>
+    <ChakraProvider theme={extendTheme({
+      direction: dir,
+      }, withDefaultColorScheme({ colorScheme: theme || 'teal' }),)}>
       <div dir={dir} id="story-wrapper" style={{ minHeight: "100vh" }}>
         <ColorModeToggleBar />
         <StoryFn />

--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -73,19 +73,19 @@ export const outlines = () => (
 
 export const withVariants = () => (
   <HStack spacing="24px">
-    <Button colorScheme="teal" variant="solid">
+    <Button variant="solid">
       Button
     </Button>
-    <Button colorScheme="teal" variant="outline">
+    <Button variant="outline">
       Button
     </Button>
-    <Button colorScheme="teal" variant="ghost">
+    <Button variant="ghost">
       Button
     </Button>
-    <Button colorScheme="teal" variant="link">
+    <Button variant="link">
       Button
     </Button>
-    <Button colorScheme="teal" variant="unstyled">
+    <Button variant="unstyled">
       Button
     </Button>
   </HStack>

--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -41,31 +41,7 @@ export const basic = () => (
 
 export const outlines = () => (
   <>
-    <Button variant="outline" colorScheme="red">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="green">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="blue">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="teal">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="pink">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="purple">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="cyan">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="orange">
-      Button
-    </Button>
-    <Button variant="outline" colorScheme="yellow">
+    <Button variant="outline">
       Button
     </Button>
   </>
@@ -93,16 +69,16 @@ export const withVariants = () => (
 
 export const withSizes = () => (
   <HStack>
-    <Button colorScheme="blue" size="xs">
+    <Button size="xs">
       Button
     </Button>
-    <Button colorScheme="blue" size="sm">
+    <Button size="sm">
       Button
     </Button>
-    <Button colorScheme="blue" size="md">
+    <Button size="md">
       Button
     </Button>
-    <Button colorScheme="blue" size="lg">
+    <Button size="lg">
       Button
     </Button>
   </HStack>
@@ -110,12 +86,11 @@ export const withSizes = () => (
 
 export const WithIcon = () => (
   <Stack direction="row" spacing={4}>
-    <Button leftIcon={<EmailIcon />} colorScheme="teal" variant="solid">
+    <Button leftIcon={<EmailIcon />} variant="solid">
       Email
     </Button>
     <Button
       rightIcon={<ArrowForwardIcon />}
-      colorScheme="teal"
       variant="outline"
     >
       Call us
@@ -125,10 +100,10 @@ export const WithIcon = () => (
 
 export const withReactIcons = () => (
   <Stack direction="row" spacing={4} align="center">
-    <Button leftIcon={<MdBuild />} colorScheme="pink" variant="solid">
+    <Button leftIcon={<MdBuild />} variant="solid">
       Settings
     </Button>
-    <Button rightIcon={<MdCall />} colorScheme="blue" variant="outline">
+    <Button rightIcon={<MdCall />} variant="outline">
       Call us
     </Button>
   </Stack>
@@ -136,14 +111,14 @@ export const withReactIcons = () => (
 
 export const WithLoading = () => (
   <Stack direction="row" spacing={4} align="center">
-    <Button size="lg" isLoading colorScheme="teal">
+    <Button size="lg" isLoading>
       Email
     </Button>
 
     <Button
       isLoading
       colorScheme="blue"
-      spinner={<BeatLoader size={8} color="white" />}
+      spinner={<BeatLoader size={8} />}
     >
       Click me
     </Button>
@@ -151,7 +126,6 @@ export const WithLoading = () => (
     <Button
       isLoading
       loadingText="Submitting..."
-      colorScheme="teal"
       variant="outline"
     >
       Submit
@@ -164,7 +138,6 @@ export const WithLoadingSpinnerPlacement = () => (
     <Button
       isLoading
       loadingText="Loading"
-      colorScheme="teal"
       variant="outline"
       spinnerPosition="start"
     >
@@ -173,7 +146,6 @@ export const WithLoadingSpinnerPlacement = () => (
     <Button
       isLoading
       loadingText="Loading"
-      colorScheme="teal"
       variant="outline"
       spinnerPlacement="end"
     >
@@ -184,16 +156,16 @@ export const WithLoadingSpinnerPlacement = () => (
 
 export const withDisabled = () => (
   <HStack spacing="24px">
-    <Button isDisabled colorScheme="teal" variant="solid">
+    <Button isDisabled variant="solid">
       Button
     </Button>
-    <Button isDisabled colorScheme="teal" variant="outline">
+    <Button isDisabled variant="outline">
       Button
     </Button>
-    <Button isDisabled colorScheme="teal" variant="ghost">
+    <Button isDisabled variant="ghost">
       Button
     </Button>
-    <Button isDisabled colorScheme="teal" variant="link">
+    <Button isDisabled variant="link">
       Button
     </Button>
   </HStack>
@@ -216,12 +188,11 @@ export const iconButton = () => (
     <IconButton aria-label="Search database" icon={<SearchIcon />} />
 
     <IconButton
-      colorScheme="blue"
       aria-label="Search database"
       icon={<SearchIcon />}
     />
 
-    <IconButton colorScheme="teal" aria-label="Call Segun" size="lg">
+    <IconButton aria-label="Call Segun" size="lg">
       <PhoneIcon />
     </IconButton>
   </Stack>
@@ -229,8 +200,8 @@ export const iconButton = () => (
 
 export const WithButtonGroup = () => (
   <ButtonGroup variant="outline">
-    <Button colorScheme="blue">Save</Button>
-    <Button>Cancel</Button>
+    <Button>Save</Button>
+    <Button colorScheme="gray">Cancel</Button>
   </ButtonGroup>
 )
 


### PR DESCRIPTION
## 📝 Description

This is work in progress. We can now select the color mode (or with small mod also a complete other theme) and let it stay persistent trough all the stories. So we can ditch setting colours everywhere and only use them when really applicable. It makes it nice to see components in their own selectable theme.

![cut](https://user-images.githubusercontent.com/25961356/134358574-a6143aaf-88a9-4dc7-93ec-fe66c3c7f796.gif)

## ⛳️ Current behavior (updates)

Storybook now just shows variants but in a defined color.

## 🚀 New behavior

You select the color scheme, and all stories with no predefined scheme will show that scheme: teal/gray/telegram/messenger/etc

See: https://chakra-ui-storybook-n27abd8jl-chakra-ui.vercel.app/?path=/story/button--with-variants

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I just started with one story since i dont know if this is something you want :) So in Buttons variants i removed the Teal schema defined on the button. Then i added all colours including the brand ones, which you can now select. The selected scheme is in the url so when you share something it stays in that schema.

solves #2190