### PR TITLE
fix(cli): use latest pkg version of /utils

### DIFF
--- a/.changeset/dirty-ravens-drum.md
+++ b/.changeset/dirty-ravens-drum.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Escape CSS custom property names

--- a/.changeset/dirty-ravens-drum.md
+++ b/.changeset/dirty-ravens-drum.md
@@ -1,5 +1,0 @@
----
-"@chakra-ui/styled-system": patch
----
-
-Escape CSS custom property names

--- a/.changeset/modern-parents-raise.md
+++ b/.changeset/modern-parents-raise.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Fixed an internal version number mismatch

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -39,7 +39,7 @@
     "dev": "node bin/index.js tokens ../../website/theme.ts"
   },
   "dependencies": {
-    "@chakra-ui/utils": "^1.10.0",
+    "@chakra-ui/utils": "^1.9.1",
     "cli-check-node": "^1.3.4",
     "cli-handle-unhandled": "^1.1.1",
     "cli-welcome": "^2.2.2",


### PR DESCRIPTION
## 📝 Description

cli package has a dependency to /utils@^1.10.0 which is not a `latest` release. See [npmjs.org](https://www.npmjs.com/package/@chakra-ui/utils)

## ⛳️ Current behavior (updates)

You can end up with multiple installed chakra versions.

## 🚀 New behavior

Replaced with `^1.9.1`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
