### PR TITLE
fix(radio): add type support for getRadioProps

### DIFF
--- a/.changeset/chatty-kings-protect.md
+++ b/.changeset/chatty-kings-protect.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Added type support for getRadioprops

--- a/packages/radio/src/use-radio-group.ts
+++ b/packages/radio/src/use-radio-group.ts
@@ -46,7 +46,18 @@ export interface UseRadioGroupProps {
 
 type RadioPropGetter = PropGetter<
   HTMLInputElement,
-  { onChange?: (e: EventOrValue) => void; value?: StringOrNumber } & Omit<
+  {
+    onChange?: (e: EventOrValue) => void
+    value?: StringOrNumber
+    /**
+     * checked is defined if isNative=true
+     */
+    checked?: boolean
+    /**
+     * isChecked is defined if isNative=false
+     */
+    isChecked?: boolean
+  } & Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
     "onChange" | "size" | "value"
   >


### PR DESCRIPTION
Closes #4951 

## 🚀 New behavior

Added type support for getRadioProps to add  `checked` & `isChecked` 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
