### PR TITLE
fix(TS): #5194 Disallow props from outside the prop interface

### DIFF
--- a/.changeset/sweet-adults-refuse.md
+++ b/.changeset/sweet-adults-refuse.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/system": patch
+---
+
+Disallow props that do not exist in the prop interface

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -75,7 +75,7 @@ export type MergeWithAs<
   }
 
 export type ComponentWithAs<Component extends As, Props extends object = {}> = {
-  <AsComponent extends As>(
+  <AsComponent extends As = Component>(
     props: MergeWithAs<
       React.ComponentProps<Component>,
       React.ComponentProps<AsComponent>,

--- a/packages/system/tests/forward-ref.test.tsx
+++ b/packages/system/tests/forward-ref.test.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import * as React from "react"
+import { chakra, forwardRef } from ".."
+
+/**
+ * These tests should fail while type checking
+ * if the typings for `ChakraComponent` change
+ * and create a type regression
+ */
+describe("`forward-ref` prop typings", () => {
+  it("should not allow props outside the prop interface", () => {
+    const Button = forwardRef<{ allowedProp?: string }, "button">(
+      (props, ref) => <chakra.button {...props} ref={ref} />,
+    )
+
+    // @ts-expect-error `test` prop should not be allowed.
+    const renderedCustomCompWithBadProp = <Button test />
+    const renderedCustomCompWithRequired = (
+      <Button allowedProp="allowed" type="submit" />
+    )
+
+    // make jest happy
+    expect(true).toBe(true)
+  })
+})
+


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5194  <!-- Github issue # here -->

## 📝 Description

Disallow props from outside the prop interface

## ⛳️ Current behavior (updates)

// This should throw a type error
<Chakra.Button test/>

## 🚀 New behavior

// Now it does!
<Chakra.Button test/>

## 💣 Is this a breaking change (Yes/No):

Possibly... but in a good way.  If people have been passing invalid props to their components, now there will be type-safety around it.

## 📝 Additional Information
