### PR TITLE
feat: add type for state returned by useCheckbox

### DIFF
--- a/.changeset/short-bananas-decide.md
+++ b/.changeset/short-bananas-decide.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+Added a `CheckboxState` type to the `useCheckbox` hook to improve usability and
+documentation

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -101,6 +101,18 @@ export interface UseCheckboxProps {
   tabIndex?: number
 }
 
+export interface CheckboxState {
+  isInvalid: boolean | undefined
+  isFocused: boolean
+  isChecked: boolean
+  isActive: boolean
+  isHovered: boolean
+  isIndeterminate: boolean | undefined
+  isDisabled: boolean | undefined
+  isReadOnly: boolean | undefined
+  isRequired: boolean | undefined
+}
+
 /**
  * useCheckbox that provides all the state and focus management logic
  * for a checkbox. It is consumed by the `Checkbox` component
@@ -373,18 +385,20 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     [isChecked, isDisabled, isInvalid],
   )
 
+  const state: CheckboxState = {
+    isInvalid,
+    isFocused,
+    isChecked,
+    isActive,
+    isHovered,
+    isIndeterminate,
+    isDisabled,
+    isReadOnly,
+    isRequired,
+  }
+
   return {
-    state: {
-      isInvalid,
-      isFocused,
-      isChecked,
-      isActive,
-      isHovered,
-      isIndeterminate,
-      isDisabled,
-      isReadOnly,
-      isRequired,
-    },
+    state,
     getRootProps,
     getCheckboxProps,
     getInputProps,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Added a `CheckboxState` type as the return type of the state returned by the `useCheckbox` hook.

## ⛳️ Current behavior (updates)

Old return type:

![image](https://user-images.githubusercontent.com/21695702/149009460-3d9f0c74-83b1-4bdb-9d3b-64e22ce0412a.png)

## 🚀 New behavior

New return type:

![image](https://user-images.githubusercontent.com/21695702/149009520-19cd9e40-4c74-41dd-bbaf-f20fe31c3728.png)

Added type:

![image](https://user-images.githubusercontent.com/21695702/149010238-33da1a0f-098d-4954-9a47-2c2c58c373e3.png)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

While working on the documentation of the `useCheckbox` hooks in [the docs repo](https://github.com/chakra-ui/chakra-ui-docs/issues/72) I figured out it would be easier to use the hook and to document it if the returned state had its own type. Thus I added a type for the state returned from the`useCheckbox` hook