### PR TITLE
fix: missing dependencies and peer dependencies

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -67,10 +67,12 @@
   },
   "devDependencies": {
     "@chakra-ui/system": "1.7.3",
+    "framer-motion": "^4.0.0",
     "react": "^17.0.1"
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
+    "framer-motion": "3.x || 4.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/anatomy/package.json
+++ b/packages/anatomy/package.json
@@ -52,5 +52,11 @@
   },
   "dependencies": {
     "@chakra-ui/theme-tools": "^1.2.1"
+  },
+  "devDependencies": {
+    "@chakra-ui/system": "1.7.3"
+  },
+  "peerDependencies": {
+    "@chakra-ui/system": ">=1.0.0"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@chakra-ui/hooks": "1.6.0",
+    "@chakra-ui/react-utils": "1.1.2",
     "@chakra-ui/spinner": "1.1.12",
     "@chakra-ui/utils": "1.8.2"
   },

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -57,12 +57,17 @@
     "@chakra-ui/hooks": "1.6.0",
     "@chakra-ui/media-query": "1.1.2",
     "@chakra-ui/system": "1.7.3",
+    "@chakra-ui/theme": "1.10.2",
     "@chakra-ui/utils": "1.8.2"
   },
   "peerDependencies": {
+    "@emotion/react": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
     "react": ">=16.8.6"
   },
   "devDependencies": {
+    "@emotion/react": "^11.1.4",
+    "@emotion/styled": "^11.0.0",
     "react": "^17.0.1"
   }
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -59,10 +59,12 @@
   },
   "devDependencies": {
     "@chakra-ui/system": "1.7.3",
+    "framer-motion": "^4.0.0",
     "react": "^17.0.1"
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
+    "framer-motion": "3.x || 4.x",
     "react": ">=16.8.6"
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Some packages have missing peer dependencies so when using yarn v2/v3 with PnP you can't build the app because it won't resolve those dependencies.

So i added the packages listed as missing by yarn. Also `@chakra-ui/button` is using `@chakra-ui/react-utils` but it was removed from its dependencies recently in 1.4.3 and it's also causing the build to fail, so i added it back.
```
➤ YN0002: │ @chakra-ui/accordion@npm:1.3.6 [6a7e1] doesn't provide framer-motion (p9e578), requested by @chakra-ui/transition
➤ YN0002: │ @chakra-ui/anatomy@npm:1.0.1 doesn't provide @chakra-ui/system (pe838a), requested by @chakra-ui/theme-tools
➤ YN0002: │ @chakra-ui/skeleton@npm:1.1.18 [6a7e1] doesn't provide @chakra-ui/theme (p8871b), requested by @chakra-ui/media-query
➤ YN0002: │ @chakra-ui/skeleton@npm:1.1.18 [6a7e1] doesn't provide @emotion/react (p05df3), requested by @chakra-ui/system
➤ YN0002: │ @chakra-ui/skeleton@npm:1.1.18 [6a7e1] doesn't provide @emotion/styled (pee1d0), requested by @chakra-ui/system
➤ YN0002: │ @chakra-ui/switch@npm:1.2.10 [6a7e1] doesn't provide framer-motion (pd2b29), requested by @chakra-ui/checkbox
```

## 💣 Is this a breaking change (Yes/No): No

