### PR TITLE
(docs): updated Custom Breakpoints sample

### DIFF
--- a/website/pages/docs/features/responsive-styles.mdx
+++ b/website/pages/docs/features/responsive-styles.mdx
@@ -193,6 +193,7 @@ const breakpoints = createBreakpoints({
   md: "768px",
   lg: "960px",
   xl: "1200px",
+  "2xl": "1536px",
 })
 
 // 3. Extend the theme
@@ -203,6 +204,10 @@ function Example() {
   return <Box width={{ base: "100%", sm: "50%", md: "25%" }} />
 }
 ```
+
+> Note: If you're using **pixels** as breakpoint values make sure to **always**
+> provide a value for the `2xl` breakpoint, which by its default pixels value is
+> **"1536px"**.
 
 ## Demo
 


### PR DESCRIPTION
## 📝 Description

Updated Custom Breakpoints sample to provide a value for the 2xl breakpoint to remind the users to always provide a value for the `2xl` breakpoint if they're using pixels as values.

## ⛳️ Current behavior (updates)

The old sample doesn't provide a value for the `2xl`, therefore copy pasting it will trigger a render loop ([here's a CodeSandbox example](https://codesandbox.io/s/custom-breakpoints-value-render-loop-xs63z?file=/src/index.tsx))

## 🚀 New behavior

The new sample includes a value for the `2xl` breakpoint and also a note below the code to serve as a reminder.

## 💣 Is this a breaking change (Yes/No):

No