### PR TITLE
refactor: persist the DescendantsManager inside the useDescendant hook with React's useRef hook

### DIFF
--- a/packages/descendant/src/use-descendant.ts
+++ b/packages/descendant/src/use-descendant.ts
@@ -8,11 +8,11 @@ import { useSafeLayoutEffect, cast } from "./utils"
  * React hook that initializes the DescendantsManager
  */
 function useDescendants<T extends HTMLElement = HTMLElement, K = {}>() {
-  const [descendants] = useState(() => new DescendantsManager<T, K>())
+  const descendants = useRef(new DescendantsManager<T, K>())
   useSafeLayoutEffect(() => {
-    return () => descendants.destroy()
+    return () => descendants.current.destroy()
   })
-  return descendants
+  return descendants.current
 }
 
 export interface UseDescendantsReturn


### PR DESCRIPTION
## 📝 Description

This refactor makes the use of a `DescendantsManager` instance more predictable inside a `useDescendant` hook call in the `@chakra-ui/descendant" package. Given there is no destructuring or usage of the setter returned from React's `useState`'s array, it would be safe to assume that no new instances of the `DescendantsManager` need to be created during the `useDescendant` hook's lifecycle. Updates to the DOM nodes in which the `DescendantsManager` maintains are all in the instance of the `DescendantsManager` itself. Persisting the instance in `useState` adds another layer of state that isn't being used.

## ⛳️ Current behavior (updates)

The `useDescendant` hook persists an instance of a `DescendantsManager` by keeping its value in React's `useState` hook.

## 🚀 New behavior

The `useDescendant` hook uses React's `useRef` hook to persist the `DescendantsManager` instance between renders, similar to an instance variable.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables