### PR TITLE
fix: gradient parser when a position is specified

### DIFF
--- a/.changeset/funny-laws-relate.md
+++ b/.changeset/funny-laws-relate.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+fix gradient parser when a position is specified

--- a/packages/styled-system/src/utils/parse-gradient.ts
+++ b/packages/styled-system/src/utils/parse-gradient.ts
@@ -64,7 +64,12 @@ export function parseGradient(value: string | null | undefined, theme: Dict) {
     // else, get and transform the color token or css value
     const key = `colors.${_color}`
     const color = key in theme.__cssMap ? theme.__cssMap[key].varRef : _color
-    return _stopOrFunc ? [color, _stopOrFunc].join(" ") : color
+    return _stopOrFunc
+      ? [
+          color,
+          ...(Array.isArray(_stopOrFunc) ? _stopOrFunc : [_stopOrFunc]),
+        ].join(" ")
+      : color
   })
 
   return `${_type}(${_values.join(", ")})`

--- a/packages/styled-system/tests/parse-gradient.test.ts
+++ b/packages/styled-system/tests/parse-gradient.test.ts
@@ -115,6 +115,21 @@ describe("linear gradient", () => {
   })
 })
 
+describe("radial gradient", () => {
+  test("should parse gradient with a named position", () => {
+    expect(
+      parseGradient("radial(circle at center, #fff, #000)", theme),
+    ).toMatchInlineSnapshot(`"radial-gradient(circle at center, #fff, #000)"`)
+  })
+  test("should parse gradient with a position", () => {
+    expect(
+      parseGradient("radial(farthest-corner at 50% 50%, #fff, #000)", theme),
+    ).toMatchInlineSnapshot(
+      `"radial-gradient(farthest-corner at 50% 50%, #fff, #000)"`,
+    )
+  })
+})
+
 describe("conic gradient", () => {
   test("basic value", () => {
     expect(parseGradient("conic(#fff, #000)", theme)).toMatchInlineSnapshot(


### PR DESCRIPTION
## 📝 Description

Fixed the gradient parsing logic when a position is specified

## ⛳️ Current behavior (updates)

Actually parsing result:
-  `radial(circle at center, #000, #FFF)` produces `radial-gradient(circle at, center, #000, #FFF)` <-- See extra comma
-  `radial(circle at 50% 50%, #000, #FFF)` produces `radial-gradient(circle at, 50%, 50%, #000, #FFF)` <-- See extra comma

## 🚀 New behavior

Fixed the parsing logic.
Added a couple of test to secure the implementation.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I just flatten the array before joining it. I could use `.flat` method but is not supported on older browser/node versions.