### PR TITLE
feat(toast): expose Toast wrapper style prop for override

### DIFF
--- a/.changeset/moody-bees-pay.md
+++ b/.changeset/moody-bees-pay.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": minor
+---
+
+exposes toast component's wrapper style prop

--- a/.changeset/moody-bees-pay.md
+++ b/.changeset/moody-bees-pay.md
@@ -2,4 +2,31 @@
 "@chakra-ui/toast": minor
 ---
 
-exposes toast component's wrapper style prop
+The `toast` function now exposes a `containerStyle` property you can use to
+override the default styles for the toast container.
+```jsx live=false
+function Example() {
+  // Via instantiation
+  const toast = useToast({
+    position: "top",
+    title: "Container style is customizable",
+    containerStyle: {
+      maxWidth: "100%",
+    },
+  })
+
+  // Or via trigger
+  return (
+    <Button
+      onClick={() => {
+        toast({
+          containerStyle: {
+            maxWidth: '100%',
+          },
+        })
+      }}
+    >
+      Click me to show toast with custom container style.
+    </Button>
+  )
+}

--- a/packages/toast/src/toast-manager.tsx
+++ b/packages/toast/src/toast-manager.tsx
@@ -27,7 +27,12 @@ interface Props {
 type CreateToastOptions = Partial<
   Pick<
     ToastOptions,
-    "status" | "duration" | "position" | "id" | "onCloseComplete"
+    | "status"
+    | "duration"
+    | "position"
+    | "id"
+    | "onCloseComplete"
+    | "wrapperStyle"
   >
 >
 
@@ -167,6 +172,7 @@ export class ToastManager extends React.Component<Props, ToastState> {
       onRequestRemove: () => this.removeToast(String(id), position),
       status: options.status,
       requestClose: false,
+      wrapperStyle: options.wrapperStyle,
     }
   }
 

--- a/packages/toast/src/toast-manager.tsx
+++ b/packages/toast/src/toast-manager.tsx
@@ -32,7 +32,7 @@ type CreateToastOptions = Partial<
     | "position"
     | "id"
     | "onCloseComplete"
-    | "wrapperStyle"
+    | "containerStyle"
   >
 >
 
@@ -172,7 +172,7 @@ export class ToastManager extends React.Component<Props, ToastState> {
       onRequestRemove: () => this.removeToast(String(id), position),
       status: options.status,
       requestClose: false,
-      wrapperStyle: options.wrapperStyle,
+      containerStyle: options.containerStyle,
     }
   }
 

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -68,7 +68,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
     requestClose = false,
     position = "bottom",
     duration = 5000,
-    wrapperStyle = {},
+    containerStyle = {},
   } = props
 
   const [delay, setDelay] = React.useState(duration)
@@ -122,7 +122,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
           maxWidth: 560,
           minWidth: 300,
           margin: "0.5rem",
-          ...wrapperStyle,
+          ...containerStyle,
         }}
       >
         {isFunction(message) ? message({ id, onClose: close }) : message}

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -68,6 +68,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
     requestClose = false,
     position = "bottom",
     duration = 5000,
+    wrapperStyle = {},
   } = props
 
   const [delay, setDelay] = React.useState(duration)
@@ -121,6 +122,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
           maxWidth: 560,
           minWidth: 300,
           margin: "0.5rem",
+          ...wrapperStyle,
         }}
       >
         {isFunction(message) ? message({ id, onClose: close }) : message}

--- a/packages/toast/src/toast.types.ts
+++ b/packages/toast/src/toast.types.ts
@@ -57,7 +57,7 @@ export interface ToastOptions {
   /**
    * Optional style overrides for the toast component.
    */
-  wrapperStyle?: React.CSSProperties
+  containerStyle?: React.CSSProperties
 }
 
 export type ToastState = {

--- a/packages/toast/src/toast.types.ts
+++ b/packages/toast/src/toast.types.ts
@@ -54,6 +54,10 @@ export interface ToastOptions {
    * anyone else, but documented regardless.
    */
   requestClose?: boolean
+  /**
+   * Optional style overrides for the toast component.
+   */
+  wrapperStyle?: React.CSSProperties
 }
 
 export type ToastState = {

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -74,6 +74,10 @@ export interface UseToastOptions {
    * Callback function to run side effects after the toast has closed.
    */
   onCloseComplete?: () => void
+  /**
+   * Optional style overrides for the container wrapping the toast component.
+   */
+  wrapperStyle?: React.CSSProperties
 }
 
 type UseToastOptionsNormalized = WithoutLogicalPosition<UseToastOptions>

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -77,7 +77,7 @@ export interface UseToastOptions {
   /**
    * Optional style overrides for the container wrapping the toast component.
    */
-  wrapperStyle?: React.CSSProperties
+  containerStyle?: React.CSSProperties
 }
 
 type UseToastOptionsNormalized = WithoutLogicalPosition<UseToastOptions>

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -248,11 +248,11 @@ export const UseToastWithDefaults = () => {
   return <Button onClick={() => toast()}>toast</Button>
 }
 
-export const UseToastWithCustomWrapperStyle = () => {
+export const UseToastWithCustomContainerStyle = () => {
   const toast = useToast({
     position: "top",
-    title: "Wrapper style is updated",
-    wrapperStyle: {
+    title: "Container style is updated",
+    containerStyle: {
       width: "800px",
       maxWidth: "100%",
       border: "20px solid red",

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -248,6 +248,20 @@ export const UseToastWithDefaults = () => {
   return <Button onClick={() => toast()}>toast</Button>
 }
 
+export const UseToastWithCustomWrapperStyle = () => {
+  const toast = useToast({
+    position: "top",
+    title: "Wrapper style is updated",
+    wrapperStyle: {
+      width: "800px",
+      maxWidth: "100%",
+      border: "20px solid red",
+    },
+  })
+
+  return <Button onClick={() => toast()}>toast</Button>
+}
+
 export const useToastCustomRenderUpdate = () => {
   const [id, setId] = React.useState(null)
   const toast = useToast()


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4387

This PR is a continuation of #4432 since that PR seems to have been abandoned. As such, the description is copied from that original PR and extended if necessary.

## 📝 Description

When users set a fixed-width on their custom toast, this causes their toast to not be centered. This is because we set a fixed `maxWidth` property on the wrapper component around the toast, which results in the invisible wrapper being centered correctly, but the visible custom component overflowing the parent (the wrapper), making it seem off-centered.

A more detailed explanation of why this arises can be found [here](https://github.com/chakra-ui/chakra-ui/issues/4387#issuecomment-884419618)

## ⛳️ Current behavior (updates)

The div (with `class="chakra-toast__inner"`) wrapping the dispatched `Toast` component currently has a hardcoded style, causing toasts to appear off-center if its child element has a width that is higher than the hardcoded `maxWidth` of `560px`.

## 🚀 New behavior

Instead of only exposing the maxWidth prop so that that behaviour can be fixed, instead opt to expose (a new) `wrapperStyles` prop so users can freely update the hardcoded style and more.

For example, the off-center bug can be fixed with

```ts
// Via instantiation
const toast = useToast({
    position: "top",
    title: "Wrapper style is updated",
    wrapperStyle: {
      maxWidth: "100%",
    },
})

// Via trigger
<Button onClick={() => toast({ wrapperStyle: { maxWidth: "100%" } })}>
    toast
</Button>
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No 

## 📝 Additional Information
