### PR TITLE
refactor(progress): fix stripeAnimation variable spelling

### DIFF
--- a/packages/progress/src/progress.tsx
+++ b/packages/progress/src/progress.tsx
@@ -145,7 +145,7 @@ export const Progress: React.FC<ProgressProps> = (props) => {
     propBorderRadius ??
     (styles.track?.borderRadius as string | number | undefined)
 
-  const stripAnimation = { animation: `${stripe} 1s linear infinite` }
+  const stripeAnimation = { animation: `${stripe} 1s linear infinite` }
 
   /**
    * We should not use stripe if it is `indeterminate`
@@ -158,7 +158,7 @@ export const Progress: React.FC<ProgressProps> = (props) => {
    * Generate styles for stripe and stripe animation
    */
   const css: Interpolation<any> = {
-    ...(shouldAnimateStripe && stripAnimation),
+    ...(shouldAnimateStripe && stripeAnimation),
     ...(isIndeterminate && {
       position: "absolute",
       willChange: "left",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Changed spelling of `stripAnimation` to `stripeAnimation`

## 💣 Is this a breaking change (Yes/No):

No