### PR TITLE
ci: skip pr publish step if actor is not org member

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,7 +88,27 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Check if PR author is Org member
+        id: membercheck
+        uses: actions/github-scripts@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let member
+            try {
+              const response = await github.rest.repos.checkCollaborator({
+                username: context.actor,
+                owner: 'chakra-ui',
+                repo: 'chakra-ui',
+              })
+              member = response.data === undefined
+            } catch {
+              member = false
+            }
+            return member
+
       - name: Release to @pr channel
+        if: steps.membercheck.outputs.result == 'true'
         run: |
           yarn changeset version --snapshot pr
           yarn changeset publish --tag pr
@@ -98,11 +118,13 @@ jobs:
 
       - name: Get released version
         id: version
+        if: steps.membercheck.outputs.result == 'true'
         run:
           echo ::set-output name=version::$(node -p
           "require('./packages/react/package.json').version")
 
       - name: Create comment
+        if: steps.membercheck.outputs.result == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: "pr-release"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Check if PR author is Org member
         id: membercheck
-        uses: actions/github-scripts@v5
+        uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,6 +102,7 @@ jobs:
                 repo: 'chakra-ui',
               })
               member = response.data === undefined
+              console.log({ actor: context.actor, isMember: member })
             } catch {
               member = false
             }


### PR DESCRIPTION
## 📝 Description

An improvement to our PR workflow. At the moment, we create an NPM snapshot each time a PR is made to make it easier to test features/fixes in a local project.

This workflow step fails if the PR author is not a member of the Chakra UI org since it needs access to the NPM_TOKEN. This PR updates the workflow step to skip the workflow if the author is not a member.
