### PR TITLE
fix(cli): replace runtime require of prettier with import

### DIFF
--- a/tooling/cli/src/utils/format-with-prettier.ts
+++ b/tooling/cli/src/utils/format-with-prettier.ts
@@ -1,25 +1,13 @@
-import type { format, resolveConfig } from "prettier"
+import { format, resolveConfig } from "prettier"
 
-const createFormatFileWithPrettier = (prettier: {
-  format: typeof format
-  resolveConfig: typeof resolveConfig
-}) => async (content: string) => {
-  const prettierConfig = await prettier.resolveConfig(process.cwd())
-  return prettier.format(String(content), {
+async function createFormatFileWithPrettier(content: string) {
+  const prettierConfig = await resolveConfig(process.cwd())
+  return format(String(content), {
     ...prettierConfig,
     parser: "typescript",
   })
 }
 
 export async function formatWithPrettierIfAvailable(content: string) {
-  let prettier
-  try {
-    // eslint-disable-next-line global-require
-    prettier = require("prettier")
-  } catch {
-    // silent exit if prettier is not installed
-    return content
-  }
-
-  return createFormatFileWithPrettier(prettier)(content)
+  return createFormatFileWithPrettier(content)
 }

--- a/tooling/cli/test/format-with-prettier.test.ts
+++ b/tooling/cli/test/format-with-prettier.test.ts
@@ -14,18 +14,4 @@ describe("Format With Prettier", () => {
       "
     `)
   })
-
-  it("should not fail if prettier is not available", async () => {
-    jest.mock("prettier", () => {
-      throw new Error("module not found")
-    })
-
-    const content =
-      "export interface ThemeTypings { fonts: 'test1'|'test2'|'test3'}"
-    const pretty = await formatWithPrettierIfAvailable(content)
-
-    expect(pretty).toMatchInlineSnapshot(
-      `"export interface ThemeTypings { fonts: 'test1'|'test2'|'test3'}"`,
-    )
-  })
 })


### PR DESCRIPTION
Follow up PR to #5225
Closes #5219

## 📝 Description

Prettier is used to format the TS interface created by the `chakra-cli tokens` command.

## ⛳️ Current behavior (updates)

Prettier was required during runtime, and if it was not available it should be skipped. 
This breaks the node worker script setup.

## 🚀 New behavior

Added prettier as dependency (previous PR) and import prettier the "normal" way.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
