### PR TITLE
fix: not overwritable aria label prop on TagCloseButton

### DIFF
--- a/.changeset/yellow-baboons-hang.md
+++ b/.changeset/yellow-baboons-hang.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tag": patch
+---
+
+Change order of aria-label prop on TagCloseButton to be overwritable

--- a/packages/tag/src/tag.tsx
+++ b/packages/tag/src/tag.tsx
@@ -109,9 +109,9 @@ export const TagCloseButton: React.FC<TagCloseButtonProps> = (props) => {
 
   return (
     <chakra.button
+      aria-label="close"
       {...rest}
       type="button"
-      aria-label="close"
       disabled={isDisabled}
       __css={btnStyles}
     >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5587 

## 📝 Description

Change order of aria-label prop on TagCloseButton to be overwritable

## ⛳️ Current behavior (updates)

aria-label of TagCloseButton can not be overwritten

## 🚀 New behavior

aria-label of TagCloseButton can be overwritten

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
