### PR TITLE
fix(useCheckboxGroup): fixing the issue when using the useCheckboxGroup hook with numbers

### DIFF
--- a/.changeset/soft-countries-sin.md
+++ b/.changeset/soft-countries-sin.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/checkbox": patch
+"@chakra-ui/utils": patch
+---
+
+Fixing a bug that happens when using the useCheckboxGroup hook with number
+values instead of string values

--- a/packages/checkbox/src/use-checkbox-group.ts
+++ b/packages/checkbox/src/use-checkbox-group.ts
@@ -85,8 +85,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
       const checkedKey = isNative ? "checked" : "isChecked"
       return {
         ...props,
-        [checkedKey]:
-          value.includes(props.value) || value.includes(`${props.value}`),
+        [checkedKey]: value.some((val) => props.value == val),
         onChange: handleChange,
       }
     },

--- a/packages/checkbox/src/use-checkbox-group.ts
+++ b/packages/checkbox/src/use-checkbox-group.ts
@@ -85,7 +85,8 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
       const checkedKey = isNative ? "checked" : "isChecked"
       return {
         ...props,
-        [checkedKey]: value.includes(props.value),
+        [checkedKey]:
+          value.includes(props.value) || value.includes(`${props.value}`),
         onChange: handleChange,
       }
     },

--- a/packages/checkbox/src/use-checkbox-group.ts
+++ b/packages/checkbox/src/use-checkbox-group.ts
@@ -1,11 +1,5 @@
 import { useCallbackRef, useControllableState } from "@chakra-ui/hooks"
-import {
-  addItem,
-  Dict,
-  removeItem,
-  StringOrNumber,
-  isInputEvent,
-} from "@chakra-ui/utils"
+import { addItem, Dict, StringOrNumber, isInputEvent } from "@chakra-ui/utils"
 import { ChangeEvent, useCallback } from "react"
 
 type EventOrValue = ChangeEvent<HTMLInputElement> | StringOrNumber
@@ -73,7 +67,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
 
       const nextValue = isChecked
         ? addItem(value, selectedValue)
-        : removeItem(value, selectedValue)
+        : value.filter((v) => String(v) !== String(selectedValue))
 
       setValue(nextValue)
     },
@@ -85,7 +79,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
       const checkedKey = isNative ? "checked" : "isChecked"
       return {
         ...props,
-        [checkedKey]: value.some((val) => props.value == val),
+        [checkedKey]: value.some((val) => String(props.value) === String(val)),
         onChange: handleChange,
       }
     },

--- a/packages/checkbox/stories/checkbox.stories.tsx
+++ b/packages/checkbox/stories/checkbox.stories.tsx
@@ -1,8 +1,17 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { Icon } from "@chakra-ui/icon"
-import { Container, Divider, Heading, Stack } from "@chakra-ui/layout"
+import {
+  Container,
+  Divider,
+  Heading,
+  Stack,
+  Flex,
+  Box,
+  Text,
+} from "@chakra-ui/layout"
+import { chakra } from "@chakra-ui/system"
 import * as React from "react"
-import { Checkbox, CheckboxGroup, useCheckbox } from "../src"
+import { Checkbox, CheckboxGroup, useCheckbox, useCheckboxGroup } from "../src"
 
 export default {
   title: "Components / Forms / Checkbox",
@@ -220,5 +229,57 @@ export const ControlledCheckboxGroup = () => {
         <Checkbox value="three">Three</Checkbox>
       </Stack>
     </CheckboxGroup>
+  )
+}
+
+export const CustomCheckboxGroup = () => {
+  function CustomCheckbox(props: any) {
+    const { state, getCheckboxProps, getInputProps, getLabelProps, htmlProps } =
+      useCheckbox(props)
+
+    return (
+      <chakra.label
+        display="flex"
+        flexDirection="row"
+        alignItems="center"
+        gridColumnGap={2}
+        maxW="40"
+        bg="green.50"
+        border="1px solid"
+        borderColor="green.500"
+        rounded="lg"
+        px={3}
+        py={1}
+        cursor="pointer"
+        {...htmlProps}
+      >
+        <input {...getInputProps()} hidden />
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          border="2px solid"
+          borderColor="green.500"
+          w={4}
+          h={4}
+          {...getCheckboxProps()}
+        >
+          {state.isChecked && <Box w={2} h={2} bg="green.500" />}
+        </Flex>
+        <Text {...getLabelProps()}>Click me for {props.value}</Text>
+      </chakra.label>
+    )
+  }
+
+  const { value, getCheckboxProps } = useCheckboxGroup({
+    defaultValue: [2],
+  })
+
+  return (
+    <Stack>
+      <Text>The selected checkboxes are: {value.sort().join(" and ")}</Text>
+      <CustomCheckbox {...getCheckboxProps({ value: 1 })} />
+      <CustomCheckbox {...getCheckboxProps({ value: 2 })} />
+      <CustomCheckbox {...getCheckboxProps({ value: 3 })} />
+    </Stack>
   )
 }

