### PR TITLE
docs(show-hide): adding props descriptions to Show / Hide components

### DIFF
--- a/.changeset/breezy-dogs-sniff.md
+++ b/.changeset/breezy-dogs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+Added props descriptions to Show / Hide components

--- a/packages/media-query/src/media-query.tsx
+++ b/packages/media-query/src/media-query.tsx
@@ -46,11 +46,11 @@ export interface ShowProps {
    */
   breakpoint?: string
   /**
-   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and below. Similar to `max-width`. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and below. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
    */
   below?: string
   /**
-   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and above. Similar to `min-width`. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and above. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
    */
   above?: string
   children?: React.ReactNode

--- a/packages/media-query/src/media-query.tsx
+++ b/packages/media-query/src/media-query.tsx
@@ -41,8 +41,17 @@ if (__DEV__) {
 }
 
 export interface ShowProps {
+  /**
+   * A custom css media query that determines when the `children` are rendered. Will render `children` if that query resolves to `true`.
+   */
   breakpoint?: string
+  /**
+   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and below. Similar to `max-width`. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   */
   below?: string
+  /**
+   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and above. Similar to `min-width`. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   */
   above?: string
   children?: React.ReactNode
 }

--- a/packages/media-query/src/media-query.tsx
+++ b/packages/media-query/src/media-query.tsx
@@ -42,15 +42,18 @@ if (__DEV__) {
 
 export interface ShowProps {
   /**
-   * A custom css media query that determines when the `children` are rendered. Will render `children` if that query resolves to `true`.
+   * A custom css media query that determines when the `children` are rendered.
+   * Will render `children` if that query resolves to `true`.
    */
   breakpoint?: string
   /**
-   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and below. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   * A value from the `breakpoints` section in the theme. Will render `children`
+   * from that breakpoint and below. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
    */
   below?: string
   /**
-   * A value from the `breakpoints` section in the theme. Will render `children` from that breakpoint and above. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
+   * A value from the `breakpoints` section in the theme. Will render `children`
+   * from that breakpoint and above. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
    */
   above?: string
   children?: React.ReactNode


### PR DESCRIPTION
Closes #5573 

## 📝 Description

The `Show` / `Hide` components don't have descriptions set for their props.

## ⛳️ Current behavior (updates)

The `Show` / `Hide` components don't have descriptions set for their props.

## 🚀 New behavior

The `Show` / `Hide` components now have descriptions set for their props, and the `props-docs` package is ready to be regenerated.

## 💣 Is this a breaking change (Yes/No):

No
