### PR TITLE
fix(popper): allow useCallback to do its thing

### DIFF
--- a/.changeset/smart-dingos-worry.md
+++ b/.changeset/smart-dingos-worry.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popper": patch
+---
+
+fix(popper): allow useCallback to do its thing

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -108,7 +108,7 @@ export type ArrowCSSVarProps = {
 export function usePopper(props: UsePopperProps = {}) {
   const {
     enabled = true,
-    modifiers = [],
+    modifiers,
     placement: placementProp = "bottom",
     strategy = "absolute",
     arrowPadding = 8,
@@ -167,7 +167,7 @@ export function usePopper(props: UsePopperProps = {}) {
           options: { boundary },
         },
         // allow users override internal modifiers
-        ...modifiers,
+        ...(modifiers ?? []),
       ],
       strategy,
     })


### PR DESCRIPTION
## 📝 Description

When not passing `modifiers` to the usePopper hook, the property gets initialized to a new empty array.
When this array is passed to the useCallback deps, it causes the useCallback to never return the memoized instance (it's always a different new empty array), which causes other useCallback in the same hook to never return their memoized instances.

This PR fixes it by not initializing modifiers to a new empty array.

## 💣 Is this a breaking change (Yes/No):
No

Current workaround I'm using:
```ts
const { ... } = usePopper({
  ...
  modifiers: useMemo(() => [], []),
  ...
});
```