### PR TITLE
fix(modal): show footer with size=full

### DIFF
--- a/.changeset/twelve-papayas-judge.md
+++ b/.changeset/twelve-papayas-judge.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Fixed an issue where the Modal Footer was out of the viewport for `size="full"`.

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -83,7 +83,14 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
 function getSize(value: string): PartsStyleObject<typeof parts> {
   if (value === "full") {
     return {
-      dialog: { maxW: "100vw", minH: "100vh", my: 0 },
+      dialog: {
+        maxW: "100vw",
+        minH: "100vh",
+        "@supports(min-height: -webkit-fill-available)": {
+          minH: "-webkit-fill-available",
+        },
+        my: 0,
+      },
     }
   }
   return {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4903

## 📝 Description

`<Modal size="full">` is currently not completely visible on iOS.

## ⛳️ Current behavior (updates)

Footer is missing

## 🚀 New behavior

Use `@supports(min-height: -webkit-fill-available)` query to apply the correct height.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Really looking forward to [Dynamic Viewport Units](https://css-tricks.com/the-large-small-and-dynamic-viewports/)
