### PR TITLE
feat(cli): generate strict theme variant and size types

### DIFF
--- a/.changeset/empty-tools-smash.md
+++ b/.changeset/empty-tools-smash.md
@@ -1,0 +1,21 @@
+---
+"@chakra-ui/system": minor
+"@chakra-ui/cli": minor
+---
+
+Use the feature flag `--strict-component-types` for `@chakra-ui/cli tokens` to
+generate strict component type for the theming props `variant` and `size`.
+
+```bash
+chakra-cli tokens --strict-component-types
+```
+
+```tsx
+// before
+<Button variant="abc" />
+// valid type but variant is not available in the theme
+
+// after
+<Button variant="abc" /> // invalid
+// Type '"abc"' is not assignable to type '"link" | "outline" | "ghost" | "solid" | "unstyled" | undefined'.
+```

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -10,12 +10,12 @@ import * as React from "react"
 
 export interface ThemingProps<ThemeComponent extends string = string> {
   variant?: ThemeComponent extends keyof ThemeTypings["components"]
-    ? ThemeTypings["components"][ThemeComponent]["variants"] | (string & {})
-    : string
+    ? ThemeTypings["components"][ThemeComponent]["variants"]
+    : never
   size?: ThemeComponent extends keyof ThemeTypings["components"]
-    ? ThemeTypings["components"][ThemeComponent]["sizes"] | (string & {})
-    : string
-  colorScheme?: ThemeTypings["colorSchemes"] | (string & {})
+    ? ThemeTypings["components"][ThemeComponent]["sizes"]
+    : never
+  colorScheme?: ThemeTypings["colorSchemes"]
   orientation?: "vertical" | "horizontal"
   styleConfig?: Dict
 }
