### PR TITLE
fix(grid): move `area` prop from Grid to GridItem

### DIFF
--- a/.changeset/itchy-singers-behave.md
+++ b/.changeset/itchy-singers-behave.md
@@ -1,0 +1,18 @@
+---
+"@chakra-ui/layout": patch
+---
+
+### Add support for `area` prop on `GridItem`
+
+Deprecated `area` prop on `Grid` and added support for `area` prop to be used
+with `GridItem` instead. This allows for usage of `GridItem`'s that have named
+template areas to be used in conjunction with a `Grid` that has a defined
+template area.
+
+```jsx live=false
+<Grid templateAreas='"one two three"'>
+   <GridItem area='one'>one</Grid>
+   <GridItem area='two'>two</Grid>
+   <GridItem area='three'>three</Grid>
+</Grid>
+```

--- a/packages/layout/src/grid.tsx
+++ b/packages/layout/src/grid.tsx
@@ -110,6 +110,9 @@ export interface GridOptions {
   /**
    * Short hand prop for `gridArea`
    * @type SystemProps["gridArea"]
+   * @deprecated
+   * Use `GridItem` with the `area` prop instead. Will be removed in a future
+   * version.
    */
   area?: SystemProps["gridArea"]
   /**
@@ -125,6 +128,11 @@ export interface GridOptions {
 }
 
 export interface GridItemProps extends BoxProps {
+  /**
+   * Short hand prop for `gridArea`
+   * @type SystemProps["gridArea"]
+   */
+  area?: SystemProps["gridArea"]
   /**
    * The number of columns the grid item should `span`.
    * @type ResponsiveValue<number | "auto">
@@ -160,10 +168,19 @@ function spanFn(span?: ResponsiveValue<number | "auto">) {
 }
 
 export const GridItem = forwardRef<GridItemProps, "div">((props, ref) => {
-  const { colSpan, colStart, colEnd, rowEnd, rowSpan, rowStart, ...rest } =
-    props
+  const {
+    area,
+    colSpan,
+    colStart,
+    colEnd,
+    rowEnd,
+    rowSpan,
+    rowStart,
+    ...rest
+  } = props
 
   const styles = filterUndefined({
+    gridArea: area,
     gridColumn: spanFn(colSpan),
     gridRow: spanFn(rowSpan),
     gridColumnStart: colStart,

--- a/packages/layout/stories/grid.stories.tsx
+++ b/packages/layout/stories/grid.stories.tsx
@@ -1,40 +1,62 @@
 import * as React from "react"
-import { Box, GridItem, SimpleGrid } from "../src"
+import { GridItem, Grid } from "../src"
 
 export default {
-  title: "Components / Layout / SimpleGrid",
+  title: "Components / Layout / Grid",
 }
 
-export const WithColumns = () => (
-  <SimpleGrid columns={[2, null, 3]} spacing="40px">
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-  </SimpleGrid>
+export const WithTemplateColumns = () => (
+  <Grid templateColumns="repeat(5, 1fr)" gap={4}>
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+  </Grid>
 )
 
-export const WithAutofit = () => (
-  <SimpleGrid minChildWidth="300px" spacing="40px">
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-    <Box bg="tomato" height="200px" />
-  </SimpleGrid>
+export const WithTemplateRows = () => (
+  <Grid templateRows="repeat(2, 1fr)" gap={4}>
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+  </Grid>
 )
 
-export const WithColSpan = () => (
-  <SimpleGrid
-    columns={{ base: 2, md: 4 }}
-    spacing={{ base: "24px", md: "40px" }}
-  >
-    <GridItem bg="green.500" colSpan={{ base: 1, md: 3 }}>
-      Column 1
-    </GridItem>
-    <GridItem bg="pink.500" colSpan={{ base: 1, md: 1 }}>
-      Column 2
-    </GridItem>
-  </SimpleGrid>
+export const WithTemplateRowsAndColumns = () => (
+  <Grid templateRows="repeat(2, 1fr)" templateColumns="repeat(3, 1fr)" gap={4}>
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+    <GridItem bg="tomato" height="200px" />
+  </Grid>
 )
+
+export const WithTemplateAreas = () => {
+  const gridTemplateAreas = `
+    "one one two three"
+    "four five five three"
+  `
+  return (
+    <Grid templateAreas={gridTemplateAreas} gap={4}>
+      <GridItem bg="green.500" area="one">
+        one
+      </GridItem>
+      <GridItem bg="pink.500" area="two">
+        two
+      </GridItem>
+      <GridItem bg="red.500" area="three">
+        three
+      </GridItem>
+      <GridItem bg="teal.500" area="four">
+        four
+      </GridItem>
+      <GridItem bg="yellow.500" area="five">
+        five
+      </GridItem>
+    </Grid>
+  )
+}

--- a/packages/layout/stories/simple-grid.stories.tsx
+++ b/packages/layout/stories/simple-grid.stories.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import { Box, SimpleGrid } from "../src"
+
+export default {
+  title: "Components / Layout / SimpleGrid",
+}
+
+export const WithColumns = () => (
+  <SimpleGrid columns={[2, null, 3]} spacing="40px">
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+  </SimpleGrid>
+)
+
+export const WithAutofit = () => (
+  <SimpleGrid minChildWidth="300px" spacing="40px">
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+    <Box bg="tomato" height="200px" />
+  </SimpleGrid>
+)
+
+export const WithColSpan = () => (
+  <SimpleGrid
+    columns={{ base: 2, md: 4 }}
+    spacing={{ base: "24px", md: "40px" }}
+  >
+    <Box bg="green.500" colSpan={{ base: 1, md: 3 }}>
+      Column 1
+    </Box>
+    <Box bg="pink.500" colSpan={{ base: 1, md: 1 }}>
+      Column 2
+    </Box>
+  </SimpleGrid>
+)


### PR DESCRIPTION
## 📝 Description

Allows for usage of GridItem's that have named template areas to be used in conjunction with a Grid that has a defined template area.
This matches the usage pattern of a grid container and its children using grid template areas.
Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas

## ⛳️ Current behavior (updates)

Currently `GridItem` doesn't have an `area` prop which means we cannot have a `Grid` that defines a grid template area to contain `GridItems` with a named grid area. The `area` prop is currently defined on `Grid` so the following works but is not semantically correct:
```
<Grid templateAreas='"one two three"'>
   <Grid area='one'>one</Grid>
   <Grid area='two'>two</Grid>
   <Grid area='three'>three</Grid>
</Grid>
```

## 🚀 New behavior
Have moved the `area` prop from `Grid` to `GridItem` so the following is now possible:
```
<Grid templateAreas='"one two three"'>
   <GridItem area='one'>one</Grid>
   <GridItem area='two'>two</Grid>
   <GridItem area='three'>three</Grid>
</Grid>
```


## 💣 Is this a breaking change (Yes/No):

Yes. Users that have implemented `Grid` with template areas and have setup named template areas using the `area` prop on nested `Grid` elements will need to change their implementation to use `GridItem` with the `area` prop instead.
