### PR TITLE
fix(icon): auto assign key for each path element if createIcon prop path is array

### DIFF
--- a/.changeset/young-guests-bow.md
+++ b/.changeset/young-guests-bow.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/icon": major
+---
+
+Minor change: auto assign key when passing array of paths to createIcon

--- a/packages/icon/src/create-icon.tsx
+++ b/packages/icon/src/create-icon.tsx
@@ -32,14 +32,14 @@ export function createIcon(options: CreateIconOptions) {
   const {
     viewBox = "0 0 24 24",
     d: pathDefinition,
-    path,
     displayName,
     defaultProps = {},
   } = options
+  const path = React.Children.toArray(options.path)
 
   const Comp = forwardRef<IconProps, "svg">((props, ref) => (
     <Icon ref={ref} viewBox={viewBox} {...defaultProps} {...props}>
-      {path ?? <path fill="currentColor" d={pathDefinition} />}
+      {path.length ? path : <path fill="currentColor" d={pathDefinition} />}
     </Icon>
   ))
 

--- a/packages/icon/stories/icon.stories.tsx
+++ b/packages/icon/stories/icon.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Md3DRotation } from "react-icons/md"
-import { Icon, IconProps } from "../src"
+import { Icon, IconProps, createIcon } from "../src"
 
 export default {
   title: "Components / Media and Icons / Icon",
@@ -22,3 +22,13 @@ export const CustomIcon = () => <ArrowIcon boxSize="40px" color="red.100" />
 export const UsingReactIcon = () => (
   <Icon as={Md3DRotation} boxSize="40px" color="tomato" />
 )
+
+const HeartIcon = createIcon({
+  displayName: "HeartIcon",
+  path: [
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />,
+    <path d="M19.5 13.572l-7.5 7.428l-7.5 -7.428m0 0a5 5 0 1 1 7.5 -6.566a5 5 0 1 1 7.5 6.572" />,
+  ],
+})
+
+export const UsingCreateIcon = () => <HeartIcon boxSize="40px" />


### PR DESCRIPTION
## 📝 Description

> Assign key for each path if we pass array of paths for createIcon

## ⛳️ Current behavior (updates)

> We will need to pass key for each path manually

```ts
import { createIcon } from '@chakra-ui/icons';

export const HeartIcon = createIcon({
  displayName: 'HeartIcon',
  path: [
    <path key={0} stroke='none' d='M0 0h24v24H0z' fill='none' />,
    <path
      key={1}
      d='M19.5 13.572l-7.5 7.428l-7.5 -7.428m0 0a5 5 0 1 1 7.5 -6.566a5 5 0 1 1 7.5 6.572'
    />,
  ],
});
```

## 🚀 New behavior

> createIcon will assign key automatically for each path, we don't need to assign when passing to the prop

```ts
import { createIcon } from '@chakra-ui/icons';

import { defaultProps } from './common';

export const HeartIcon = createIcon({
  displayName: 'HeartIcon',
  defaultProps,
  path: [
    <path stroke='none' d='M0 0h24v24H0z' fill='none' />,
    <path
      d='M19.5 13.572l-7.5 7.428l-7.5 -7.428m0 0a5 5 0 1 1 7.5 -6.566a5 5 0 1 1 7.5 6.572'
    />,
  ],
});
```

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

This will fix #5127 