### PR TITLE
fix(@chakra-ui/toast): index LogicalPlacementMap

### DIFF
--- a/packages/toast/src/toast.placement.ts
+++ b/packages/toast/src/toast.placement.ts
@@ -39,6 +39,6 @@ export function getToastPlacement(
     "bottom-end": { ltr: "bottom-right", rtl: "bottom-left" },
   }
 
-  const logical = logicals[position]
+  const logical = logicals[position as never]
   return logical?.[dir] ?? position
 }


### PR DESCRIPTION
Closes #5173

## 📝 Description

> 

## ⛳️ Current behavior (updates)

> Get build error 
error TS7053: Element implicitly has an 'any' type because expression of type 'ToastPositionWithLogical' can't be used to index type 'LogicalPlace
mentMap'.
  Property 'bottom' does not exist on type 'LogicalPlacementMap'.


## 🚀 New behavior

> No build error

## 💣 Is this a breaking change (Yes/No): 
> No