### PR TITLE
documentation: Quote installation packages with carats

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -13,11 +13,11 @@ Inside your React project directory, install Chakra UI by running either of the
 following:
 
 ```bash
-npm i @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+npm i @chakra-ui/react '@emotion/react@^11' '@emotion/styled@^11' 'framer-motion@^4'
 ```
 
 ```bash
-yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
+yarn add @chakra-ui/react '@emotion/react@^11' '@emotion/styled@^11' 'framer-motion@^4'
 ```
 
 > For `create-react-app` installation instructions, check this


### PR DESCRIPTION
Closes (no issue opened)

## 📝 Description

Adds quoting to the installation lines of the getting started docs.

I think in general `^` needs escaping, but on zsh it's specially noticeable due to the default `NO_NOMATCH` setting.

## ⛳️ Current behavior (updates)

Unquoted, the installation snippets in zsh just error out:

```
❯ yarn add @chakra-ui/react @emotion/react@^11 @emotion/styled@^11 framer-motion@^4
zsh: no matches found: @emotion/react@^11
```

## 🚀 New behavior

Packages are installed as expected.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
