### PR TITLE
fix: fixed an issue with setting href on span

### DIFF
--- a/.changeset/lemon-crews-tickle.md
+++ b/.changeset/lemon-crews-tickle.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/breadcrumb": patch
+---
+
+`href` attribute will no longer be set on the inner element of the
+`BreadcrumbLink` if the parent `BreadcrumbItem` has `isCurrentPage` prop set to
+true. Such a `BreadcrumbLink` is not an actual link and it ends up being a
+`span` (by default).

--- a/packages/breadcrumb/src/breadcrumb.tsx
+++ b/packages/breadcrumb/src/breadcrumb.tsx
@@ -61,7 +61,7 @@ export interface BreadcrumbLinkProps extends HTMLChakraProps<"a"> {
  */
 export const BreadcrumbLink = forwardRef<BreadcrumbLinkProps, "a">(
   (props, ref) => {
-    const { isCurrentPage, as, className, ...rest } = props
+    const { isCurrentPage, as, className, href, ...rest } = props
     const styles = useStyles()
 
     const sharedProps = {
@@ -77,7 +77,7 @@ export const BreadcrumbLink = forwardRef<BreadcrumbLinkProps, "a">(
       )
     }
 
-    return <chakra.a __css={styles.link} {...sharedProps} />
+    return <chakra.a __css={styles.link} href={href} {...sharedProps} />
   },
 )
 

--- a/packages/breadcrumb/tests/breadcrumb.test.tsx
+++ b/packages/breadcrumb/tests/breadcrumb.test.tsx
@@ -57,3 +57,33 @@ test("separator can be changed", () => {
   )
   expect(screen.getAllByText("-")).toHaveLength(1)
 })
+
+test("breadcrumb link has its href attribute correctly set", () => {
+  render(
+    <Breadcrumb>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="#">Link 1</BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbItem isCurrentPage>
+        <BreadcrumbLink href="#">Link 2</BreadcrumbLink>
+      </BreadcrumbItem>
+    </Breadcrumb>,
+  )
+  const breadcrumbLink = screen.getByText("Link 1")
+  expect(breadcrumbLink.getAttribute("href")).toBe("#")
+})
+
+test("current page link doesn't have href attribute set", () => {
+  render(
+    <Breadcrumb>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="#">Link 1</BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbItem isCurrentPage>
+        <BreadcrumbLink href="#">Link 2</BreadcrumbLink>
+      </BreadcrumbItem>
+    </Breadcrumb>,
+  )
+  const currentPageLink = screen.getByText("Link 2")
+  expect(currentPageLink.getAttribute("href")).toBe(null)
+})


### PR DESCRIPTION
## 📝 Description

`href` attribute will no longer be set on the inner element of the
`BreadcrumbLink` if the parent `BreadcrumbItem` has `isCurrentPage` prop set to
true. Such a `BreadcrumbLink` is not an actual link and it ends up being a
`span` (by default).

## ⛳️ Current behavior (updates)

`href` gets set on `span`

## 🚀 New behavior

`href` is not set on `span`

## 💣 Is this a breaking change (Yes/No):

It shouldn't be

