### PR TITLE
fix(checkbox): remove focus styles when disabled

### DIFF
--- a/.changeset/old-pigs-flow.md
+++ b/.changeset/old-pigs-flow.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+fix(checkbox): remove focus styles when disabled

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -11,6 +11,7 @@ import React, {
   ChangeEvent,
   KeyboardEvent,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react"
@@ -188,6 +189,12 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       inputRef.current.indeterminate = Boolean(isIndeterminate)
     }
   }, [isIndeterminate])
+
+  useEffect(() => {
+    if (isDisabled) {
+      setFocused.off()
+    }
+  }, [isDisabled, setFocused])
 
   const trulyDisabled = isDisabled && !isFocusable
 


### PR DESCRIPTION
Closes #4596

## 📝 Description

related issue is in the React library.see https://github.com/facebook/react/issues/9142

## ⛳️ Current behavior (updates)

If it is disabled, then remove disabled.The focused style cannot be removed

## 🚀 New behavior

Once disabled, focus styles are removed

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

Since the switch is not isLoading, I use isDisabled instead.It would be nice if you could add isLoading to the switch