### PR TITLE
fix(menu): omit is is-disabled props from MenuItemProps

### DIFF
--- a/.changeset/olive-planes-think.md
+++ b/.changeset/olive-planes-think.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Omit is `disabled` and `aria-disabled` props from `MenuItemProps` types

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -252,8 +252,13 @@ interface MenuItemOptions
 
 type HTMLAttributes = React.HTMLAttributes<HTMLElement>
 
+/**
+ * Use prop `isDisabled` instead
+ */
+type IsDisabledProps = "disabled" | "aria-disabled"
+
 export interface MenuItemProps
-  extends HTMLChakraProps<"button">,
+  extends Omit<HTMLChakraProps<"button">, IsDisabledProps>,
     MenuItemOptions {}
 
 export const MenuItem = forwardRef<MenuItemProps, "button">((props, ref) => {

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -513,7 +513,7 @@ export function useMenuPositioner(props: any = {}) {
  * -----------------------------------------------------------------------------------------------*/
 
 export interface UseMenuItemProps
-  extends Omit<React.HTMLAttributes<Element>, "color"> {
+  extends Omit<React.HTMLAttributes<Element>, "color" | "disabled"> {
   /**
    * If `true`, the menuitem will be disabled
    */


### PR DESCRIPTION
Closes #4935

## 📝 Description

Omit `disabled` and `aria-disabled` from type `MenuItemProps`. They will be overridden by `useClickable`.

## ⛳️ Current behavior (updates)

```tsx
<MenuItemProps disabled /> 
// No error, but prop won't be proxied to DOM element
```

## 🚀 New behavior

```tsx
<MenuItemProps disabled /> 
// TS error
```

## 💣 Is this a breaking change (Yes/No):

No, it'll catch bugs.

## 📝 Additional Information
