### PR TITLE
fix(popover): add open and close delay for focus and blur events with popover hover

### DIFF
--- a/packages/popover/stories/hover.stories.tsx
+++ b/packages/popover/stories/hover.stories.tsx
@@ -76,3 +76,19 @@ export function WithCustomAnimation() {
     </Popover>
   )
 }
+
+export function HoverWithDelay() {
+  return (
+    <Popover trigger="hover" openDelay={500} closeDelay={200}>
+      <PopoverTrigger>
+        <IconButton aria-label="Check" p={8}>
+          <MdCheck />
+        </IconButton>
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverBody>Are you sure you want to have that milkshake?</PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/popover/tests/popover.test.tsx
+++ b/packages/popover/tests/popover.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -107,6 +108,88 @@ test("load content lazily", async () => {
   expect(content).toBeInTheDocument()
 })
 
+test("should delay opening content on hover", async () => {
+  jest.useFakeTimers()
+  const utils = render(
+    <Component trigger="hover" openDelay={500} closeDelay={0} />,
+  )
+
+  // by default, content should not be visible
+  expect(screen.queryByText("Popover content")).not.toBeVisible()
+
+  // only pass 40% of the time
+  act(() => {
+    fireEvent.mouseOver(utils.getByText(/open/i))
+    jest.advanceTimersByTime(200)
+  })
+
+  // content should still not appear since 500ms has not occurred
+  expect(screen.queryByText("Popover content")).not.toBeVisible()
+
+  // Pass 100% of the time
+  act(() => {
+    jest.advanceTimersByTime(300)
+  })
+
+  // content should be visible to user
+  await waitFor(() => {
+    expect(screen.getByText("Popover content")).toBeVisible()
+  })
+
+  jest.useRealTimers()
+})
+
+test("should not display popover content when leaving the trigger before the targeted delay time", () => {
+  jest.useFakeTimers()
+  render(<Component trigger="hover" openDelay={500} closeDelay={0} />)
+
+  // by default, content should not be visible
+  expect(screen.queryByText("Popover content")).not.toBeVisible()
+
+  // simulate an entry that is less than the open delay and then leave
+  act(() => {
+    fireEvent.mouseOver(screen.getByRole("button", { name: "Open" }))
+    jest.advanceTimersByTime(200)
+    fireEvent.mouseLeave(screen.getByRole("button", { name: "Open" }))
+    jest.advanceTimersByTime(300)
+  })
+
+  expect(screen.queryByText("Popover content")).not.toBeVisible()
+  jest.useRealTimers()
+})
+
+test("should delay closing content on hover leave", async () => {
+  jest.useFakeTimers()
+  render(<Component trigger="hover" openDelay={0} closeDelay={500} />)
+
+  // by default, content should not be visible
+  expect(screen.queryByText("Popover content")).not.toBeVisible()
+
+  // leave the hover to start the close delay
+  act(() => {
+    fireEvent.mouseOver(screen.getByRole("button", { name: "Open" }))
+    jest.advanceTimersByTime(200)
+    fireEvent.mouseLeave(screen.getByRole("button", { name: "Open" }))
+  })
+
+  // since only 40% of the time has passed, content should still appear
+  await waitFor(() => {
+    expect(screen.queryByText("Popover content")).toBeVisible()
+  })
+
+  // pass 100% of the time
+  act(() => {
+    jest.advanceTimersByTime(300)
+  })
+
+  // content should not be visible
+  await waitFor(() => {
+    expect(screen.queryByText("Popover content")).not.toBeVisible()
+  })
+
+  jest.useRealTimers()
+})
+
 // For testing focus interaction, use another component with a focusable element inside.
 const FocusTestComponent = (props: UsePopoverProps) => {
   const {
@@ -159,7 +242,9 @@ test("when 'trigger'='hover', keep content visible while the tab focus is inside
   // open the popover and it will have focus and be visible.
   userEvent.tab()
   expect(content).toHaveFocus()
-  expect(content).toBeVisible()
+  await waitFor(() => {
+    expect(content).toBeVisible()
+  })
 
   // move focus to next focusable element. Popover should be visible still.
   userEvent.tab()


### PR DESCRIPTION
Closes #4786

## 📝 Description

Adds consistent hover behavior for the `Popover` component when using an `openDelay` and/or `closeDelay`.

## ⛳️ Current behavior (updates)

There is currently no timeout being set on the `focus` or `blur` events, so when a user hovers over a `Popover` with a `trigger` of `hover` and an opening and/or closing delay set, the popover's content will show immediately regardless of the delay passed to the component.

## 🚀 New behavior

Adds opening and closing delay functionality when hovering a `Popover` component.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

When initiating a `Popover`'s delayed opening, we must check to see if there is already an opening timeout set. This becomes relevant in the case when a `Popover` has a `trigger` type of `hover`. In this situation, both the `focus` and `mouseEnter` events will trigger when a user "clicks" the trigger (despite us not adding a `click` event listener for a `trigger` type of `hover`). The `focus` and `mouseEnter` both register, so there are two open timeouts running.