### PR TITLE
fix(select): allow icon spacing to be customized via theme

### DIFF
--- a/.changeset/funny-steaks-heal.md
+++ b/.changeset/funny-steaks-heal.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/select": patch
+"@chakra-ui/theme": patch
+---
+
+Fixed an styling issue where it was not possible to customize the icon spacing of the `Select` component.

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -130,10 +130,11 @@ export const Select = forwardRef<SelectProps, "select">((props, ref) => {
     color,
   }
 
-  const fieldStyles: SystemStyleObject = mergeWith({}, styles.field, {
-    paddingEnd: "2rem",
-    _focus: { zIndex: "unset" },
-  })
+  const fieldStyles: SystemStyleObject = mergeWith(
+    { paddingEnd: "2rem" },
+    styles.field,
+    { _focus: { zIndex: "unset" } },
+  )
 
   return (
     <chakra.div

--- a/packages/select/tests/select.test.tsx
+++ b/packages/select/tests/select.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { render, testA11y } from "@chakra-ui/test-utils"
 import { FormControl } from "@chakra-ui/form-control"
+import { ChakraProvider, extendTheme, theme } from "@chakra-ui/react"
 import { Select } from "../src"
 
 test("should pass a11y check", async () => {
@@ -67,3 +68,60 @@ test("renders in disabled state if wrapped by FormControl with isDisabled=true",
   expect(select).toBeDisabled()
   expect(iconWrapper).toHaveAttribute("data-disabled", "")
 })
+
+describe.each(Object.keys(theme.components.Select.sizes))(
+  "icon spacing for '%s' size",
+  (size) => {
+    const defaultSpacing = "2rem"
+
+    test("defaults icon spacing in theme", () => {
+      const { container } = render(<Select size={size} />)
+      const select = container.querySelector("select") as HTMLElement
+
+      expect(select).toHaveStyle({ "padding-inline-end": defaultSpacing })
+    })
+
+    test("defaults icon spacing in component", () => {
+      const theme = extendTheme({
+        components: {
+          Select: {
+            sizes: {
+              lg: { field: { paddingInlineEnd: null, px: null } },
+              md: { field: { paddingInlineEnd: null, px: null } },
+              sm: { field: { paddingInlineEnd: null, px: null } },
+              xs: { field: { paddingInlineEnd: null, px: null } },
+            },
+          },
+        },
+      })
+      const { container } = render(
+        <ChakraProvider theme={theme}>
+          <Select />
+        </ChakraProvider>,
+      )
+      const select = container.querySelector("select") as HTMLElement
+
+      expect(select).toHaveStyle({ "padding-inline-end": defaultSpacing })
+    })
+
+    test("allows icon spacing to be overridden in theme", () => {
+      const sizes = {
+        lg: { field: { paddingInlineEnd: "8px" } },
+        md: { field: { paddingInlineEnd: "6px" } },
+        sm: { field: { paddingInlineEnd: "4px" } },
+        xs: { field: { paddingInlineEnd: "2px" } },
+      }
+      const theme = extendTheme({ components: { Select: { sizes } } })
+      const { container } = render(
+        <ChakraProvider theme={theme}>
+          <Select size={size} />
+        </ChakraProvider>,
+      )
+      const select = container.querySelector("select") as HTMLElement
+
+      expect(select).toHaveStyle({
+        "padding-inline-end": sizes[size].field.paddingInlineEnd,
+      })
+    })
+  },
+)

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -5,6 +5,7 @@ import type {
   SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
+import { mergeWith } from "@chakra-ui/utils"
 import { mode } from "@chakra-ui/theme-tools"
 import Input from "./input"
 
@@ -38,13 +39,27 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   icon: baseStyleIcon,
 })
 
-const sizes: Record<string, PartsStyleObject<typeof parts>> = {
-  ...Input.sizes,
-  xs: {
-    ...Input.sizes.xs,
-    icon: { insetEnd: "0.25rem" },
+const iconSpacing = { paddingInlineEnd: "2rem" }
+
+const sizes: Record<string, PartsStyleObject<typeof parts>> = mergeWith(
+  {},
+  Input.sizes,
+  {
+    lg: {
+      field: iconSpacing,
+    },
+    md: {
+      field: iconSpacing,
+    },
+    sm: {
+      field: iconSpacing,
+    },
+    xs: {
+      field: iconSpacing,
+      icon: { insetEnd: "0.25rem" },
+    },
   },
-}
+)
 
 export default {
   parts: parts.keys,


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4938

## 📝 Description

Allow the spacing between the `field` and `icon` parts of the `Select` component to be applied from the theme.

## ⛳️ Current behavior (updates)

The spacing is currently hard-coded as `2rem` in the `Select` component here: https://github.com/chakra-ui/chakra-ui/blob/445fc8b15bd1155a53ac95c5c1ba74d671062355/packages/select/src/select.tsx#L133-L136.

## 🚀 New behavior

Allow said spacing to be applied in the `Select` component's theme, while preserving the current default behavior as best as possible.

## 💣 Is this a breaking change (Yes/No):

No
