### PR TITLE
feat: add CSSVars component

### DIFF
--- a/.changeset/great-days-yawn.md
+++ b/.changeset/great-days-yawn.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/system": minor
+---
+
+Add React component `<CSSVars cssVarsRoot=":host, :root" />` to allow rehoising
+CSS vars

--- a/.changeset/great-days-yawn.md
+++ b/.changeset/great-days-yawn.md
@@ -2,5 +2,5 @@
 "@chakra-ui/system": minor
 ---
 
-Add React component `<CSSVars cssVarsRoot=":host, :root" />` to allow rehoising
+Add React component `<CSSVars cssVarsRoot=":host, :root" />` to allow rehoisting
 CSS vars

--- a/packages/system/src/providers.tsx
+++ b/packages/system/src/providers.tsx
@@ -16,7 +16,22 @@ import {
 } from "@emotion/react"
 import * as React from "react"
 
-export interface ThemeProviderProps extends EmotionThemeProviderProps {
+export interface ThemeProviderProps
+  extends EmotionThemeProviderProps,
+    CSSVarsProps {}
+
+export const ThemeProvider = (props: ThemeProviderProps) => {
+  const { cssVarsRoot, theme, children } = props
+  const computedTheme = React.useMemo(() => toCSSVar(theme), [theme])
+  return (
+    <EmotionThemeProvider theme={computedTheme}>
+      <CSSVars cssVarsRoot={cssVarsRoot} />
+      {children}
+    </EmotionThemeProvider>
+  )
+}
+
+export interface CSSVarsProps {
   /**
    * The element to attach the CSS custom properties to.
    * @default ":host, :root"
@@ -24,20 +39,13 @@ export interface ThemeProviderProps extends EmotionThemeProviderProps {
   cssVarsRoot?: string
 }
 
-export const ThemeProvider = (props: ThemeProviderProps) => {
-  const { cssVarsRoot = ":host, :root", theme, children } = props
-  const computedTheme = React.useMemo(() => toCSSVar(theme), [theme])
-  return (
-    <EmotionThemeProvider theme={computedTheme}>
-      <Global styles={(theme: any) => ({ [cssVarsRoot]: theme.__cssVars })} />
-      {children}
-    </EmotionThemeProvider>
-  )
-}
+export const CSSVars = ({ cssVarsRoot = ":host, :root" }: CSSVarsProps) => (
+  <Global styles={(theme: any) => ({ [cssVarsRoot]: theme.__cssVars })} />
+)
 
 export function useTheme<T extends object = Dict>() {
   const theme = React.useContext(
-    (ThemeContext as unknown) as React.Context<T | undefined>,
+    ThemeContext as unknown as React.Context<T | undefined>,
   )
   if (!theme) {
     throw Error(


### PR DESCRIPTION
## 📝 Description

Extract the hoisting of CSS variable to its own component to allow rehoisting.

## ⛳️ Current behavior (updates)

Inline Code

## 🚀 New behavior

Render `<CSSVars cssVarsRoot=".my-css-selector" />` to attach CSS variables.

## 💣 Is this a breaking change (Yes/No):

No