### PR TITLE
fix(tooltip): add some background props for options to style arrow bg

### DIFF
--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -73,14 +73,22 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
     hasArrow,
     bg,
     portalProps,
+    background,
+    backgroundColor,
+    bgColor,
     ...rest
   } = ownProps
 
-  if (bg) {
-    styles.bg = bg
-    styles[popperCSSVars.arrowBg.var] = getCSSVar(theme, "colors", bg)
-  }
+  const userDefinedBg = background ?? backgroundColor ?? bg ?? bgColor
 
+  if (userDefinedBg) {
+    styles.bg = userDefinedBg
+    styles[popperCSSVars.arrowBg.var] = getCSSVar(
+      theme,
+      "colors",
+      userDefinedBg,
+    )
+  }
   const tooltip = useTooltip({ ...rest, direction: theme.direction })
 
   const shouldWrap = isString(children) || shouldWrapChildren


### PR DESCRIPTION
Closes #5283

## 📝 Description

Fix an issue where arrow tooltip background color only consider `bg` props.

## ⛳️ Current behavior (updates)

Currently `Tooltip` only consider `bg` props.

## 🚀 New behavior

While, in this PR, I try to add some additional bg props to be considered while customize the arrow background color.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
