### PR TITLE
docs: update storybook url to enable composition

### DIFF
--- a/.changeset/long-dancers-vanish.md
+++ b/.changeset/long-dancers-vanish.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Update storybook url configuration for `@chakra-ui/react` to
+[https://storybook.chakra-ui.com](https://storybook.chakra-ui.com)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -91,7 +91,7 @@
   ],
   "storybook": {
     "title": "Chakra UI",
-    "url": "https://chakra-ui.netlify.app"
+    "url": "https://storybook.chakra-ui.com"
   },
   "devDependencies": {
     "@emotion/react": "^11.4.0",


### PR DESCRIPTION
## 📝 Description

Hi Chakra UI team 😊 
This PR update the Storybook URL to the correct Storybook deployment URL so the automatic composition of Storybook works out of the box.

## ⛳️ Current behavior (updates)

Using (automatic) composition, [we have the following result](https://start-ui.vercel.app/storybook) (check the bottom of the nav)

![image](https://user-images.githubusercontent.com/3920615/142886876-f81676de-8ebf-4ed4-b365-1fd2f911d517.png)

This is because the Storybook deployed on Netlify is old.

## 🚀 New behavior

Using (automatic) composition with the new URL, we should have the following result 

![image](https://user-images.githubusercontent.com/3920615/142887764-84218f26-ac7a-40f2-8e5e-f8e3fbaf4b6f.png)


## 💣 Is this a breaking change (Yes/No):

I think this change could impact users with Storybook v5 

## 📝 Additional Information

### Before the merge of this PR

Users using Storybook v6 can do the following to their `main.js` file to enable composition

```js
  refs: {
    'chakra-ui': {
      title: 'Chakra UI',
      url: 'https://storybook.chakra-ui.com',
    },
    '@chakra-ui/react': { disable: true },
  },
```

### After the merge of this PR

I guess users using older Storybook can do the following to their `main.js` file to enable composition

```js
  refs: {
    'chakra-ui': {
      title: 'Chakra UI',
      url: 'https://chakra-ui.netlify.app',
    },
    '@chakra-ui/react': { disable: true },
  },
```

I tried to explain everything I can, feel free to reach me on Discord (I'm on the server **YoannFleuryDev#0001**) or on this PR if you want to discuss about it.