### PR TITLE
useBreakpointValue return type

### DIFF
--- a/packages/media-query/src/use-breakpoint-value.ts
+++ b/packages/media-query/src/use-breakpoint-value.ts
@@ -20,11 +20,9 @@ import { useBreakpoint } from "./use-breakpoint"
 export function useBreakpointValue<T = any>(
   values: Record<string, T> | T[],
   defaultBreakpoint?: string,
-): T | undefined {
+): T {
   const breakpoint = useBreakpoint(defaultBreakpoint)
   const theme = useTheme()
-
-  if (!breakpoint) return undefined
 
   /**
    * Get the non-number breakpoint keys from the provided breakpoints


### PR DESCRIPTION
Hi and thanks for the great work on Chakra UI !

We can simplify the code here because `useBreakpoint` cannot return `undefined`. That's also more convenient this way so we don't have to deal with the `undefined` case when using this hook.

Tell me if I'm missing something here.

Cheers !
