### PR TITLE
fix(modal): add missing div props

### DIFF
--- a/.changeset/silver-bugs-heal.md
+++ b/.changeset/silver-bugs-heal.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Add HTMLChakraProps<"div"> to ModalProps since remaining props are injected to a
+container div

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -92,7 +92,8 @@ type MotionPreset = "slideInBottom" | "slideInRight" | "scale" | "none"
 export interface ModalProps
   extends UseModalProps,
     ModalOptions,
-    ThemingProps<"Modal"> {
+    ThemingProps<"Modal">,
+    HTMLChakraProps<"div"> {
   children: React.ReactNode
   /**
    *  If `true`, the modal will be centered on screen.


### PR DESCRIPTION
## 📝 Description

Include missing `HTMLChakraProps<"div">` to `ModalProps`, it is possible to pass those additional props as seen in https://github.com/chakra-ui/chakra-ui/blob/910a701f9f3b16157f287479a3df64a2ea84090b/packages/modal/src/modal.tsx#L253-L254

## ⛳️ Current behavior (updates)

We can see the following error when customizing the `Modal` even though the props are passed correctly to the container `div`
```
Type '{ children: Element[]; isOpen: boolean; justifyContent: string; onClose: () => void; }' is not assignable to type 'IntrinsicAttributes & ModalProps & { children?: ReactNode; }'.
  Property 'justifyContent' does not exist on type 'IntrinsicAttributes & ModalProps & { children?: ReactNode; }'
```

```tsx
   <>
      <Button onClick={onOpen}>Trigger modal</Button>

      <Modal onClose={onClose} isOpen={isOpen} justifyContent="flex-start">
        <ModalOverlay />
        <ModalContent>
          <ModalHeader>Modal Title</ModalHeader>
          <ModalCloseButton />
          <ModalBody>
            <Lorem count={2} />
          </ModalBody>
          <ModalFooter>
            <Button onClick={onClose}>Close</Button>
          </ModalFooter>
        </ModalContent>
      </Modal>
    </>
```

## 🚀 New behavior

Extend `ModalProps` interface to also include `HTMLChakraProps<"div">`, which removes the above error and allows to fully customise the `Modal` with the correct interface

## 💣 Is this a breaking change (No)


## 📝 Additional Information
