### PR TITLE
fix: #4251 layout flashing from useBreakpoint

### DIFF
--- a/.changeset/unlucky-mugs-jump.md
+++ b/.changeset/unlucky-mugs-jump.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+useBreakpointValue returns the correct value on first tick, if matchMedia is
+available

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -33,6 +33,19 @@ export function useBreakpoint(defaultBreakpoint?: string) {
   )
 
   const [currentBreakpoint, setCurrentBreakpoint] = React.useState(() => {
+    if (env.window.matchMedia) {
+      let maxBreakpoint
+      mediaQueries.forEach(({ query, ...breakpoint }) => {
+        const mediaQuery = env.window.matchMedia(query)
+        if (mediaQuery.matches) {
+          maxBreakpoint = breakpoint
+        }
+      })
+      if (maxBreakpoint) {
+        return maxBreakpoint
+      }
+    }
+
     if (!defaultBreakpoint) {
       return undefined
     }

--- a/packages/media-query/tests/use-breakpoint-value-ssr.test.tsx
+++ b/packages/media-query/tests/use-breakpoint-value-ssr.test.tsx
@@ -1,0 +1,118 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { ThemeProvider } from "@chakra-ui/system"
+import { theme } from "./test-data"
+import { useBreakpointValue } from "../src"
+
+describe("with defaultBreakpoint", () => {
+  // To clean up erroneous console warnings from react, we temporarliy force
+  // useLayoutEffect to behave like useEffect. Since neither can run in our SSR
+  // tests, it has no functional impact, but stops the huge console dumps that
+  // React causes.
+  let useLayoutEffect: typeof React.useLayoutEffect
+  beforeAll(() => {
+    useLayoutEffect = React.useLayoutEffect
+    React.useLayoutEffect = React.useEffect
+  })
+  afterAll(() => {
+    React.useLayoutEffect = useLayoutEffect
+  })
+
+  // NOTE: We do not setup matchMedia as we wish to simulate an SSR environment
+  const values = {
+    base: "base",
+    sm: "sm",
+    md: "md",
+    lg: "lg",
+    xl: "xl",
+    customBreakpoint: "customBreakpoint",
+  }
+
+  test("sm", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "sm")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "sm") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("md", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "md")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "md") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("lg", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "lg")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "lg") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("xl", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "xl")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "xl") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("customBreakpoint", () => {
+    const html = ssrRenderWithDefaultBreakpoint(values, "customBreakpoint")
+
+    Object.keys(values).forEach((key) => {
+      if (key === "customBreakpoint") {
+        expect(html).toContain(key)
+      } else {
+        expect(html).not.toContain(key)
+      }
+    })
+  })
+
+  test("base value is used if no breakpoint matches", () => {
+    const values = { base: "base", md: "md" }
+    const html = ssrRenderWithDefaultBreakpoint(values, "sm")
+    expect(html).toContain("base")
+  })
+})
+
+function ssrRenderWithDefaultBreakpoint(
+  values: any,
+  defaultBreakpoint: string,
+) {
+  return renderToStaticMarkup(
+    <ThemeProvider theme={theme}>
+      <TestComponent values={values} defaultBreakpoint={defaultBreakpoint} />
+    </ThemeProvider>,
+  )
+}
+
+const TestComponent = ({
+  values,
+  defaultBreakpoint = undefined,
+}: {
+  values: any
+  defaultBreakpoint?: string
+}) => {
+  const value = useBreakpointValue(values, defaultBreakpoint)
+  return <>{value}</>
+}

--- a/packages/media-query/tests/use-breakpoint-value.test.tsx
+++ b/packages/media-query/tests/use-breakpoint-value.test.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { renderToStaticMarkup } from "react-dom/server"
 import { ThemeProvider } from "@chakra-ui/system"
 import { render, screen } from "@chakra-ui/test-utils"
 import MatchMediaMock from "jest-matchmedia-mock"
@@ -194,113 +193,11 @@ describe("with array", () => {
   })
 })
 
