### PR TITLE
fix(popper): usePopperProps offset type definition

### DIFF
--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -19,7 +19,7 @@ export interface UsePopperProps {
    * The main and cross-axis offset to displace popper element
    * from its reference element.
    */
-  offset?: [crossAxis: number, mainAxis: number]
+  offset?: [number, number]
   /**
    * The distance or margin between the reference and popper.
    * It is used internally to create an `offset` modifier.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

UsePopperProps offset has Typescript error.
simply fixed type definition

## ⛳️ Current behavior (updates)

```
',' expected.  TS1005

    11 |      * from its reference element.
    12 |      */
  > 13 |     offset?: [crossAxis: number, mainAxis: number];
       |                        ^
    14 |     /**
    15 |      * The distance or margin between the reference and popper.
    16 |      * It is used internally to create an `offset` modifier.
```

## 🚀 New behavior

fixed this error.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
