### PR TITLE
fix: broken link in tooltip js-doc

### DIFF
--- a/.changeset/smooth-comics-sing.md
+++ b/.changeset/smooth-comics-sing.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tooltip": patch
+---
+
+Fix broken link in Tooltip JSDoc

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -57,7 +57,7 @@ const StyledTooltip = chakra(motion.div)
 /**
  * Tooltips display informative text when users hover, focus on, or tap an element.
  *
- * @see Docs     https://chakra-ui.com/components/tooltip
+ * @see Docs     https://chakra-ui.com/docs/overlay/tooltip
  * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#tooltip
  */
 export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {


### PR DESCRIPTION
## 📝 Description

Update JSDoc link in Tooltip component to go the correct link. The current link is broken.

## ⛳️ Current behavior (updates)

Clicking on JSDoc link directs to broken link

## 🚀 New behavior

Clicking on JSDoc link directs to correct link

## 💣 Is this a breaking change (Yes/No):

No
