### PR TITLE
fix: loosen ThemingProps type

### DIFF
--- a/.changeset/modern-wombats-march.md
+++ b/.changeset/modern-wombats-march.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/system": patch
+---
+
+Fixed an TypeScript issue where the ThemingProps type was too strict

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -8,7 +8,7 @@ import { Dict } from "@chakra-ui/utils"
 import { Interpolation } from "@emotion/react"
 import * as React from "react"
 
-export interface ThemingProps<ThemeComponent extends string = string> {
+export interface ThemingProps<ThemeComponent extends string = any> {
   variant?: ThemeComponent extends keyof ThemeTypings["components"]
     ? ThemeTypings["components"][ThemeComponent]["variants"]
     : never


### PR DESCRIPTION
Closes #5324

## 📝 Description

This PR fixes a regression introduced with #5243

## ⛳️ Current behavior (updates)

In some types and function definition TS throws an error like: 

```
Types of property 'variant' are incompatible.
    Type 'string' is not assignable to type 'never'.
```

## 🚀 New behavior

Updated the generic fallback type.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
