### PR TITLE
refactor: update media query to use no deprecated functions

### DIFF
--- a/.changeset/sharp-snakes-camp.md
+++ b/.changeset/sharp-snakes-camp.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/media-query": minor
+---
+
+Update media query to use `addEventListener` and `removeEventListener` instead
+of the deprecated `addListener` and `removeListener` functions

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -74,7 +74,7 @@ export function useBreakpoint(defaultBreakpoint?: string) {
       }
 
       // add media query-listener
-      mediaQuery.addListener(handleChange)
+      mediaQuery.addEventListener("change", handleChange)
 
       // push the media query list handleChange
       // so we can use it to remove Listener
@@ -82,14 +82,14 @@ export function useBreakpoint(defaultBreakpoint?: string) {
 
       return () => {
         // clean up 1
-        mediaQuery.removeListener(handleChange)
+        mediaQuery.removeEventListener("change", handleChange)
       }
     })
 
     return () => {
       // clean up 2: for safety
       listeners.forEach(({ mediaQuery, handleChange }) => {
-        mediaQuery.removeListener(handleChange)
+        mediaQuery.removeEventListener("change", handleChange)
       })
       listeners.clear()
     }

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -33,14 +33,14 @@ export function useMediaQuery(query: string | string[]): boolean[] {
           ),
         )
 
-      mediaQuery.addListener(listener)
+      mediaQuery.addEventListener("change", listener)
 
       return listener
     })
 
     return () => {
       mediaQueryList.forEach((mediaQuery, index) => {
-        mediaQuery.removeListener(listenerList[index])
+        mediaQuery.removeEventListener("change", listenerList[index])
       })
     }
   }, [query])

--- a/yarn.lock
+++ b/yarn.lock
@@ -4798,15 +4798,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@popperjs/core@2.4.4":
+"@popperjs/core@2.4.4", "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
-
-"@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.1.tgz#728ecd95ab207aab8a9a4e421f0422db329232be"
-  integrity sha512-HnUhk1Sy9IuKrxEMdIRCxpIqPw6BFsbYSEUO9p/hNw5sMld/+3OLMWQP80F8/db9qsv3qUjs7ZR5bS/R+iinXw==
 
 "@reach/alert@0.13.2":
   version "0.13.2"
@@ -22449,7 +22444,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^17.0.1:
+react-dom@17.0.1, react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
   integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
@@ -22855,7 +22850,7 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^17.0.1:
+react@17.0.1, react@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

update media query to use `addEventListener` and `removeEventListener`
instead of the deprecated `addListener` and `removeListener` functions.
https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener

## ⛳️ Current behavior (updates)

The used functions in the `media-query` package are deprecated.

## 🚀 New behavior

The used functions in the `media-query` package are not deprecated.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
