### PR TITLE
chore(color-mode): fix flaky color-mode-script test

### DIFF
--- a/.changeset/mean-bikes-work.md
+++ b/.changeset/mean-bikes-work.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+Fixed flaky color-mode test

--- a/packages/color-mode/test/color-mode-script.test.tsx
+++ b/packages/color-mode/test/color-mode-script.test.tsx
@@ -1,5 +1,4 @@
-import { setScript } from "../src"
-import { ConfigColorMode } from "../dist/chakra-ui-color-mode.cjs"
+import { setScript, ConfigColorMode } from "../src"
 
 describe("color-mode-script", () => {
   it.each(
@@ -16,12 +15,10 @@ describe("color-mode-script", () => {
     })),
   )("%s", (entry) => {
     const systemIsDarkMode = entry.system === "dark"
-    const documentMock = jest.fn()
-    Object.defineProperty(document, "documentElement", {
-      writable: true,
-      configurable: true,
-      value: { style: { setProperty: documentMock } },
-    })
+    const documentMock = jest.spyOn(
+      document.documentElement.style,
+      "setProperty",
+    )
     global.matchMedia = jest.fn().mockImplementation((query) => {
       if (query === "(prefers-color-scheme: dark)") {
         return {


### PR DESCRIPTION
## 📝 Description

Now and then it happened that the `color-mode` [test failed](https://github.com/chakra-ui/chakra-ui/runs/4217655474?check_suite_focus=true).  I assumed that this happened because of the `Object.define` in the `color-mode.script.test` . I replaced it with a `jest.spyOn` and now the mock should work without interfering with other tests. 

