### PR TITLE
chore(jest): replace remaining ts-jest with @swc-node/jest

### DIFF
--- a/packages/anatomy/jest.config.js
+++ b/packages/anatomy/jest.config.js
@@ -1,9 +1,8 @@
 module.exports = {
-  preset: "ts-jest",
   testEnvironment: "node",
   collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
   transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
+    ".(ts|tsx)$": "@swc-node/jest",
   },
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],

--- a/packages/env/jest.config.js
+++ b/packages/env/jest.config.js
@@ -1,9 +1,8 @@
 module.exports = {
-  preset: "ts-jest",
   testEnvironment: "node",
   collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
   transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
+    ".(ts|tsx)$": "@swc-node/jest",
   },
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],

--- a/packages/react-utils/jest.config.js
+++ b/packages/react-utils/jest.config.js
@@ -1,9 +1,8 @@
 module.exports = {
-  preset: "ts-jest",
   testEnvironment: "node",
   collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
   transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
+    ".(ts|tsx)$": "@swc-node/jest",
   },
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],

--- a/plop-templates/component/jest.config.js.hbs
+++ b/plop-templates/component/jest.config.js.hbs
@@ -1,9 +1,8 @@
 module.exports = {
-  preset: "ts-jest",
   testEnvironment: "node",
   collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
   transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
+    ".(ts|tsx)$": "@swc-node/jest",
   },
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],

--- a/tooling/cli/jest.config.js
+++ b/tooling/cli/jest.config.js
@@ -1,9 +1,8 @@
 module.exports = {
-  preset: "ts-jest",
   testEnvironment: "node",
   collectCoverageFrom: ["tests/**/*.{ts,tsx,js,jsx}"],
   transform: {
-    ".(ts|tsx)$": "ts-jest/dist",
+    "^.+\\.(ts|tsx)?$": "@swc-node/jest",
   },
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],


### PR DESCRIPTION
## 📝 Description

> Add a brief description
The ts-jest settings were still in place, so switch these to `@swc/jest`.

## ⛳️ Current behavior (updates)
Some packages specify ts-jest which is removed, so you will get an error.

## 🚀 New behavior
All tests will succeed🚀


## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