--- a/packages/checkbox/tests/checkbox.test.tsx
+++ b/packages/checkbox/tests/checkbox.test.tsx
@@ -15,6 +15,7 @@ import {
   CheckboxGroupProps,
   useCheckbox,
   UseCheckboxProps,
+  useCheckboxGroup,
 } from "../src"
 
 it("passes a11y test", async () => {
@@ -276,4 +277,71 @@ test("can pass tabIndex directly to input component", () => {
 
   expect(checkboxOne).toHaveAttribute("tabIndex", "-1")
   expect(checkboxTwo).not.toHaveAttribute("tabIndex")
+})
+
+test("useCheckboxGroup can handle both strings and numbers", () => {
+  const Group = () => {
+    const { value, getCheckboxProps } = useCheckboxGroup({
+      defaultValue: [2, 3],
+    })
+
+    return (
+      <div>
+        <p id="value">{value.sort().join(", ")}</p>
+        <Checkbox {...getCheckboxProps({ value: 1 })} />
+        <Checkbox {...getCheckboxProps({ value: "2" })} />
+        <Checkbox {...getCheckboxProps({ value: 3 })} />
+      </div>
+    )
+  }
+
+  const { container } = render(<Group />)
+
+  {
+    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
+      container.querySelectorAll("input"),
+    )
+    const values = container.querySelector("p")?.innerHTML
+    expect(values).toMatch("2, 3")
+    expect(checkboxOne).not.toBeChecked()
+    expect(checkboxTwo).toBeChecked()
+    expect(checkboxThree).toBeChecked()
+  }
+
+  {
+    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
+      container.querySelectorAll("input"),
+    )
+    fireEvent.click(checkboxOne)
+    const values = container.querySelector("p")?.innerHTML
+    expect(values).toMatch("1, 2, 3")
+    expect(checkboxOne).toBeChecked()
+    expect(checkboxTwo).toBeChecked()
+    expect(checkboxThree).toBeChecked()
+  }
+
+  {
+    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
+      container.querySelectorAll("input"),
+    )
+    fireEvent.click(checkboxTwo)
+    fireEvent.click(checkboxThree)
+    const values = container.querySelector("p")?.innerHTML
+    expect(values).toMatch("1")
+    expect(checkboxOne).toBeChecked()
+    expect(checkboxTwo).not.toBeChecked()
+    expect(checkboxThree).not.toBeChecked()
+  }
+
+  {
+    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
+      container.querySelectorAll("input"),
+    )
+    fireEvent.click(checkboxOne)
+    const values = container.querySelector("p")?.innerHTML
+    expect(values).toMatch("")
+    expect(checkboxOne).not.toBeChecked()
+    expect(checkboxTwo).not.toBeChecked()
+    expect(checkboxThree).not.toBeChecked()
+  }
 })

--- a/packages/checkbox/tests/checkbox.test.tsx
+++ b/packages/checkbox/tests/checkbox.test.tsx
@@ -297,51 +297,33 @@ test("useCheckboxGroup can handle both strings and numbers", () => {
 
   const { container } = render(<Group />)
 
-  {
-    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
-      container.querySelectorAll("input"),
-    )
-    const values = container.querySelector("p")?.innerHTML
-    expect(values).toMatch("2, 3")
-    expect(checkboxOne).not.toBeChecked()
-    expect(checkboxTwo).toBeChecked()
-    expect(checkboxThree).toBeChecked()
-  }
+  const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
+    container.querySelectorAll("input"),
+  )
 
