### PR TITLE
refactoring(theme): Simplify exports

### DIFF
--- a/.changeset/popular-jars-know.md
+++ b/.changeset/popular-jars-know.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+refactoring(theme): Simplify exports

--- a/packages/theme/src/components/index.ts
+++ b/packages/theme/src/components/index.ts
@@ -1,83 +1,41 @@
-import Accordion from "./accordion"
-import Alert from "./alert"
-import Avatar from "./avatar"
-import Badge from "./badge"
-import Breadcrumb from "./breadcrumb"
-import Button from "./button"
-import Checkbox from "./checkbox"
-import CloseButton from "./close-button"
-import Code from "./code"
-import Container from "./container"
-import Divider from "./divider"
-import Drawer from "./drawer"
-import Editable from "./editable"
-import Form from "./form"
-import FormLabel from "./form-label"
-import Heading from "./heading"
-import Input from "./input"
-import Kbd from "./kbd"
-import Link from "./link"
-import List from "./list"
-import Menu from "./menu"
-import Modal from "./modal"
-import NumberInput from "./number-input"
-import PinInput from "./pin-input"
-import Popover from "./popover"
-import Progress from "./progress"
-import Radio from "./radio"
-import Select from "./select"
-import Skeleton from "./skeleton"
-import SkipLink from "./skip-link"
-import Slider from "./slider"
-import Spinner from "./spinner"
-import Stat from "./stat"
-import Switch from "./switch"
-import Table from "./table"
-import Tabs from "./tabs"
-import Tag from "./tag"
-import Textarea from "./textarea"
-import Tooltip from "./tooltip"
-import FormError from "./form-error"
+export { default as Accordion } from "./accordion"
+export { default as Alert } from "./alert"
+export { default as Avatar } from "./avatar"
+export { default as Badge } from "./badge"
+export { default as Breadcrumb } from "./breadcrumb"
+export { default as Button } from "./button"
+export { default as Checkbox } from "./checkbox"
+export { default as CloseButton } from "./close-button"
+export { default as Code } from "./code"
+export { default as Container } from "./container"
+export { default as Divider } from "./divider"
+export { default as Drawer } from "./drawer"
+export { default as Editable } from "./editable"
+export { default as Form } from "./form"
+export { default as FormError } from "./form-error"
+export { default as FormLabel } from "./form-label"
+export { default as Heading } from "./heading"
+export { default as Input } from "./input"
+export { default as Kbd } from "./kbd"
+export { default as Link } from "./link"
+export { default as List } from "./list"
+export { default as Menu } from "./menu"
+export { default as Modal } from "./modal"
+export { default as NumberInput } from "./number-input"
+export { default as PinInput } from "./pin-input"
+export { default as Popover } from "./popover"
+export { default as Progress } from "./progress"
+export { default as Radio } from "./radio"
+export { default as Select } from "./select"
+export { default as Skeleton } from "./skeleton"
+export { default as SkipLink } from "./skip-link"
+export { default as Slider } from "./slider"
+export { default as Spinner } from "./spinner"
+export { default as Stat } from "./stat"
+export { default as Switch } from "./switch"
+export { default as Table } from "./table"
+export { default as Tabs } from "./tabs"
+export { default as Tag } from "./tag"
+export { default as Textarea } from "./textarea"
+export { default as Tooltip } from "./tooltip"
 
-export default {
-  Accordion,
-  Alert,
-  Avatar,
-  Badge,
-  Breadcrumb,
-  Button,
-  Checkbox,
-  CloseButton,
-  Code,
-  Container,
-  Divider,
-  Drawer,
-  Editable,
-  Form,
-  FormLabel,
-  Heading,
-  Input,
-  Kbd,
-  Link,
-  List,
-  Menu,
-  Modal,
-  NumberInput,
-  PinInput,
-  Popover,
-  Progress,
-  Radio,
-  Select,
-  Skeleton,
-  SkipLink,
-  Slider,
-  Spinner,
-  Stat,
-  Switch,
-  Table,
-  Tabs,
-  Tag,
-  Textarea,
-  Tooltip,
-  FormError,
-}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,4 +1,4 @@
-import components from "./components"
+import * as components from "./components"
 import foundations from "./foundations"
 import styles from "./styles"
 import type { ThemeConfig, ThemeDirection } from "./theme.types"


### PR DESCRIPTION
Remove more than half the code by using more modern syntax.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Came across a unnecessarily bloated way of re-exporting default exports. This change simplifies it a bit.

## 💣 Is this a breaking change (Yes/No):

Nope.

## 📝 Additional Information

Totally understand if this is a stylistic choice, so if you don't want it, just close my PR, no feelings will be hurt.
