### PR TITLE
fix(switch): add position: relative to containerStyles

### DIFF
--- a/.changeset/bright-months-impress.md
+++ b/.changeset/bright-months-impress.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/switch": patch
+---
+
+Fix issue where focusing the Switch could lead to unexpected page scrolls.

--- a/packages/switch/src/switch.tsx
+++ b/packages/switch/src/switch.tsx
@@ -40,6 +40,7 @@ export const Switch = forwardRef<SwitchProps, "input">((props, ref) => {
   const containerStyles: SystemStyleObject = React.useMemo(
     () => ({
       display: "inline-block",
+      position: "relative",
       verticalAlign: "middle",
       lineHeight: "normal",
       ...styles.container,


### PR DESCRIPTION
Closes #49040

## 📝 Description

> This PR sets Switch's container's position to `relative` so that its checkbox positioning is more reliable.

## ⛳️ Current behavior (updates)

> issue #4940 describes circumstances, in which browsers misplace a hidden checkbox used by the Switch component. This causes browsers to unexpectedly scroll the page when focusing the Switch.

## 🚀 New behavior

> The checkbox is positioned relative to the container and should not be placed outside.

## 💣 Is this a breaking change (Yes/No):

Probably no.