-  {
-    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
-      container.querySelectorAll("input"),
-    )
-    fireEvent.click(checkboxOne)
-    const values = container.querySelector("p")?.innerHTML
-    expect(values).toMatch("1, 2, 3")
-    expect(checkboxOne).toBeChecked()
-    expect(checkboxTwo).toBeChecked()
-    expect(checkboxThree).toBeChecked()
-  }
+  const values = container.querySelector("p")
 
-  {
-    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
-      container.querySelectorAll("input"),
-    )
-    fireEvent.click(checkboxTwo)
-    fireEvent.click(checkboxThree)
-    const values = container.querySelector("p")?.innerHTML
-    expect(values).toMatch("1")
-    expect(checkboxOne).toBeChecked()
-    expect(checkboxTwo).not.toBeChecked()
-    expect(checkboxThree).not.toBeChecked()
-  }
+  expect(values?.innerHTML).toMatch("2, 3")
+  expect(checkboxOne).not.toBeChecked()
+  expect(checkboxTwo).toBeChecked()
+  expect(checkboxThree).toBeChecked()
 
-  {
-    const [checkboxOne, checkboxTwo, checkboxThree] = Array.from(
-      container.querySelectorAll("input"),
-    )
-    fireEvent.click(checkboxOne)
-    const values = container.querySelector("p")?.innerHTML
-    expect(values).toMatch("")
-    expect(checkboxOne).not.toBeChecked()
-    expect(checkboxTwo).not.toBeChecked()
-    expect(checkboxThree).not.toBeChecked()
-  }
+  fireEvent.click(checkboxOne)
+  expect(values?.innerHTML).toMatch("1, 2, 3")
+  expect(checkboxOne).toBeChecked()
+  expect(checkboxTwo).toBeChecked()
+  expect(checkboxThree).toBeChecked()
+
+  fireEvent.click(checkboxTwo)
+  fireEvent.click(checkboxThree)
+  expect(values?.innerHTML).toMatch("1")
+  expect(checkboxOne).toBeChecked()
+  expect(checkboxTwo).not.toBeChecked()
+  expect(checkboxThree).not.toBeChecked()
+
+  fireEvent.click(checkboxOne)
+  expect(values?.innerHTML).toMatch("")
+  expect(checkboxOne).not.toBeChecked()
+  expect(checkboxTwo).not.toBeChecked()
+  expect(checkboxThree).not.toBeChecked()
 })

--- a/packages/utils/src/array.ts
+++ b/packages/utils/src/array.ts
@@ -26,7 +26,7 @@ export function addItem<T>(array: T[], item: T): T[] {
 }
 
 export function removeItem<T>(array: T[], item: T): T[] {
-  return array.filter((eachItem) => eachItem !== item)
+  return array.filter((eachItem) => eachItem != item)
 }
 
 /**

--- a/packages/utils/src/array.ts
+++ b/packages/utils/src/array.ts
@@ -26,7 +26,7 @@ export function addItem<T>(array: T[], item: T): T[] {
 }
 
 export function removeItem<T>(array: T[], item: T): T[] {
-  return array.filter((eachItem) => eachItem != item)
+  return array.filter((eachItem) => eachItem !== item)
 }
 
 /**


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5501

## 📝 Description

When using the `useCheckboxGroup` hook with numbers instead of strings the checkboxes aren't reflecting the changes. I noticed the issue in two places:
- `use-checkbox-group.ts` on line 89: the `values` array may contain both string and number values. The comparison doesn't take that into account. Instead of `includes`, which relies on the type as well, I replaced it with `value.some((val) => String(props.value) === String(val))`, so that both strings and numbers can be taken into an account.
- `use-checkbox-group.ts` on line 70: I replaced the `remove` method with a local `filter` that compares the string values for the same reason.

## ⛳️ Current behavior (updates)

The checkboxes don't reflect the changes.

## 🚀 New behavior

The checkboxes do reflect the changes.

## 💣 Is this a breaking change (Yes/No):

No (hopefully)

## 📝 Additional Information
I've also added an additional example in the storybook to test this fix.