-describe("with defaultBreakpoint", () => {
-  // To clean up erroneous console warnings from react, we temporarliy force
-  // useLayoutEffect to behave like useEffect. Since neither can run in our SSR
-  // tests, it has no functional impact, but stops the huge console dumps that
-  // React causes.
-  let useLayoutEffect: typeof React.useLayoutEffect
-  beforeAll(() => {
-    useLayoutEffect = React.useLayoutEffect
-    React.useLayoutEffect = React.useEffect
-  })
-  afterAll(() => {
-    React.useLayoutEffect = useLayoutEffect
-  })
-
-  // NOTE: We do not setup matchMedia as we wish to simulate an SSR environment
-  const values = {
-    base: "base",
-    sm: "sm",
-    md: "md",
-    lg: "lg",
-    xl: "xl",
-    customBreakpoint: "customBreakpoint",
-  }
-
-  test("sm", () => {
-    const html = ssrRenderWithDefaultBreakpoint(values, "sm")
-
-    Object.keys(values).forEach((key) => {
-      if (key === "sm") {
-        expect(html).toContain(key)
-      } else {
-        expect(html).not.toContain(key)
-      }
-    })
-  })
-
-  test("md", () => {
-    const html = ssrRenderWithDefaultBreakpoint(values, "md")
-
-    Object.keys(values).forEach((key) => {
-      if (key === "md") {
-        expect(html).toContain(key)
-      } else {
-        expect(html).not.toContain(key)
-      }
-    })
-  })
-
-  test("lg", () => {
-    const html = ssrRenderWithDefaultBreakpoint(values, "lg")
-
-    Object.keys(values).forEach((key) => {
-      if (key === "lg") {
-        expect(html).toContain(key)
-      } else {
-        expect(html).not.toContain(key)
-      }
-    })
-  })
-
-  test("xl", () => {
-    const html = ssrRenderWithDefaultBreakpoint(values, "xl")
-
-    Object.keys(values).forEach((key) => {
-      if (key === "xl") {
-        expect(html).toContain(key)
-      } else {
-        expect(html).not.toContain(key)
-      }
-    })
-  })
-
-  test("customBreakpoint", () => {
-    const html = ssrRenderWithDefaultBreakpoint(values, "customBreakpoint")
-
-    Object.keys(values).forEach((key) => {
-      if (key === "customBreakpoint") {
-        expect(html).toContain(key)
-      } else {
-        expect(html).not.toContain(key)
-      }
-    })
-  })
-
-  test("base value is used if no breakpoint matches", () => {
-    const values = { base: "base", md: "md" }
-    const html = ssrRenderWithDefaultBreakpoint(values, "sm")
-    expect(html).toContain("base")
-  })
-})
-
 function renderWithQuery(values: any, query: string) {
   matchMedia.useMediaQuery(query)
   return render(
     <ThemeProvider theme={theme}>
       <TestComponent values={values} />
-    </ThemeProvider>,
-  )
-}
-
-function ssrRenderWithDefaultBreakpoint(
-  values: any,
-  defaultBreakpoint: string,
-) {
-  return renderToStaticMarkup(
-    <ThemeProvider theme={theme}>
-      <TestComponent values={values} defaultBreakpoint={defaultBreakpoint} />
     </ThemeProvider>,
   )
 }


### PR DESCRIPTION
If `env.window.matchMedia` is available when the hook mounts, use it to find the initial state. This prevents the value changing the next "tick" after the hook mounts, often causing layout changes that look like flashes on the screen.

I am having trouble with the tests, the SSR test suite doesn't mock matchMedia, but it seems to be "working" and matching the "sm" breakpoint. In SSR it should return the default breakpoint as I have tested for `env.window.matchMedia`.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Addresses #4251

## 📝 Description

Even though `defaultBreakpoint` was added, the essential problem of an incorrect first value is still present.

## ⛳️ Current behavior (updates)

When useBreakpoint mounts, its first returned value is `defaultBreakpoint` or `undefined`, even when `window.matchMedia` is available.
<img width="1092" alt="Screen Shot 2021-12-10 at 2 36 17 PM" src="https://user-images.githubusercontent.com/10361543/145644452-ee20268c-3da7-4463-9167-3d8f97398047.png">


## 🚀 New behavior

When `window.matchMedia` is available, the first returned value is correct.
<img width="1092" alt="Screen Shot 2021-12-10 at 2 33 34 PM" src="https://user-images.githubusercontent.com/10361543/145644467-a99c77fb-bb2b-4a04-ab1d-65cefd481ccc.png">


## 💣 Is this a breaking change (Yes/No):

No

