### PR TITLE
improve typings

### DIFF
--- a/packages/styled-system/src/utils/parse-border.ts
+++ b/packages/styled-system/src/utils/parse-border.ts
@@ -13,7 +13,7 @@ const styleMatch = /none|hidden|dotted|dashed|solid|double|groove|ridge|inset|ou
  * raw values.
  */
 export function parseBorder(value: string, key = "border") {
-  const css = {}
+  const css: Record<string, string> = {}
 
   const split = value.split(" ")
   const [style] = matchString(value, styleMatch) || [""]


### PR DESCRIPTION
VSCode kept complaining `Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'` on css[borderStyleKey]. This seems to silence it