### PR TITLE
fix(editable): set focus on EditableInput when startsWithEditView is …

### DIFF
--- a/.changeset/smart-apes-divide.md
+++ b/.changeset/smart-apes-divide.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/editable": patch
+---
+
+When the Editable component has its startsWithEditView set to true, then focus
+should be set to the EditableInput element when the component is mounted.

--- a/packages/editable/src/use-editable.ts
+++ b/packages/editable/src/use-editable.ts
@@ -2,6 +2,7 @@ import {
   useControllableState,
   useFocusOnPointerDown,
   useUpdateEffect,
+  useSafeLayoutEffect,
 } from "@chakra-ui/hooks"
 import { EventKeyMap, mergeRefs, PropGetter } from "@chakra-ui/react-utils"
 import {
@@ -126,6 +127,14 @@ export function useEditable(props: UseEditableProps = {}) {
   })
 
   const isInteractive = !isEditing || !isDisabled
+
+  useSafeLayoutEffect(() => {
+    if (isEditing) {
+      focus(inputRef.current, {
+        selectTextIfInput: selectAllOnFocus,
+      })
+    }
+  }, [])
 
   useUpdateEffect(() => {
     if (!isEditing) {

--- a/packages/editable/tests/editable.test.tsx
+++ b/packages/editable/tests/editable.test.tsx
@@ -211,3 +211,16 @@ test("can submit on blur", () => {
   fireEvent.blur(input)
   expect(onSubmit).toHaveBeenCalledWith("testing")
 })
+
+test("startWithEditView when true focuses on the input ", () => {
+  render(
+    <Editable startWithEditView={true} defaultValue="Chakra testing">
+      <EditablePreview />
+      <EditableInput data-testid="input" />
+    </Editable>,
+  )
+
+  const input = screen.getByTestId("input")
+
+  expect(document.activeElement === input).toBe(true)
+})


### PR DESCRIPTION
…true

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5201  <!-- Github issue # here -->

## 📝 Description

> When startsWithEditView is true, the EditableInput should receive focus after mounting.

## ⛳️ Current behavior (updates)

> Currently the focus is not being set on the EditableInput when startsWithEditView is set. This give the appearance that the component is still in a preview state.

## 🚀 New behavior

> Upon mounting the component if the startsWithEditView is set, the EditableInput will receive focus.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
