### PR TITLE
Remove redundant `useMemo` from `FormControl`

### DIFF
--- a/.changeset/thirty-swans-shave.md
+++ b/.changeset/thirty-swans-shave.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/form-control": patch
+---
+
+Remove redundant `useMemo` from `FormControl`

--- a/packages/form-control/src/form-control.tsx
+++ b/packages/form-control/src/form-control.tsx
@@ -220,10 +220,9 @@ export const FormControl = forwardRef<FormControlProps, "div">((props, ref) => {
   )
 
   const className = cx("chakra-form-control", props.className)
-  const contextValue = React.useMemo(() => context, [context])
 
   return (
-    <FormControlProvider value={contextValue}>
+    <FormControlProvider value={context}>
       <StylesProvider value={styles}>
         <chakra.div
           {...getRootProps({}, ref)}


### PR DESCRIPTION
This is a very simple change that just drops a line of code that is basically a "noop" here. 