### PR TITLE
fix(slider): add className props to class list for Slider and SliderF…

### DIFF
--- a/.changeset/fresh-jars-wave.md
+++ b/.changeset/fresh-jars-wave.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/slider": patch
+---
+
+Allow classNames specified on Slider and SliderFilledTrack to be added to the
+class list

--- a/packages/slider/src/slider.tsx
+++ b/packages/slider/src/slider.tsx
@@ -53,7 +53,7 @@ export const Slider = forwardRef<SliderProps, "div">((props, ref) => {
       <StylesProvider value={styles}>
         <chakra.div
           {...rootProps}
-          className="chakra-slider"
+          className={cx("chakra-slider", props.className)}
           __css={styles.container}
         >
           {props.children}
@@ -127,7 +127,7 @@ export const SliderFilledTrack = forwardRef<SliderInnerTrackProps, "div">(
     return (
       <chakra.div
         {...trackProps}
-        className="chakra-slider__filled-track"
+        className={cx("chakra-slider__filled-track", props.className)}
         __css={styles.filledTrack}
       />
     )

--- a/packages/slider/tests/slider.test.tsx
+++ b/packages/slider/tests/slider.test.tsx
@@ -1,6 +1,7 @@
 import { extendTheme, ThemeProvider } from "@chakra-ui/react"
 import { press, render, testA11y } from "@chakra-ui/test-utils"
 import * as React from "react"
+import styled from "@emotion/styled"
 import {
   Slider,
   SliderFilledTrack,
@@ -28,6 +29,45 @@ const SimpleSlider = (props: {
     </SliderTrack>
     <SliderThumb />
   </Slider>
+)
+
+const StyledSlider = styled(Slider)`
+  width: 400px;
+  background-color: pink;
+`
+
+// This gets applied to SliderTrack!
+const StyledSliderTrack = styled(SliderTrack)`
+  background-color: blue;
+`
+
+// This doesn't get applied to SliderFilledTrack,
+const StyledSliderFilledTrack = styled(SliderFilledTrack)`
+  background-color: green;
+`
+// This gets applied to SliderThumb!
+const StyledSliderThumb = styled(SliderThumb)`
+  background-color: red;
+`
+
+const SimpleStyledSlider = (props: {
+  defaultValue?: number
+  isReversed?: boolean
+  orientation?: UseSliderProps["orientation"]
+}) => (
+  <StyledSlider
+    data-testid="slider"
+    aria-label="slider-2"
+    colorScheme="red"
+    orientation={props.orientation}
+    isReversed={props.isReversed || undefined}
+    defaultValue={props.defaultValue || defaultValue}
+  >
+    <StyledSliderTrack data-testid="slider-track">
+      <StyledSliderFilledTrack data-testid="slider-filled-track" />
+    </StyledSliderTrack>
+    <StyledSliderThumb data-testid="slider-thumb" />
+  </StyledSlider>
 )
 
 test("passes a11y test", async () => {
@@ -138,4 +178,27 @@ test("renders correctly/unaffected by 'rtl' when orientation: vertical", () => {
 
   press.End(thumb)
   expect(thumb).toHaveAttribute("aria-valuenow", "100")
+})
+
+test("should have colors from styled", () => {
+  const { getByTestId } = render(<SimpleStyledSlider />)
+  let sliderElement = getByTestId("slider")
+  let styles = getComputedStyle(sliderElement)
+
+  expect(styles.backgroundColor).toBe("pink")
+
+  sliderElement = getByTestId("slider-track")
+  styles = getComputedStyle(sliderElement)
+
+  expect(styles.backgroundColor).toBe("blue")
+
+  sliderElement = getByTestId("slider-filled-track")
+  styles = getComputedStyle(sliderElement)
+
+  expect(styles.backgroundColor).toBe("green")
+
+  sliderElement = getByTestId("slider-thumb")
+  styles = getComputedStyle(sliderElement)
+
+  expect(styles.backgroundColor).toBe("red")
 })


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5232 <!-- Github issue # here -->

## 📝 Description

> Allow className prop for Slider and SliderFilledTrack to be added to the class list for the element

## ⛳️ Current behavior (updates)

> When a className prop is specified for Slider or SliderFilledTrack, the className is not added to the class list.

## 🚀 New behavior

> The className prop is now added to the class list and styling via Styled or a CSS class selector will work correctly.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
