### PR TITLE
fix: prevent `onKeyDown` callback from de/registering on every call of `useTooltip`

### DIFF
--- a/.changeset/quiet-worms-float.md
+++ b/.changeset/quiet-worms-float.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tooltip": patch
+---
+
+Prevent `onKeyDown` callback from de/registering on every call of `useTooltip`

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -135,11 +135,11 @@ export function useTooltip(props: UseTooltipProps = {}) {
     }
   }, [closeOnMouseDown, closeWithDelay])
 
-  const onKeyDown = (event: KeyboardEvent) => {
+  const onKeyDown = React.useCallback((event: KeyboardEvent) => {
     if (isOpen && event.key === "Escape") {
       closeWithDelay()
     }
-  }
+  }, [isOpen, closeWithDelay])
 
   useEventListener("keydown", onKeyDown)
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

`onKeyDown` callback is de/registred on every call of `useTooltip`, which can cause performance issues

## ⛳️ Current behavior (updates)

`onKeyDown` callback is de/registred on every call of `useTooltip`

## 🚀 New behavior

`onKeyDown` callback is de/registred only on change of its dependencies via `React.useCallback`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
