### PR TITLE
fix(system):  deep merge styles to allow overwriting of pseudo props

### DIFF
--- a/.changeset/three-dolls-smile.md
+++ b/.changeset/three-dolls-smile.md
@@ -1,0 +1,16 @@
+---
+"@chakra-ui/system": major
+---
+
+Nested Styles are now deep merged.
+
+Previously we've used `Object.assign` to merge different Style-soruces
+(sx,\_\_css,baseStyle, component-style-props).
+
+This was fine when using 1 dimensional objects, since the latter always
+overwrote the previous value.
+
+With the usage of `pseudos` like `_dark`, `_selected`,... a simple
+`Object.assign` isn't sufficient, since those props are always overridden.
+
+This change introduces a deep-merge of those styles.

--- a/packages/system/src/system.ts
+++ b/packages/system/src/system.ts
@@ -4,7 +4,12 @@ import {
   StyleProps,
   SystemStyleObject,
 } from "@chakra-ui/styled-system"
-import { filterUndefined, objectFilter, runIfFn } from "@chakra-ui/utils"
+import {
+  filterUndefined,
+  objectFilter,
+  runIfFn,
+  mergeWith,
+} from "@chakra-ui/utils"
 import _styled, { CSSObject, FunctionInterpolation } from "@emotion/styled"
 import { shouldForwardProp } from "./should-forward-prop"
 import { As, ChakraComponent, ChakraProps, PropsOf } from "./system.types"
@@ -38,20 +43,22 @@ interface GetStyleObject {
  * behaviors. Right now, the `sx` prop has the highest priority so the resolved
  * fontSize will be `40px`
  */
-export const toCSSObject: GetStyleObject = ({ baseStyle }) => (props) => {
-  const { theme, css: cssProp, __css, sx, ...rest } = props
-  const styleProps = objectFilter(rest, (_, prop) => isStyleProp(prop))
-  const finalBaseStyle = runIfFn(baseStyle, props)
-  const finalStyles = Object.assign(
-    {},
-    __css,
-    finalBaseStyle,
-    filterUndefined(styleProps),
-    sx,
-  )
-  const computedCSS = css(finalStyles)(props.theme)
-  return cssProp ? [computedCSS, cssProp] : computedCSS
-}
+export const toCSSObject: GetStyleObject =
+  ({ baseStyle }) =>
+  (props) => {
+    const { theme, css: cssProp, __css, sx, ...rest } = props
+    const styleProps = objectFilter(rest, (_, prop) => isStyleProp(prop))
+    const finalBaseStyle = runIfFn(baseStyle, props)
+    const finalStyles = mergeWith(
+      {},
+      __css,
+      finalBaseStyle,
+      filterUndefined(styleProps),
+      sx,
+    )
+    const computedCSS = css(finalStyles)(props.theme)
+    return cssProp ? [computedCSS, cssProp] : computedCSS
+  }
 
 interface StyledOptions {
   shouldForwardProp?(prop: string): boolean
@@ -97,8 +104,7 @@ type ChakraFactory = {
   ): ChakraComponent<T, P>
 }
 
-export const chakra = (styled as unknown) as ChakraFactory &
-  HTMLChakraComponents
+export const chakra = styled as unknown as ChakraFactory & HTMLChakraComponents
 
 domElements.forEach((tag) => {
   chakra[tag] = chakra(tag)

--- a/packages/system/tests/system.test.tsx
+++ b/packages/system/tests/system.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@chakra-ui/test-utils"
 import * as React from "react"
-import { chakra } from "../src"
+import { chakra, toCSSObject } from "../src"
+import { theme } from "@chakra-ui/theme"
 
 const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
 
@@ -17,4 +18,18 @@ test("should allow custom should forward props", () => {
    * React-DOM should show an error about `isBig` getting to the DOM
    */
   expect(consoleSpy).toHaveBeenCalled()
+})
+
+test("allows overwriting of pseudo selectors", () => {
+  expect(
+    toCSSObject({})({
+      theme,
+      __css: { _selected: { bg: "yellow.500" } },
+      _selected: { bg: "red.500" },
+    }),
+  ).toEqual({
+    "&[aria-selected=true], &[data-selected]": {
+      background: "red.500",
+    },
+  })
 })

--- a/packages/tabs/stories/tabs.stories.tsx
+++ b/packages/tabs/stories/tabs.stories.tsx
@@ -260,3 +260,22 @@ export const withinDrawer = () => (
     </DrawerOverlay>
   </Drawer>
 )
+
+export const pseudoOverwrite = () => (
+  <>
+    <Tabs variant="enclosed" orientation="horizontal">
+      <TabList>
+        <Tab
+          _selected={{
+            bg: "yellow", // same here
+          }}
+        >
+          tab2
+        </Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>content2</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </>
+)


### PR DESCRIPTION
Closes #5583

## 📝 Description

Nested Styles are now deeply merged.

## ⛳️ Current behavior (updates)


Previously we've used `Object.assign` to merge different Style-soruces like `sx`,`__css`,`baseStyle`, or the provided component-style-props

This was fine when using 1-dimensional objects, since the latter always
overwrote the previous value.

With the usage of `pseudos` like `_dark`, `_selected`,... a simple
`Object.assign` isn't sufficient, since those props are always overridden.

so if you have the following defined in a component theme (let's call this component `ExampleComponent`)


```json
{
  _selected:{
    bg: 'yellow.500',
    color:'red.500'
  }
}
```

the usage of `ExampleComponent` like the following

```tsx
<ExampleComponent _selected={{bg:'blue.500'}}/>
```

Would overwrite the `bg` and the `color` from the component theme.


## 🚀 New behavior

This change introduces a deep-merge of those styles.

In case of the `ExampleComponent` the resulting value would be:

```json
{
  bg:"blue.500",
  color: "red.500"
}
```

## 💣 Is this a breaking change (Yes/No):

Yes! Since the deep-merged value of the pseudo-props is used additional styles may suddenly appear from the components.

## 📝 Additional Information

- since we're using `mergeWith` instead of `Object.assign` the rendering time could be affected. Since every chakra-component is affected by this change we need to check if this change is worth it.

## Possible improvements
we could improve the performance by only doing a deep merge if the user uses a `pseudo`-prop in the component call
