### PR TITLE
Increase scan depth for Chakra CLI on non-color tokens

### DIFF
--- a/.changeset/six-bags-bake.md
+++ b/.changeset/six-bags-bake.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": minor
+---
+
+Increased scan depth for tokens in cli tooling

--- a/tooling/cli/src/command/tokens/extract-property-paths.ts
+++ b/tooling/cli/src/command/tokens/extract-property-paths.ts
@@ -36,7 +36,7 @@ export function printUnionMap(
 /**
  * Extract recursively all property paths with a max depth
  */
-export function extractPropertyPaths(target: unknown, maxDepth = 1) {
+export function extractPropertyPaths(target: unknown, maxDepth = 3) {
   if ((!isObject(target) && !Array.isArray(target)) || !maxDepth) {
     return []
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5457

## 📝 Description

I would be happy if the scan depth for non-color tokens in Chakras CLI script for generating typings could be increased from one.

## ⛳️ Current behavior (updates)

Currently, the chakra CLI tool scans theme variables and generates typings for them, by scanning for a depth of up to 3 for color variables, but only up to one for everything else. This means that a color with the token name "general.brand.default" would be found, but "general.brand.default.subprop" not. However, in our project we also use nested font sizes and font weights, e.g. "body.small" is one of the font size values. If the CLI tool would scan that as well, it would help us by providing better typings.

## 🚀 New behavior

Default scan depth increased to 3.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
