### PR TITLE
fix(menu): fix performance when computePositionOnMount is not set

### DIFF
--- a/.changeset/plenty-cougars-protect.md
+++ b/.changeset/plenty-cougars-protect.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fix issue where computePositionOnMount didn't work without explict value

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -138,7 +138,7 @@ export function useMenu(props: UseMenuProps = {}) {
     placement = "bottom-start",
     lazyBehavior = "unmount",
     direction,
-    computePositionOnMount,
+    computePositionOnMount = false,
     ...popperProps
   } = props
   const { isOpen, onOpen, onClose, onToggle } = useDisclosure({


### PR DESCRIPTION
## 📝 Description

Unless `computePositionOnMount` is set to true, popper shouldn't be initialized until the menu is open.
Currently this is broken and if `computePositionOnMount` is not explicitly set, popper.js is always initialized on Menu mount and it causes bad scroll performance.

The same issue was fixed for `Popover` in `@chakra-ui/react@1.6.10`.

## 💣 Is this a breaking change (Yes/No):

No

