### PR TITLE
feat(cli): add token scales `blur`, `borderStyles` and `borderWidths`

### DIFF
--- a/.changeset/silly-bees-build.md
+++ b/.changeset/silly-bees-build.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": minor
+---
+
+Added token scales `blur`, `borderStyles` and `borderWidths`.

--- a/tooling/cli/src/command/tokens/config.ts
+++ b/tooling/cli/src/command/tokens/config.ts
@@ -1,7 +1,10 @@
 import { ThemeKeyOptions } from "./create-theme-typings-interface"
 
 export const themeKeyConfiguration: ThemeKeyOptions[] = [
+  { key: "blur" },
   { key: "borders" },
+  { key: "borderStyles" },
+  { key: "borderWidths" },
   { key: "breakpoints", filter: (value) => Number.isNaN(Number(value)) },
   { key: "colors", maxScanDepth: 3 },
   { key: "fonts" },


### PR DESCRIPTION
## 📝 Description

Added token scales blur, borderStyles and borderWidths to cli tokens command

## ⛳️ Current behavior (updates)

No TypeScript types are generated for those scales.

## 🚀 New behavior

Types are generated

## 💣 Is this a breaking change (Yes/No):

No
