### PR TITLE
fix: iframe bug on firefox

### DIFF
--- a/.changeset/few-jars-tan.md
+++ b/.changeset/few-jars-tan.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/utils": patch
+---
+
+Fixed iframe bug on firefox when using `getRelatedTarget` function

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -94,8 +94,7 @@ export function getRelatedTarget(
 ) {
   const target = (event.target ?? event.currentTarget) as HTMLElement
   const activeElement = getActiveElement(target)
-  const originalTarget = (event as any).nativeEvent.explicitOriginalTarget
-  return (event.relatedTarget ?? originalTarget ?? activeElement) as HTMLElement
+  return (event.relatedTarget ?? activeElement) as HTMLElement
 }
 
 export function isRightClick(event: Pick<MouseEvent, "button">): boolean {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4425 <!-- Github issue # here -->

## 📝 Description

This PR fixes the bug where the popover window will not close when clicking on an iframe on Firefox.

## ⛳️ Current behavior (updates)

The `getRelatedTarget()` function [here](https://github.com/chakra-ui/chakra-ui/blob/7d54710a00472ac1658592fa2537175c742fb346/packages/popover/src/use-popover.ts#L223), uses `explicitOriginalTarget`, a Firefox/Mozilla-specific API, which causes inconsistent behavior between browsers. `explicitOriginalTarget` evaluates a valid element on Firefox, but `null` for other browsers (Safari, Chrome)

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

This is my attempt to address the issue mentioned, any inputs/feedbacks are welcome, and appreciated as I am not sure if this is the best approach.

For this PR, I removed `explicitOriginalTarget` from the `getRelatedTarget` function, which is being referenced by **Editable** and **Popover** package, both seem working fine after the change.