### PR TITLE
fix(cli): add missing prettier dependency

### DIFF
--- a/.changeset/grumpy-trains-change.md
+++ b/.changeset/grumpy-trains-change.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Fixed an issue where the cli fails when prettier is not installed

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -46,6 +46,7 @@
     "commander": "^6.2.1",
     "module-alias": "^2.2.2",
     "ora": "^5.3.0",
+    "prettier": "^2.4.1",
     "regenerator-runtime": "^0.13.7",
     "ts-node": "10.4.0",
     "tsconfig-paths": "^3.11.0",


### PR DESCRIPTION
Closes #5219

## 📝 Description

Fixed an error where the cli fails when prettier is not installed.

## ⛳️ Current behavior (updates)

If the package prettier is not found the std.err will be polluted and the cli fails.

~~Added token scales `blur`, `borderStyles` and `borderWidths`.~~

## 🚀 New behavior

Removed the optional prettier run and prettified the output itself.

## 💣 Is this a breaking change (Yes/No):

No
