### PR TITLE
fix(radio): support styling the container based on state

### DIFF
--- a/.changeset/dirty-emus-grab.md
+++ b/.changeset/dirty-emus-grab.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Add Support for styling the container element based on the radio state

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -76,6 +76,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
     getInputProps,
     getCheckboxProps,
     getLabelProps,
+    getRootProps,
     htmlProps,
   } = useRadio({
     ...rest,
@@ -91,6 +92,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
   const checkboxProps = getCheckboxProps(otherProps)
   const inputProps = getInputProps({}, ref)
   const labelProps = getLabelProps()
+  const rootProps = Object.assign(layoutProps, getRootProps())
 
   const rootStyles = {
     width: isFullWidth ? "full" : undefined,
@@ -115,7 +117,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
   }
 
   return (
-    <chakra.label className="chakra-radio" {...layoutProps} __css={rootStyles}>
+    <chakra.label className="chakra-radio" {...rootProps} __css={rootStyles}>
       <input className="chakra-radio__input" {...inputProps} />
       <chakra.span
         className="chakra-radio__control"

--- a/packages/radio/src/use-radio.ts
+++ b/packages/radio/src/use-radio.ts
@@ -256,6 +256,14 @@ export function useRadio(props: UseRadioProps = {}) {
     "data-invalid": dataAttr(isInvalid),
   })
 
+  const getRootProps: PropGetter = (pros, ref = null) => ({
+    ...props,
+    ref,
+    "data-disabled": dataAttr(isDisabled),
+    "data-checked": dataAttr(isChecked),
+    "data-invalid": dataAttr(isInvalid),
+  })
+
   return {
     state: {
       isInvalid,
@@ -270,6 +278,7 @@ export function useRadio(props: UseRadioProps = {}) {
     getCheckboxProps,
     getInputProps,
     getLabelProps,
+    getRootProps,
     htmlProps,
   }
 }


### PR DESCRIPTION
Closes #4741

## 📝 Description
Currently, it isn't possible to style the container of the `Radio`-element depending on the current state.

## 🚀 New behavior

Added `data-disabled` `data-checked` and `data-invalid` to the container of `Radio` to support the pseudo-selectors `_disabled` `_checked` and `_invalid` on the container

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
