### PR TITLE
fix(@chakra-ui/layout): style provider in list with specific error me…

### DIFF
--- a/.changeset/tricky-waves-serve.md
+++ b/.changeset/tricky-waves-serve.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/layout": minor
+---
+
+To give a better error message, list is creating the context directly to pass in
+a more clear error message

--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -1,18 +1,23 @@
 import { Icon, IconProps } from "@chakra-ui/icon"
+import { createContext, getValidChildren } from "@chakra-ui/react-utils"
+import { SystemStyleObject } from "@chakra-ui/styled-system"
 import {
   chakra,
-  SystemProps,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
+  SystemProps,
   ThemingProps,
   useMultiStyleConfig,
-  StylesProvider,
-  useStyles,
 } from "@chakra-ui/system"
-import { __DEV__ } from "@chakra-ui/utils"
-import { getValidChildren } from "@chakra-ui/react-utils"
+import { Dict, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createContext<Dict<SystemStyleObject>>({
+  name: "StylesContext",
+  errorMessage:
+    "useStyles: `styles` is undefined. Seems you forgot to wrap the components in a `<*List />` ",
+})
 
 interface ListOptions {
   /**


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # https://github.com/chakra-ui/chakra-ui/issues/5119

## 📝 Description

Instead of using the shared `StylesProvider` from `@chakra-ui/system`, we are creating the Context directly in `List` to give a more relevant error message.

## ⛳️ Current behavior (updates)

`list.tsx` is using `StylesProvider` and `useStyles` from `@chakra-ui/system` which has a generic error message.

## 🚀 New behavior

`list.tsx` creates the context directly to pass in a more concise error message.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

More components are using StylesProvider and if we are moving forward with this solution, we should refactor all components to use this pattern to give a better error message.

We could also investigate wrapping 
```const [StylesProvider, useStyles] = createContext<Dict<SystemStyleObject>>({
  name: "StylesContext",
  errorMessage:
    "useStyles: `styles` is undefined. Seems you forgot to wrap the components in a `<*List />` ",
})```
into a function that takes component name and calls `createContext` for us.

Looking for input.