### PR TITLE
feat(modal): add onCloseComplete prop to Modal

### DIFF
--- a/.changeset/twenty-plants-burn.md
+++ b/.changeset/twenty-plants-burn.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/modal": patch
+"@chakra-ui/modal": minor
 ---
 
 Add `onCloseComplete` prop to Modal which is called when all DOM nodes of the `Modal` are removed.

--- a/.changeset/twenty-plants-burn.md
+++ b/.changeset/twenty-plants-burn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Add `onCloseComplete` prop to Modal which is called when all DOM nodes of the `Modal` are removed.

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -115,6 +115,10 @@ export interface ModalProps
    * The transition that should be used for the modal
    */
   motionPreset?: MotionPreset
+  /**
+   * Fires when all exiting nodes have completed animating out
+   */
+  onCloseComplete?: () => void
 }
 
 interface ModalContext extends ModalOptions, UseModalReturn {
@@ -153,6 +157,7 @@ export const Modal: React.FC<ModalProps> = (props) => {
     preserveScrollBarGap,
     motionPreset,
     lockFocusAcrossFrames,
+    onCloseComplete,
   } = props
 
   const styles = useMultiStyleConfig("Modal", props)
@@ -175,7 +180,7 @@ export const Modal: React.FC<ModalProps> = (props) => {
   return (
     <ModalContextProvider value={context}>
       <StylesProvider value={styles}>
-        <AnimatePresence>
+        <AnimatePresence onExitComplete={onCloseComplete}>
           {context.isOpen && <Portal {...portalProps}>{children}</Portal>}
         </AnimatePresence>
       </StylesProvider>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> add `onCloseComplete` prop to Modal, it  from support provided by AnimatePresence。

## ⛳️ Current behavior (updates)

> I can't do something after the Modal close animation is over

## 🚀 New behavior

> I can do something after the Modal close animation is over

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
NO

## 📝 Additional Information
