### PR TITLE
Support for custom theme types via TypeScript module augmentation

### DIFF
--- a/.changeset/grumpy-moons-look.md
+++ b/.changeset/grumpy-moons-look.md
@@ -1,0 +1,43 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Modify theme types to make it possible to customize token types via TypeScript
+module augmentation and declaration merging in addition to allowing
+customization via the Chakra CLI.
+
+This makes it possible to do the following:
+
+- Distribute custom types with a component library based on Chakra
+- Customize theme types by hand
+- Version control your theme types
+
+To customize themes using the new mechanism, augment the `CustomThemeTypings`
+type in a definitions file such as `types/chakra.d.ts`:
+
+> ⚠️ NOTE: your `CustomThemeTypings` _must_ implement/extend `BaseThemeTypings`,
+> otherwise the types will fall back to the default Chakra types (or custom
+> output from **@chakra-ui/cli**)
+
+```ts
+import { BaseThemeTypings } from "@chakra-ui/styled-system";
+
+type DefaultSizes = 'small' | 'medium' | 'large';
+
+declare module "@chakra-ui/styled-system" {
+  export interface CustomThemeTypings extends BaseThemeTypings {
+    // Example custom `borders` tokens
+    borders: 'none' | 'thin' | 'thick';
+    // ...
+    // Other custom tokens
+    // ...
+    components: {
+      Button: {
+        // Example custom component sizes and variants
+        sizes: DefaultSizes;
+        variants: 'solid' | 'outline' | 'wacky' | 'chill';
+      };
+      // ...
+     }
+  }
+```

--- a/packages/styled-system/src/index.ts
+++ b/packages/styled-system/src/index.ts
@@ -1,7 +1,6 @@
 export * from "./config"
 export * from "./css"
 export * from "./system.types"
-export * from "./theming.types"
 export * from "./system"
 export * from "./create-theme-vars"
 export * from "./pseudos"
@@ -13,3 +12,4 @@ export type {
 } from "./utils"
 export { tokenToCSSVar } from "./utils/create-transform"
 export type OmitSpaceXY<T> = Omit<T, "spaceX" | "spaceY">
+export type { ThemeTypings, BaseThemeTypings, CustomThemeTypings } from "./theme.types"

--- a/packages/styled-system/src/theme.types.ts
+++ b/packages/styled-system/src/theme.types.ts
@@ -1,0 +1,63 @@
+import type { ThemeTypings as GeneratedThemeTypings } from "./theming.types"
+
+export interface BaseThemeTypings {
+  borders: string
+  colors: string
+  breakpoints: string
+  colorSchemes: string
+  fonts: string
+  fontSizes: string
+  fontWeights: string
+  layerStyles: string
+  letterSpacings: string
+  lineHeights: string
+  radii: string
+  shadows: string
+  sizes: string
+  space: string
+  textStyles: string
+  zIndices: string
+  components: {
+    [componentName: string]: {
+      sizes: string
+      variants: string
+    }
+  }
+}
+
+/**
+ * This is a placeholder meant to be implemented via TypeScript's Module
+ * Augmentation feature and is an alternative to running `npx @chakra-ui/cli
+ * tokens`
+ *
+ * @example
+ * ```ts
+ * import { BaseThemeTypings } from "@chakra-ui/styled-system";
+ * 
+ * type DefaultSizes = 'small' | 'medium' | 'large';
+ * 
+ * declare module "@chakra-ui/styled-system" {
+ *   export interface CustomThemeTypings extends BaseThemeTypings {
+ *     // Example custom `borders` tokens
+ *     borders: 'none' | 'thin' | 'thick';
+ *     // ...
+ *     // Other custom tokens
+ *     // ...
+ *     components: {
+ *       Button: {
+ *         // Example custom component sizes and variants
+ *         sizes: DefaultSizes;
+ *         variants: 'solid' | 'outline' | 'wacky' | 'chill';
+ *       };
+ *       // ...
+ *      }
+ *   }
+ * ```
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ */
+export interface CustomThemeTypings {}
+
+export type ThemeTypings = CustomThemeTypings extends BaseThemeTypings
+  ? CustomThemeTypings
+  : GeneratedThemeTypings

--- a/packages/styled-system/src/theming.types.ts
+++ b/packages/styled-system/src/theming.types.ts
@@ -1,30 +1,6 @@
 /**
  * This file will be replaced by running "npx @chakra-ui/cli tokens"
  */
+import type { BaseThemeTypings } from "./theme.types"
 
