### PR TITLE
chore: include functions in style config types

### DIFF
--- a/.changeset/real-socks-rest.md
+++ b/.changeset/real-socks-rest.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/theme-tools": patch
+---
+
+Allow style function types to be part of `StyleConfig` and `MultiStyleConfig`
+types to reflect the possible usage of style functions instead of style objects.

--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -6,9 +6,9 @@ import { Dict, runIfFn } from "@chakra-ui/utils"
  * -----------------------------------------------------------------------------*/
 
 export interface StyleConfig {
-  baseStyle?: SystemStyleObject
-  sizes?: { [size: string]: SystemStyleObject }
-  variants?: { [variant: string]: SystemStyleObject }
+  baseStyle?: SystemStyleObject | SystemStyleFunction
+  sizes?: { [size: string]: SystemStyleObject | SystemStyleFunction }
+  variants?: { [variant: string]: SystemStyleObject | SystemStyleFunction }
   defaultProps?: {
     size?: string
     variant?: string
@@ -20,7 +20,7 @@ export interface StyleConfig {
 type Anatomy = { __type: string }
 
 export interface MultiStyleConfig<T extends Anatomy = Anatomy> {
-  baseStyle?: PartsStyleObject<T>
+  baseStyle?: PartsStyleObject<T> | PartsStyleFunction<T>
   sizes?: { [size: string]: PartsStyleObject<T> | PartsStyleFunction<T> }
   variants?: { [variant: string]: PartsStyleObject<T> | PartsStyleFunction<T> }
   defaultProps?: StyleConfig["defaultProps"]

--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -6,9 +6,9 @@ import { Dict, runIfFn } from "@chakra-ui/utils"
  * -----------------------------------------------------------------------------*/
 
 export interface StyleConfig {
-  baseStyle?: SystemStyleObject | SystemStyleFunction
-  sizes?: { [size: string]: SystemStyleObject | SystemStyleFunction }
-  variants?: { [variant: string]: SystemStyleObject | SystemStyleFunction }
+  baseStyle?: SystemStyleObject | SystemStyleFunction
+  sizes?: { [size: string]: SystemStyleObject | SystemStyleFunction }
+  variants?: { [variant: string]: SystemStyleObject | SystemStyleFunction }
   defaultProps?: {
     size?: string
     variant?: string


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I noticed that the types `StyleConfig` and `MultiStyleConfig` do currently not allow style functions for their properties even though they are supported as stated in the [docs](https://chakra-ui.com/docs/theming/advanced). So I just took the existing types for the style functions and added them as possible options to `StyleConfig` and `MultiStyleConfig`.

## ⛳️ Current behavior (updates)

The types `StyleConfig` and `MultiStyleConfig` only allow style objects for their properties right now. These types are therefore too strict as style functions (`(options: StyleOptions) => StyleObject`) are also allowed here.

## 🚀 New behavior

The new types for `StyleConfig` and `MultiStyleConfig` are including `SystemStyleFunction` and `PartsStyleFunction` as possible options for their properties, so that the types are reflecting the actual possibilities mentioned in the [docs](https://chakra-ui.com/docs/theming/advanced).

## 💣 Is this a breaking change (Yes/No):
No
