### PR TITLE
fix(popover): make popover close button themable

### DIFF
--- a/.changeset/bright-pets-fly.md
+++ b/.changeset/bright-pets-fly.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/anatomy": minor
+"@chakra-ui/popover": minor
+"@chakra-ui/theme": minor
+---
+
+Made PopoverCloseButton themeable

--- a/packages/anatomy/src/index.ts
+++ b/packages/anatomy/src/index.ts
@@ -91,7 +91,7 @@ export const pinInputAnatomy = anatomy("pininput").parts("field")
 
 export const popoverAnatomy = anatomy("popover")
   .parts("content", "header", "body", "footer")
-  .extend("popper", "arrow")
+  .extend("popper", "arrow", "closeButton")
 
 export const progressAnatomy = anatomy("progress").parts(
   "label",

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -183,15 +183,13 @@ export type PopoverCloseButtonProps = CloseButtonProps
 
 export const PopoverCloseButton: React.FC<CloseButtonProps> = (props) => {
   const { onClose } = usePopoverContext()
+  const styles = useStyles()
   return (
     <CloseButton
       size="sm"
       onClick={onClose}
-      position="absolute"
-      borderRadius="md"
-      top="0.25rem"
-      insetEnd="0.5rem"
-      padding="0.5rem"
+      className={cx("chakra-popover__close-btn", props.className)}
+      __css={styles.closeButton}
       {...props}
     />
   )

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -54,6 +54,14 @@ const baseStyleFooter: SystemStyleObject = {
   borderTopWidth: "1px",
 }
 
+const baseStyleCloseButton: SystemStyleObject = {
+  position: "absolute",
+  borderRadius: "md",
+  top: 1,
+  insetEnd: 2,
+  padding: 2,
+}
+
 const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   popper: baseStylePopper,
   content: baseStyleContent(props),
@@ -61,6 +69,7 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   body: baseStyleBody,
   footer: baseStyleFooter,
   arrow: {},
+  closeButton: baseStyleCloseButton,
 })
 
 export default {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4928 

## 📝 Description

> Adds theming to the PopoverCloseButton

## ⛳️ Current behavior (updates)

> PopoverCloseButton is not themeable

## 🚀 New behavior

> PopoverCloseButton is now themeable

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
