### PR TITLE
fix: allow comma to be a decimal separator in NumberInput

### DIFF
--- a/.changeset/eight-hornets-decide.md
+++ b/.changeset/eight-hornets-decide.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/number-input": patch
+---
+
+Allow comma to be a decimal separator in NumberInput

--- a/packages/number-input/src/utils.ts
+++ b/packages/number-input/src/utils.ts
@@ -1,4 +1,4 @@
-const FLOATING_POINT_REGEX = /^[Ee0-9+\-.]$/
+const FLOATING_POINT_REGEX = /^[Ee0-9+\-.,]$/
 
 /**
  * Determine if a character is a DOM floating point character


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Doesn't close but helps with #4474 

## 📝 Description

Not every country has a dot (.) as a decimal separator, [some](https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_decimal_comma) are using comma (,) for this. In these countries it makes `NumberInput` unusable on iOS, because the digital keyboard only contains a comma which doesn't pass a regex test in `isFloatingPointNumericCharacter` resulting in comma not being allowed in the field.

![image](https://user-images.githubusercontent.com/5007929/142934477-e9bca34f-5450-4926-9fb8-c5155055dc06.png)

## ⛳️ Current behavior (updates)

Comma is not allowed in a decimal number in NumberInput.

## 🚀 New behavior

Comma is allowed in a decimal number in NumberInput, allowing to use this field on iOS in [regions](https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_decimal_comma) where comma is the default decimal separator. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
