### PR TITLE
fix(drawer): add ThemingProps type

### DIFF
--- a/.changeset/cyan-drinks-jump.md
+++ b/.changeset/cyan-drinks-jump.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Update `DrawerProps` type to include `ThemingProps` for the Drawer component

--- a/packages/modal/src/drawer.tsx
+++ b/packages/modal/src/drawer.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   HTMLChakraProps,
   SystemStyleObject,
+  ThemingProps,
   useStyles,
   useTheme,
 } from "@chakra-ui/system"
@@ -45,7 +46,11 @@ interface DrawerOptions {
 
 export interface DrawerProps
   extends DrawerOptions,
-    Omit<ModalProps, "scrollBehavior" | "motionPreset" | "isCentered"> {}
+    ThemingProps<"Drawer">,
+    Omit<
+      ModalProps,
+      "scrollBehavior" | "motionPreset" | "isCentered" | keyof ThemingProps
+    > {}
 
 export function Drawer(props: DrawerProps) {
   const {
@@ -86,11 +91,8 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
   (props, ref) => {
     const { className, children, ...rest } = props
 
-    const {
-      getDialogProps,
-      getDialogContainerProps,
-      isOpen,
-    } = useModalContext()
+    const { getDialogProps, getDialogContainerProps, isOpen } =
+      useModalContext()
 
     const dialogProps = getDialogProps(rest, ref) as any
     const containerProps = getDialogContainerProps()


### PR DESCRIPTION
Closes #5334

## 📝 Description

Update `DrawerProps` type to include `ThemingProps` for the Drawer component

## ⛳️ Current behavior (updates)

Type `DrawerProps` extends `ModalProps` and inherits the size and variant typings.

## 🚀 New behavior

DrawerProps is now extending the `ThemingProps<'Drawer'>` explicitly.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
