### PR TITLE
feat: add flex gap

### DIFF
--- a/.changeset/brown-rivers-switch.md
+++ b/.changeset/brown-rivers-switch.md
@@ -1,6 +1,6 @@
 ---
-"@chakra-ui/layout": patch
-"@chakra-ui/styled-system": patch
+"@chakra-ui/layout": minor
+"@chakra-ui/styled-system": minor
 ---
 
-Add support for `gap` CSS flexbox/grid gap property
+Add support for `gap` style prop. This maps to the CSS flexbox/grid gap property

--- a/.changeset/brown-rivers-switch.md
+++ b/.changeset/brown-rivers-switch.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/layout": patch
+"@chakra-ui/styled-system": patch
+---
+
+Add support for `gap` CSS flexbox/grid gap property

--- a/.changeset/brown-rivers-switch.md
+++ b/.changeset/brown-rivers-switch.md
@@ -3,4 +3,6 @@
 "@chakra-ui/styled-system": minor
 ---
 
-Add support for `gap` style prop. This maps to the CSS flexbox/grid gap property
+Add support for style props `gap`, `columnGap` and `rowGap`. Those CSS
+properties are valid in a grid or flex context. For further information see
+https://developer.mozilla.org/en-US/docs/Web/CSS/gap.

--- a/packages/layout/src/flex.tsx
+++ b/packages/layout/src/flex.tsx
@@ -70,6 +70,7 @@ export const Flex = forwardRef<FlexProps, "div">((props, ref) => {
     basis,
     grow,
     shrink,
+    gap,
     ...rest
   } = props
 
@@ -82,6 +83,7 @@ export const Flex = forwardRef<FlexProps, "div">((props, ref) => {
     flexBasis: basis,
     flexGrow: grow,
     flexShrink: shrink,
+    gap,
   }
 
   return <chakra.div ref={ref} __css={styles} {...rest} />

--- a/packages/layout/src/flex.tsx
+++ b/packages/layout/src/flex.tsx
@@ -62,17 +62,8 @@ export interface FlexProps extends HTMLChakraProps<"div">, FlexOptions {}
  * @see Docs https://chakra-ui.com/flex
  */
 export const Flex = forwardRef<FlexProps, "div">((props, ref) => {
-  const {
-    direction,
-    align,
-    justify,
-    wrap,
-    basis,
-    grow,
-    shrink,
-    gap,
-    ...rest
-  } = props
+  const { direction, align, justify, wrap, basis, grow, shrink, ...rest } =
+    props
 
   const styles = {
     display: "flex",
@@ -83,7 +74,6 @@ export const Flex = forwardRef<FlexProps, "div">((props, ref) => {
     flexBasis: basis,
     flexGrow: grow,
     flexShrink: shrink,
-    gap,
   }
 
   return <chakra.div ref={ref} __css={styles} {...rest} />

--- a/packages/layout/stories/flex.stories.tsx
+++ b/packages/layout/stories/flex.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Box, Flex } from "../src"
 
 export default {
-  title: "Flex",
+  title: "Components / Layout / Flex",
 }
 
 export const Vertical = () => (

--- a/packages/layout/stories/flex.stories.tsx
+++ b/packages/layout/stories/flex.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { Box, Flex } from "../src"
+
+export default {
+  title: "Flex",
+}
+
+export const Vertical = () => (
+  <Flex gap={4} direction="column">
+    <span>ooooooo</span>
+    <span>ahhhhh</span>
+    <span>Woah!</span>
+  </Flex>
+)
+
+export const Horizontal = () => (
+  <Flex gap={4}>
+    <span>ooooooo</span>
+    <span>ahhhhh</span>
+    <span>Woah!</span>
+  </Flex>
+)
+
+export const VerticalWithMargin = () => (
+  <Flex gap={4} direction="column">
+    <Box boxSize="40px" bg="red" borderRadius="full" />
+    <Box boxSize="40px" bg="red" borderRadius="full" />
+    <Box boxSize="40px" bg="red" borderRadius="full" mt={4} />
+  </Flex>
+)

--- a/packages/styled-system/src/config/flexbox.ts
+++ b/packages/styled-system/src/config/flexbox.ts
@@ -38,6 +38,7 @@ export const flexbox: Config = {
   placeItems: true,
   placeContent: true,
   placeSelf: true,
+  gap: t.space("gap"),
 }
 
 Object.assign(flexbox, {
@@ -138,6 +139,15 @@ export interface FlexboxProps {
    * @see [Mozilla Docs](https://developer.mozilla.org/docs/Web/CSS/flex)
    */
   flex?: Token<CSS.Property.Flex<Length>>
+  /**
+   * The CSS `gap` property.
+   *
+   * It defines the gap between items in both flex and
+   * grid contexts.
+   *
+   * @see [Mozilla Docs](https://developer.mozilla.org/docs/Web/CSS/gap)
+   */
+  gap?: Token<CSS.Property.Gap<Length>>
   /**
    * The CSS `justify-self` property.
    *

--- a/packages/styled-system/src/config/flexbox.ts
+++ b/packages/styled-system/src/config/flexbox.ts
@@ -39,6 +39,8 @@ export const flexbox: Config = {
   placeContent: true,
   placeSelf: true,
   gap: t.space("gap"),
+  rowGap: t.space("rowGap"),
+  columnGap: t.space("columnGap"),
 }
 
 Object.assign(flexbox, {
@@ -147,7 +149,23 @@ export interface FlexboxProps {
    *
    * @see [Mozilla Docs](https://developer.mozilla.org/docs/Web/CSS/gap)
    */
-  gap?: Token<CSS.Property.Gap<Length>>
+  gap?: Token<CSS.Property.Gap<Length>, "space">
+  /**
+   * The CSS `row-gap` property.
+   *
+   * It sets the size of the gap (gutter) between an element's grid rows.
+   *
+   * @see [Mozilla Docs](https://developer.mozilla.org/docs/Web/CSS/row-gap)
+   */
+  rowGap?: Token<CSS.Property.RowGap<Length>, "space">
+  /**
+   * The CSS `column-gap` property.
+   *
+   * It sets the size of the gap (gutter) between an element's columns.
+   *
+   * @see [Mozilla Docs](https://developer.mozilla.org/docs/Web/CSS/column-gap)
+   */
+  columnGap?: Token<CSS.Property.ColumnGap<Length>, "space">
   /**
    * The CSS `justify-self` property.
    *


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2720

Follow up PR of #4671

Thank you @MichaelKilbane for your time creating the initial PR!

## 📝 Description

Add CSS properties gap, columnGap and rowGap to the StyleProps.

## ⛳️ Current behavior (updates)

Some chakra users use `gridGap` as current workaround.

## 🚀 New behavior

We can use `gap`, `columnGap` and `rowGap` which map to the token scale _space_.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

https://developer.mozilla.org/en-US/docs/Web/CSS/gap
