### PR TITLE
fix: drawer content ref returns null

### DIFF
--- a/.changeset/tasty-hounds-buy.md
+++ b/.changeset/tasty-hounds-buy.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/transition": patch
+---
+
+Fixed issue where the `ref` of `Slider` returns `null` due to prop override

--- a/packages/transition/src/slide.tsx
+++ b/packages/transition/src/slide.tsx
@@ -93,7 +93,6 @@ export const Slide = React.forwardRef<HTMLDivElement, SlideProps>(
       <AnimatePresence custom={custom}>
         {show && (
           <motion.div
-            ref={ref}
             initial="exit"
             className={cx("chakra-slide", className)}
             animate={animate}
@@ -102,6 +101,7 @@ export const Slide = React.forwardRef<HTMLDivElement, SlideProps>(
             variants={variants as _Variants}
             style={computedStyle}
             {...rest}
+            ref={ref}
           />
         )}
       </AnimatePresence>


### PR DESCRIPTION
The ref prop of the <DrawerContent /> component returns null. The issue is with this component though, because that is where the ref is passed. I guess the issue is with the order of props passed, as they are overwritten with the spread {...rest}

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

The `<DrawerContent />` component `ref` props returns null

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
