### PR TITLE
fix: reduce bundle size of framer motion

### DIFF
--- a/.changeset/flat-shoes-yell.md
+++ b/.changeset/flat-shoes-yell.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/accordion": major
+"@chakra-ui/checkbox": major
+"@chakra-ui/menu": major
+"@chakra-ui/popover": major
+"@chakra-ui/popper": major
+"@chakra-ui/system": major
+"@chakra-ui/toast": major
+"@chakra-ui/tooltip": major
+"@chakra-ui/transition": major
+"@chakra-ui/docs": major
+---
+
+Reduce framer-motion bundle size

--- a/packages/accordion/stories/accordion.stories.tsx
+++ b/packages/accordion/stories/accordion.stories.tsx
@@ -169,6 +169,7 @@ const data = [
 ]
 
 export function Bug_2160() {
+  // see: https://github.com/chakra-ui/chakra-ui/issues/2160
   const inputRef = React.useRef<HTMLInputElement>()
   const [displayData, setDisplayData] = React.useState(data)
   const [filter, setFilter] = React.useState("")
@@ -194,6 +195,10 @@ export function Bug_2160() {
 
   return (
     <chakra.div padding={4}>
+      <Text>
+        Accordion (when used as filterable list of items) is not stealing focus
+        from input field.
+      </Text>
       <chakra.div mt={3} mb={12}>
         <chakra.input
           ref={inputRef}

--- a/packages/checkbox/src/checkbox-icon.tsx
+++ b/packages/checkbox/src/checkbox-icon.tsx
@@ -1,12 +1,16 @@
 import { chakra, PropsOf } from "@chakra-ui/system"
-import { AnimatePresence, CustomDomComponent, motion } from "framer-motion"
+import {
+  AnimatePresence,
+  CustomDomComponent,
+  domAnimation,
+  LazyMotion,
+  m,
+} from "framer-motion"
 import * as React from "react"
 
 // @future: only call `motion(chakra.svg)` when we drop framer-motion v3 support
 const MotionSvg: CustomDomComponent<PropsOf<typeof chakra.svg>> =
-  "custom" in motion
-    ? (motion as any).custom(chakra.svg)
-    : (motion as any)(chakra.svg)
+  "custom" in m ? (m as any).custom(chakra.svg) : (m as any)(chakra.svg)
 
 const CheckIcon = (props: PropsOf<typeof MotionSvg>) => (
   <MotionSvg
@@ -61,27 +65,29 @@ const IndeterminateIcon = (props: PropsOf<typeof MotionSvg>) => (
 )
 
 const CheckboxTransition = ({ open, children }: any) => (
-  <AnimatePresence initial={false}>
-    {open && (
-      <motion.div
-        variants={{
-          unchecked: { scale: 0.5 },
-          checked: { scale: 1 },
-        }}
-        initial="unchecked"
-        animate="checked"
-        exit="unchecked"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          height: "100%",
-        }}
-      >
-        {children}
-      </motion.div>
-    )}
-  </AnimatePresence>
+  <LazyMotion features={domAnimation}>
+    <AnimatePresence initial={false}>
+      {open && (
+        <m.div
+          variants={{
+            unchecked: { scale: 0.5 },
+            checked: { scale: 1 },
+          }}
+          initial="unchecked"
+          animate="checked"
+          exit="unchecked"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+          }}
+        >
+          {children}
+        </m.div>
+      )}
+    </AnimatePresence>
+  </LazyMotion>
 )
 
 export interface CheckboxIconProps extends PropsOf<typeof MotionSvg> {

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -14,7 +14,13 @@ import {
   useTheme,
 } from "@chakra-ui/system"
 import { cx, runIfFn, __DEV__ } from "@chakra-ui/utils"
-import { CustomDomComponent, motion, Variants } from "framer-motion"
+import {
+  CustomDomComponent,
+  domAnimation,
+  LazyMotion,
+  m,
+  Variants,
+} from "framer-motion"
 import * as React from "react"
 import {
   MenuDescendantsProvider,
@@ -149,9 +155,7 @@ const motionVariants: Variants = {
 
 // @future: only call `motion(chakra.div)` when we drop framer-motion v3 support
 const MotionDiv: CustomDomComponent<PropsOf<typeof chakra.div>> =
-  "custom" in motion
-    ? (motion as any).custom(chakra.div)
-    : (motion as any)(chakra.div)
+  "custom" in m ? (m as any).custom(chakra.div) : (m as any)(chakra.div)
 
 export const MenuList = forwardRef<MenuListProps, "div">((props, ref) => {
   const { rootProps, ...rest } = props
@@ -163,27 +167,29 @@ export const MenuList = forwardRef<MenuListProps, "div">((props, ref) => {
   const styles = useStyles()
 
   return (
-    <chakra.div
-      {...positionerProps}
-      __css={{ zIndex: props.zIndex ?? styles.list?.zIndex }}
-    >
-      <MotionDiv
-        {...menulistProps}
-        /**
-         * We could call this on either `onAnimationComplete` or `onUpdate`.
-         * It seems the re-focusing works better with the `onUpdate`
-         */
-        onUpdate={onTransitionEnd}
-        className={cx("chakra-menu__menu-list", menulistProps.className)}
-        variants={motionVariants}
-        initial={false}
-        animate={isOpen ? "enter" : "exit"}
-        __css={{
-          outline: 0,
-          ...styles.list,
-        }}
-      />
-    </chakra.div>
+    <LazyMotion features={domAnimation}>
+      <chakra.div
+        {...positionerProps}
+        __css={{ zIndex: props.zIndex ?? styles.list?.zIndex }}
+      >
+        <MotionDiv
+          {...menulistProps}
+          /**
+           * We could call this on either `onAnimationComplete` or `onUpdate`.
+           * It seems the re-focusing works better with the `onUpdate`
+           */
+          onUpdate={onTransitionEnd}
+          className={cx("chakra-menu__menu-list", menulistProps.className)}
+          variants={motionVariants}
+          initial={false}
+          animate={isOpen ? "enter" : "exit"}
+          __css={{
+            outline: 0,
+            ...styles.list,
+          }}
+        />
+      </chakra.div>
+    </LazyMotion>
   )
 })
 

--- a/packages/popover/src/popover-transition.tsx
+++ b/packages/popover/src/popover-transition.tsx
@@ -1,5 +1,11 @@
 import { chakra, HTMLChakraProps } from "@chakra-ui/system"
-import { HTMLMotionProps, motion, Variant } from "framer-motion"
+import {
+  domAnimation,
+  HTMLMotionProps,
+  LazyMotion,
+  m,
+  Variant,
+} from "framer-motion"
 import { mergeWith } from "@chakra-ui/utils"
 import React from "react"
 import { usePopoverContext } from "./popover-context"
@@ -56,7 +62,7 @@ const scaleFade: MotionVariants = {
   },
 }
 
-const Section = motion(chakra.section)
+const Section = m(chakra.section)
 
 export interface PopoverTransitionProps
   extends HTMLMotionChakraProps<"section"> {}
@@ -65,13 +71,15 @@ export const PopoverTransition = React.forwardRef(
   (props: HTMLMotionChakraProps<"section">, ref: React.Ref<any>) => {
     const { isOpen } = usePopoverContext()
     return (
-      <Section
-        ref={ref}
-        variants={mergeVariants(props.variants)}
-        {...props}
-        initial={false}
-        animate={isOpen ? "enter" : "exit"}
-      />
+      <LazyMotion features={domAnimation}>
+        <Section
+          ref={ref}
+          variants={mergeVariants(props.variants)}
+          {...props}
+          initial={false}
+          animate={isOpen ? "enter" : "exit"}
+        />
+      </LazyMotion>
     )
   },
 )

--- a/packages/popover/stories/popover.stories.tsx
+++ b/packages/popover/stories/popover.stories.tsx
@@ -15,6 +15,7 @@ import {
 } from "../src"
 
 export function PopoverExample() {
+  // not working before this PR.
   const { getTriggerProps, getPopoverProps, onClose } = usePopover()
 
   return (

--- a/packages/popper/stories/popper-v2.stories.tsx
+++ b/packages/popper/stories/popper-v2.stories.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion"
+import { m } from "framer-motion"
 import * as React from "react"
 import { usePopper } from "../src"
 
@@ -121,7 +121,7 @@ export const WithAnimation = () => {
         Trigger
       </button>
       <div {...getPopperProps()}>
-        <motion.div
+        <m.div
           style={{
             transformOrigin,
             background: "red",
@@ -143,7 +143,7 @@ export const WithAnimation = () => {
             <div {...getArrowInnerProps()} />
           </div>
           Popper
-        </motion.div>
+        </m.div>
       </div>
     </div>
   )

--- a/packages/popper/stories/popper.stories.tsx
+++ b/packages/popper/stories/popper.stories.tsx
@@ -1,5 +1,5 @@
 import { useDisclosure } from "@chakra-ui/hooks"
-import { motion, Variants } from "framer-motion"
+import { domAnimation, LazyMotion, m, Variants } from "framer-motion"
 import * as React from "react"
 import { usePopper } from "../src"
 
@@ -62,26 +62,28 @@ export const WithTransition = () => {
         Toggle
       </button>
       <div ref={popperRef} style={{ "--popper-arrow-bg": "red" }}>
-        <motion.div
-          transition={{
-            duration: 0.15,
-            easings: "easeInOut",
-          }}
-          variants={slide}
-          initial={false}
-          animate={isOpen ? "enter" : "exit"}
-          style={{
-            background: bg,
-            width: 200,
-            transformOrigin: "var(--popper-transform-origin)",
-            borderRadius: 4,
-          }}
-        >
-          Testing
-          <div data-popper-arrow="">
-            <div data-popper-arrow-inner="" />
-          </div>
-        </motion.div>
+        <LazyMotion features={domAnimation}>
+          <m.div
+            transition={{
+              duration: 0.15,
+              easings: "easeInOut",
+            }}
+            variants={slide}
+            initial={false}
+            animate={isOpen ? "enter" : "exit"}
+            style={{
+              background: bg,
+              width: 200,
+              transformOrigin: "var(--popper-transform-origin)",
+              borderRadius: 4,
+            }}
+          >
+            Testing
+            <div data-popper-arrow="">
+              <div data-popper-arrow-inner="" />
+            </div>
+          </m.div>
+        </LazyMotion>
       </div>
     </>
   )

--- a/packages/system/stories/system.stories.tsx
+++ b/packages/system/stories/system.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import theme from "@chakra-ui/theme"
 import { Text } from "@chakra-ui/layout"
-import { motion } from "framer-motion"
+import { domAnimation, LazyMotion, m } from "framer-motion"
 import {
   chakra,
   PropsOf,
@@ -15,21 +15,23 @@ export default {
   title: "System",
 }
 
-const MotionBox = motion(chakra.div)
+const MotionBox = m(chakra.div)
 
 export const WithFramerMotion = () => (
-  <MotionBox
-    mt="40px"
-    w="40px"
-    h="40px"
-    bg="red.200"
-    ml="60px"
-    animate={{
-      scale: [1, 2, 2, 1, 1],
-      rotate: [0, 0, 270, 270, 0],
-      borderRadius: ["20%", "20%", "50%", "50%", "20%"],
-    }}
-  />
+  <LazyMotion features={domAnimation}>
+    <MotionBox
+      mt="40px"
+      w="40px"
+      h="40px"
+      bg="red.200"
+      ml="60px"
+      animate={{
+        scale: [1, 2, 2, 1, 1],
+        rotate: [0, 0, 270, 270, 0],
+        borderRadius: ["20%", "20%", "50%", "50%", "20%"],
+      }}
+    />
+  </LazyMotion>
 )
 
 export const ApplyProp = () => (

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -1,7 +1,13 @@
 import { useTimeout, useUpdateEffect } from "@chakra-ui/hooks"
 import { isFunction, __DEV__ } from "@chakra-ui/utils"
 import ReachAlert from "@reach/alert"
-import { motion, useIsPresent, Variants } from "framer-motion"
+import {
+  domAnimation,
+  LazyMotion,
+  m,
+  useIsPresent,
+  Variants,
+} from "framer-motion"
 import * as React from "react"
 import type { ToastOptions } from "./toast.types"
 import { getToastStyle } from "./toast.utils"
@@ -102,30 +108,32 @@ export const Toast: React.FC<ToastProps> = (props) => {
   const style = React.useMemo(() => getToastStyle(position), [position])
 
   return (
-    <motion.li
-      layout
-      className="chakra-toast"
-      variants={toastMotionVariants}
-      initial="initial"
-      animate="animate"
-      exit="exit"
-      onHoverStart={onMouseEnter}
-      onHoverEnd={onMouseLeave}
-      custom={{ position }}
-      style={style}
-    >
-      <ReachAlert
-        className="chakra-toast__inner"
-        style={{
-          pointerEvents: "auto",
-          maxWidth: 560,
-          minWidth: 300,
-          margin: "0.5rem",
-        }}
+    <LazyMotion features={domAnimation}>
+      <m.li
+        layout
+        className="chakra-toast"
+        variants={toastMotionVariants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        onHoverStart={onMouseEnter}
+        onHoverEnd={onMouseLeave}
+        custom={{ position }}
+        style={style}
       >
-        {isFunction(message) ? message({ id, onClose: close }) : message}
-      </ReachAlert>
-    </motion.li>
+        <ReachAlert
+          className="chakra-toast__inner"
+          style={{
+            pointerEvents: "auto",
+            maxWidth: 560,
+            minWidth: 300,
+            margin: "0.5rem",
+          }}
+        >
+          {isFunction(message) ? message({ id, onClose: close }) : message}
+        </ReachAlert>
+      </m.li>
+    </LazyMotion>
   )
 }
 

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -11,7 +11,7 @@ import {
 } from "@chakra-ui/system"
 import { isString, omit, pick, __DEV__, getCSSVar } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, domAnimation, LazyMotion, m } from "framer-motion"
 import * as React from "react"
 import { scale } from "./tooltip.transition"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
@@ -52,7 +52,7 @@ export interface TooltipProps
   portalProps?: Pick<PortalProps, "appendToParentPortal" | "containerRef">
 }
 
-const StyledTooltip = chakra(motion.div)
+const StyledTooltip = chakra(m.div)
 
 /**
  * Tooltips display informative text when users hover, focus on, or tap an element.
@@ -137,31 +137,35 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
                 pointerEvents: "none",
               }}
             >
-              <StyledTooltip
-                variants={scale}
-                {...(tooltipProps as any)}
-                initial="exit"
-                animate="enter"
-                exit="exit"
-                __css={styles}
-              >
-                {label}
-                {hasAriaLabel && (
-                  <VisuallyHidden {...hiddenProps}>{ariaLabel}</VisuallyHidden>
-                )}
-                {hasArrow && (
-                  <chakra.div
-                    data-popper-arrow
-                    className="chakra-tooltip__arrow-wrapper"
-                  >
+              <LazyMotion features={domAnimation}>
+                <StyledTooltip
+                  variants={scale}
+                  {...(tooltipProps as any)}
+                  initial="exit"
+                  animate="enter"
+                  exit="exit"
+                  __css={styles}
+                >
+                  {label}
+                  {hasAriaLabel && (
+                    <VisuallyHidden {...hiddenProps}>
+                      {ariaLabel}
+                    </VisuallyHidden>
+                  )}
+                  {hasArrow && (
                     <chakra.div
-                      data-popper-arrow-inner
-                      className="chakra-tooltip__arrow"
-                      __css={{ bg: styles.bg }}
-                    />
-                  </chakra.div>
-                )}
-              </StyledTooltip>
+                      data-popper-arrow
+                      className="chakra-tooltip__arrow-wrapper"
+                    >
+                      <chakra.div
+                        data-popper-arrow-inner
+                        className="chakra-tooltip__arrow"
+                        __css={{ bg: styles.bg }}
+                      />
+                    </chakra.div>
+                  )}
+                </StyledTooltip>
+              </LazyMotion>
             </chakra.div>
           </Portal>
         )}

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { Modal, ModalContent, ModalOverlay } from "@chakra-ui/modal"
 import { Portal } from "@chakra-ui/portal"
 import { chakra } from "@chakra-ui/system"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, domAnimation, LazyMotion, m } from "framer-motion"
 import * as React from "react"
 import { Tooltip, useTooltip } from "../src"
 
@@ -80,37 +80,39 @@ export const WithTransition = () => {
         {isOpen && (
           <Portal>
             <div {...getTooltipPositionerProps()}>
-              <motion.div
-                initial="exit"
-                animate="enter"
-                exit="exit"
-                {...(getTooltipProps() as any)}
-              >
-                <motion.div
-                  transition={{
-                    duration: 0.12,
-                    ease: [0.4, 0, 0.2, 1],
-                    bounce: 0.5,
-                  }}
-                  variants={{
-                    exit: { scale: 0.9, opacity: 0 },
-                    enter: { scale: 1, opacity: 1 },
-                  }}
-                  style={{
-                    transformOrigin: "var(--popper-transform-origin)",
-                    background: "tomato",
-                    "--popper-arrow-bg": "tomato",
-                    color: "white",
-                    borderRadius: "4px",
-                    padding: "0.5em 1em",
-                  }}
+              <LazyMotion features={domAnimation}>
+                <m.div
+                  initial="exit"
+                  animate="enter"
+                  exit="exit"
+                  {...(getTooltipProps() as any)}
                 >
-                  Fade! This is tooltip
-                  <div data-popper-arrow>
-                    <div data-popper-arrow-inner />
-                  </div>
-                </motion.div>
-              </motion.div>
+                  <m.div
+                    transition={{
+                      duration: 0.12,
+                      ease: [0.4, 0, 0.2, 1],
+                      bounce: 0.5,
+                    }}
+                    variants={{
+                      exit: { scale: 0.9, opacity: 0 },
+                      enter: { scale: 1, opacity: 1 },
+                    }}
+                    style={{
+                      transformOrigin: "var(--popper-transform-origin)",
+                      background: "tomato",
+                      "--popper-arrow-bg": "tomato",
+                      color: "white",
+                      borderRadius: "4px",
+                      padding: "0.5em 1em",
+                    }}
+                  >
+                    Fade! This is tooltip
+                    <div data-popper-arrow>
+                      <div data-popper-arrow-inner />
+                    </div>
+                  </m.div>
+                </m.div>
+              </LazyMotion>
             </div>
           </Portal>
         )}

--- a/packages/transition/src/collapse.tsx
+++ b/packages/transition/src/collapse.tsx
@@ -1,8 +1,10 @@
 import { cx, mergeWith, warn, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -136,25 +138,27 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
     const animate = isOpen || unmountOnExit ? "enter" : "exit"
 
     return (
-      <AnimatePresence initial={false} custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            {...rest}
-            className={cx("chakra-collapse", className)}
-            style={{
-              overflow: "hidden",
-              display: "block",
-              ...style,
-            }}
-            custom={custom}
-            variants={variants as _Variants}
-            initial={unmountOnExit ? "exit" : false}
-            animate={animate}
-            exit="exit"
-          />
-        )}
-      </AnimatePresence>
+      <LazyMotion features={domAnimation}>
+        <AnimatePresence initial={false} custom={custom}>
+          {show && (
+            <m.div
+              ref={ref}
+              {...rest}
+              className={cx("chakra-collapse", className)}
+              style={{
+                overflow: "hidden",
+                display: "block",
+                ...style,
+              }}
+              custom={custom}
+              variants={variants as _Variants}
+              initial={unmountOnExit ? "exit" : false}
+              animate={animate}
+              exit="exit"
+            />
+          )}
+        </AnimatePresence>
+      </LazyMotion>
     )
   },
 )

--- a/packages/transition/src/fade.tsx
+++ b/packages/transition/src/fade.tsx
@@ -1,8 +1,10 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -57,16 +59,18 @@ export const Fade = React.forwardRef<HTMLDivElement, FadeProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            className={cx("chakra-fade", className)}
-            custom={custom}
-            {...fadeConfig}
-            animate={animate}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <m.div
+              ref={ref}
+              className={cx("chakra-fade", className)}
+              custom={custom}
+              {...fadeConfig}
+              animate={animate}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/packages/transition/src/scale-fade.tsx
+++ b/packages/transition/src/scale-fade.tsx
@@ -1,8 +1,10 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -75,16 +77,18 @@ export const ScaleFade = React.forwardRef<HTMLDivElement, ScaleFadeProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            className={cx("chakra-offset-slide", className)}
-            {...scaleFadeConfig}
-            animate={animate}
-            custom={custom}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <m.div
+              ref={ref}
+              className={cx("chakra-offset-slide", className)}
+              {...scaleFadeConfig}
+              animate={animate}
+              custom={custom}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/packages/transition/src/slide-fade.tsx
+++ b/packages/transition/src/slide-fade.tsx
@@ -1,8 +1,10 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import * as React from "react"
@@ -102,16 +104,18 @@ export const SlideFade = React.forwardRef<HTMLDivElement, SlideFadeProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            className={cx("chakra-offset-slide", className)}
-            custom={custom}
-            {...slideFadeConfig}
-            animate={animate}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <m.div
+              ref={ref}
+              className={cx("chakra-offset-slide", className)}
+              custom={custom}
+              {...slideFadeConfig}
+              animate={animate}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/packages/transition/src/slide.tsx
+++ b/packages/transition/src/slide.tsx
@@ -1,8 +1,10 @@
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
-  motion,
+  LazyMotion,
+  m,
   MotionStyle,
   Variants as _Variants,
 } from "framer-motion"
@@ -91,19 +93,21 @@ export const Slide = React.forwardRef<HTMLDivElement, SlideProps>(
 
     return (
       <AnimatePresence custom={custom}>
-        {show && (
-          <motion.div
-            ref={ref}
-            initial="exit"
-            className={cx("chakra-slide", className)}
-            animate={animate}
-            exit="exit"
-            custom={custom}
-            variants={variants as _Variants}
-            style={computedStyle}
-            {...rest}
-          />
-        )}
+        <LazyMotion features={domAnimation}>
+          {show && (
+            <m.div
+              ref={ref}
+              initial="exit"
+              className={cx("chakra-slide", className)}
+              animate={animate}
+              exit="exit"
+              custom={custom}
+              variants={variants as _Variants}
+              style={computedStyle}
+              {...rest}
+            />
+          )}
+        </LazyMotion>
       </AnimatePresence>
     )
   },

--- a/website/src/components/mobile-nav.tsx
+++ b/website/src/components/mobile-nav.tsx
@@ -11,7 +11,13 @@ import {
   useColorModeValue,
   useUpdateEffect,
 } from "@chakra-ui/react"
-import { AnimatePresence, motion, useElementScroll } from "framer-motion"
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m,
+  useElementScroll,
+} from "framer-motion"
 import useRouteChanged from "hooks/use-route-changed"
 import { getRoutes } from "layouts/mdx"
 import NextLink from "next/link"
@@ -89,59 +95,61 @@ export function MobileNavContent(props: MobileNavContentProps) {
 
   return (
     <AnimatePresence>
-      {isOpen && (
-        <RemoveScroll forwardProps>
-          <motion.div
-            transition={{ duration: 0.08 }}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-          >
-            <Flex
-              direction="column"
-              w="100%"
-              bg={useColorModeValue("white", "gray.800")}
-              h="100vh"
-              overflow="auto"
-              pos="absolute"
-              top="0"
-              left="0"
-              zIndex={20}
-              pb="8"
+      <LazyMotion features={domAnimation}>
+        {isOpen && (
+          <RemoveScroll forwardProps>
+            <m.div
+              transition={{ duration: 0.08 }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
             >
-              <Box>
-                <Flex justify="space-between" px="6" pt="5" pb="4">
-                  <Logo sx={{ rect: { fill: "teal.300" } }} />
-                  <HStack spacing="5">
-                    <SponsorButton display="flex" />
-                    <CloseButton ref={closeBtnRef} onClick={onClose} />
-                  </HStack>
-                </Flex>
-                <Box px="6" pb="6" pt="2" shadow={shadow}>
-                  <HStack>
-                    <NavLink href="/docs/getting-started">Docs</NavLink>
-                    <NavLink href="/guides/integrations/with-cra">
-                      Guides
-                    </NavLink>
-                    <NavLink href="/team">Team</NavLink>
-                  </HStack>
-                </Box>
-              </Box>
-
-              <ScrollView
-                onScroll={(scrolled) => {
-                  setShadow(scrolled ? "md" : undefined)
-                }}
+              <Flex
+                direction="column"
+                w="100%"
+                bg={useColorModeValue("white", "gray.800")}
+                h="100vh"
+                overflow="auto"
+                pos="absolute"
+                top="0"
+                left="0"
+                zIndex={20}
+                pb="8"
               >
-                <SidebarContent
-                  pathname={pathname}
-                  routes={getRoutes(pathname)}
-                />
-              </ScrollView>
-            </Flex>
-          </motion.div>
-        </RemoveScroll>
-      )}
+                <Box>
+                  <Flex justify="space-between" px="6" pt="5" pb="4">
+                    <Logo sx={{ rect: { fill: "teal.300" } }} />
+                    <HStack spacing="5">
+                      <SponsorButton display="flex" />
+                      <CloseButton ref={closeBtnRef} onClick={onClose} />
+                    </HStack>
+                  </Flex>
+                  <Box px="6" pb="6" pt="2" shadow={shadow}>
+                    <HStack>
+                      <NavLink href="/docs/getting-started">Docs</NavLink>
+                      <NavLink href="/guides/integrations/with-cra">
+                        Guides
+                      </NavLink>
+                      <NavLink href="/team">Team</NavLink>
+                    </HStack>
+                  </Box>
+                </Box>
+
+                <ScrollView
+                  onScroll={(scrolled) => {
+                    setShadow(scrolled ? "md" : undefined)
+                  }}
+                >
+                  <SidebarContent
+                    pathname={pathname}
+                    routes={getRoutes(pathname)}
+                  />
+                </ScrollView>
+              </Flex>
+            </m.div>
+          </RemoveScroll>
+        )}
+      </LazyMotion>
     </AnimatePresence>
   )
 }
@@ -156,7 +164,7 @@ const ScrollView = (props: BoxProps & { onScroll?: any }) => {
   }, [scrollY])
 
   useUpdateEffect(() => {
-    onScroll?.(y > 5 ? true : false)
+    onScroll?.(y > 5)
   }, [y])
 
   return (

--- a/website/src/components/page-transition.tsx
+++ b/website/src/components/page-transition.tsx
@@ -1,12 +1,14 @@
 import * as React from "react"
-import { HTMLMotionProps, motion } from "framer-motion"
+import { domAnimation, HTMLMotionProps, LazyMotion, m } from "framer-motion"
 
 const PageTransition = (props: HTMLMotionProps<"div">) => (
-  <motion.div
-    initial={{ y: -16, opacity: 0 }}
-    animate={{ y: 0, opacity: 1 }}
-    {...props}
-  />
+  <LazyMotion features={domAnimation}>
+    <m.div
+      initial={{ y: -16, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      {...props}
+    />
+  </LazyMotion>
 )
 
 export default PageTransition


### PR DESCRIPTION
Closes #4958

## 📝 Description
Chakra UI uses framer motion in some components, and once one of  that component is used, the bundle size increases by 100kb.
For example, if you use only Button and Checkbox, the bundle size will be 100kb (gzip:31kb) larger than if you use Button. This prevents the user from using Chakra UI casually.

Fortunately, Framer Motion provides an official bundle size reduction method; by using motion's alternative component `m` and feature packages, we can reduce the bundle size up to 18kb.

## ⛳️ Current behavior (updates)
Using checkbox (or other some components) increases bundle size by 100kb(gzip:31kb) . This means that 21% of the total bundle code is framer motion.


## 🚀 New behavior
The increase in bundle size can be kept to 18kb(gzipped).
There were several options for bundle size reduction. What do you think about the following issues?

### Limited or relatively many features
`m` does not have an animation function, so you will need to load the animation function separately. There are two features provided:
> `domAnimation`: This provides support for animations, variants, exit animations, and tap/hover/focus gestures. (~13kb)

> `domMax`: This provides support for all of the above, plus pan/drag gestures and layout animations. (~18kb)
`domAnimation`

`domAnimation` has less features, but the current component works fine as far as I can confirm. User-extended code might use features which are not in `domAnimation`, but this should not be a problem since Chakra Doc requires that `motion` be imported.
https://chakra-ui.com/guides/integrations/with-framer

### Loading Features
For bundle size, still we can 2 options.
#### Synchronous loading
> By passing one of these feature packages to `LazyMotion`, they'll be bundled into your main JavaScript bundle.
> `<LazyMotion features={domAnimations} />`

#### Async loading
> If you're using a bundler like Webpack or Rollup, we can pass a dynamic import function to features that will fetch features only after we've performed our initial render.
> `<LazyMotion features={() => import("./path/to/feature").then(res => res.default)} />`

To summarize, synchronous loading will increase the main bundle size, and lazy loading will increase the amount of code. But, I am not familiar with what happens when the library uses lazy loading internally.

**domAnimation or domMax, and Async or sync loading. What do you think?**

## 💣 Is this a breaking change (Yes/No):
Maybe yes. For users who have been using the framer motion property without enclosing it in `motion`, this may cause the animation to stop working.
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

