### PR TITLE
fix: EditablePreview becomes unclickable when empty

### DIFF
--- a/.changeset/funny-steaks-punch.md
+++ b/.changeset/funny-steaks-punch.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/theme": patch
+---
+
+added minWidth to EditablePreview
+
+fixes #5423

--- a/packages/theme/src/components/editable.ts
+++ b/packages/theme/src/components/editable.ts
@@ -9,6 +9,7 @@ const baseStylePreview: SystemStyleObject = {
   py: "3px",
   transitionProperty: "common",
   transitionDuration: "normal",
+  minWidth: "2px",
 }
 
 const baseStyleInput: SystemStyleObject = {


### PR DESCRIPTION
Closes #5423

## 📝 Description

adds a minWIdth to EditablePreview

## 💣 Is this a breaking change (Yes/No):

No