### PR TITLE
fix(docs): fix ColorModeScript for Next.js highlight code line

### DIFF
--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -87,7 +87,7 @@ syncing to work correctly.
 
 For Next.js, you need to add the `ColorModeScript` to the `_document.js` file.
 
-```jsx live=false ln={16}
+```jsx live=false ln={14}
 // pages/_document.js
 
 import { ColorModeScript } from "@chakra-ui/react"
@@ -100,6 +100,7 @@ export default class Document extends NextDocument {
       <Html lang="en">
         <Head />
         <body>
+          {/* 👇 Here's the script */}
           <ColorModeScript initialColorMode={theme.config.initialColorMode} />
           <Main />
           <NextScript />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
The highlighted part of the code in ColorModeScript for Next.js in the document page was wrong, so I fixed it.



## ⛳️ Current behavior (updates)

### before
<img width="903" alt="screenshot 2021-10-06 12 01 58" src="https://user-images.githubusercontent.com/44772513/136134399-df4860a5-97cf-40b5-8825-cb02733cd4f8.png">


## 🚀 New behavior
### after
<img width="894" alt="screenshot 2021-10-06 12 03 49" src="https://user-images.githubusercontent.com/44772513/136134459-ae35fbc7-d544-4afc-bd93-8ab8f77ae3bd.png">

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
