### PR TITLE
fix(avatar): use srcSet attr

### DIFF
--- a/.changeset/green-news-boil.md
+++ b/.changeset/green-news-boil.md
@@ -2,4 +2,5 @@
 "@chakra-ui/avatar": patch
 ---
 
-Fixed srcSet prop not being used in AvatarImg
+Added the prop `srcSet` to the `<Avatar />` and `<AvatarImage />` components to allow responsive image sources.
+[Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-srcset)

--- a/.changeset/green-news-boil.md
+++ b/.changeset/green-news-boil.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/avatar": patch
+---
+
+Fixed srcSet prop not being used in AvatarImg

--- a/packages/avatar/src/avatar.tsx
+++ b/packages/avatar/src/avatar.tsx
@@ -183,6 +183,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
 
   const {
     src,
+    srcSet,
     name,
     showBorder,
     borderRadius = "full",
@@ -218,6 +219,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
       <StylesProvider value={styles}>
         <AvatarImage
           src={src}
+          srcSet={srcSet}
           loading={loading}
           onError={onError}
           getInitials={getInitials}
@@ -246,6 +248,7 @@ interface AvatarImageProps
 const AvatarImage: React.FC<AvatarImageProps> = (props) => {
   const {
     src,
+    srcSet,
     onError,
     getInitials,
     name,
@@ -293,6 +296,7 @@ const AvatarImage: React.FC<AvatarImageProps> = (props) => {
   return (
     <chakra.img
       src={src}
+      srcSet={srcSet}
       alt={name}
       className="chakra-avatar__img"
       loading={loading}

--- a/packages/avatar/stories/avatar.stories.tsx
+++ b/packages/avatar/stories/avatar.stories.tsx
@@ -71,6 +71,25 @@ export const WithSizes = () => (
   </Stack>
 )
 
+export const WithSrcSet = () => {
+  const small =
+    "https://accelerated.atoms.crystallize.digital/snowball/images/PalmaSpeedJusterteBilder-15/_resized_300.jpg"
+  const medium =
+    "https://accelerated.atoms.crystallize.digital/snowball/images/PalmaSpeedJusterteBilder-15/_resized_768.jpg"
+  const large =
+    "https://accelerated.atoms.crystallize.digital/snowball/images/PalmaSpeedJusterteBilder-15/_resized_1280.jpg"
+  const xlarge =
+    "https://accelerated.atoms.crystallize.digital/snowball/images/PalmaSpeedJusterteBilder-15/_resized_3200.jpg"
+
+  return (
+    <Avatar
+      name="Uchiha Itachi"
+      src={small}
+      srcSet={`${small} 300w, ${medium} 768w, ${large} 1280w, ${xlarge} 3200w`}
+    />
+  )
+}
+
 /**
  * Use the AvatarGroup component to stack
  * multiple avatars and add some space between them


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5256

## 📝 Description

Avatar Img didn't use the srcSet attribute when we passed.

## ⛳️ Current behavior (updates)

srcSet prop passed in Avatar is not used.

## 🚀 New behavior

Added srcSet prop passed in Avatar to use in AvatarImg.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

