### PR TITLE
feat: allow ThemingProps variant and size for non theme components

### DIFF
--- a/.changeset/spotty-pandas-hide.md
+++ b/.changeset/spotty-pandas-hide.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/system": patch
+---
+
+Updated type `ThemingProps` to allow string values for the props `variant` and
+`size` even on components which are not in the default theme.

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -11,10 +11,10 @@ import * as React from "react"
 export interface ThemingProps<ThemeComponent extends string = any> {
   variant?: ThemeComponent extends keyof ThemeTypings["components"]
     ? ThemeTypings["components"][ThemeComponent]["variants"]
-    : never
+    : string
   size?: ThemeComponent extends keyof ThemeTypings["components"]
     ? ThemeTypings["components"][ThemeComponent]["sizes"]
-    : never
+    : string
   colorScheme?: ThemeTypings["colorSchemes"]
   orientation?: "vertical" | "horizontal"
   styleConfig?: Dict


### PR DESCRIPTION
## 📝 Description

Updated type `ThemingProps` to allow string values for the props `variant` and `size` even on components which are not in the default theme.

## ⛳️ Current behavior (updates)

Components which are not in the default chakra theme are not allowed to have a variant or size prop.

```tsx
<Text variant="impressive" />
//                          ^- impressive is not assignable to `undefined`
```

## 🚀 New behavior

`string` values are allowed

```tsx
<Text variant="impressive" />
//  works
```

## 💣 Is this a breaking change (Yes/No):

No
