### PR TITLE
chore(website): remove deprecated `experimental.modern` option

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -11,7 +11,6 @@ const defaultConfig = {
   }),
   experimental: {
     optimizeFonts: true,
-    modern: true,
   },
   redirects: require("./next-redirect"),
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`experimental.modern: true` is deprecated and removed from Next.js around `v10.0.3`.

https://github.com/vercel/next.js/pull/19275

## ⛳️ Current behavior (updates)

That flag just ignored.

## 🚀 New behavior

No behavior changes.

## 💣 Is this a breaking change (Yes/No): No


## 📝 Additional Information

I think website bundle size lightening is in a different context, this PR just remove deprecated flag.