### PR TITLE
Change the placement of the default --out option

### DIFF
--- a/.changeset/moody-icons-shake.md
+++ b/.changeset/moody-icons-shake.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Update README to reflect the change of the default `--out` path to `node_modules/@chakra-ui/styled-system/dist/declarations/src/theming.types.d.ts`

--- a/tooling/cli/README.md
+++ b/tooling/cli/README.md
@@ -21,7 +21,7 @@ Usage: chakra-cli tokens [options]
 
 Options:
   --out <path>  output directory e.g.
-                node_modules/@chakra-ui/styled-system/dist/types/theming.types.d.ts
+                node_modules/@chakra-ui/styled-system/dist/declarations/src/theming.types.d.ts
   -h, --help    display help for command
 
 Example call:


### PR DESCRIPTION
The default placement of types is now a different spot than earlier.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> The suggested path in the readme did not work with the latest of Chakra UI. This PR just updates the text.
