### PR TITLE
chore: upgrade peerDependency framer-motion v5

### DIFF
--- a/.changeset/curvy-eels-wave.md
+++ b/.changeset/curvy-eels-wave.md
@@ -1,0 +1,13 @@
+---
+"@chakra-ui/checkbox": patch
+"@chakra-ui/menu": patch
+"@chakra-ui/modal": patch
+"@chakra-ui/popover": patch
+"@chakra-ui/react": patch
+"@chakra-ui/theme": patch
+"@chakra-ui/toast": patch
+"@chakra-ui/tooltip": patch
+"@chakra-ui/transition": patch
+---
+
+Allow usage of framer-motion 5.x as peerDependency

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   }

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -85,7 +85,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   },

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -1,4 +1,5 @@
 import { tableAnatomy as parts } from "@chakra-ui/anatomy"
+
 import { mode } from "@chakra-ui/theme-tools"
 import type {
   PartsStyleFunction,

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   }

--- a/packages/transition/package.json
+++ b/packages/transition/package.json
@@ -56,7 +56,7 @@
     "@chakra-ui/utils": "1.8.4"
   },
   "peerDependencies": {
-    "framer-motion": "3.x || 4.x",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #4942 

## 📝 Description

Allow to use chakra-ui with `framer-motion` v5. 

checked https://www.framer.com/docs/guide-upgrade/#50 if we're using anything is breaking but everything seems fine.


## 💣 Is this a breaking change (Yes/No):

No

