### PR TITLE
fix: always use fromEntries polyfill from @chakra-ui/utils #4872

### DIFF
--- a/.changeset/tall-shoes-remain.md
+++ b/.changeset/tall-shoes-remain.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react": patch
+"@chakra-ui/theme-tools": patch
+"@chakra-ui/utils": patch
+---
+
+fix: always use fromEntries polyfill from @chakra-ui/utils #4872

--- a/packages/react/src/theme-extensions/with-default-color-scheme.ts
+++ b/packages/react/src/theme-extensions/with-default-color-scheme.ts
@@ -1,5 +1,5 @@
 import { ThemingProps } from "@chakra-ui/system"
-import { Dict, isObject } from "@chakra-ui/utils"
+import { Dict, isObject, fromEntries } from "@chakra-ui/utils"
 import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
 
 export function withDefaultColorScheme({
@@ -19,7 +19,7 @@ export function withDefaultColorScheme({
     }
 
     return mergeThemeOverride(theme, {
-      components: Object.fromEntries(
+      components: fromEntries(
         names.map((componentName) => {
           const withColorScheme = {
             defaultProps: {

--- a/packages/react/src/theme-extensions/with-default-size.ts
+++ b/packages/react/src/theme-extensions/with-default-size.ts
@@ -1,5 +1,5 @@
 import { ThemingProps } from "@chakra-ui/system"
-import { Dict, isObject } from "@chakra-ui/utils"
+import { Dict, isObject, fromEntries } from "@chakra-ui/utils"
 import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
 
 export function withDefaultSize({
@@ -19,7 +19,7 @@ export function withDefaultSize({
     }
 
     return mergeThemeOverride(theme, {
-      components: Object.fromEntries(
+      components: fromEntries(
         names.map((componentName) => {
           const withSize = {
             defaultProps: {

--- a/packages/react/src/theme-extensions/with-default-variant.ts
+++ b/packages/react/src/theme-extensions/with-default-variant.ts
@@ -1,5 +1,5 @@
 import { ThemingProps } from "@chakra-ui/system"
-import { Dict, isObject } from "@chakra-ui/utils"
+import { Dict, isObject, fromEntries } from "@chakra-ui/utils"
 import { mergeThemeOverride, ThemeExtension } from "../extend-theme"
 
 export function withDefaultVariant({
@@ -19,7 +19,7 @@ export function withDefaultVariant({
     }
 
     return mergeThemeOverride(theme, {
-      components: Object.fromEntries(
+      components: fromEntries(
         names.map((componentName) => {
           const withVariant = {
             defaultProps: {

--- a/packages/theme-tools/src/anatomy.ts
+++ b/packages/theme-tools/src/anatomy.ts
@@ -1,3 +1,4 @@
+import { fromEntries } from "@chakra-ui/utils"
 /**
  * Used to define the anatomy/parts of a component in a way that provides
  * a consistent API for `className`, css selector and `theming`.
@@ -49,7 +50,7 @@ export class Anatomy<T extends string = string> {
    * Get all selectors for the component anatomy
    */
   get selectors() {
-    const value = Object.fromEntries(
+    const value = fromEntries(
       Object.entries(this.map).map(([key, part]) => [
         key,
         (part as any).selector,
@@ -62,7 +63,7 @@ export class Anatomy<T extends string = string> {
    * Get all classNames for the component anatomy
    */
   get classNames() {
-    const value = Object.fromEntries(
+    const value = fromEntries(
       Object.entries(this.map).map(([key, part]) => [
         key,
         (part as any).className,

--- a/packages/utils/src/walk-object.ts
+++ b/packages/utils/src/walk-object.ts
@@ -1,4 +1,5 @@
 import { isArray, isObject } from "./assertion"
+import { fromEntries } from "./object"
 
 export type WalkObjectPredicate<Leaf = unknown> = (
   value: unknown,
@@ -23,7 +24,7 @@ export function walkObject<Target, LeafType>(
     }
 
     if (isObject(value)) {
-      return Object.fromEntries(
+      return fromEntries(
         Object.entries(value).map(([key, child]) => [
           key,
           inner(child, [...path, key]),


### PR DESCRIPTION
Closes  #4872 

## 📝 Description

Removes references to `Object.fromEntries` and replaces them with the polyfilled version from `@chakra-ui/utils`

## 💣 Is this a breaking change (Yes/No): No
