### PR TITLE
fix(switch): Change lineHeight from "normal" to 0 to remove a few extra pixels in …

### DIFF
--- a/.changeset/breezy-bananas-sell.md
+++ b/.changeset/breezy-bananas-sell.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/switch": patch
+---
+
+Fixed an UI issue where the Switch component rendered a few pixels off the baseline.

--- a/packages/switch/src/switch.tsx
+++ b/packages/switch/src/switch.tsx
@@ -42,7 +42,7 @@ export const Switch = forwardRef<SwitchProps, "input">((props, ref) => {
       display: "inline-block",
       position: "relative",
       verticalAlign: "middle",
-      lineHeight: "normal",
+      lineHeight: 0,
       ...styles.container,
     }),
     [styles.container],


### PR DESCRIPTION
…height at the bottom.

## 📝 Description

Change the lineHeight of the switch container to 0 so that inline child elements will not have extra pixels in height.

## ⛳️ Current behavior (updates)

There are a few extra pixels at the bottom of the switch for all the sizes.

## 🚀 New behavior

Removes a few extra pixels in height at the bottom of the switch for all the sizes.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
