### PR TITLE
fix: prop-docs package

### DIFF
--- a/.changeset/dull-weeks-drum.md
+++ b/.changeset/dull-weeks-drum.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/props-docs": patch
+---
+
+Fix issue where package doesn't include a `dist` folder and doesn't work when
+installed from npm.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build packages
         run: yarn build
 
-      # - name: Build CRA templates
-      #   run: yarn build:templates ../cra-templates
+      - name: Build prop docs
+        run: yarn build:prop-docs
 
       - name: Run tests
         run: yarn test:ci

--- a/tooling/props-docs/package.json
+++ b/tooling/props-docs/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "main": "dist/chakra-ui-props-docs.cjs.js",
   "module": "dist/chakra-ui-props-docs.esm.js",
-  "types": "dist/chakra-ui-props-docs.d.ts",
+  "types": "dist/chakra-ui-props-docs.cjs.d.ts",
   "files": [
     "dist"
   ],

--- a/tooling/props-docs/src/build.ts
+++ b/tooling/props-docs/src/build.ts
@@ -188,7 +188,7 @@ ${esmPropExports}`,
 
 function writeTypes(componentInfo: ComponentInfo[]) {
   const typeExports = componentInfo
-    .map(({ exportName }) => `export declare const ${exportName}:  PropDoc`)
+    .map(({ exportName }) => `export declare const ${exportName}: PropDoc`)
     .join("\n")
 
   const baseType = `

--- a/tooling/props-docs/src/build.ts
+++ b/tooling/props-docs/src/build.ts
@@ -30,19 +30,11 @@ const rootDir = path.join(__dirname, "..", "..", "..")
 const sourcePath = path.join(rootDir, "packages")
 const outputPath = path.join(__dirname, "..", "dist", "components")
 
-const cjsIndexFilePath = path.join(
-  __dirname,
-  "..",
-  "dist",
-  "chakra-ui-props-docs.cjs.js",
-)
+const basePath = path.join(__dirname, "..", "dist")
 
-const esmIndexFilePath = path.join(
-  __dirname,
-  "..",
-  "dist",
-  "chakra-ui-props-docs.esm.js",
-)
+const cjsIndexFilePath = path.join(basePath, "chakra-ui-props-docs.cjs.js")
+const esmIndexFilePath = path.join(basePath, "chakra-ui-props-docs.esm.js")
+const typeFilePath = path.join(basePath, "chakra-ui-props-docs.cjs.d.ts")
 
 const tsConfigPath = path.join(sourcePath, "..", "tsconfig.json")
 
@@ -65,6 +57,7 @@ export async function main() {
   log("Writing index files...")
   writeIndexCJS(componentInfo)
   writeIndexESM(componentInfo)
+  writeTypes(componentInfo)
 
   log(`Processed ${componentInfo.length} components`)
 }
@@ -191,6 +184,48 @@ function writeIndexESM(componentInfo: ComponentInfo[]) {
     `${esmPropImports}
 ${esmPropExports}`,
   )
+}
+
+function writeTypes(componentInfo: ComponentInfo[]) {
+  const typeExports = componentInfo
+    .map(({ exportName }) => `export declare const ${exportName}:  PropDoc`)
+    .join("\n")
+
+  const baseType = `
+    export interface Parent {
+        fileName: string;
+        name: string;
+    }
+
+    export interface Declaration {
+        fileName: string;
+        name: string;
+    }
+
+    export interface DefaultProps {
+        defaultValue?: any;
+        description: string | JSX.Element;
+        name: string;
+        parent: Parent;
+        declarations: Declaration[];
+        required: boolean;
+        type: { name: string };
+    }
+
+    export interface PropDoc {
+        tags: { see: string };
+        filePath: string;
+        description: string | JSX.Element;
+        displayName: string;
+        methods: any[];
+        props: {
+          defaultProps?: DefaultProps;
+          components?: DefaultProps;
+        };
+    }
+  `
+
+  writeFileSync(typeFilePath, `${baseType}\n${typeExports}`)
 }
 
 function log(...args: unknown[]) {

--- a/website/src/components/props-table.tsx
+++ b/website/src/components/props-table.tsx
@@ -19,7 +19,7 @@ export type PropsTableProps = {
   /**
    * displayName of the target component
    */
-  of: string
+  of: keyof typeof ComponentProps
   /**
    * prop names to omit
    */
@@ -43,11 +43,10 @@ const PropsTable = ({
   ],
   only,
 }: PropsTableProps) => {
-  const propList = React.useMemo(() => makePropsTable({ of, omit, only }), [
-    of,
-    omit,
-    only,
-  ])
+  const propList = React.useMemo(
+    () => makePropsTable({ of, omit, only }),
+    [of, omit, only],
+  )
 
   if (!propList.length) {
     // this error breaks the build to notify you when there would be an empty table
@@ -138,7 +137,7 @@ interface MakePropsTableOptions extends PropsTableProps {}
 const TYPE_GENERIC_THEMABLE = "(string & {})"
 
 function makePropsTable({ of, omit, only }: MakePropsTableOptions) {
-  const props = ComponentProps[of]?.props as Record<string, any>
+  const props = ComponentProps[of]?.props
 
   const themeKey = themeComponentKeyAliases[of] ?? of
   const componentTheme = theme.components[themeKey]

--- a/website/src/utils/convert-backticks-to-inline-code.tsx
+++ b/website/src/utils/convert-backticks-to-inline-code.tsx
@@ -21,7 +21,7 @@ function toInlineCode(input: string) {
     )
 }
 
-export function convertBackticksToInlineCode(input?: string) {
+export function convertBackticksToInlineCode(input?: string | JSX.Element) {
   if (!input) return ""
   return isObject(input) ? input : toInlineCode(input)
 }


### PR DESCRIPTION
## 📝 Description

This PR fixes a build issue with the prop-docs package and adds types for the output files.

## ⛳️ Current behavior (updates)

Based on the last release, there's currently no `dist` output for this package. This is an unintended side-effect from the migration to preconstruct.

## 🚀 New behavior

Added `yarn build:prop-docs` to the CI after running the build command so we can get the correct build artifacts for that package

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- Updated the website prop-table to be more typesafe
- The build script is quite slow and expect that we can improve this. It takes as long as `yarn preconstruct build` which is strange but understandable, perhaps it's related to the slowness of `ts-node`.