### PR TITLE
fix(@chakra-ui/switch): react-hook-form story example

### DIFF
--- a/.changeset/yellow-donuts-eat.md
+++ b/.changeset/yellow-donuts-eat.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/switch": patch
+---
+
+Fix <Switch /> story example when using react-hook-form

--- a/packages/switch/stories/switch.stories.tsx
+++ b/packages/switch/stories/switch.stories.tsx
@@ -80,9 +80,9 @@ export const WithReactHookForm = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input name="name" placeholder="name" ref={register} />
-      {/* <input type="checkbox" name="boolean" ref={register} /> */}
-      <Switch name="boolean" ref={register} />
+      <input placeholder="name" {...register("name")} />
+      {/* <input type="checkbox" {...register("boolean")} /> */}
+      <Switch {...register("boolean")} />
       <button type="submit">Submit</button>
     </form>
   )


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The `<Switch />` example using `react-hook-form` isn't working as expected.

## ⛳️ Current behavior (updates)

It's happening when I access the URL: https://storybook.chakra-ui.com/?path=/story/components-forms-switch--with-react-hook-form

![Screen Shot 2021-12-04 at 14 59 24](https://user-images.githubusercontent.com/3528126/144721922-3c10cec8-af48-48cd-834b-11d235907de9.png)


## 🚀 New behavior

![ezgif com-gif-maker](https://user-images.githubusercontent.com/3528126/144721943-da5dfcc7-7a31-4198-8488-092fb0f935fe.gif)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I fixed the `props` using `register` to config `name`, `ref`, `onBlur` and `onChange`.
