### PR TITLE
fix(descendant): enable property access via index

### DIFF
--- a/packages/descendant/src/descendant.ts
+++ b/packages/descendant/src/descendant.ts
@@ -31,7 +31,7 @@ export type Descendant<T, K> = DescendantOptions<K> & {
  */
 export class DescendantsManager<
   T extends HTMLElement,
-  K extends Record<string, any> = {}
+  K extends Record<string, any> = {},
 > {
   private descendants = new Map<T, Descendant<T, K>>()
 
@@ -61,7 +61,7 @@ export class DescendantsManager<
     this.descendants.forEach((descendant) => {
       const index = descendants.indexOf(descendant.node)
       descendant.index = index
-      descendant.node.dataset.index = descendant.index.toString()
+      descendant.node.dataset["index"] = descendant.index.toString()
     })
   }
 

--- a/packages/descendant/src/use-descendant.ts
+++ b/packages/descendant/src/use-descendant.ts
@@ -26,13 +26,12 @@ export interface UseDescendantsReturn
   NB:  I recommend using `createDescendantContext` below
  * -----------------------------------------------------------------------------------------------*/
 
-const [
-  DescendantsContextProvider,
-  useDescendantsContext,
-] = createContext<UseDescendantsReturn>({
-  name: "DescendantsProvider",
-  errorMessage: "useDescendantsContext must be used within DescendantsProvider",
-})
+const [DescendantsContextProvider, useDescendantsContext] =
+  createContext<UseDescendantsReturn>({
+    name: "DescendantsProvider",
+    errorMessage:
+      "useDescendantsContext must be used within DescendantsProvider",
+  })
 
 /**
  * @internal
@@ -57,7 +56,7 @@ function useDescendant<T extends HTMLElement = HTMLElement, K = {}>(
 
   useSafeLayoutEffect(() => {
     if (!ref.current) return
-    const dataIndex = Number(ref.current.dataset.index)
+    const dataIndex = Number(ref.current.dataset["index"])
     if (index != dataIndex && !Number.isNaN(dataIndex)) {
       setIndex(dataIndex)
     }
@@ -82,7 +81,7 @@ function useDescendant<T extends HTMLElement = HTMLElement, K = {}>(
 
 export function createDescendantContext<
   T extends HTMLElement = HTMLElement,
-  K = {}
+  K = {},
 >() {
   type ContextProviderType = React.Provider<DescendantsManager<T, K>>
   const ContextProvider = cast<ContextProviderType>(DescendantsContextProvider)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5317 <!-- Github issue # here -->

## 📝 Description
> Enable property access via index

## ⛳️ Current behavior (updates)

>  Strict type checking with "noPropertyAccessFromIndexSignature": true enables accessing a field via the “dot” (obj.key) syntax, and “indexed” (obj["key"]) .Property is accessed via the "dot"(obj.key) syntax

## 🚀 New behavior

>Since the Property 'index' comes from an index signature, it is now accessed with ['index']

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