@@ -56,19 +56,19 @@ export type PropsOf<T extends As> = React.ComponentPropsWithoutRef<T> & {
 
 export type OmitCommonProps<
   Target,
-  OmitAdditionalProps extends keyof any = never
+  OmitAdditionalProps extends keyof any = never,
 > = Omit<Target, "transition" | "as" | "color" | OmitAdditionalProps>
 
 export type RightJoinProps<
   SourceProps extends object = {},
-  OverrideProps extends object = {}
+  OverrideProps extends object = {},
 > = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps
 
 export type MergeWithAs<
   ComponentProps extends object,
   AsProps extends object,
   AdditionalProps extends object = {},
-  AsComponent extends As = As
+  AsComponent extends As = As,
 > = RightJoinProps<ComponentProps, AdditionalProps> &
   RightJoinProps<AsProps, AdditionalProps> & {
     as?: AsComponent

--- a/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
+++ b/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
@@ -39,12 +39,12 @@ export interface ThemeKeyOptions {
 
 export interface CreateThemeTypingsInterfaceOptions {
   config: ThemeKeyOptions[]
-  strict?: boolean
+  strictComponentTypes?: boolean
 }
 
 export async function createThemeTypingsInterface(
   theme: Record<string, unknown>,
-  { config, strict = false }: CreateThemeTypingsInterfaceOptions,
+  { config, strictComponentTypes = false }: CreateThemeTypingsInterfaceOptions,
 ) {
   const unions = config.reduce(
     (
@@ -74,8 +74,8 @@ export async function createThemeTypingsInterface(
     `// regenerate by running
 // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
 export interface ThemeTypings {
-  ${printUnionMap({ ...unions, textStyles, layerStyles, colorSchemes }, strict)}
-  ${printComponentTypes(componentTypes, strict)}
+  ${printUnionMap({ ...unions, textStyles, layerStyles, colorSchemes })}
+  ${printComponentTypes(componentTypes, strictComponentTypes)}
 }
 
 `

--- a/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
+++ b/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
@@ -39,11 +39,12 @@ export interface ThemeKeyOptions {
 
 export interface CreateThemeTypingsInterfaceOptions {
   config: ThemeKeyOptions[]
+  strict?: boolean
 }
 
 export async function createThemeTypingsInterface(
   theme: Record<string, unknown>,
-  { config }: CreateThemeTypingsInterfaceOptions,
+  { config, strict = false }: CreateThemeTypingsInterfaceOptions,
 ) {
   const unions = config.reduce(
     (
@@ -73,8 +74,8 @@ export async function createThemeTypingsInterface(
     `// regenerate by running
 // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
 export interface ThemeTypings {
-  ${printUnionMap({ ...unions, textStyles, layerStyles, colorSchemes })}
-  ${printComponentTypes(componentTypes)}
+  ${printUnionMap({ ...unions, textStyles, layerStyles, colorSchemes }, strict)}
+  ${printComponentTypes(componentTypes, strict)}
 }
 
 `

--- a/tooling/cli/src/command/tokens/extract-component-types.ts
+++ b/tooling/cli/src/command/tokens/extract-component-types.ts
@@ -35,12 +35,13 @@ function escapeComponentName(componentName: string) {
 
 export function printComponentTypes(
   componentTypes: Record<string, ComponentType>,
+  strict = false,
 ) {
   const types = Object.entries(componentTypes)
     .map(
       ([componentName, unions]) =>
         `${escapeComponentName(componentName)}: {
-  ${printUnionMap(unions)}
+  ${printUnionMap(unions, strict)}
 }`,
     )
     .join(`\n`)

--- a/tooling/cli/src/command/tokens/extract-property-paths.ts
+++ b/tooling/cli/src/command/tokens/extract-property-paths.ts
@@ -1,25 +1,35 @@
 import { isObject } from "@chakra-ui/utils"
 
+const AutoCompleteStringType = "(string & {})"
+
 function wrapWithQuotes(value: unknown) {
   return `"${value}"`
 }
 
-function printUnionType(values: string[]) {
+function printUnionType(values: string[], strict = false) {
   if (!values.length) {
-    return "never"
+    return strict ? "never" : AutoCompleteStringType
   }
 
-  return values.map(wrapWithQuotes).join(" | ")
+  return values
+    .map(wrapWithQuotes)
+    .concat(strict ? [] : [AutoCompleteStringType])
+    .join(" | ")
 }
 
 /**
  * @example
  * { colors: ['red.500', 'green.500'] } => `colors: "red.500" | "green.500"`
  */
-export function printUnionMap(unions: Record<string, string[]>) {
+export function printUnionMap(
+  unions: Record<string, string[]>,
+  strict = false,
+) {
   return Object.entries(unions)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([targetKey, union]) => `${targetKey}: ${printUnionType(union)};`)
+    .map(
+      ([targetKey, union]) => `${targetKey}: ${printUnionType(union, strict)};`,
+    )
     .join("\n")
 }
 

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -14,14 +14,14 @@ const writeFileAsync = promisify(writeFile)
 
 async function runTemplateWorker({
   themeFile,
-  strict,
+  strictComponentTypes,
 }: {
   themeFile: string
-  strict?: boolean
+  strictComponentTypes?: boolean
 }): Promise<string> {
   const worker = fork(
     path.join(__dirname, "..", "..", "scripts", "read-theme-file.worker.js"),
-    [themeFile].concat(strict ? "--strict" : []),
+    [themeFile].concat(strictComponentTypes ? "--strict-component-types" : []),
     {
       stdio: ["pipe", "pipe", "pipe", "ipc"],
       cwd: process.cwd(),
@@ -45,15 +45,18 @@ async function runTemplateWorker({
 export async function generateThemeTypings({
   themeFile,
   out,
-  strict,
+  strictComponentTypes,
 }: {
   themeFile: string
   out: string
-  strict?: boolean
+  strictComponentTypes?: boolean
 }) {
   const spinner = ora("Generating chakra theme typings").start()
   try {
-    const template = await runTemplateWorker({ themeFile, strict })
+    const template = await runTemplateWorker({
+      themeFile,
+      strictComponentTypes,
+    })
     const outPath = await resolveOutputPath(out)
 
     spinner.info()

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -14,12 +14,14 @@ const writeFileAsync = promisify(writeFile)
 
 async function runTemplateWorker({
   themeFile,
+  strict,
 }: {
   themeFile: string
+  strict?: boolean
 }): Promise<string> {
   const worker = fork(
     path.join(__dirname, "..", "..", "scripts", "read-theme-file.worker.js"),
-    [themeFile],
+    [themeFile].concat(strict ? "--strict" : []),
     {
       stdio: ["pipe", "pipe", "pipe", "ipc"],
       cwd: process.cwd(),
@@ -43,13 +45,15 @@ async function runTemplateWorker({
 export async function generateThemeTypings({
   themeFile,
   out,
+  strict,
 }: {
   themeFile: string
   out: string
+  strict?: boolean
 }) {
   const spinner = ora("Generating chakra theme typings").start()
   try {
-    const template = await runTemplateWorker({ themeFile })
+    const template = await runTemplateWorker({ themeFile, strict })
     const outPath = await resolveOutputPath(out)
 
     spinner.info()

--- a/tooling/cli/src/index.ts
+++ b/tooling/cli/src/index.ts
@@ -16,9 +16,10 @@ export async function run() {
       "--out <path>",
       `output file e.g. ${path.join(...themeInterfaceDestination)}`,
     )
+    .option(" --strict", "Generate strict types")
     .action(async (themeFile: string, command: Command) => {
-      const { out } = command.opts()
-      await generateThemeTypings({ themeFile, out })
+      const { out, strict } = command.opts()
+      await generateThemeTypings({ themeFile, out, strict })
     })
 
   program.on("--help", () => {

--- a/tooling/cli/src/index.ts
+++ b/tooling/cli/src/index.ts
@@ -16,10 +16,17 @@ export async function run() {
       "--out <path>",
       `output file e.g. ${path.join(...themeInterfaceDestination)}`,
     )
-    .option(" --strict", "Generate strict types")
+    .option(
+      "--strict-component-types",
+      "Generate strict types for props variant and size",
+    )
     .action(async (themeFile: string, command: Command) => {
-      const { out, strict } = command.opts()
-      await generateThemeTypings({ themeFile, out, strict })
+      const { out, strictComponentTypes } = command.opts()
+      await generateThemeTypings({
+        themeFile,
+        out,
+        strictComponentTypes,
+      })
     })
 
   program.on("--help", () => {

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -99,7 +99,7 @@ async function readTheme(themeFilePath: string) {
  */
 async function run() {
   const themeFile = process.argv[2]
-  const strict = process.argv.includes("--strict")
+  const strictComponentTypes = process.argv.includes("--strict-component-types")
 
   if (!themeFile) {
     throw new Error("No path to theme file provided.")
@@ -113,7 +113,7 @@ async function run() {
 
   const template = await createThemeTypingsInterface(theme, {
     config: themeKeyConfiguration,
-    strict,
+    strictComponentTypes,
   })
 
   if (process.send) {

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -99,6 +99,7 @@ async function readTheme(themeFilePath: string) {
  */
 async function run() {
   const themeFile = process.argv[2]
+  const strict = process.argv.includes("--strict")
 
   if (!themeFile) {
     throw new Error("No path to theme file provided.")
@@ -112,6 +113,7 @@ async function run() {
 
   const template = await createThemeTypingsInterface(theme, {
     config: themeKeyConfiguration,
+    strict,
   })
 
   if (process.send) {

--- a/tooling/cli/test/extract-property-paths.test.ts
+++ b/tooling/cli/test/extract-property-paths.test.ts
@@ -63,18 +63,40 @@ describe("Extract Property Paths", () => {
 
   it("should print TS union", () => {
     const union = { key: ["value1", "value2"] }
+    const strict = false
 
-    const interfacePartial = printUnionMap(union)
+    const interfacePartial = printUnionMap(union, strict)
+
+    expect(interfacePartial).toMatchInlineSnapshot(
+      `"key: \\"value1\\" | \\"value2\\" | (string & {});"`,
+    )
+  })
+
+  it("should print strict TS union", () => {
+    const union = { key: ["value1", "value2"] }
+    const strict = true
+
+    const interfacePartial = printUnionMap(union, strict)
 
     expect(interfacePartial).toMatchInlineSnapshot(
       `"key: \\"value1\\" | \\"value2\\";"`,
     )
   })
 
-  it("should print type never for empty array", () => {
+  it("should print type (string & {}) for empty array", () => {
     const union = { key: [] }
+    const strict = false
 
-    const interfacePartial = printUnionMap(union)
+    const interfacePartial = printUnionMap(union, strict)
+
+    expect(interfacePartial).toMatchInlineSnapshot(`"key: (string & {});"`)
+  })
+
+  it("should print type never for empty array in strict mode", () => {
+    const union = { key: [] }
+    const strict = true
+
+    const interfacePartial = printUnionMap(union, strict)
 
     expect(interfacePartial).toMatchInlineSnapshot(`"key: never;"`)
   })

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -161,7 +161,7 @@ describe("Theme typings", () => {
     `)
   })
 
-  it("should emit empty strict unions as never", async () => {
+  it("should emit strict component types", async () => {
     const themeInterface = await createThemeTypingsInterface(smallTheme, {
       config: themeKeyConfiguration,
       strictComponentTypes: true,

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -84,7 +84,10 @@ describe("Theme typings", () => {
       "// regenerate by running
       // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
       export interface ThemeTypings {
+        blur: string & {}
         borders: \\"sm\\" | \\"md\\" | (string & {})
+        borderStyles: string & {}
+        borderWidths: string & {}
         breakpoints: \\"sm\\" | \\"md\\" | (string & {})
         colors:
           | \\"niceColor\\"
@@ -138,7 +141,10 @@ describe("Theme typings", () => {
       "// regenerate by running
       // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
       export interface ThemeTypings {
+        blur: string & {}
         borders: string & {}
+        borderStyles: string & {}
+        borderWidths: string & {}
         breakpoints: string & {}
         colors: string & {}
         colorSchemes: string & {}
@@ -171,10 +177,10 @@ describe("Theme typings", () => {
       "// regenerate by running
       // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
       export interface ThemeTypings {
-        blur: (string & {})
+        blur: string & {}
         borders: \\"sm\\" | \\"md\\" | (string & {})
-        borderStyles: (string & {})
-        borderWidths: (string & {})
+        borderStyles: string & {}
+        borderWidths: string & {}
         breakpoints: \\"sm\\" | \\"md\\" | (string & {})
         colors:
           | \\"niceColor\\"

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -76,10 +76,95 @@ const smallTheme: Record<string, unknown> = {
 
 describe("Theme typings", () => {
   it("should create typings for a theme", async () => {
-    const themeUnderTest = smallTheme
-
-    const themeInterface = await createThemeTypingsInterface(themeUnderTest, {
+    const themeInterface = await createThemeTypingsInterface(smallTheme, {
       config: themeKeyConfiguration,
+    })
+
+    expect(themeInterface).toMatchInlineSnapshot(`
+      "// regenerate by running
+      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+      export interface ThemeTypings {
+        borders: \\"sm\\" | \\"md\\" | (string & {})
+        breakpoints: \\"sm\\" | \\"md\\" | (string & {})
+        colors:
+          | \\"niceColor\\"
+          | \\"suchWowColor\\"
+          | \\"onlyColorSchemeColor.50\\"
+          | \\"onlyColorSchemeColor.100\\"
+          | \\"onlyColorSchemeColor.200\\"
+          | \\"onlyColorSchemeColor.300\\"
+          | \\"onlyColorSchemeColor.400\\"
+          | \\"onlyColorSchemeColor.500\\"
+          | \\"onlyColorSchemeColor.600\\"
+          | \\"onlyColorSchemeColor.700\\"
+          | \\"onlyColorSchemeColor.800\\"
+          | \\"onlyColorSchemeColor.900\\"
+          | \\"such.deep.color\\"
+          | (string & {})
+        colorSchemes: \\"onlyColorSchemeColor\\" | (string & {})
+        fonts: \\"sm\\" | \\"md\\" | (string & {})
+        fontSizes: \\"sm\\" | \\"md\\" | (string & {})
+        fontWeights: \\"sm\\" | \\"md\\" | (string & {})
+        layerStyles: \\"red\\" | \\"blue\\" | (string & {})
+        letterSpacings: \\"sm\\" | \\"md\\" | (string & {})
+        lineHeights: \\"sm\\" | \\"md\\" | (string & {})
+        radii: \\"sm\\" | \\"md\\" | (string & {})
+        shadows: \\"sm\\" | \\"md\\" | (string & {})
+        sizes: \\"sm\\" | \\"md\\" | (string & {})
+        space: \\"sm\\" | \\"-sm\\" | \\"md\\" | \\"-md\\" | (string & {})
+        textStyles: \\"small\\" | \\"large\\" | (string & {})
+        transition: \\"sm\\" | \\"md\\" | (string & {})
+        zIndices: \\"sm\\" | \\"md\\" | (string & {})
+        components: {
+          Button: {
+            sizes: \\"sm\\" | (string & {})
+            variants: \\"extraordinary\\" | \\"awesome\\" | \\"unused\\" | (string & {})
+          }
+        }
+      }
+      "
+    `)
+  })
+
+  it("should not omit empty unions", async () => {
+    const themeInterface = await createThemeTypingsInterface(
+      {},
+      {
+        config: themeKeyConfiguration,
+      },
+    )
+
+    expect(themeInterface).toMatchInlineSnapshot(`
+      "// regenerate by running
+      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+      export interface ThemeTypings {
+        borders: string & {}
+        breakpoints: string & {}
+        colors: string & {}
+        colorSchemes: string & {}
+        fonts: string & {}
+        fontSizes: string & {}
+        fontWeights: string & {}
+        layerStyles: string & {}
+        letterSpacings: string & {}
+        lineHeights: string & {}
+        radii: string & {}
+        shadows: string & {}
+        sizes: string & {}
+        space: string & {}
+        textStyles: string & {}
+        transition: string & {}
+        zIndices: string & {}
+        components: {}
+      }
+      "
+    `)
+  })
+
+  it("should emit empty strict unions as never", async () => {
+    const themeInterface = await createThemeTypingsInterface(smallTheme, {
+      config: themeKeyConfiguration,
+      strict: true,
     })
 
     expect(themeInterface).toMatchInlineSnapshot(`
@@ -130,12 +215,14 @@ describe("Theme typings", () => {
     `)
   })
 
-  it("should not omit empty unions", async () => {
-    const themeUnderTest = {}
-
-    const themeInterface = await createThemeTypingsInterface(themeUnderTest, {
-      config: themeKeyConfiguration,
-    })
+  it("should emit empty strict unions as never", async () => {
+    const themeInterface = await createThemeTypingsInterface(
+      {},
+      {
+        config: themeKeyConfiguration,
+        strict: true,
+      },
+    )
 
     expect(themeInterface).toMatchInlineSnapshot(`
       "// regenerate by running

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -126,7 +126,7 @@ describe("Theme typings", () => {
     `)
   })
 
-  it("should not omit empty unions", async () => {
+  it("should emit empty scales as loose type", async () => {
     const themeInterface = await createThemeTypingsInterface(
       {},
       {
@@ -164,18 +164,18 @@ describe("Theme typings", () => {
   it("should emit empty strict unions as never", async () => {
     const themeInterface = await createThemeTypingsInterface(smallTheme, {
       config: themeKeyConfiguration,
-      strict: true,
+      strictComponentTypes: true,
     })
 
     expect(themeInterface).toMatchInlineSnapshot(`
       "// regenerate by running
       // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
       export interface ThemeTypings {
-        blur: never
-        borders: \\"sm\\" | \\"md\\"
-        borderStyles: never
-        borderWidths: never
-        breakpoints: \\"sm\\" | \\"md\\"
+        blur: (string & {})
+        borders: \\"sm\\" | \\"md\\" | (string & {})
+        borderStyles: (string & {})
+        borderWidths: (string & {})
+        breakpoints: \\"sm\\" | \\"md\\" | (string & {})
         colors:
           | \\"niceColor\\"
           | \\"suchWowColor\\"
@@ -190,65 +190,27 @@ describe("Theme typings", () => {
           | \\"onlyColorSchemeColor.800\\"
           | \\"onlyColorSchemeColor.900\\"
           | \\"such.deep.color\\"
-        colorSchemes: \\"onlyColorSchemeColor\\"
-        fonts: \\"sm\\" | \\"md\\"
-        fontSizes: \\"sm\\" | \\"md\\"
-        fontWeights: \\"sm\\" | \\"md\\"
-        layerStyles: \\"red\\" | \\"blue\\"
-        letterSpacings: \\"sm\\" | \\"md\\"
-        lineHeights: \\"sm\\" | \\"md\\"
-        radii: \\"sm\\" | \\"md\\"
-        shadows: \\"sm\\" | \\"md\\"
-        sizes: \\"sm\\" | \\"md\\"
-        space: \\"sm\\" | \\"-sm\\" | \\"md\\" | \\"-md\\"
-        textStyles: \\"small\\" | \\"large\\"
-        transition: \\"sm\\" | \\"md\\"
-        zIndices: \\"sm\\" | \\"md\\"
+          | (string & {})
+        colorSchemes: \\"onlyColorSchemeColor\\" | (string & {})
+        fonts: \\"sm\\" | \\"md\\" | (string & {})
+        fontSizes: \\"sm\\" | \\"md\\" | (string & {})
+        fontWeights: \\"sm\\" | \\"md\\" | (string & {})
+        layerStyles: \\"red\\" | \\"blue\\" | (string & {})
+        letterSpacings: \\"sm\\" | \\"md\\" | (string & {})
+        lineHeights: \\"sm\\" | \\"md\\" | (string & {})
+        radii: \\"sm\\" | \\"md\\" | (string & {})
+        shadows: \\"sm\\" | \\"md\\" | (string & {})
+        sizes: \\"sm\\" | \\"md\\" | (string & {})
+        space: \\"sm\\" | \\"-sm\\" | \\"md\\" | \\"-md\\" | (string & {})
+        textStyles: \\"small\\" | \\"large\\" | (string & {})
+        transition: \\"sm\\" | \\"md\\" | (string & {})
+        zIndices: \\"sm\\" | \\"md\\" | (string & {})
         components: {
           Button: {
             sizes: \\"sm\\"
             variants: \\"extraordinary\\" | \\"awesome\\" | \\"unused\\"
           }
         }
-      }
-      "
-    `)
-  })
-
-  it("should emit empty strict unions as never", async () => {
-    const themeInterface = await createThemeTypingsInterface(
-      {},
-      {
-        config: themeKeyConfiguration,
-        strict: true,
-      },
-    )
-
-    expect(themeInterface).toMatchInlineSnapshot(`
-      "// regenerate by running
-      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
-      export interface ThemeTypings {
-        blur: never
-        borders: never
-        borderStyles: never
-        borderWidths: never
-        breakpoints: never
-        colors: never
-        colorSchemes: never
-        fonts: never
-        fontSizes: never
-        fontWeights: never
-        layerStyles: never
-        letterSpacings: never
-        lineHeights: never
-        radii: never
-        shadows: never
-        sizes: never
-        space: never
-        textStyles: never
-        transition: never
-        zIndices: never
-        components: {}
       }
       "
     `)


### PR DESCRIPTION
Closes #5153

## 📝 Description

The type for variants and sizes are hardcoded as loose types:

```tsx
<Button variant="abc" /> // valid type but not available in the theme
```

## ⛳️ Current behavior (updates)

```tsx
<Button variant="abc" /> // invalid
```  

## 🚀 New behavior

```bash
chakra-cli tokens --strict-component-types
```

will generate following types:

```ts
export interface ThemeTypings {
  // ...

  components: {
    Button: {
      sizes: "sm" | "md" | "lg"
      variants: "solid" | "outline" | "ghost"
    }
  }
}
```

## 💣 Is this a breaking change (Yes/No):

No, because of opt in.

## Additional Information

This PR could have a follow up to expand the strict mode to the theme tokens as well.