### PR TITLE
feat(tooltip): support `motionPreset`

### DIFF
--- a/.changeset/purple-readers-decide.md
+++ b/.changeset/purple-readers-decide.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/tooltip": patch
+"@chakra-ui/docs": patch
+---
+
+- Add `motionPreset` prop to tooltip to be able to change default transition

--- a/packages/tooltip/src/tooltip.transition.tsx
+++ b/packages/tooltip/src/tooltip.transition.tsx
@@ -1,3 +1,4 @@
+import { scaleFadeConfig, slideFadeConfig } from "@chakra-ui/transition"
 import { Variants } from "framer-motion"
 
 export const scale: Variants = {
@@ -16,5 +17,14 @@ export const scale: Variants = {
       opacity: { easings: "easeOut", duration: 0.2 },
       scale: { duration: 0.2, ease: [0.175, 0.885, 0.4, 1.1] },
     },
+  },
+}
+
+export const transitions = {
+  none: {},
+  scale: { ...scaleFadeConfig, variants: scale },
+  slideInTop: {
+    ...slideFadeConfig,
+    custom: { offsetX: 0, offsetY: -20 },
   },
 }

--- a/packages/tooltip/src/tooltip.transition.tsx
+++ b/packages/tooltip/src/tooltip.transition.tsx
@@ -27,4 +27,16 @@ export const transitions = {
     ...slideFadeConfig,
     custom: { offsetX: 0, offsetY: -20 },
   },
+  slideInBottom: {
+    ...slideFadeConfig,
+    custom: { offsetX: 0, offsetY: 20 },
+  },
+  slideInLeft: {
+    ...slideFadeConfig,
+    custom: { offsetX: -20, offsetY: 0 },
+  },
+  slideInRight: {
+    ...slideFadeConfig,
+    custom: { offsetX: 20, offsetY: 0 },
+  },
 }

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -16,7 +16,13 @@ import * as React from "react"
 import { transitions } from "./tooltip.transition"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
 
-type MotionPreset = "slideInTop" | "scale" | "none"
+type MotionPreset =
+  | "slideInTop"
+  | "slideInBottom"
+  | "slideInLeft"
+  | "slideInRight"
+  | "scale"
+  | "none"
 
 export interface TooltipProps
   extends HTMLChakraProps<"div">,

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -13,8 +13,10 @@ import { isString, omit, pick, __DEV__, getCSSVar } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
 import { AnimatePresence, motion } from "framer-motion"
 import * as React from "react"
-import { scale } from "./tooltip.transition"
+import { transitions } from "./tooltip.transition"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
+
+type MotionPreset = "slideInTop" | "scale" | "none"
 
 export interface TooltipProps
   extends HTMLChakraProps<"div">,
@@ -50,6 +52,10 @@ export interface TooltipProps
    * Props to be forwarded to the portal component
    */
   portalProps?: Pick<PortalProps, "appendToParentPortal" | "containerRef">
+  /**
+   * The transition that should be used for the tooltip
+   */
+  motionPreset?: MotionPreset
 }
 
 const StyledTooltip = chakra(motion.div)
@@ -73,6 +79,7 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
     hasArrow,
     bg,
     portalProps,
+    motionPreset,
     ...rest
   } = ownProps
 
@@ -124,6 +131,8 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
     return <>{children}</>
   }
 
+  const motionProps = transitions[motionPreset || "scale"]
+
   return (
     <>
       {trigger}
@@ -138,11 +147,8 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
               }}
             >
               <StyledTooltip
-                variants={scale}
+                {...motionProps}
                 {...(tooltipProps as any)}
-                initial="exit"
-                animate="enter"
-                exit="exit"
                 __css={styles}
               >
                 {label}

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -1,6 +1,7 @@
 import { Modal, ModalContent, ModalOverlay } from "@chakra-ui/modal"
 import { Portal } from "@chakra-ui/portal"
 import { chakra } from "@chakra-ui/system"
+import { HStack } from "@chakra-ui/react"
 import { AnimatePresence, motion } from "framer-motion"
 import * as React from "react"
 import { Tooltip, useTooltip } from "../src"
@@ -242,6 +243,31 @@ export const withAutoPlacement = () => (
       Can't Touch This
     </button>
   </Tooltip>
+)
+
+export const withMotionPreset = () => (
+  <HStack spacing="48px">
+    <Tooltip label="Hello world">Default</Tooltip>
+    <Tooltip label="Hello world" motionPreset="none">
+      None
+    </Tooltip>
+    <Tooltip label="Hello world" motionPreset="slideInTop" placement="top">
+      Top
+    </Tooltip>
+    <Tooltip
+      label="Hello world"
+      motionPreset="slideInBottom"
+      placement="bottom"
+    >
+      Bottom
+    </Tooltip>
+    <Tooltip label="Hello world" motionPreset="slideInLeft" placement="left">
+      Left
+    </Tooltip>
+    <Tooltip label="Hello world" motionPreset="slideInRight" placement="right">
+      Right
+    </Tooltip>
+  </HStack>
 )
 
 declare module "csstype" {

--- a/website/pages/docs/overlay/tooltip.mdx
+++ b/website/pages/docs/overlay/tooltip.mdx
@@ -105,7 +105,7 @@ cursor out of the element.
 ### Changing Tooltip transition
 
 Change the `Tooltip` transition using a `motionPreset` prop that can be either
-`slideInTop`, `scale` or `none`. Default is set to `scale`.
+`slideInTop`, `slideInBottom`, `slideInLeft`, `slideInRight`, `scale` or `none`. Default is set to `scale`.
 
 ```jsx
 <Wrap spacing={6}>

--- a/website/pages/docs/overlay/tooltip.mdx
+++ b/website/pages/docs/overlay/tooltip.mdx
@@ -102,6 +102,33 @@ cursor out of the element.
 </Tooltip>
 ```
 
+### Changing Tooltip transition
+
+Change the `Tooltip` transition using a `motionPreset` prop that can be either
+`slideInTop`, `scale` or `none`. Default is set to `scale`.
+
+```jsx
+<Wrap spacing={6}>
+  <WrapItem>
+    <Tooltip label="Hello world" motionPreset="none">
+      No transition
+    </Tooltip>
+  </WrapItem>
+
+  <WrapItem>
+    <Tooltip label="Hello world" motionPreset="slideInTop">
+      Slide-in-Top
+    </Tooltip>
+  </WrapItem>
+
+  <WrapItem>
+    <Tooltip label="Hello world" motionPreset="scale">
+      Scale
+    </Tooltip>
+  </WrapItem>
+</Wrap>
+```
+
 ## Placement
 
 Using the `placement` prop you can adjust where your tooltip will be displayed.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Partially Closes #4722 

## 📝 Description

Add support for `motionPreset` to be either `none`, `slideInTop` and `scale` on Tooltip component.

## ⛳️ Current behavior (updates)

Current the Tooltip component only has one transition which is scale.

## 🚀 New behavior

You can try different transitions or disable them with the `motionPreset` prop.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information

![tooltip](https://user-images.githubusercontent.com/30840709/136678295-553b7025-563c-44b1-835e-51747fa7c382.gif)

