### PR TITLE
chore: update jest module mock scoping to mimic server environment in ColorModeProvider server tests

### DIFF
--- a/packages/color-mode/test/color-mode-provider__browser.test.tsx
+++ b/packages/color-mode/test/color-mode-provider__browser.test.tsx
@@ -1,18 +1,25 @@
 import React from "react"
 import { render } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import {
-  mockIsBrowser,
   createMockStorageManager,
   defaultThemeOptions,
   getColorModeButton,
   DummyComponent,
 } from "./utils"
 import * as colorModeUtils from "../src/color-mode.utils"
-import userEvent from "@testing-library/user-event"
+
+jest.mock("@chakra-ui/utils", () => {
+  const actual = jest.requireActual("@chakra-ui/utils")
+
+  return {
+    ...actual,
+    isBrowser: true,
+  }
+})
 
 beforeEach(() => {
   jest.resetAllMocks()
-  mockIsBrowser(true)
 })
 
 describe("<ColorModeProvider /> localStorage browser", () => {

--- a/packages/color-mode/test/color-mode-provider__server.test.tsx
+++ b/packages/color-mode/test/color-mode-provider__server.test.tsx
@@ -9,9 +9,17 @@ import {
 } from "./utils"
 import * as colorModeUtils from "../src/color-mode.utils"
 
+jest.mock("@chakra-ui/utils", () => {
+  const actual = jest.requireActual("@chakra-ui/utils")
+
+  return {
+    ...actual,
+    isBrowser: false,
+  }
+})
+
 beforeEach(() => {
   jest.resetAllMocks()
-  mockIsBrowser(false)
 })
 
 describe("<ColorModeProvider /> localStorage server", () => {

--- a/packages/color-mode/test/color-mode-provider__server.test.tsx
+++ b/packages/color-mode/test/color-mode-provider__server.test.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { render } from "@testing-library/react"
 import {
-  mockIsBrowser,
   createMockStorageManager,
   defaultThemeOptions,
   getColorModeButton,
@@ -61,7 +60,6 @@ describe("<ColorModeProvider /> localStorage server", () => {
   })
 
   test("adds no mediaQueryListener if theme.config.useSystemColorMode is false", () => {
-    mockIsBrowser(false)
     const { ColorModeProvider } = require("../src/color-mode-provider")
 
     const addListenerSpy = jest.spyOn(colorModeUtils, "addListener")

--- a/packages/color-mode/test/utils.tsx
+++ b/packages/color-mode/test/utils.tsx
@@ -30,14 +30,3 @@ export const createMockStorageManager = (
     type,
   }
 }
-
-export const mockIsBrowser = (isBrowser: boolean) => {
-  jest.mock("@chakra-ui/utils", () => {
-    const actual = jest.requireActual("@chakra-ui/utils")
-
-    return {
-      ...actual,
-      isBrowser,
-    }
-  })
-}


### PR DESCRIPTION
## 📝 Description

Fixes a failing unit test inside the server tests for the `ColorModeProvider`.

## ⛳️ Current behavior (updates)

The unit test asserting if the local storage object's `get` method is called is failing because the mocked jest module is inside of a separate utility function, which gives it a different scope than where the actual import for `@chakra-ui/utils` is being called in each test.

See:

> [Note: In order to mock properly, Jest needs jest.mock('moduleName') to be in the same scope as the require/import statement.](https://jestjs.io/docs/26.x/manual-mocks#examples)

## 🚀 New behavior

Puts the mocked module inside of the `color-mode-provider__server.test.tsx` file so that all unit tests have the scope to this mocked module.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A