### PR TITLE
Apply theme styles for input element

### DIFF
--- a/.changeset/five-tables-warn.md
+++ b/.changeset/five-tables-warn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/input": patch
+---
+
+Apply theme styles for `InputLeftElement` and `InputRightElement`.

--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -36,6 +36,7 @@ const InputElement = forwardRef<InputElementProps, "div">((props, ref) => {
     width: input?.height ?? input?.h,
     height: input?.height ?? input?.h,
     fontSize: input?.fontSize,
+    ...styles.element,
   }
 
   return <StyledElement ref={ref} __css={elementStyles} {...rest} />


### PR DESCRIPTION
This commit makes it possible to style input elements from the theme files.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

You can style both the input field and the input addon components from the theme config. However, that wasn't possible with the current solution. 

This pull request applies any styling scoped under the `element` part.

## ⛳️ Current behavior (updates)

Previously, when you added styles to the theme config with the `element` part name, they were ignored. 

## 🚀 New behavior

With this change, those styles will be applied in the same way done in the addon component.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
Nope, this should not impact any existing code.
