### PR TITLE
fix(cli): resolve ts-config from dirname

### DIFF
--- a/.changeset/loud-poets-care.md
+++ b/.changeset/loud-poets-care.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Fixed an issue where the CLI failed with
+`SyntaxError: JSON5: invalid character`.

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -30,8 +30,9 @@ async function importTheme(path: string) {
 async function readTheme(themeFilePath: string) {
   const cwd = process.cwd()
   const absoluteThemePath = path.join(cwd, themeFilePath)
+  const absoluteThemeDir = path.dirname(absoluteThemePath)
 
-  const tsConfig = tsConfigPaths.loadConfig(absoluteThemePath)
+  const tsConfig = tsConfigPaths.loadConfig(absoluteThemeDir)
   if (tsConfig.resultType === "success") {
     tsNode.register({
       // use the TS projects own tsconfig file


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4755

## 📝 Description

The chakra CLI fails unexpectedly with a SyntaxError.

## ⛳️ Current behavior (updates)
The cli uses the theme file path to resolve a userland project `ts-config.json`.
It uses the npm package `tsconfig-paths` to resolve it, and its function `loadConfig()` requires a directory path to search for the `ts-config.json`. If it receives a file path it just uses this file. 

## 🚀 New behavior

Provide the directory of the given theme file to `loadConfig()` to let `tsconfig-paths` search for the correct `ts-config.json`.

## 💣 Is this a breaking change (Yes/No):

No
