### PR TITLE
fix: range slider out of bounds error

### DIFF
--- a/.changeset/gold-files-guess.md
+++ b/.changeset/gold-files-guess.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/slider": patch
+---
+
+fixed the bug in RangeSlider where an index out of bounds error would occur
+incase of stacked thumb

--- a/packages/slider/src/use-range-slider.ts
+++ b/packages/slider/src/use-range-slider.ts
@@ -347,9 +347,14 @@ export function useRangeSlider(props: UseRangeSliderProps) {
   const onPanSessionStart = (event: AnyPointerEvent) => {
     const pointValue = getValueFromPointer(event) || 0
     const distances = value.map((val) => Math.abs(val - pointValue))
-    const isThumbStacked = new Set(distances).size !== distances.length
     const closest = Math.min(...distances)
     let index = distances.indexOf(closest)
+
+    // check if the clicked thumb is stacked by checking if there are multiple
+    // thumbs at the same distance
+    const isThumbStacked =
+      distances.filter((distance) => distance === closest).length > 1
+
     // when two thumbs are stacked and the user clicks at a point larger than
     // their values, pick the next closest thumb
     if (isThumbStacked && pointValue > value[index]) {
@@ -361,7 +366,7 @@ export function useRangeSlider(props: UseRangeSliderProps) {
   }
 
   const onPan = (event: AnyPointerEvent) => {
-    if (activeIndex == -1) return;
+    if (activeIndex == -1) return
     const pointValue = getValueFromPointer(event) || 0
     setActiveIndex(activeIndex)
     actions.setValueAtIndex(activeIndex, pointValue)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/4981

## 📝 Description

fixed the bug in RangeSlider where an index out of bounds error would occur in
case of stacked thumbs

The logic to check if a thumb was stacked or not was incorrect. 

## ⛳️ Current behavior (updates)

It would previously only check for duplicate values and if a duplicate value existed, it would consider that the current thumb was stacked

## 🚀 New behavior

The check has been changed to find if duplicates of the current closest thumbs are present

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
