### PR TITLE
docs: added additional explanation to the customizing global styles section

### DIFF
--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -198,7 +198,7 @@ const overrides = extendTheme({
   },
 })
 
-//Provide the customized theme to [`ChakraProvider`](https://chakra-ui.com/docs/getting-started#set-up-provider) component at the root of your app
+//Provide the customized theme to `ChakraProvider` component at the root of your app
 
 //index.js
 import theme from "./theme";

--- a/website/pages/docs/theming/customize-theme.mdx
+++ b/website/pages/docs/theming/customize-theme.mdx
@@ -197,6 +197,15 @@ const overrides = extendTheme({
     }),
   },
 })
+
+//Provide the customized theme to [`ChakraProvider`](https://chakra-ui.com/docs/getting-started#set-up-provider) component at the root of your app
+
+//index.js
+import theme from "./theme";
+
+<ChakraProvider theme={theme}>
+  <App />
+</ChakraProvider>
 ```
 
 ## Scaling out your project


### PR DESCRIPTION
## 📝 Description
I've added the final step to [customizing-global-styles](https://chakra-ui.com/docs/theming/customize-theme#customizing-global-styles) that we should provide the customized theme to `ChakraProvider` component. 

I've noticed that there's a demand for adding additional explanation to customizing 


## ⛳️ Current behavior (updates)

Although there's a reminder that we should pass the custom theme to  `ChakraProvider` in the end of [updating-the-theme-config](https://chakra-ui.com/docs/features/color-mode#updating-the-theme-config), some people who miss this section and started to configure their theme according to [customizing-global-styles](https://chakra-ui.com/docs/theming/customize-theme#customizing-global-styles) might miss this step and have issues that their changes aren’t applied: [Example 1](https://github.com/chakra-ui/chakra-ui/issues/591), [Example 2](https://stackoverflow.com/questions/64558533/changing-the-dark-mode-color-in-chakra-ui)

## 🚀 New behavior

Now there's a description of the final step of applying custom theme at the end of [customizing-global-styles](https://chakra-ui.com/docs/theming/customize-theme#customizing-global-styles) :

```
//Provide the customized theme to `ChakraProvider` component at the root of your app

//index.js
import theme from "./theme";

<ChakraProvider theme={theme}>
  <App />
</ChakraProvider>
```

## 💣 Is this a breaking change (Yes/No): No
