### PR TITLE
fix: multi-value css inset property behavior

### DIFF
--- a/.changeset/wet-drinks-wonder.md
+++ b/.changeset/wet-drinks-wonder.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+fix: multi-value css inset property behavior

--- a/packages/styled-system/src/config/position.ts
+++ b/packages/styled-system/src/config/position.ts
@@ -6,7 +6,7 @@ export const position: Config = {
   position: true,
   pos: t.prop("position"),
   zIndex: t.prop("zIndex", "zIndices"),
-  inset: t.spaceT(["top", "right", "bottom", "left"]),
+  inset: t.spaceT("inset"),
   insetX: t.spaceT(["left", "right"]),
   insetInline: t.spaceT("insetInline"),
   insetY: t.spaceT(["top", "bottom"]),
@@ -77,15 +77,15 @@ export interface PositionProps {
   /**
    * The CSS `left`, `right`, `top`, `bottom` property
    */
-  inset?: Token<CSS.Property.Left | number, "sizes">
+  inset?: Token<CSS.Property.Inset | number, "sizes">
   /**
    * The CSS `left`, and `right` property
    */
-  insetX?: Token<CSS.Property.Left | number, "sizes">
+  insetX?: Token<CSS.Property.Inset | number, "sizes">
   /**
    * The CSS `top`, and `bottom` property
    */
-  insetY?: Token<CSS.Property.Left | number, "sizes">
+  insetY?: Token<CSS.Property.Inset | number, "sizes">
   /**
    * The CSS `position` property
    */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5191 

## 📝 Description

I've also fixed inset types

## ⛳️ Current behavior (updates)

setting `inset="4px 8px"`
produced

```css
top: 4px 8px;
right: 4px 8px;
bottom: 4px 8px;
left: 4px 8px;
```


## 🚀 New behavior

now it produces 

```css
top: 4px;
right: 8px;
bottom: 4px;
left: 8px;
```

## 💣 Is this a breaking change (Yes/No):

Nope, the old behavior was producing invalid css

## 📝 Additional Information

This is my first PR here, so please be patient