### PR TITLE
feat: add entrypoints for theme parts

### DIFF
--- a/.changeset/tender-forks-grow.md
+++ b/.changeset/tender-forks-grow.md
@@ -1,0 +1,28 @@
+---
+"@chakra-ui/theme": minor
+---
+
+Add entrypoints to the different parts of the theme (colors, fonts, components,
+spacing, etc.)
+
+```jsx live=false
+// Now you can use only colors from the theme
+import colors from "@chakra-ui/theme/foundations/colors"
+```
+
+Here's a table of the theme parts and entrypoints
+
+| Part        | Entrypoint                                  |
+| ----------- | ------------------------------------------- |
+| components  | `"@chakra-ui/theme/components"`             |
+| foundations | `"@chakra-ui/theme/foundations"`            |
+| colors      | `"@chakra-ui/theme/foundations/colors"`     |
+| sizes       | `"@chakra-ui/theme/foundations/sizes"`      |
+| spacing     | `"@chakra-ui/theme/foundations/spacing"`    |
+| typography  | `"@chakra-ui/theme/foundations/typography"` |
+| radius      | `"@chakra-ui/theme/foundations/radius"`     |
+| shadows     | `"@chakra-ui/theme/foundations/shadows"`    |
+| transition  | `"@chakra-ui/theme/foundations/transition"` |
+| zIndex      | `"@chakra-ui/theme/foundations/z-index"`    |
+| blur        | `"@chakra-ui/theme/foundations/blur"`       |
+| borders     | `"@chakra-ui/theme/foundations/borders"`    |

--- a/packages/theme/components/package.json
+++ b/packages/theme/components/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-components.cjs.js",
+  "module": "dist/chakra-ui-theme-components.esm.js"
+}

--- a/packages/theme/foundations/blur/package.json
+++ b/packages/theme/foundations/blur/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-blur.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-blur.esm.js"
+}

--- a/packages/theme/foundations/borders/package.json
+++ b/packages/theme/foundations/borders/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-borders.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-borders.esm.js"
+}

--- a/packages/theme/foundations/breakpoints/package.json
+++ b/packages/theme/foundations/breakpoints/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-breakpoints.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-breakpoints.esm.js"
+}

--- a/packages/theme/foundations/colors/package.json
+++ b/packages/theme/foundations/colors/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-colors.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-colors.esm.js"
+}

--- a/packages/theme/foundations/package.json
+++ b/packages/theme/foundations/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations.esm.js"
+}

--- a/packages/theme/foundations/radius/package.json
+++ b/packages/theme/foundations/radius/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-radius.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-radius.esm.js"
+}

--- a/packages/theme/foundations/shadows/package.json
+++ b/packages/theme/foundations/shadows/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-shadows.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-shadows.esm.js"
+}

--- a/packages/theme/foundations/sizes/package.json
+++ b/packages/theme/foundations/sizes/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-sizes.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-sizes.esm.js"
+}

--- a/packages/theme/foundations/spacing/package.json
+++ b/packages/theme/foundations/spacing/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-spacing.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-spacing.esm.js"
+}

--- a/packages/theme/foundations/transition/package.json
+++ b/packages/theme/foundations/transition/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-transition.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-transition.esm.js"
+}

--- a/packages/theme/foundations/typography/package.json
+++ b/packages/theme/foundations/typography/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-typography.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-typography.esm.js"
+}

--- a/packages/theme/foundations/z-index/package.json
+++ b/packages/theme/foundations/z-index/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/chakra-ui-theme-foundations-z-index.cjs.js",
+  "module": "dist/chakra-ui-theme-foundations-z-index.esm.js"
+}

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,8 +17,39 @@
   "types": "dist/chakra-ui-theme.cjs.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "components",
+    "foundations",
+    "foundations/blur",
+    "foundations/borders",
+    "foundations/breakpoints",
+    "foundations/colors",
+    "foundations/radius",
+    "foundations/shadows",
+    "foundations/sizes",
+    "foundations/spacing",
+    "foundations/typography",
+    "foundations/transition",
+    "foundations/z-index"
   ],
+  "preconstruct": {
+    "entrypoints": [
+      "index.ts",
+      "components/index.ts",
+      "foundations/index.ts",
+      "foundations/blur.ts",
+      "foundations/borders.ts",
+      "foundations/breakpoints.ts",
+      "foundations/colors.ts",
+      "foundations/radius.ts",
+      "foundations/shadows.ts",
+      "foundations/sizes.ts",
+      "foundations/spacing.ts",
+      "foundations/typography.ts",
+      "foundations/transition.ts",
+      "foundations/z-index.ts"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## 📝 Description

This PR creates entry points for the theme object to help non-`@chakra-ui/react` users consume parts of the theme without the overhead of our large theme object.

When I say non-`@chakra-ui/react`, I mean users who use `@chakra-ui/system` or even `@chakra-ui/styled-system` directly to build their internal design systems.

## 💣 Is this a breaking change (Yes/No):

No
