### PR TITLE
fix: respect the closure of the color mode script

### DIFF
--- a/.changeset/tiny-knives-hang.md
+++ b/.changeset/tiny-knives-hang.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+Fixed an issue where the ColorModeScript tried to access a non-existent variable

--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import { ColorMode, ConfigColorMode } from "./color-mode-provider"
-import { root } from "./color-mode.utils"
 
 export function setScript(initialValue: ConfigColorMode) {
   const mql = window.matchMedia("(prefers-color-scheme: dark)")
@@ -29,7 +28,14 @@ export function setScript(initialValue: ConfigColorMode) {
   }
 
   if (colorMode) {
-    root.set(colorMode)
+    /**
+     * Keep in sync with `root.set() {@file ./color-mode.utils.ts}
+     */
+    document.documentElement.style.setProperty(
+      "--chakra-ui-color-mode",
+      colorMode,
+    )
+    document.documentElement.setAttribute("data-theme", colorMode)
   }
 }
 


### PR DESCRIPTION
Closes #5453

## 📝 Description

The ColorModeScript tries to evaluate `root` but it is not present in the closure.

## ⛳️ Current behavior (updates)

Remove access to out of scope variable.

## 🚀 New behavior

Replaced with duplicate code

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
