### PR TITLE
fix(button): use iconSpacing for ButtonSpinner

### DIFF
--- a/.changeset/wise-donuts-grow.md
+++ b/.changeset/wise-donuts-grow.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/button": patch
+---
+
+Fixed an issue where the `iconSpacing` for the `<ButtonSpinner />` was hardcoded.

--- a/packages/button/src/button-spinner.tsx
+++ b/packages/button/src/button-spinner.tsx
@@ -37,12 +37,12 @@ export const ButtonSpinner: React.FC<ButtonSpinnerProps> = (props) => {
       display: "flex",
       alignItems: "center",
       position: label ? "relative" : "absolute",
-      [marginProp]: label ? "0.5rem" : 0,
+      [marginProp]: label ? spacing : 0,
       fontSize: "1em",
       lineHeight: "normal",
       ...__css,
     }),
-    [__css, label, marginProp],
+    [__css, label, marginProp, spacing],
   )
 
   return (

--- a/packages/button/src/button-spinner.tsx
+++ b/packages/button/src/button-spinner.tsx
@@ -21,7 +21,7 @@ export const ButtonSpinner: React.FC<ButtonSpinnerProps> = (props) => {
   const {
     label,
     placement,
-    spacing = "0.5",
+    spacing = "0.5rem",
     children = <Spinner color="currentColor" width="1em" height="1em" />,
     className,
     __css,

--- a/packages/button/src/button-spinner.tsx
+++ b/packages/button/src/button-spinner.tsx
@@ -21,7 +21,7 @@ export const ButtonSpinner: React.FC<ButtonSpinnerProps> = (props) => {
   const {
     label,
     placement,
-    spacing,
+    spacing = "0.5",
     children = <Spinner color="currentColor" width="1em" height="1em" />,
     className,
     __css,

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -141,6 +141,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
           className="chakra-button__spinner--start"
           label={loadingText}
           placement="start"
+          spacing={iconSpacing}
         >
           {spinner}
         </ButtonSpinner>
@@ -161,6 +162,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
           className="chakra-button__spinner--end"
           label={loadingText}
           placement="end"
+          spacing={iconSpacing}
         >
           {spinner}
         </ButtonSpinner>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5056 

## 📝 Description

> iconSpacing got removed from spinner as part of this [pull request](https://github.com/chakra-ui/chakra-ui/pull/3732)



## ⛳️ Current behavior (updates)

> Spinner has hardcoded spacing of **0.5**

## 🚀 New behavior

> passing iconSpace to spinner and using it for spacing

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
