### PR TITLE
fix(form-error): unify lineHeight for FormError and FormHelper

### DIFF
--- a/.changeset/seven-berries-invent.md
+++ b/.changeset/seven-berries-invent.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Align the lineHeight for `FormErrorMessage` and `FormHelperText`

--- a/packages/theme/src/components/form-error.ts
+++ b/packages/theme/src/components/form-error.ts
@@ -10,6 +10,7 @@ const baseStyleText: SystemStyleFunction = (props) => {
     color: mode("red.500", "red.300")(props),
     mt: 2,
     fontSize: "sm",
+    lineHeight: "normal",
   }
 }
 


### PR DESCRIPTION
Closes #5294

## 📝 Description

There is a content shift due different `lineHeight` of FormError and FormHelper

## ⛳️ Current behavior (updates)

`lineHeight` is not set for FormError

## 🚀 New behavior

`lineHeight` is set to `"normal"`

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
