### PR TITLE
fix(color-mode): fix colormode in system-view

### DIFF
--- a/.changeset/wild-bikes-sneeze.md
+++ b/.changeset/wild-bikes-sneeze.md
@@ -1,0 +1,19 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+Fixed color mode behavior priority in the following order:
+
+- if `useSystemColorMode` is true system-color will be used as default - initial
+  colormode is the fallback if system color mode isn't resolved
+
+- if `--chakra-ui-color-mode` is defined through e.g. `ColorModeScript` this
+  will be used
+
+- if `colorModeManager` = `localStorage` and a value is defined for
+  `chakra-ui-color-mode` this will be used
+
+- if `initialColorMode` = `system` system-color will be used as default -
+  initial colormode is the fallback if system color mode isn't resolved
+
+- if `initialColorMode` = `'light'|'dark'` the corresponding value will be used

--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -83,22 +83,39 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
      * reasons, do so after hydration.
      *
      * Priority:
-     * - system color mode
-     * - defined value on <ColorModeScript />, if present
-     * - previously stored value
+     * - if `useSystemColorMode` is true system-color will be used as default - initial
+     * colormode is the fallback if system color mode isn't resolved
+     *
+     * - if `--chakra-ui-color-mode` is defined through e.g. `ColorModeScript` this
+     * will be used
+     *
+     * - if `colorModeManager` = `localStorage` and a value is defined for
+     * `chakra-ui-color-mode` this will be used
+     *
+     * - if `initialColorMode` = `system` system-color will be used as default -
+     * initial colormode is the fallback if system color mode isn't resolved
+     *
+     * - if `initialColorMode` = `'light'|'dark'` the corresponding value will be used
      */
     if (isBrowser && colorModeManager.type === "localStorage") {
-      const mode = useSystemColorMode
-        ? getColorScheme(defaultColorMode)
-        : root.get() ||
-          colorModeManager.get() ||
-          getColorScheme(defaultColorMode)
-
-      if (mode) {
-        rawSetColorMode(mode)
+      const systemColorWithFallback = getColorScheme(defaultColorMode)
+      if (useSystemColorMode) {
+        return rawSetColorMode(systemColorWithFallback)
       }
+      const rootGet = root.get()
+      const colorManagerGet = colorModeManager.get()
+      if (rootGet) {
+        return rawSetColorMode(rootGet)
+      }
+      if (colorManagerGet) {
+        return rawSetColorMode(colorManagerGet)
+      }
+      if (initialColorMode === "system") {
+        return rawSetColorMode(systemColorWithFallback)
+      }
+      return rawSetColorMode(defaultColorMode)
     }
-  }, [colorModeManager, useSystemColorMode, defaultColorMode])
+  }, [colorModeManager, useSystemColorMode, defaultColorMode, initialColorMode])
 
   React.useEffect(() => {
     const isDark = colorMode === "dark"

--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { ConfigColorMode } from "./color-mode-provider"
 
-function setScript(initialValue: ConfigColorMode) {
+export function setScript(initialValue: ConfigColorMode) {
   const mql = window.matchMedia("(prefers-color-scheme: dark)")
   const systemPreference = mql.matches ? "dark" : "light"
 

--- a/packages/color-mode/src/color-mode.utils.ts
+++ b/packages/color-mode/src/color-mode.utils.ts
@@ -44,6 +44,7 @@ export const queries = {
 export const lightQuery = queries.light
 export const darkQuery = queries.dark
 
+// check on system preference if it can't find any use fallback
 export function getColorScheme(fallback?: ColorMode) {
   const isDark = getMediaQuery(queries.dark) ?? fallback === "dark"
   return isDark ? "dark" : "light"
@@ -61,7 +62,6 @@ export function addListener(
   }
 
   const mediaQueryList = window.matchMedia(queries.dark)
-
   const listener = () => {
     fn(mediaQueryList.matches ? "dark" : "light", true)
   }
@@ -77,7 +77,7 @@ export const root = {
   get: () =>
     document.documentElement.style.getPropertyValue(
       "--chakra-ui-color-mode",
-    ) as ColorMode,
+    ) as ColorMode | "",
   set: (mode: ColorMode) => {
     if (isBrowser) {
       document.documentElement.style.setProperty("--chakra-ui-color-mode", mode)

--- a/packages/color-mode/test/color-mode-provider__browser.test.tsx
+++ b/packages/color-mode/test/color-mode-provider__browser.test.tsx
@@ -1,4 +1,6 @@
 import { act, render } from "@testing-library/react"
+import React from "react"
+import { render, cleanup } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import * as React from "react"
 import { ColorModeProvider } from "../src"
@@ -17,101 +19,186 @@ jest.mock("@chakra-ui/utils", () => ({
 
 beforeEach(() => {
   jest.resetAllMocks()
+  cleanup()
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => {
+      if (query === "(prefers-color-scheme: dark)") {
+        return {
+          matches: false,
+          media: "(prefers-color-scheme: dark)",
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        }
+      }
+    }),
+  })
+  document.documentElement.style.setProperty("--chakra-ui-color-mode", "")
 })
 
 describe("<ColorModeProvider /> localStorage browser", () => {
-  test("by default, picks from theme.config.initialColorMode", () => {
-    render(
-      <ColorModeProvider options={defaultThemeOptions}>
-        <DummyComponent />
-      </ColorModeProvider>,
-    )
+  it.each(
+    [
+      { system: "light", initial: "light", useSystem: false, expect: "light" },
+      { system: "dark", initial: "light", useSystem: false, expect: "light" },
+      //
+      { system: "light", initial: "dark", useSystem: false, expect: "dark" },
+      { system: "dark", initial: "dark", useSystem: false, expect: "dark" },
+      { system: "light", initial: "system", useSystem: false, expect: "light" },
+      //
+      { system: "dark", initial: "system", useSystem: false, expect: "dark" },
 
-    expect(getColorModeButton()).toHaveTextContent(
-      defaultThemeOptions.initialColorMode,
-    )
-  })
+      { system: "light", initial: "light", useSystem: true, expect: "light" },
+      //
+      { system: "dark", initial: "light", useSystem: true, expect: "dark" },
+      { system: "light", initial: "dark", useSystem: true, expect: "light" },
+      //
+      { system: "dark", initial: "dark", useSystem: true, expect: "dark" },
+      { system: "light", initial: "system", useSystem: true, expect: "light" },
+      //
+      { system: "dark", initial: "system", useSystem: true, expect: "dark" },
+    ].map((item) => ({
+      ...item,
+      toString: () => "case: " + JSON.stringify(item),
+    })),
+  )("%s", (result) => {
+    const { ColorModeProvider } = require("../src/color-mode-provider")
 
-  test("prefers useSystemColorMode over root property", () => {
-    const getColorSchemeSpy = jest
-      .spyOn(colorModeUtils, "getColorScheme")
-      .mockReturnValueOnce("dark")
-    const rootGetSpy = jest.spyOn(colorModeUtils.root, "get")
-    const mockLocalStorageManager = createMockStorageManager("localStorage")
+    jest.spyOn(colorModeUtils.root, "set").mockImplementation(jest.fn())
 
-    render(
-      <ColorModeProvider
-        options={{ ...defaultThemeOptions, useSystemColorMode: true }}
-        colorModeManager={mockLocalStorageManager}
-      >
-        <DummyComponent />
-      </ColorModeProvider>,
-    )
-
-    expect(getColorSchemeSpy).toHaveBeenCalledTimes(1)
-
-    expect(rootGetSpy).not.toHaveBeenCalled()
-    expect(mockLocalStorageManager.get).not.toHaveBeenCalled()
-
-    expect(getColorModeButton()).not.toHaveTextContent(
-      defaultThemeOptions.initialColorMode,
-    )
-  })
-
-  test("prefers root property over localStorage", () => {
-    const rootGetSpy = jest
+    jest
       .spyOn(colorModeUtils.root, "get")
-      // @ts-expect-error only happens if value doesn't exist, e.g. CSR
-      .mockReturnValueOnce("")
-
+      // @ts-expect-error only happens if value doesn't exist
+      .mockReturnValue("")
     const mockLocalStorageManager = createMockStorageManager(
       "localStorage",
-      "dark",
+      undefined,
     )
+    const systemIsDarkMode = result.system === "dark"
 
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => {
+        if (query === "(prefers-color-scheme: dark)") {
+          return {
+            matches: systemIsDarkMode,
+            media: "(prefers-color-scheme: dark)",
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+          }
+        }
+      }),
+    })
     render(
       <ColorModeProvider
-        options={defaultThemeOptions}
+        options={{
+          useSystemColorMode: result.useSystem,
+          initialColorMode: result.initial,
+        }}
         colorModeManager={mockLocalStorageManager}
       >
         <DummyComponent />
       </ColorModeProvider>,
     )
-
-    expect(rootGetSpy).toHaveBeenCalledTimes(1)
-    expect(mockLocalStorageManager.get).toHaveBeenCalledTimes(1)
-
-    expect(getColorModeButton()).not.toHaveTextContent(
-      defaultThemeOptions.initialColorMode,
-    )
+    expect(getColorModeButton()).toHaveTextContent(result.expect)
   })
+})
 
-  test("onChange sets value to all listeners", () => {
-    const rootSet = jest.spyOn(colorModeUtils.root, "set")
-    const mockLocalStorageManager = createMockStorageManager("localStorage")
+test("by default, picks from theme.config.initialColorMode", () => {
+  const { ColorModeProvider } = require("../src/color-mode-provider")
 
-    render(
-      <ColorModeProvider
-        options={defaultThemeOptions}
-        colorModeManager={mockLocalStorageManager}
-      >
-        <DummyComponent />
-      </ColorModeProvider>,
-    )
+  render(
+    <ColorModeProvider options={defaultThemeOptions}>
+      <DummyComponent />
+    </ColorModeProvider>,
+  )
 
-    expect(rootSet).toHaveBeenCalledTimes(1)
-    expect(mockLocalStorageManager.set).not.toHaveBeenCalled()
+  expect(getColorModeButton()).toHaveTextContent(
+    defaultThemeOptions.initialColorMode,
+  )
+})
 
-    act(() => userEvent.click(getColorModeButton()))
+test("prefers useSystemColorMode over root property", () => {
+  const getColorSchemeSpy = jest
+    .spyOn(colorModeUtils, "getColorScheme")
+    .mockReturnValueOnce("dark")
+  const rootGetSpy = jest.spyOn(colorModeUtils.root, "get")
+  const mockLocalStorageManager = createMockStorageManager("localStorage")
 
-    expect(rootSet).toHaveBeenCalledTimes(2)
-    expect(rootSet).toHaveBeenCalledWith("dark")
+  render(
+    <ColorModeProvider
+      options={{ ...defaultThemeOptions, useSystemColorMode: true }}
+      colorModeManager={mockLocalStorageManager}
+    >
+      <DummyComponent />
+    </ColorModeProvider>,
+  )
 
-    expect(mockLocalStorageManager.set).toHaveBeenCalledTimes(1)
-    expect(mockLocalStorageManager.set).toHaveBeenCalledWith("dark")
+  expect(getColorSchemeSpy).toHaveBeenCalledTimes(1)
 
-    expect(getColorModeButton()).toHaveTextContent("dark")
-  })
+  expect(rootGetSpy).not.toHaveBeenCalled()
+  expect(mockLocalStorageManager.get).not.toHaveBeenCalled()
+
+  expect(getColorModeButton()).not.toHaveTextContent(
+    defaultThemeOptions.initialColorMode,
+  )
+})
+
+test("prefers root property over localStorage", () => {
+  const rootGetSpy = jest
+    .spyOn(colorModeUtils.root, "get")
+    // @ts-expect-error only happens if value doesn't exist, e.g. CSR
+    .mockReturnValueOnce("")
+
+  const mockLocalStorageManager = createMockStorageManager(
+    "localStorage",
+    "dark",
+  )
+
+  render(
+    <ColorModeProvider
+      options={defaultThemeOptions}
+      colorModeManager={mockLocalStorageManager}
+    >
+      <DummyComponent />
+    </ColorModeProvider>,
+  )
+
+  expect(rootGetSpy).toHaveBeenCalledTimes(1)
+  expect(mockLocalStorageManager.get).toHaveBeenCalledTimes(1)
+
+  expect(getColorModeButton()).not.toHaveTextContent(
+    defaultThemeOptions.initialColorMode,
+  )
+})
+
+test("onChange sets value to all listeners", () => {
+  const rootSet = jest.spyOn(colorModeUtils.root, "set")
+
+  const mockLocalStorageManager = createMockStorageManager("localStorage")
+
+  render(
+    <ColorModeProvider
+      options={defaultThemeOptions}
+      colorModeManager={mockLocalStorageManager}
+    >
+      <DummyComponent />
+    </ColorModeProvider>,
+  )
+
+  expect(rootSet).toHaveBeenCalledTimes(1)
+  expect(mockLocalStorageManager.set).not.toHaveBeenCalled()
+
+  act(() => userEvent.click(getColorModeButton()))
+
+  expect(rootSet).toHaveBeenCalledTimes(2)
+  expect(rootSet).toHaveBeenCalledWith("dark")
+
+  expect(mockLocalStorageManager.set).toHaveBeenCalledTimes(1)
+  expect(mockLocalStorageManager.set).toHaveBeenCalledWith("dark")
+
+  expect(getColorModeButton()).toHaveTextContent("dark")
 })
 
 describe("<ColorModeProvider /> cookie browser", () => {

--- a/packages/color-mode/test/color-mode-script.test.tsx
+++ b/packages/color-mode/test/color-mode-script.test.tsx
@@ -1,0 +1,38 @@
+import { setScript } from "../src"
+import { ConfigColorMode } from "../dist/types"
+
+describe("color-mode-script", () => {
+  it.each(
+    [
+      { system: "light", initial: "light", expect: "light" },
+      { system: "dark", initial: "light", expect: "light" },
+      { system: "light", initial: "dark", expect: "dark" },
+      { system: "dark", initial: "dark", expect: "dark" },
+      { system: "light", initial: "system", expect: "light" },
+      { system: "dark", initial: "system", expect: "dark" },
+    ].map((item) => ({
+      ...item,
+      toString: () => `case: ${JSON.stringify(item)}`,
+    })),
+  )("%s", (entry) => {
+    const systemIsDarkMode = entry.system === "dark"
+    const documentMock = jest.fn()
+    Object.defineProperty(document, "documentElement", {
+      writable: true,
+      configurable: true,
+      value: { style: { setProperty: documentMock } },
+    })
+    global.matchMedia = jest.fn().mockImplementation((query) => {
+      if (query === "(prefers-color-scheme: dark)") {
+        return {
+          matches: systemIsDarkMode,
+        }
+      }
+    })
+    setScript(entry.initial as ConfigColorMode)
+    expect(documentMock).toHaveBeenCalledWith(
+      "--chakra-ui-color-mode",
+      entry.expect,
+    )
+  })
+})

--- a/website/pages/docs/features/color-mode.mdx
+++ b/website/pages/docs/features/color-mode.mdx
@@ -55,7 +55,8 @@ const theme = extendTheme({ config })
 export default theme
 ```
 
-For typescript, you need to explicitly describe the theme config type as `ThemeConfig` object.
+For typescript, you need to explicitly describe the theme config type as
+`ThemeConfig` object.
 
 ```jsx live=false
 // theme.ts
@@ -64,7 +65,7 @@ For typescript, you need to explicitly describe the theme config type as `ThemeC
 import { extendTheme, ThemeConfig } from "@chakra-ui/react"
 
 // 2. Add your color mode config
-const config : ThemeConfig = {
+const config: ThemeConfig = {
   initialColorMode: "light",
   useSystemColorMode: false,
 }
@@ -78,10 +79,41 @@ export default theme
 > Remember to pass your custom `theme` to the `ChakraProvider`, otherwise your
 > color mode config won't be taken into consideration.
 
+#### Behavior of ColorMode
+
+The current hierarchy how the color mode is defined is as follows:
+
+- if `useSystemColorMode` is true `system`-color will be used as default -
+  `initialColorMode` is the fallback if system color mode can't be resolved
+
+- if `--chakra-ui-color-mode` is defined through e.g. `ColorModeScript` / after
+  modification/initial load of the colorMode this value will be used
+
+- if `colorModeManager` = `localStorage` and a value is defined for
+  `chakra-ui-color-mode` this will be used
+
+- if `initialColorMode` = `system` system-color will be used as default -
+  `initialColorMode` is the fallback if system color mode isn't resolved
+
+- if `initialColorMode` = `'light'|'dark'` the corresponding value will be used
+
+We currently accept 3 different values for `initialColorMode`:
+`light`,`dark`,`system`
+
+#### Difference between `initialColorMode='system'` and `useSystemColorMode`
+
+if `useSystemColorMode=true` we will always try to match the users
+`system`-color and fallback to `initialColorMode` With this behavior the
+colorMode toggle won't have any effect.
+
+if `initialColorMode='system'` we will as well always try to match the users
+`system`-color and fallback to `light`. after the user has toggled the value,
+this value will be used.
+
 ### Adding the `ColorModeScript`
 
-The color mode script needs to be added before the content inside the `body` tag for local storage
-syncing to work correctly.
+The color mode script needs to be added before the content inside the `body` tag
+for local storage syncing to work correctly.
 
 > When setting the initial color mode, we recommend adding it as a config to
 > your theme and reference that in the `ColorModeScript`.
@@ -142,7 +174,8 @@ ReactDOM.render(
 
 #### For Gatsby
 
-Install `@chakra-ui/gatsby-plugin` into your project. You can read more in the [Chakra UI + Gatsby guide](/guides/integrations/with-gatsby).
+Install `@chakra-ui/gatsby-plugin` into your project. You can read more in the
+[Chakra UI + Gatsby guide](/guides/integrations/with-gatsby).
 
 ## Changing Color Mode
 
@@ -295,11 +328,11 @@ export function getServerSideProps({ req }) {
 import { Chakra } from "../src/Chakra"
 
 export default function App({ Component, pageProps }) {
-    return (
-    	<Chakra cookies={pageProps.cookies}>
-    		<Component {...pageProps} />
-    	</Chakra>
-    );
+  return (
+    <Chakra cookies={pageProps.cookies}>
+      <Component {...pageProps} />
+    </Chakra>
+  )
 }
 
 // e.g pages/index.js
@@ -311,9 +344,9 @@ export default function Index() {
 export { getServerSideProps } from "./Chakra"
 ```
 
-> If you need to know the name of the Chakra cookie for specific reasons,
-> it's `chakra-ui-color-mode`. Also, if you use `colorModeManager`, you can
-> avoid adding the `<ColorModeScript />` to `_document.js`.
+> If you need to know the name of the Chakra cookie for specific reasons, it's
+> `chakra-ui-color-mode`. Also, if you use `colorModeManager`, you can avoid
+> adding the `<ColorModeScript />` to `_document.js`.
 
 > **Important:** if you're using `Next.js 9.3` or newer, the Next.js team
 > recommends avoiding `getInitialProps`. The following example is for Next 9.2


### PR DESCRIPTION
Closes #4987

## 📝 Description

Fix the behavior of color-mode when in system mode 

## 🚀 New behavior

Fixed color mode behavior priority in the following order:

- if `useSystemColorMode` is true system-color will be used as default - initial
  colormode is the fallback if system color mode isn't resolved

- if `--chakra-ui-color-mode` is defined through e.g. `ColorModeScript` this
  will be used

- if `colorModeManager` = `localStorage` and a value is defined for
  `chakra-ui-color-mode` this will be used

- if `initialColorMode` = `system` system-color will be used as default -
  initial colormode is the fallback if system color mode isn't resolved

- if `initialColorMode` = `'light'|'dark'` the corresponding value will be used

## 💣 Is this a breaking change (Yes/No):

No

