### PR TITLE
fix(media-query): correct useMediaQuery hook to correctly report quer…

### DIFF
--- a/.changeset/fifty-starfishes-drop.md
+++ b/.changeset/fifty-starfishes-drop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+Corrected eslint errors.

--- a/.changeset/three-peaches-matter.md
+++ b/.changeset/three-peaches-matter.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+This fixes an issue where the useMediaQuery was not updating the array of
+statuses correctly when resizing the view. It also removes deprecated calls
+addListener and removeListener in favor of the recommended addEventListener and
+removeEventListener calls.

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -26,21 +26,24 @@ export function useMediaQuery(query: string | string[]): boolean[] {
     const mediaQueryList = queries.map((query) => env.window.matchMedia(query))
 
     const listenerList = mediaQueryList.map((mediaQuery, index) => {
-      const listener = () =>
-        setMatches((prev) =>
-          prev.map((prevValue, idx) =>
-            index === idx ? !!mediaQuery.matches : prevValue,
-          ),
-        )
+      const listener = () => {
+        const isEqual = (prev: boolean[], curr: boolean[]) =>
+          prev.length === curr.length &&
+          prev.every((elem, idx) => elem === curr[idx])
 
-      mediaQuery.addListener(listener)
+        const currentMatches = mediaQueryList.map((query) => query.matches)
+
+        !isEqual(matches, currentMatches) && setMatches(currentMatches)
+      }
+
+      env.window.addEventListener("resize", listener)
 
       return listener
     })
 
     return () => {
       mediaQueryList.forEach((mediaQuery, index) => {
-        mediaQuery.removeListener(listenerList[index])
+        env.window.removeEventListener("resize", listenerList[index])
       })
     }
   }, [query])

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -25,15 +25,19 @@ export function useMediaQuery(query: string | string[]): boolean[] {
 
     const mediaQueryList = queries.map((query) => env.window.matchMedia(query))
 
-    const listenerList = mediaQueryList.map((mediaQuery, index) => {
+    const listenerList = mediaQueryList.map(() => {
       const listener = () => {
         const isEqual = (prev: boolean[], curr: boolean[]) =>
           prev.length === curr.length &&
           prev.every((elem, idx) => elem === curr[idx])
 
-        const currentMatches = mediaQueryList.map((query) => query.matches)
+        const currentMatches = mediaQueryList.map(
+          (mediaQuery) => mediaQuery.matches,
+        )
 
-        !isEqual(matches, currentMatches) && setMatches(currentMatches)
+        if (!isEqual(matches, currentMatches)) {
+          setMatches(currentMatches)
+        }
       }
 
       env.window.addEventListener("resize", listener)
@@ -42,7 +46,7 @@ export function useMediaQuery(query: string | string[]): boolean[] {
     })
 
     return () => {
-      mediaQueryList.forEach((mediaQuery, index) => {
+      mediaQueryList.forEach((_, index) => {
         env.window.removeEventListener("resize", listenerList[index])
       })
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4657

## 📝 Description

This PR fixes the issue with the `useMediaQuery` hook. When passing an array of queries to the hook, a change in size of the window did not set the previously set state back to false. As a result, multiple values you indicate a true state.

## ⛳️ Current behavior (updates)

 Please describe the current behavior that you are modifying

## 🚀 New behavior

Array of boolean states for the media queries now accurately reflects the current media state. [CSB app](https://codesandbox.io/s/usemediaquery-fix-je4ed) demonstrates usage of the original `useMediaQuery` hook and the hook with the fixed applied. The fix also replaces deprecated calls to `addListener` and `removeListener` with the recommended `addEventListener` and `removeEventListener` calls.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
