### PR TITLE
fix(use-media-query): conditional check if addEventListener is supported

### DIFF
--- a/.changeset/chilly-boxes-kick.md
+++ b/.changeset/chilly-boxes-kick.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/media-query": major
+---
+
+Support useMediaQuery for older browsers. Conditionally check if the
+MediaQueryList object supports the addEventListener() method, else fallback to
+the legacy .addListener() method.

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -54,10 +54,10 @@ export function useMediaQuery(query: string | string[]): boolean[] {
       // media query is matched. Using addEventListener on the window object
       // to listen for the resize event will call the callback on every
       // viewport resize.
-      if(typeof mediaQueryList[index].addEventListener === 'function') {
-        mediaQueryList[index].addEventListener("change", listener);
+      if (typeof mediaQueryList[index].addEventListener === "function") {
+        mediaQueryList[index].addEventListener("change", listener)
       } else {
-        mediaQueryList[index].addListener(listener);
+        mediaQueryList[index].addListener(listener)
       }
 
       return listener
@@ -65,10 +65,13 @@ export function useMediaQuery(query: string | string[]): boolean[] {
 
     return () => {
       mediaQueryList.forEach((_, index) => {
-        if(typeof mediaQueryList[index].removeEventListener === 'function') {
-          mediaQueryList[index].removeEventListener("change", listenerList[index]);
+        if (typeof mediaQueryList[index].removeEventListener === "function") {
+          mediaQueryList[index].removeEventListener(
+            "change",
+            listenerList[index],
+          )
         } else {
-          mediaQueryList[index].removeListener(listenerList[index]);
+          mediaQueryList[index].removeListener(listenerList[index])
         }
       })
     }

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -54,14 +54,22 @@ export function useMediaQuery(query: string | string[]): boolean[] {
       // media query is matched. Using addEventListener on the window object
       // to listen for the resize event will call the callback on every
       // viewport resize.
-      mediaQueryList[index].addEventListener("change", listener)
+      if(mediaQueryList[index].addEventListener) {
+        mediaQueryList[index].addEventListener("change", listener);
+      } else {
+        mediaQueryList[index].addListener(listener);
+      }
 
       return listener
     })
 
     return () => {
       mediaQueryList.forEach((_, index) => {
-        mediaQueryList[index].removeEventListener("change", listenerList[index])
+        if(mediaQueryList[index].removeEventListener) {
+          mediaQueryList[index].removeEventListener("change", listenerList[index]);
+        } else {
+          mediaQueryList[index].removeListener(listenerList[index]);
+        }
       })
     }
   }, [])

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -54,7 +54,7 @@ export function useMediaQuery(query: string | string[]): boolean[] {
       // media query is matched. Using addEventListener on the window object
       // to listen for the resize event will call the callback on every
       // viewport resize.
-      if(mediaQueryList[index].addEventListener) {
+      if(typeof mediaQueryList[index].addEventListener === 'function') {
         mediaQueryList[index].addEventListener("change", listener);
       } else {
         mediaQueryList[index].addListener(listener);
@@ -65,7 +65,7 @@ export function useMediaQuery(query: string | string[]): boolean[] {
 
     return () => {
       mediaQueryList.forEach((_, index) => {
-        if(mediaQueryList[index].removeEventListener) {
+        if(typeof mediaQueryList[index].removeEventListener === 'function') {
           mediaQueryList[index].removeEventListener("change", listenerList[index]);
         } else {
           mediaQueryList[index].removeListener(listenerList[index]);


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

#5467 and #5197

## 📝 Description

> Add a brief description

Support useMediaQuery for older browsers. Conditionally check if the
MediaQueryList object supports the addEventListener() method, else fallback to
the legacy .addListener() method.

## ⛳️ Current behavior (updates)

Website crashes on Safari browsers < v13

> Please describe the current behavior that you are modifying

## 🚀 New behavior

the method `addListener()` is used instead of `addEventListener()`

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
