### PR TITLE
docs(tooltip): rephrase usage when no React element is passed as children

### DIFF
--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -21,8 +21,8 @@ import { Tooltip } from "@chakra-ui/react"
 
 ## Usage
 
-If the `children` of Tooltip is a string, we wrap with in a `span` with
-`tabIndex` set to `0`, to ensure it meets the accessibility requirements.
+If the `children` of Tooltip is a string, it will be wrapped with a focusable
+`span` element to ensure the Tooltip meets accessibility requirements.
 
 ```jsx
 <Tooltip label="Hey, I'm here!">Hover me</Tooltip>


### PR DESCRIPTION
## 📝 Description

Rephrases the documentation for the Tooltip component to explain why Chakra wraps the Tooltip in a `span` if no React element is passed to `children`.

## ⛳️ Current behavior (updates)

The documentation sentence structure is slightly difficult to follow:

> [If the `children` of Tooltip is a string, we wrap with in a `span` with `tabIndex` set to 0, to ensure it meets the accessibility requirements.](https://chakra-ui.com/docs/overlay/tooltip#usage)

## 🚀 New behavior

Rewords the documentation to abstract the implementation details for how Chakra makes a Tooltip accessible:

> If the `children` of Tooltip is a string, it will be wrapped with a focusable `span` element to ensure the Tooltip meets accessibility requirements.

## 💣 Is this a breaking change (Yes/No):

No