### PR TITLE
fix(radio):  removed aria-readonly in favor of wcag 4.1.2

### DIFF
--- a/.changeset/two-weeks-think.md
+++ b/.changeset/two-weeks-think.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/radio": patch
+---
+
+#4851 Removed aria-readonly from checkbox in favor of wcag 4.1.2

--- a/packages/radio/src/use-radio.ts
+++ b/packages/radio/src/use-radio.ts
@@ -222,8 +222,8 @@ export function useRadio(props: UseRadioProps = {}) {
         required: isRequired,
         "aria-invalid": ariaAttr(isInvalid),
         "aria-disabled": ariaAttr(trulyDisabled),
-        "aria-readonly": ariaAttr(isReadOnly),
         "aria-required": ariaAttr(isRequired),
+        "data-readonly": dataAttr(isReadOnly),
         style: visuallyHiddenStyle,
       }
     },

--- a/packages/radio/tests/radio.test.tsx
+++ b/packages/radio/tests/radio.test.tsx
@@ -155,7 +155,7 @@ test("should derive values from surrounding FormControl", () => {
   expect(radio).toHaveAttribute("id", "radio")
   expect(radio).toHaveAttribute("aria-invalid", "true")
   expect(radio).toHaveAttribute("aria-required", "true")
-  expect(radio).toHaveAttribute("aria-readonly", "true")
+  expect(radio).toHaveAttribute("data-readonly", "")
   expect(radio).toHaveAttribute("aria-invalid", "true")
 
   fireEvent.focus(radio)


### PR DESCRIPTION
Closes #4851 

## 🚀 New behavior

Removed `aria-readonly` from radio in favor of wcag 4.1.2 https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html

## 💣 Is this a breaking change (Yes/No):

Yes - if someone checks on `aria-readonly` for any reason but it doesn't affect the `_readonly` pseudo selector.

