### PR TITLE
fix: update storybook url

### DIFF
--- a/.changeset/quick-hats-smile.md
+++ b/.changeset/quick-hats-smile.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Update storybook url configuration for `@chakra-ui/react` to
+[https://storybook.chakra-ui.com](https://storybook.chakra-ui.com)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -91,7 +91,7 @@
   ],
   "storybook": {
     "title": "Chakra UI",
-    "url": "https://chakra-ui.netlify.app"
+    "url": "https://storybook.chakra-ui.com"
   },
   "devDependencies": {
     "@emotion/react": "^11.4.0",


### PR DESCRIPTION
## 📝 Description

Current `storybook.url` for `@chakra-ui/react` is outdated.

## ⛳️ Current behavior (updates)

Use https://storybook.chakra-ui.com/

## 🚀 New behavior

Automatic storybook integration works again

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

https://storybook.js.org/docs/react/workflows/package-composition#for-package-authors
