### PR TITLE
chore: allow framer motion v6

### DIFF
--- a/.changeset/pretty-beans-reply.md
+++ b/.changeset/pretty-beans-reply.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/accordion": patch
+"@chakra-ui/checkbox": patch
+"@chakra-ui/menu": patch
+"@chakra-ui/modal": patch
+"@chakra-ui/popover": patch
+"@chakra-ui/react": patch
+"@chakra-ui/switch": patch
+"@chakra-ui/toast": patch
+"@chakra-ui/tooltip": patch
+"@chakra-ui/transition": patch
+---
+
+allow framer motion v6 as peer dependency

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   }

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   },

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6"
   }
 }

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=1.0.0",
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"
   }

--- a/packages/transition/package.json
+++ b/packages/transition/package.json
@@ -36,7 +36,7 @@
     "@chakra-ui/utils": "1.10.0"
   },
   "peerDependencies": {
-    "framer-motion": "3.x || 4.x || 5.x",
+    "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6"
   },
   "devDependencies": {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5483 

## 📝 Description

Updated the list of valid versions for framer motion as peerDependency to include v6

## ⛳️ Current behavior (updates)

List of peerDependencies was including v3, v4 and v5

## 🚀 New behavior

List of peerDependencies was including v3, v4, v5 and v6

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
