### PR TITLE
chore: fix types for refs in hooks

### DIFF
--- a/.changeset/tasty-gorillas-stare.md
+++ b/.changeset/tasty-gorillas-stare.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+loosen ref type for hooks to allow passing anything extending HTMLElement as a
+ref

--- a/packages/hooks/src/use-dimensions.ts
+++ b/packages/hooks/src/use-dimensions.ts
@@ -8,8 +8,8 @@ import { useSafeLayoutEffect } from "./use-safe-layout-effect"
  * @param ref ref of the component to measure
  * @param observe if `true`, resize and scroll observers will be turned on
  */
-export function useDimensions(
-  ref: React.RefObject<HTMLElement>,
+export function useDimensions<T extends HTMLElement>(
+  ref: React.RefObject<T>,
   observe?: boolean,
 ) {
   const [dimensions, setDimensions] = React.useState<BoxModel | null>(null)

--- a/packages/hooks/src/use-focus-on-pointerdown.ts
+++ b/packages/hooks/src/use-focus-on-pointerdown.ts
@@ -9,9 +9,9 @@ import {
 import { RefObject } from "react"
 import { usePointerEvent } from "./use-pointer-event"
 
-export interface UseFocusOnMouseDownProps {
+export interface UseFocusOnMouseDownProps<T extends HTMLElement> {
   enabled?: boolean
-  ref: RefObject<HTMLElement>
+  ref: RefObject<T>
   elements?: Array<RefObject<HTMLElement> | HTMLElement | null>
 }
 
@@ -24,7 +24,9 @@ export interface UseFocusOnMouseDownProps {
  *
  * @internal
  */
-export function useFocusOnPointerDown(props: UseFocusOnMouseDownProps) {
+export function useFocusOnPointerDown<T extends HTMLElement>(
+  props: UseFocusOnMouseDownProps<T>,
+) {
   const { ref, elements, enabled } = props
 
   const isSafari = detectBrowser("Safari")

--- a/packages/hooks/src/use-outside-click.ts
+++ b/packages/hooks/src/use-outside-click.ts
@@ -2,7 +2,7 @@ import { getOwnerDocument } from "@chakra-ui/utils"
 import { RefObject, useEffect, useRef } from "react"
 import { useCallbackRef } from "./use-callback-ref"
 
-export interface UseOutsideClickProps {
+export interface UseOutsideClickProps<T extends HTMLElement> {
   /**
    * Whether the hook is enabled
    */
@@ -10,7 +10,7 @@ export interface UseOutsideClickProps {
   /**
    * The reference to a DOM element.
    */
-  ref: RefObject<HTMLElement>
+  ref: RefObject<T>
   /**
    * Function invoked when a click is triggered outside the referenced element.
    */
@@ -21,7 +21,9 @@ export interface UseOutsideClickProps {
  * Example, used in components like Dialogs and Popovers so they can close
  * when a user clicks outside them.
  */
-export function useOutsideClick(props: UseOutsideClickProps) {
+export function useOutsideClick<T extends HTMLElement>(
+  props: UseOutsideClickProps<T>,
+) {
   const { ref, handler, enabled = true } = props
   const savedHandler = useCallbackRef(handler)
 

--- a/packages/hooks/src/use-pan-gesture.ts
+++ b/packages/hooks/src/use-pan-gesture.ts
@@ -18,8 +18,8 @@ export interface UsePanGestureProps {
   threshold?: number
 }
 
-export function usePanGesture(
-  ref: React.RefObject<HTMLElement>,
+export function usePanGesture<T extends HTMLElement>(
+  ref: React.RefObject<T>,
   props: UsePanGestureProps,
 ) {
   const {


### PR DESCRIPTION
## 📝 Description

> loosen ref type for hooks to allow passing anything extending HTMLElement as a ref

## ⛳️ Current behavior (updates)

> Currently some of the hooks require ref's to equal `HTMLElement`, requiring in unnecessary typecasting when used

## 🚀 New behavior

> Allow passing anything extending `HTMLElement` as a ref

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
