### PR TITLE
fix: resolve native input size prop conflict with input theme props

### DIFF
--- a/.changeset/chilled-pugs-wink.md
+++ b/.changeset/chilled-pugs-wink.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/input": minor
+---
+
+Add htmlProp to enable the usage of the native input size prop

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -58,15 +58,11 @@ export const Input = forwardRef<InputProps, "input">((props, ref) => {
   const input = useFormControl<HTMLInputElement>(ownProps)
   const _className = cx("chakra-input", props.className)
 
-  // This is used to remove the default width=100% when size is set, which otherwise conflicts
-  const { width, ...fieldStyles } = styles.field
-  const cssStyles = htmlSize ? { ...fieldStyles } : { ...styles.field }
-
   return (
     <chakra.input
       size={htmlSize}
       {...input}
-      __css={cssStyles}
+      __css={styles.field}
       ref={ref}
       className={_className}
     />

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -6,11 +6,28 @@ import {
   ThemingProps,
   useMultiStyleConfig,
   HTMLChakraProps,
+  PropsOf,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
-interface InputOptions {
+interface NativeInputOptions {
+  /**
+   * The native HTML `size` attribute to be passed to the `input`
+   */
+  htmlSize?: number
+}
+
+interface NativeInputProps extends PropsOf<"input">, NativeInputOptions {}
+
+const NativeInput = React.forwardRef(
+  (props: NativeInputProps, ref: React.Ref<any>) => {
+    const { htmlSize, ...rest } = props
+    return <input size={htmlSize} ref={ref} {...rest} />
+  },
+)
+
+interface InputOptions extends NativeInputOptions {
   /**
    * The border color when the input is focused. Use color keys in `theme.colors`
    * @example
@@ -47,15 +64,23 @@ export interface InputProps
  * Element that allows users enter single valued data.
  */
 export const Input = forwardRef<InputProps, "input">((props, ref) => {
-  const styles = useMultiStyleConfig("Input", props)
-  const ownProps = omitThemingProps(props)
+  const { htmlSize, ...rest } = props
+
+  const styles = useMultiStyleConfig("Input", rest)
+  const ownProps = omitThemingProps(rest)
   const input = useFormControl<HTMLInputElement>(ownProps)
   const _className = cx("chakra-input", props.className)
 
+  // This is used to remove the default width=100% when size is set, which otherwise conflicts
+  const { width, ...fieldStyles } = styles.field
+  const cssStyles = htmlSize ? { ...fieldStyles } : { ...styles.field }
+
   return (
     <chakra.input
+      as={NativeInput}
+      htmlSize={htmlSize}
       {...input}
-      __css={styles.field}
+      __css={{ ...cssStyles }}
       ref={ref}
       className={_className}
     />

--- a/packages/input/src/input.tsx
+++ b/packages/input/src/input.tsx
@@ -6,28 +6,11 @@ import {
   ThemingProps,
   useMultiStyleConfig,
   HTMLChakraProps,
-  PropsOf,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
-interface NativeInputOptions {
-  /**
-   * The native HTML `size` attribute to be passed to the `input`
-   */
-  htmlSize?: number
-}
-
-interface NativeInputProps extends PropsOf<"input">, NativeInputOptions {}
-
-const NativeInput = React.forwardRef(
-  (props: NativeInputProps, ref: React.Ref<any>) => {
-    const { htmlSize, ...rest } = props
-    return <input size={htmlSize} ref={ref} {...rest} />
-  },
-)
-
-interface InputOptions extends NativeInputOptions {
+interface InputOptions {
   /**
    * The border color when the input is focused. Use color keys in `theme.colors`
    * @example
@@ -48,6 +31,10 @@ interface InputOptions extends NativeInputOptions {
    *  please use the props `maxWidth` or `width` to configure
    */
   isFullWidth?: boolean
+  /**
+   * The native HTML `size` attribute to be passed to the `input`
+   */
+  htmlSize?: number
 }
 
 type Omitted = "disabled" | "required" | "readOnly" | "size"
@@ -77,10 +64,9 @@ export const Input = forwardRef<InputProps, "input">((props, ref) => {
 
   return (
     <chakra.input
-      as={NativeInput}
-      htmlSize={htmlSize}
+      size={htmlSize}
       {...input}
-      __css={{ ...cssStyles }}
+      __css={cssStyles}
       ref={ref}
       className={_className}
     />

--- a/packages/input/stories/input.stories.tsx
+++ b/packages/input/stories/input.stories.tsx
@@ -57,7 +57,7 @@ export const WithSizes = () => (
   </Stack>
 )
 
-export const WithNativeSize = () => <Input htmlSize={4} p="0" />
+export const WithNativeSize = () => <Input htmlSize={4} width="auto" p="0" />
 
 export const WithStates = () => (
   <Stack align="start">

--- a/packages/input/stories/input.stories.tsx
+++ b/packages/input/stories/input.stories.tsx
@@ -57,6 +57,8 @@ export const WithSizes = () => (
   </Stack>
 )
 
+export const WithNativeSize = () => <Input htmlSize={4} p="0" />
+
 export const WithStates = () => (
   <Stack align="start">
     <Input placeholder="Idle" />

--- a/packages/input/tests/input.test.tsx
+++ b/packages/input/tests/input.test.tsx
@@ -45,3 +45,9 @@ test("Readonly input renders correctly", () => {
 
   expect(screen.getByRole("textbox")).toHaveAttribute("aria-readonly", "true")
 })
+
+test("Input with native size renders correctly", () => {
+  render(<Input htmlSize={4} />)
+
+  expect(screen.getByRole("textbox")).toHaveAttribute("size", "4")
+})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5489 

## 📝 Description

Add htmlSize prop to enable the usage of the native size prop and to resolve the conflict with the input theme prop size.

## ⛳️ Current behavior (updates)

The native input size prop can't be used because it gets overriden by the input theme prop size.

## 🚀 New behavior

There is a new htmlSize prop to pass the native size prop to an input.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Added Storybook story to test the behaviour with the native size prop