### PR TITLE
fix(color-mode): correct rendering of child components for dark and l…

### DIFF
--- a/.changeset/spotty-oranges-impress.md
+++ b/.changeset/spotty-oranges-impress.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+Fix Dark and Light mode tags from always rerendering children even if the child
+is memoized. <LightMode> and <DarkMode> components are now memoized to prevent
+unnecessary rendering of their child components.

--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -176,12 +176,18 @@ if (__DEV__) {
 /**
  * Locks the color mode to `dark`, without any way to change it.
  */
-export const DarkMode: React.FC = (props) => (
-  <ColorModeContext.Provider
-    value={{ colorMode: "dark", toggleColorMode: noop, setColorMode: noop }}
-    {...props}
-  />
-)
+export const DarkMode: React.FC = (props) => {
+  const context = React.useMemo<ColorModeContextType>(
+    () => ({
+      colorMode: "dark",
+      toggleColorMode: noop,
+      setColorMode: noop,
+    }),
+    [],
+  )
+
+  return <ColorModeContext.Provider value={context} {...props} />
+}
 
 if (__DEV__) {
   DarkMode.displayName = "DarkMode"
@@ -190,12 +196,18 @@ if (__DEV__) {
 /**
  * Locks the color mode to `light` without any way to change it.
  */
-export const LightMode: React.FC = (props) => (
-  <ColorModeContext.Provider
-    value={{ colorMode: "light", toggleColorMode: noop, setColorMode: noop }}
-    {...props}
-  />
-)
+export const LightMode: React.FC = (props) => {
+  const context = React.useMemo<ColorModeContextType>(
+    () => ({
+      colorMode: "light",
+      toggleColorMode: noop,
+      setColorMode: noop,
+    }),
+    [],
+  )
+
+  return <ColorModeContext.Provider value={context} {...props} />
+}
 
 if (__DEV__) {
   LightMode.displayName = "LightMode"

--- a/packages/color-mode/test/dark-mode.test.tsx
+++ b/packages/color-mode/test/dark-mode.test.tsx
@@ -2,9 +2,45 @@ import { render } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React from "react"
 import { DarkMode } from "../src/color-mode-provider"
-import { DummyComponent, getColorModeButton } from "./utils"
+import {
+  DummyComponent,
+  getColorModeButton,
+  MemoizedComponent,
+  RegularComponent,
+  resetCounter,
+} from "./utils"
+
+const MemoTest = () => {
+  const [_, setRenderCount] = React.useState(0)
+
+  return (
+    <>
+      <DarkMode>
+        <MemoizedComponent />
+      </DarkMode>
+      <button onClick={() => setRenderCount((c) => c + 1)}>Rerender</button>
+    </>
+  )
+}
+
+const NoMemoTest = () => {
+  const [_, setRenderCount] = React.useState(0)
+
+  return (
+    <>
+      <DarkMode>
+        <RegularComponent />
+      </DarkMode>
+      <button onClick={() => setRenderCount((c) => c + 1)}>Rerender</button>
+    </>
+  )
+}
 
 describe("<DarkMode />", () => {
+  beforeEach(() => {
+    resetCounter()
+  })
+
   test("is always dark", () => {
     render(
       <DarkMode>
@@ -19,5 +55,23 @@ describe("<DarkMode />", () => {
     userEvent.click(button)
 
     expect(getColorModeButton()).toHaveTextContent("dark")
+  })
+
+  test("memoized component renders once", () => {
+    const { getByText, getByTestId } = render(<MemoTest />)
+
+    userEvent.click(getByText("Rerender"))
+    userEvent.click(getByText("Rerender"))
+
+    expect(getByTestId("rendered")).toHaveTextContent("1")
+  })
+
+  test("non memoized component renders multiple", () => {
+    const { getByText, getByTestId } = render(<NoMemoTest />)
+
+    userEvent.click(getByText("Rerender"))
+    userEvent.click(getByText("Rerender"))
+
+    expect(getByTestId("rendered")).toHaveTextContent("3")
   })
 })

--- a/packages/color-mode/test/light-mode.test.tsx
+++ b/packages/color-mode/test/light-mode.test.tsx
@@ -2,9 +2,45 @@ import { render } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React from "react"
 import { LightMode } from "../src/color-mode-provider"
-import { DummyComponent, getColorModeButton } from "./utils"
+import {
+  DummyComponent,
+  getColorModeButton,
+  MemoizedComponent,
+  RegularComponent,
+  resetCounter,
+} from "./utils"
+
+const MemoTest = () => {
+  const [_, setRenderCount] = React.useState(0)
+
+  return (
+    <>
+      <LightMode>
+        <MemoizedComponent />
+      </LightMode>
+      <button onClick={() => setRenderCount((c) => c + 1)}>Rerender</button>
+    </>
+  )
+}
+
+const NoMemoTest = () => {
+  const [_, setRenderCount] = React.useState(0)
+
+  return (
+    <>
+      <LightMode>
+        <RegularComponent />
+      </LightMode>
+      <button onClick={() => setRenderCount((c) => c + 1)}>Rerender</button>
+    </>
+  )
+}
 
 describe("<LightMode />", () => {
+  beforeEach(() => {
+    resetCounter()
+  })
+
   test("is always light", () => {
     render(
       <LightMode>
@@ -19,5 +55,23 @@ describe("<LightMode />", () => {
     userEvent.click(button)
 
     expect(getColorModeButton()).toHaveTextContent("light")
+  })
+
+  test("memoized component renders once", () => {
+    const { getByText, getByTestId } = render(<MemoTest />)
+
+    userEvent.click(getByText("Rerender"))
+    userEvent.click(getByText("Rerender"))
+
+    expect(getByTestId("rendered")).toHaveTextContent("1")
+  })
+
+  test("non memoized component renders multiple", () => {
+    const { getByText, getByTestId } = render(<NoMemoTest />)
+
+    userEvent.click(getByText("Rerender"))
+    userEvent.click(getByText("Rerender"))
+
+    expect(getByTestId("rendered")).toHaveTextContent("3")
   })
 })

--- a/packages/color-mode/test/utils.tsx
+++ b/packages/color-mode/test/utils.tsx
@@ -16,6 +16,22 @@ export const DummyComponent = () => {
   )
 }
 
+var renderCount = 0
+
+export const resetCounter = () => {
+  renderCount = 0
+}
+
+export const MemoizedComponent = React.memo(() => {
+  renderCount = renderCount + 1
+  return <div data-testid="rendered">{renderCount}</div>
+})
+
+export const RegularComponent = () => {
+  renderCount = renderCount + 1
+  return <div data-testid="rendered">{renderCount}</div>
+}
+
 export const getColorModeButton = () => screen.getByRole("button")
 
 export const defaultThemeOptions = theme.config as Required<ColorModeOptions>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4080

## 📝 Description

> Fixes an issue with `LightMode` and `DarkMode` tags where the memoized children are re-rendered when the tag is re-rendered. 

## ⛳️ Current behavior (updates)

> Given the `MemoComponent` implements the `useMemo` hook, the following component 
> ```jsx
> <LightMode>
>    <MemoComponent />
> </LightMode>
>```
>causes the `MemoComponent` to be rendered each time the `LightMode` component is rendered.

## 🚀 New behavior

> Given the component above, them memoized child is no longer needlessly rendered.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
