### PR TITLE
fix(text): fix prop no of line with responsive object

### DIFF
--- a/.changeset/tiny-dolphins-own.md
+++ b/.changeset/tiny-dolphins-own.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+fix issue with Text prop noOfLines to receive ResponsiveObject

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@chakra-ui/icon": "2.0.1",
+    "@chakra-ui/media-query": "1.2.4",
     "@chakra-ui/react-utils": "1.2.1",
     "@chakra-ui/utils": "1.10.0"
   },

--- a/packages/layout/src/text.tsx
+++ b/packages/layout/src/text.tsx
@@ -1,3 +1,4 @@
+import { useBreakpointValue } from "@chakra-ui/media-query"
 import {
   chakra,
   forwardRef,
@@ -28,6 +29,8 @@ export interface TextProps extends HTMLChakraProps<"p">, ThemingProps<"Text"> {
   casing?: SystemProps["textTransform"]
 }
 
+const defaultNoOfLines = 3
+
 /**
  * Used to render texts or paragraphs.
  *
@@ -35,9 +38,14 @@ export interface TextProps extends HTMLChakraProps<"p">, ThemingProps<"Text"> {
  */
 export const Text = forwardRef<TextProps, "p">((props, ref) => {
   const styles = useStyleConfig("Text", props)
-  const { className, align, decoration, casing, ...rest } = omitThemingProps(
-    props,
-  )
+  const {
+    className,
+    align,
+    decoration,
+    casing,
+    noOfLines = [],
+    ...rest
+  } = omitThemingProps(props)
 
   const aliasedProps = filterUndefined({
     textAlign: props.align,
@@ -45,11 +53,17 @@ export const Text = forwardRef<TextProps, "p">((props, ref) => {
     textTransform: props.casing,
   })
 
+  const noOfLinesValue =
+    useBreakpointValue(
+      typeof noOfLines === "number" ? [noOfLines] : noOfLines,
+    ) || defaultNoOfLines
+
   return (
     <chakra.p
       ref={ref}
       className={cx("chakra-text", props.className)}
       {...aliasedProps}
+      noOfLines={noOfLinesValue}
       {...rest}
       __css={styles}
     />

--- a/packages/layout/stories/text.stories.tsx
+++ b/packages/layout/stories/text.stories.tsx
@@ -35,3 +35,20 @@ export const overrideVariant = () => (
     </Text>
   </ChakraProvider>
 )
+
+// see https://github.com/chakra-ui/chakra-ui/issues/5473
+export const withNoOfLinesResponsive = () => (
+  <ChakraProvider theme={theme}>
+    <Text maxWidth="500px" noOfLines={{ lg: 3, md: 5, sm: 7 }}>
+      "Lorem Ipsum is simply dummy text of the printing and typesetting
+      industry. Lorem Ipsum has been the industry's standard dummy text ever
+      since the 1500s, when an unknown printer took a galley of type and
+      scrambled it to make a type specimen book. It has survived not only five
+      centuries, but also the leap into electronic typesetting, remaining
+      essentially unchanged. It was popularised in the 1960s with the release of
+      Letraset sheets containing Lorem Ipsum passages, and more recently with
+      desktop publishing software like Aldus PageMaker including versions of
+      Lorem Ipsum."
+    </Text>
+  </ChakraProvider>
+)


### PR DESCRIPTION
Issue:
Bugfix noOfLines props in text to pass when user pass in responsiveObject.
https://github.com/chakra-ui/chakra-ui/issues/5473

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5473 

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

Current acceptance of responsive object `noOfLines={{ lg: 3, md: 5, sm: 7 }}` doesn't convert values into correct responsive array that is need

## 🚀 New behavior
Will convert `noOfLines={{ lg: 3, md: 5, sm: 7 }}` to `[7, 5, 3]` as required

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
