### PR TITLE
docs: accessibility fixes for Search button

### DIFF
--- a/website/src/components/algolia-search.tsx
+++ b/website/src/components/algolia-search.tsx
@@ -44,7 +44,6 @@ export const SearchButton = React.forwardRef(
       <chakra.button
         flex="1"
         type="button"
-        role="search"
         mx="6"
         ref={ref}
         lineHeight="1.2"
@@ -60,7 +59,6 @@ export const SearchButton = React.forwardRef(
         _focus={{ shadow: "outline" }}
         shadow="base"
         rounded="md"
-        aria-label="Search the docs"
         {...props}
       >
         <SearchIcon />


### PR DESCRIPTION
The button to open the search text field had a `role=search` on it, as well as an `aria-label`.

[`role=search` is a type of landmark](https://www.w3.org/TR/wai-aria-1.2/#search), and not a role that indicates it is actionable.    Removing this role allows the control to be correctly exposed as a button element.

The `aria-label="Search the docs"` on the button suppresses the announcement of its child content, making it so that the key commands to open the search modal will not be announced.  

As "Search the docs" is already child content of the button (line 67), removing the `aria-label` allows the name of this button to still be announced correctly, and the additional "press ... to search" content will now be announced.

If you would like the search landmark to still be used / exposed, it must be an element that wraps this button, and not used on the button itself.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