-export interface ThemeTypings extends EmptyThemeTypings {}
-
-export interface EmptyThemeTypings {
-  borders: string
-  colors: string
-  breakpoints: string
-  colorSchemes: string
-  fonts: string
-  fontSizes: string
-  fontWeights: string
-  layerStyles: string
-  letterSpacings: string
-  lineHeights: string
-  radii: string
-  shadows: string
-  sizes: string
-  space: string
-  textStyles: string
-  zIndices: string
-  components: {
-    [componentName: string]: {
-      sizes: string
-      variants: string
-    }
-  }
-}
+export interface ThemeTypings extends BaseThemeTypings {}

--- a/packages/styled-system/src/utils/types.ts
+++ b/packages/styled-system/src/utils/types.ts
@@ -1,5 +1,5 @@
 import { AnalyzeBreakpointsReturn, Dict } from "@chakra-ui/utils"
-import { ThemeTypings } from "../theming.types"
+import { ThemeTypings } from "../theme.types"
 
 export type ResponsiveArray<T> = Array<T | null>
 
@@ -15,7 +15,7 @@ export type Union<T> = T | (string & {})
 
 export type Token<
   CSSType,
-  ThemeKey = unknown
+  ThemeKey = unknown,
 > = ThemeKey extends keyof ThemeTypings
   ? ResponsiveValue<Union<CSSType | ThemeTypings[ThemeKey]>>
   : ResponsiveValue<CSSType>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Here I'm following up on a previous idea I had mentioned [in this PR](https://github.com/chakra-ui/chakra-ui/pull/4067#pullrequestreview-666149028). The TypeScript experience when distributing a component library based on Chakra still isn't _great_ on account of the Chakra CLI step being required for consumers to the library to get the proper language server/editor experience. Not only is it an extra step, but there are multiple ways in which it can break preventing consumers of our library from getting accurate type definitions.

In this PR, I'm proposing a small change to the way that these custom types are defined that both allow the existing CLI functionality to continue working exactly as it had previously, but also providing an optional advanced feature that would allow custom type definitions to be shipped _with_ component libraries that are based on Chakra that would not require end users to install and run the CLI. It also makes it possible to manually customize the type definitions, if desired.

## ⛳️ Current behavior (updates)

Defining custom theme typings relies on the **@chakra-ui/cli** package _always_ running and overwriting the `ThemeTypings` interface in the end users' `./node_modules/` directory as documented [here](https://chakra-ui.com/docs/theming/advanced#theme-typings).

## 🚀 New behavior

This PR makes it possible to also customize the `ThemeTypings` interface using TypeScript's [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) and declaration merging features, much like custom theme types are implemented in [Styled Components](https://styled-components.com/docs/api#create-a-declarations-file) and [Emotion](https://emotion.sh/docs/typescript#define-a-theme).

In order to take advantage of this approach, the [`CustomThemeTypings`](https://github.com/jrolfs/chakra-ui/blob/feature/theme-typings-module-augmentation/packages/styled-system/src/theme.types.ts#L72) interface needs to be "augmented" and at least implement the [`DefaultThemeTypings`](https://github.com/jrolfs/chakra-ui/blob/feature/theme-typings-module-augmentation/packages/styled-system/src/theme.types.ts#L3-L26) interface, otherwise it will fall back to the existing [`ThemeTypings`](https://github.com/jrolfs/chakra-ui/blob/feature/theme-typings-module-augmentation/packages/styled-system/src/theming.types.ts#L6) interface that the CLI overwrites.

Example `types/chakra.d.ts`:

```ts
import "@chakra-ui/styled-system";

type DefaultSizes = 'small' | 'medium' | 'large';

declare module "@chakra-ui/styled-system" {
  export interface CustomThemeTypings {
    // Example custom `borders` tokens
    borders: 'none' | 'thin' | 'thick';
	// ...
	// Other custom tokens (everything in `DefaultThemeTypings` must be defined here)
	// ...
    components: {
      Button: {
        // Example custom component sizes and variants
        sizes: DefaultSizes;
        variants: 'solid' | 'outline' | 'wacky' | 'chill';
      };
      // ...
     }
  }
}
```

## 💣 Is this a breaking change (Yes/No):

No, see above.

## 📝 Additional Information

In it's current form, this PR simply makes this possible and adds some [rudimentary inline documentation](https://github.com/jrolfs/chakra-ui/blob/feature/theme-typings-module-augmentation/packages/styled-system/src/theme.types.ts#L28-L72). I think it would be reasonable (barring maybe some feedback on how I named things) to merge this PR as is. With that said, I am very much ready to add documentation explaining the feature and I was even thinking we could combine this approach with the CLI with a new option to ouput a version of the definitions that leverages the above approach as opposed to modifying the definitions directly in `./node_modules`.

In addition to making it possible to _include_ custom type definitions with a component library that's based on Chakra, I think avoiding messing around in `./node_modules/` has some pretty clear benefits. Let me know what y'all think!