### PR TITLE
fix: add missing peer dependencies

### DIFF
--- a/.changeset/twelve-dots-sip.md
+++ b/.changeset/twelve-dots-sip.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/accordion": patch
+"@chakra-ui/anatomy": patch
+"@chakra-ui/skeleton": patch
+"@chakra-ui/switch": patch
+---
+
+fix: add missing peer dependencies

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -47,10 +47,12 @@
   },
   "devDependencies": {
     "@chakra-ui/system": "1.10.1",
+    "framer-motion": "^4.0.0",
     "react": "^17.0.1"
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/anatomy/package.json
+++ b/packages/anatomy/package.json
@@ -32,5 +32,11 @@
   },
   "dependencies": {
     "@chakra-ui/theme-tools": "^1.3.1"
+  },
+  "peerDependencies": {
+    "@chakra-ui/system": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@chakra-ui/system": "1.10.1"
   }
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -41,9 +41,15 @@
     "@chakra-ui/utils": "1.10.0"
   },
   "peerDependencies": {
+    "@chakra-ui/theme": ">=1.0.0",
+    "@emotion/react": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
     "react": ">=16.8.6"
   },
   "devDependencies": {
+    "@chakra-ui/theme": "*",
+    "@emotion/react": "^11.4.0",
+    "@emotion/styled": "^11.3.0",
     "react": "^17.0.1"
   }
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -39,10 +39,12 @@
   },
   "devDependencies": {
     "@chakra-ui/system": "1.10.1",
+    "framer-motion": "^4.0.0",
     "react": "^17.0.1"
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
+    "framer-motion": "3.x || 4.x || 5.x",
     "react": ">=16.8.6"
   }
 }


### PR DESCRIPTION
## 📝 Description

This PR fixes the [implicit transitive peer dependency](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0) warnings that appear when installing `@chakra-ui/react` with Yarn 2+.

## ⛳️ Current behavior (updates)

When installing `@chakra-ui/react` with Yarn 2+ these warnings are listed:
```
➤ YN0002: │ @chakra-ui/accordion@npm:1.4.3 [12ba7] doesn't provide framer-motion (p0709a), requested by @chakra-ui/transition
➤ YN0002: │ @chakra-ui/anatomy@npm:1.2.1 doesn't provide @chakra-ui/system (p2ef3e), requested by @chakra-ui/theme-tools
➤ YN0002: │ @chakra-ui/skeleton@npm:1.2.5 [12ba7] doesn't provide @chakra-ui/theme (pd5fa7), requested by @chakra-ui/media-query
➤ YN0002: │ @chakra-ui/skeleton@npm:1.2.5 [12ba7] doesn't provide @emotion/react (p4535b), requested by @chakra-ui/system
➤ YN0002: │ @chakra-ui/skeleton@npm:1.2.5 [12ba7] doesn't provide @emotion/styled (p7cdfb), requested by @chakra-ui/system
➤ YN0002: │ @chakra-ui/switch@npm:1.3.2 [12ba7] doesn't provide framer-motion (p738cc), requested by @chakra-ui/checkbox
```

## 🚀 New behavior

The warnings no longer appear.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0
Replaces https://github.com/chakra-ui/chakra-ui/pull/4751.