### PR TITLE
fix: thumb does not move in case of stacked thumbs

### DIFF
--- a/.changeset/happy-pants-tickle.md
+++ b/.changeset/happy-pants-tickle.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/slider": patch
+---
+
+fixed a bug where a thumb would not move in case of stacked thumbs

--- a/packages/slider/src/range-slider.tsx
+++ b/packages/slider/src/range-slider.tsx
@@ -23,14 +23,12 @@ interface RangeSliderContext
   name?: string | string[]
 }
 
-const [
-  RangeSliderProvider,
-  useRangeSliderContext,
-] = createContext<RangeSliderContext>({
-  name: "SliderContext",
-  errorMessage:
-    "useSliderContext: `context` is undefined. Seems you forgot to wrap all slider components within <RangeSlider />",
-})
+const [RangeSliderProvider, useRangeSliderContext] =
+  createContext<RangeSliderContext>({
+    name: "SliderContext",
+    errorMessage:
+      "useSliderContext: `context` is undefined. Seems you forgot to wrap all slider components within <RangeSlider />",
+  })
 
 export { RangeSliderProvider, useRangeSliderContext }
 
@@ -53,10 +51,10 @@ export const RangeSlider = forwardRef<RangeSliderProps, "div">((props, ref) => {
   ownProps.direction = direction
 
   const { getRootProps, ...context } = useRangeSlider(ownProps)
-  const ctx = React.useMemo(() => ({ ...context, name: props.name }), [
-    context,
-    props.name,
-  ])
+  const ctx = React.useMemo(
+    () => ({ ...context, name: props.name }),
+    [context, props.name],
+  )
 
   return (
     <RangeSliderProvider value={ctx}>
@@ -125,6 +123,7 @@ export const RangeSliderTrack = forwardRef<RangeSliderTrackProps, "div">(
         {...trackProps}
         className={cx("chakra-slider__track", props.className)}
         __css={styles.track}
+        data-testid="chakra-range-slider-track"
       />
     )
   },

--- a/packages/slider/src/use-range-slider.ts
+++ b/packages/slider/src/use-range-slider.ts
@@ -352,13 +352,15 @@ export function useRangeSlider(props: UseRangeSliderProps) {
 
     // check if the clicked thumb is stacked by checking if there are multiple
     // thumbs at the same distance
-    const isThumbStacked =
-      distances.filter((distance) => distance === closest).length > 1
+    const thumbsAtPosition = distances.filter(
+      (distance) => distance === closest,
+    )
+    const isThumbStacked = thumbsAtPosition.length > 1
 
     // when two thumbs are stacked and the user clicks at a point larger than
-    // their values, pick the next closest thumb
+    // their values, pick the last thumb with the greatest index
     if (isThumbStacked && pointValue > value[index]) {
-      index++
+      index = thumbsAtPosition.length - 1
     }
     setActiveIndex(index)
     actions.setValueAtIndex(index, pointValue)

--- a/packages/slider/tests/range-slider.test.tsx
+++ b/packages/slider/tests/range-slider.test.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable jsx-a11y/aria-proptypes */
 import * as React from "react"
-import { press, render, screen, testA11y } from "@chakra-ui/test-utils"
+import {
+  press,
+  render,
+  screen,
+  testA11y,
+  userEvent,
+  act,
+} from "@chakra-ui/test-utils"
 import {
   RangeSlider,
   RangeSliderFilledTrack,
@@ -21,6 +28,19 @@ const HorizontalSlider = () => {
       </RangeSliderTrack>
       <RangeSliderThumb index={0} />
       <RangeSliderThumb index={1} />
+    </RangeSlider>
+  )
+}
+
+const HorizontalSliderWithStackedThumbs = () => {
+  return (
+    <RangeSlider min={0} max={100} defaultValue={[0, 0, 100]}>
+      <RangeSliderTrack>
+        <RangeSliderFilledTrack />
+      </RangeSliderTrack>
+      <RangeSliderThumb index={0} />
+      <RangeSliderThumb index={1} />
+      <RangeSliderThumb index={2} />
     </RangeSlider>
   )
 }
@@ -85,4 +105,33 @@ test("should set a thumb to its maximum value when pressing the end key", () => 
 
   press.End(rightThumb)
   expect(rightThumb).toHaveAttribute("aria-valuenow", "100")
+})
+
+test("should move the correct thumb when user clicks the track in case of stacked thumbs", async () => {
+  render(<HorizontalSliderWithStackedThumbs />)
+
+  const rangeSliderTrack = screen.getByTestId("chakra-range-slider-track")
+
+  // getBoundingClientRect is not supported by JSDOM
+  // its implementation needs to be mocked
+  jest
+    .spyOn(rangeSliderTrack, "getBoundingClientRect")
+    .mockImplementation(() => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 20,
+    }))
+
+  const clickCoordinates = { clientX: 20, clientY: 10 }
+
+  await act(() => {
+    userEvent.click(rangeSliderTrack, clickCoordinates)
+  })
+
+  const [firstThumb, secondThumb, thirdThumb] = getThumbs()
+
+  expect(firstThumb).toHaveAttribute("aria-valuenow", "0")
+  expect(secondThumb).toHaveAttribute("aria-valuenow", "20")
+  expect(thirdThumb).toHaveAttribute("aria-valuenow", "100")
 })


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/5041

## 📝 Description

fixed a bug where thumb would not move in case of stacked thumbs

## ⛳️ Current behavior (updates)

The thumb does not move because the incorrect thumb is selected

## 🚀 New behavior

Fixed the index of thumb being selected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
