### PR TITLE
fix(styled-system): trigger release after cli fixed the theme typings

### DIFF
--- a/.changeset/honest-peas-rule.md
+++ b/.changeset/honest-peas-rule.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Fixed an issue where the default theme typings went missing.


### PR DESCRIPTION
## 📝 Description

Typings for default theme went missing after the migration to preconstruct. 
This PR only consists of a changeset to trigger the release of `@chakra-ui/styled-system` with updated theme typings

## ⛳️ Current behavior (updates)

No autocomplete for theme values like sizes and colors 😨 

## 🚀 New behavior

Autocomplete 🧘 

## 💣 Is this a breaking change (Yes/No):

No
