### PR TITLE
fix(cli): add failure exit code

### DIFF
--- a/.changeset/shy-cobras-wonder.md
+++ b/.changeset/shy-cobras-wonder.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/cli": patch
+---
+
+When the [Chakra CLI](https://chakra-ui.com/docs/theming/advanced#theme-typings)
+fails to generate theme typings, it now exits with a status code of `1`. This
+resolves an issue where failures exited with a success status code.

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -69,6 +69,8 @@ export async function generateThemeTypings({
     if (e instanceof Error) {
       console.error(e.message)
     }
+    spinner.stop()
+    process.exit(1)
   } finally {
     spinner.stop()
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5523

## 📝 Description

This PR adds a `process.exit(1)` call to the `try`/`catch` of `generateThemeTypings`.

## ⛳️ Current behavior (updates)

Process exits with a success (`0`) status code in all cases.

## 🚀 New behavior

Process exits with an "Uncaught Fatal Exception" (`1`) when `generateThemeTypings` fails.

## 💣 Is this a breaking change (Yes/No):

No