### PR TITLE
feat(theme): migrate from mode to _dark and _light selectors

### DIFF
--- a/.changeset/rude-rats-sit.md
+++ b/.changeset/rude-rats-sit.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/theme": minor
+---
+
+Using `_dark`&`_light` pseudo selectors in favor of mode for all components when
+ever possible

--- a/packages/theme-tools/src/color.ts
+++ b/packages/theme-tools/src/color.ts
@@ -48,12 +48,11 @@ export const isLight = (color: string) => (theme: Dict) =>
  * @param color - the color in hex, rgb, or hsl
  * @param opacity - the amount of opacity the color should have (0-1)
  */
-export const transparentize = (color: string, opacity: number) => (
-  theme: Dict,
-) => {
-  const raw = getColor(theme, color)
-  return new TinyColor(raw).setAlpha(opacity).toRgbString()
-}
+export const transparentize =
+  (color: string, opacity: number) => (theme: Dict) => {
+    const raw = getColor(theme, color)
+    return new TinyColor(raw).setAlpha(opacity).toRgbString()
+  }
 
 /**
  * Add white to a color
@@ -110,12 +109,9 @@ export const contrast = (fg: string, bg: string) => (theme: Dict) =>
  * @param fg - the foreground or text color
  * @param bg - the background color
  */
-export const isAccessible = (
-  textColor: string,
-  bgColor: string,
-  options?: WCAG2Parms,
-) => (theme: Dict) =>
-  isReadable(getColor(theme, bgColor), getColor(theme, textColor), options)
+export const isAccessible =
+  (textColor: string, bgColor: string, options?: WCAG2Parms) => (theme: Dict) =>
+    isReadable(getColor(theme, bgColor), getColor(theme, textColor), options)
 
 export const complementary = (color: string) => (theme: Dict) =>
   new TinyColor(getColor(theme, color)).complement().toHexString()

--- a/packages/theme/src/components/accordion.ts
+++ b/packages/theme/src/components/accordion.ts
@@ -41,6 +41,7 @@ const baseStyleIcon: SystemStyleObject = {
 }
 
 const baseStyle: PartsStyleObject<typeof parts> = {
+  root: {},
   container: baseStyleContainer,
   button: baseStyleButton,
   panel: baseStylePanel,

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -1,5 +1,5 @@
 import { alertAnatomy as parts } from "@chakra-ui/anatomy"
-import { getColor, mode, transparentize } from "@chakra-ui/theme-tools"
+import { getColor, transparentize } from "@chakra-ui/theme-tools"
 import type {
   PartsStyleObject,
   PartsStyleFunction,
@@ -27,18 +27,34 @@ const baseStyle: PartsStyleObject<typeof parts> = {
   },
 }
 
-function getBg(props: StyleFunctionProps): string {
+function getBg(props: StyleFunctionProps, mode: "dark" | "light"): string {
   const { theme, colorScheme: c } = props
-  const lightBg = getColor(theme, `${c}.100`, c)
-  const darkBg = transparentize(`${c}.200`, 0.16)(theme)
-  return mode(lightBg, darkBg)(props)
+  if (mode === "dark") {
+    return transparentize(`${c}.200`, 0.16)(theme)
+  }
+  return getColor(theme, `${c}.100`, c)
 }
 
 const variantSubtle: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
-    container: { bg: getBg(props) },
-    icon: { color: mode(`${c}.500`, `${c}.200`)(props) },
+    container: {
+      _light: {
+        bg: getBg(props, "light"),
+      },
+      _dark: {
+        bg: getBg(props, "dark"),
+      },
+    },
+    icon: {
+      _light: {
+        color: `${c}.500`,
+      },
+
+      _dark: {
+        color: `${c}.200`,
+      },
+    },
   }
 }
 
@@ -48,11 +64,25 @@ const variantLeftAccent: PartsStyleFunction<typeof parts> = (props) => {
     container: {
       paddingStart: 3,
       borderStartWidth: "4px",
-      borderStartColor: mode(`${c}.500`, `${c}.200`)(props),
-      bg: getBg(props),
+
+      _light: {
+        bg: getBg(props, "light"),
+        borderStartColor: `${c}.500`,
+      },
+
+      _dark: {
+        bg: getBg(props, "dark"),
+        borderStartColor: `${c}.200`,
+      },
     },
     icon: {
-      color: mode(`${c}.500`, `${c}.200`)(props),
+      _light: {
+        color: `${c}.500`,
+      },
+
+      _dark: {
+        color: `${c}.200`,
+      },
     },
   }
 }
@@ -63,11 +93,25 @@ const variantTopAccent: PartsStyleFunction<typeof parts> = (props) => {
     container: {
       pt: 2,
       borderTopWidth: "4px",
-      borderTopColor: mode(`${c}.500`, `${c}.200`)(props),
-      bg: getBg(props),
+
+      _light: {
+        bg: getBg(props, "light"),
+        borderTopColor: `${c}.500`,
+      },
+
+      _dark: {
+        bg: getBg(props, "dark"),
+        borderTopColor: `${c}.200`,
+      },
     },
     icon: {
-      color: mode(`${c}.500`, `${c}.200`)(props),
+      _light: {
+        color: `${c}.500`,
+      },
+
+      _dark: {
+        color: `${c}.200`,
+      },
     },
   }
 }
@@ -76,8 +120,14 @@ const variantSolid: PartsStyleFunction<typeof parts> = (props) => {
   const { colorScheme: c } = props
   return {
     container: {
-      bg: mode(`${c}.500`, `${c}.200`)(props),
-      color: mode(`white`, `gray.900`)(props),
+      _light: {
+        bg: `${c}.500`,
+        color: `white`,
+      },
+      _dark: {
+        bg: `${c}.200`,
+        color: `gray.900`,
+      },
     },
   }
 }

--- a/packages/theme/src/components/avatar.ts
+++ b/packages/theme/src/components/avatar.ts
@@ -1,5 +1,5 @@
 import { avatarAnatomy as parts } from "@chakra-ui/anatomy"
-import { isDark, mode, randomColor } from "@chakra-ui/theme-tools"
+import { isDark, randomColor, SystemStyleObject } from "@chakra-ui/theme-tools"
 import type {
   PartsStyleFunction,
   PartsStyleObject,
@@ -7,19 +7,28 @@ import type {
 } from "@chakra-ui/theme-tools"
 import themeSizes from "../foundations/sizes"
 
-const baseStyleBadge: SystemStyleFunction = (props) => {
-  return {
-    transform: "translate(25%, 25%)",
-    borderRadius: "full",
-    border: "0.2em solid",
-    borderColor: mode("white", "gray.800")(props),
-  }
+const baseStyleBadge: SystemStyleObject = {
+  transform: "translate(25%, 25%)",
+  borderRadius: "full",
+  border: "0.2em solid",
+
+  _light: {
+    borderColor: "white",
+  },
+
+  _dark: {
+    borderColor: "gray.800",
+  },
 }
 
-const baseStyleExcessLabel: SystemStyleFunction = (props) => {
-  return {
-    bg: mode("gray.200", "whiteAlpha.400")(props),
-  }
+const baseStyleExcessLabel: SystemStyleObject = {
+  _light: {
+    bg: "gray.200",
+  },
+
+  _dark: {
+    bg: "whiteAlpha.400",
+  },
 }
 
 const baseStyleContainer: SystemStyleFunction = (props) => {
@@ -30,19 +39,27 @@ const baseStyleContainer: SystemStyleFunction = (props) => {
   let color = "white"
   if (!isBgDark) color = "gray.800"
 
-  const borderColor = mode("white", "gray.800")(props)
+  const borderColorLight = "white"
+  const borderColorDark = "gray.800"
 
   return {
     bg,
     color,
-    borderColor,
     verticalAlign: "top",
+
+    _light: {
+      borderColor: borderColorLight,
+    },
+
+    _dark: {
+      borderColor: borderColorDark,
+    },
   }
 }
 
 const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
-  badge: baseStyleBadge(props),
-  excessLabel: baseStyleExcessLabel(props),
+  badge: baseStyleBadge,
+  excessLabel: baseStyleExcessLabel,
   container: baseStyleContainer(props),
 })
 

--- a/packages/theme/src/components/badge.ts
+++ b/packages/theme/src/components/badge.ts
@@ -1,4 +1,4 @@
-import { getColor, mode, transparentize } from "@chakra-ui/theme-tools"
+import { getColor, transparentize } from "@chakra-ui/theme-tools"
 import type {
   SystemStyleFunction,
   SystemStyleObject,
@@ -16,8 +16,14 @@ const variantSolid: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
   const dark = transparentize(`${c}.500`, 0.6)(theme)
   return {
-    bg: mode(`${c}.500`, dark)(props),
-    color: mode(`white`, `whiteAlpha.800`)(props),
+    _light: {
+      bg: `${c}.500`,
+      color: `white`,
+    },
+    _dark: {
+      bg: dark,
+      color: `whiteAlpha.800`,
+    },
   }
 }
 
@@ -25,8 +31,14 @@ const variantSubtle: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
   const darkBg = transparentize(`${c}.200`, 0.16)(theme)
   return {
-    bg: mode(`${c}.100`, darkBg)(props),
-    color: mode(`${c}.800`, `${c}.200`)(props),
+    _light: {
+      bg: `${c}.100`,
+      color: `${c}.800`,
+    },
+    _dark: {
+      bg: darkBg,
+      color: `${c}.200`,
+    },
   }
 }
 
@@ -34,11 +46,17 @@ const variantOutline: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
   const darkColor = transparentize(`${c}.200`, 0.8)(theme)
   const lightColor = getColor(theme, `${c}.500`)
-  const color = mode(lightColor, darkColor)(props)
 
   return {
-    color,
-    boxShadow: `inset 0 0 0px 1px ${color}`,
+    _light: {
+      color: lightColor,
+      boxShadow: `inset 0 0 0px 1px ${lightColor}`,
+    },
+
+    _dark: {
+      color: darkColor,
+      boxShadow: `inset 0 0 0px 1px ${darkColor}`,
+    },
   }
 }
 

--- a/packages/theme/src/components/checkbox.ts
+++ b/packages/theme/src/components/checkbox.ts
@@ -5,7 +5,7 @@ import type {
   SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
 const baseStyleControl: SystemStyleFunction = (props) => {
   const { colorScheme: c } = props
@@ -20,31 +20,67 @@ const baseStyleControl: SystemStyleFunction = (props) => {
     color: "white",
 
     _checked: {
-      bg: mode(`${c}.500`, `${c}.200`)(props),
-      borderColor: mode(`${c}.500`, `${c}.200`)(props),
-      color: mode("white", "gray.900")(props),
-
       _hover: {
-        bg: mode(`${c}.600`, `${c}.300`)(props),
-        borderColor: mode(`${c}.600`, `${c}.300`)(props),
+        _light: {
+          bg: `${c}.600`,
+          borderColor: `${c}.600`,
+        },
+        _dark: {
+          bg: `${c}.300`,
+          borderColor: `${c}.300`,
+        },
       },
 
       _disabled: {
-        borderColor: mode("gray.200", "transparent")(props),
-        bg: mode("gray.200", "whiteAlpha.300")(props),
-        color: mode("gray.500", "whiteAlpha.500")(props),
+        _light: {
+          borderColor: "gray.200",
+          bg: "gray.200",
+          color: "gray.500",
+        },
+
+        _dark: {
+          borderColor: "transparent",
+          bg: "whiteAlpha.300",
+          color: "whiteAlpha.500",
+        },
+      },
+
+      _light: {
+        bg: `${c}.500`,
+        borderColor: `${c}.500`,
+        color: "white",
+      },
+
+      _dark: {
+        bg: `${c}.200`,
+        borderColor: `${c}.200`,
+        color: "gray.900",
       },
     },
 
     _indeterminate: {
-      bg: mode(`${c}.500`, `${c}.200`)(props),
-      borderColor: mode(`${c}.500`, `${c}.200`)(props),
-      color: mode("white", "gray.900")(props),
+      _light: {
+        bg: `${c}.500`,
+        borderColor: `${c}.500`,
+        color: "white",
+      },
+
+      _dark: {
+        bg: `${c}.200`,
+        borderColor: `${c}.200`,
+        color: "gray.900",
+      },
     },
 
     _disabled: {
-      bg: mode("gray.100", "whiteAlpha.100")(props),
-      borderColor: mode("gray.100", "transparent")(props),
+      _light: {
+        bg: "gray.100",
+        borderColor: "gray.100",
+      },
+      _dark: {
+        bg: "whiteAlpha.100",
+        borderColor: "transparent",
+      },
     },
 
     _focus: {
@@ -52,7 +88,13 @@ const baseStyleControl: SystemStyleFunction = (props) => {
     },
 
     _invalid: {
-      borderColor: mode("red.500", "red.300")(props),
+      _light: {
+        borderColor: "red.500",
+      },
+
+      _dark: {
+        borderColor: "red.300",
+      },
     },
   }
 }

--- a/packages/theme/src/components/close-button.ts
+++ b/packages/theme/src/components/close-button.ts
@@ -1,32 +1,40 @@
-import type {
-  SystemStyleFunction,
-  SystemStyleObject,
-} from "@chakra-ui/theme-tools"
-import { cssVar, mode } from "@chakra-ui/theme-tools"
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
+import { cssVar } from "@chakra-ui/theme-tools"
 
 const $size = cssVar("close-button-size")
 
-const baseStyle: SystemStyleFunction = (props) => {
-  const hoverBg = mode(`blackAlpha.100`, `whiteAlpha.100`)(props)
-  const activeBg = mode(`blackAlpha.200`, `whiteAlpha.200`)(props)
+const baseStyle: SystemStyleObject = {
+  w: [$size.reference],
+  h: [$size.reference],
+  borderRadius: "md",
+  transitionProperty: "common",
+  transitionDuration: "normal",
+  _disabled: {
+    opacity: 0.4,
+    cursor: "not-allowed",
+    boxShadow: "none",
+  },
+  _hover: {
+    _light: {
+      bg: `blackAlpha.100`,
+    },
 
-  return {
-    w: [$size.reference],
-    h: [$size.reference],
-    borderRadius: "md",
-    transitionProperty: "common",
-    transitionDuration: "normal",
-    _disabled: {
-      opacity: 0.4,
-      cursor: "not-allowed",
-      boxShadow: "none",
+    _dark: {
+      bg: `whiteAlpha.100`,
     },
-    _hover: { bg: hoverBg },
-    _active: { bg: activeBg },
-    _focus: {
-      boxShadow: "outline",
+  },
+  _active: {
+    _light: {
+      bg: `blackAlpha.200`,
     },
-  }
+
+    _dark: {
+      bg: `whiteAlpha.200`,
+    },
+  },
+  _focus: {
+    boxShadow: "outline",
+  },
 }
 
 const sizes: Record<string, SystemStyleObject> = {

--- a/packages/theme/src/components/drawer.ts
+++ b/packages/theme/src/components/drawer.ts
@@ -5,7 +5,7 @@ import type {
   SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
 /**
  * Since the `maxWidth` prop references theme.sizes internally,
@@ -40,9 +40,15 @@ const baseStyleDialog: SystemStyleFunction = (props) => {
     ...(isFullHeight && { height: "100vh" }),
     zIndex: "modal",
     maxH: "100vh",
-    bg: mode("white", "gray.700")(props),
     color: "inherit",
-    boxShadow: mode("lg", "dark-lg")(props),
+    _light: {
+      bg: "white",
+      boxShadow: "lg",
+    },
+    _dark: {
+      bg: "gray.700",
+      boxShadow: "dark-lg",
+    },
   }
 }
 

--- a/packages/theme/src/components/editable.ts
+++ b/packages/theme/src/components/editable.ts
@@ -21,9 +21,20 @@ const baseStyleInput: SystemStyleObject = {
   _placeholder: { opacity: 0.6 },
 }
 
+const baseStyleTextarea: SystemStyleObject = {
+  borderRadius: "md",
+  py: "3px",
+  transitionProperty: "common",
+  transitionDuration: "normal",
+  width: "full",
+  _focus: { boxShadow: "outline" },
+  _placeholder: { opacity: 0.6 },
+}
+
 const baseStyle: PartsStyleObject<typeof parts> = {
   preview: baseStylePreview,
   input: baseStyleInput,
+  textarea: baseStyleTextarea,
 }
 
 export default {

--- a/packages/theme/src/components/form-error.ts
+++ b/packages/theme/src/components/form-error.ts
@@ -1,30 +1,40 @@
 import { formErrorAnatomy as parts } from "@chakra-ui/anatomy"
 import type {
-  PartsStyleFunction,
-  SystemStyleFunction,
+  PartsStyleObject,
+  SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
-const baseStyleText: SystemStyleFunction = (props) => {
-  return {
-    color: mode("red.500", "red.300")(props),
-    mt: 2,
-    fontSize: "sm",
-    lineHeight: "normal",
-  }
+const baseStyleText: SystemStyleObject = {
+  mt: 2,
+  fontSize: "sm",
+  lineHeight: "normal",
+
+  _light: {
+    color: "red.500",
+  },
+
+  _dark: {
+    color: "red.300",
+  },
 }
 
-const baseStyleIcon: SystemStyleFunction = (props) => {
-  return {
-    marginEnd: "0.5em",
-    color: mode("red.500", "red.300")(props),
-  }
+const baseStyleIcon: SystemStyleObject = {
+  marginEnd: "0.5em",
+
+  _light: {
+    color: "red.500",
+  },
+
+  _dark: {
+    color: "red.300",
+  },
 }
 
-const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
-  text: baseStyleText(props),
-  icon: baseStyleIcon(props),
-})
+const baseStyle: PartsStyleObject<typeof parts> = {
+  text: baseStyleText,
+  icon: baseStyleIcon,
+}
 
 export default {
   parts: parts.keys,

--- a/packages/theme/src/components/form.ts
+++ b/packages/theme/src/components/form.ts
@@ -1,31 +1,41 @@
 import { formAnatomy as parts } from "@chakra-ui/anatomy"
 import type {
-  PartsStyleFunction,
-  SystemStyleFunction,
+  PartsStyleObject,
+  SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
-const baseStyleRequiredIndicator: SystemStyleFunction = (props) => {
-  return {
-    marginStart: 1,
-    color: mode("red.500", "red.300")(props),
-  }
+const baseStyleRequiredIndicator: SystemStyleObject = {
+  marginStart: 1,
+
+  _light: {
+    color: "red.500",
+  },
+
+  _dark: {
+    color: "red.300",
+  },
 }
 
-const baseStyleHelperText: SystemStyleFunction = (props) => {
-  return {
-    mt: 2,
-    color: mode("gray.500", "whiteAlpha.600")(props),
-    lineHeight: "normal",
-    fontSize: "sm",
-  }
+const baseStyleHelperText: SystemStyleObject = {
+  mt: 2,
+  lineHeight: "normal",
+  fontSize: "sm",
+
+  _light: {
+    color: "gray.500",
+  },
+
+  _dark: {
+    color: "whiteAlpha.600",
+  },
 }
 
-const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+const baseStyle: PartsStyleObject<typeof parts> = {
   container: { width: "100%", position: "relative" },
-  requiredIndicator: baseStyleRequiredIndicator(props),
-  helperText: baseStyleHelperText(props),
-})
+  requiredIndicator: baseStyleRequiredIndicator,
+  helperText: baseStyleHelperText,
+}
 
 export default {
   parts: parts.keys,

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -4,7 +4,7 @@ import type {
   PartsStyleObject,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { getColor, mode } from "@chakra-ui/theme-tools"
+import { getColor } from "@chakra-ui/theme-tools"
 
 const baseStyle: PartsStyleObject<typeof parts> = {
   field: {
@@ -70,14 +70,21 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
 function getDefaults(props: Record<string, any>) {
   const { focusBorderColor: fc, errorBorderColor: ec } = props
   return {
-    focusBorderColor: fc || mode("blue.500", "blue.300")(props),
-    errorBorderColor: ec || mode("red.500", "red.300")(props),
+    focusBorderColorLight: fc || "blue.500",
+    errorBorderColorLight: ec || "red.500",
+    focusBorderColorDark: fc || "blue.300",
+    errorBorderColorDark: ec || "red.300",
   }
 }
 
 const variantOutline: PartsStyleFunction<typeof parts> = (props) => {
   const { theme } = props
-  const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props)
+  const {
+    focusBorderColorLight: fcL,
+    errorBorderColorLight: ecL,
+    focusBorderColorDark: fcD,
+    errorBorderColorDark: ecD,
+  } = getDefaults(props)
 
   return {
     field: {
@@ -85,7 +92,13 @@ const variantOutline: PartsStyleFunction<typeof parts> = (props) => {
       borderColor: "inherit",
       bg: "inherit",
       _hover: {
-        borderColor: mode("gray.300", "whiteAlpha.400")(props),
+        _light: {
+          borderColor: "gray.300",
+        },
+
+        _dark: {
+          borderColor: "whiteAlpha.400",
+        },
       },
       _readOnly: {
         boxShadow: "none !important",
@@ -96,62 +109,126 @@ const variantOutline: PartsStyleFunction<typeof parts> = (props) => {
         cursor: "not-allowed",
       },
       _invalid: {
-        borderColor: getColor(theme, ec),
-        boxShadow: `0 0 0 1px ${getColor(theme, ec)}`,
+        _light: {
+          borderColor: getColor(theme, ecL),
+          boxShadow: `0 0 0 1px ${getColor(theme, ecL)}`,
+        },
+        _dark: {
+          borderColor: getColor(theme, ecD),
+          boxShadow: `0 0 0 1px ${getColor(theme, ecD)}`,
+        },
       },
       _focus: {
         zIndex: 1,
-        borderColor: getColor(theme, fc),
-        boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
+        _light: {
+          borderColor: getColor(theme, fcL),
+          boxShadow: `0 0 0 1px ${getColor(theme, fcL)}`,
+        },
+        _dark: {
+          borderColor: getColor(theme, fcD),
+          boxShadow: `0 0 0 1px ${getColor(theme, fcD)}`,
+        },
       },
     },
     addon: {
       border: "1px solid",
-      borderColor: mode("inherit", "whiteAlpha.50")(props),
-      bg: mode("gray.100", "whiteAlpha.300")(props),
+      _light: {
+        borderColor: "inherit",
+        bg: "gray.100",
+      },
+      _dark: {
+        borderColor: "whiteAlpha.50",
+        bg: "whiteAlpha.300",
+      },
     },
   }
 }
 
 const variantFilled: PartsStyleFunction<typeof parts> = (props) => {
   const { theme } = props
-  const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props)
+
+  const {
+    focusBorderColorLight: fcL,
+    errorBorderColorLight: ecL,
+    focusBorderColorDark: fcD,
+    errorBorderColorDark: ecD,
+  } = getDefaults(props)
 
   return {
     field: {
       border: "2px solid",
       borderColor: "transparent",
-      bg: mode("gray.100", "whiteAlpha.50")(props),
+
       _hover: {
-        bg: mode("gray.200", "whiteAlpha.100")(props),
+        _light: {
+          bg: "gray.200",
+        },
+
+        _dark: {
+          bg: "whiteAlpha.100",
+        },
       },
+
       _readOnly: {
         boxShadow: "none !important",
         userSelect: "all",
       },
+
       _disabled: {
         opacity: 0.4,
         cursor: "not-allowed",
       },
+
       _invalid: {
-        borderColor: getColor(theme, ec),
+        _light: {
+          borderColor: getColor(theme, ecL),
+        },
+        _dark: {
+          borderColor: getColor(theme, ecD),
+        },
       },
+
       _focus: {
         bg: "transparent",
-        borderColor: getColor(theme, fc),
+        _light: {
+          borderColor: getColor(theme, fcL),
+        },
+        _dark: {
+          borderColor: getColor(theme, fcD),
+        },
+      },
+
+      _light: {
+        bg: "gray.100",
+      },
+
+      _dark: {
+        bg: "whiteAlpha.50",
       },
     },
     addon: {
       border: "2px solid",
       borderColor: "transparent",
-      bg: mode("gray.100", "whiteAlpha.50")(props),
+
+      _light: {
+        bg: "gray.100",
+      },
+
+      _dark: {
+        bg: "whiteAlpha.50",
+      },
     },
   }
 }
 
 const variantFlushed: PartsStyleFunction<typeof parts> = (props) => {
   const { theme } = props
-  const { focusBorderColor: fc, errorBorderColor: ec } = getDefaults(props)
+  const {
+    focusBorderColorLight: fcL,
+    errorBorderColorLight: ecL,
+    focusBorderColorDark: fcD,
+    errorBorderColorDark: ecD,
+  } = getDefaults(props)
 
   return {
     field: {
@@ -165,12 +242,24 @@ const variantFlushed: PartsStyleFunction<typeof parts> = (props) => {
         userSelect: "all",
       },
       _invalid: {
-        borderColor: getColor(theme, ec),
-        boxShadow: `0px 1px 0px 0px ${getColor(theme, ec)}`,
+        _light: {
+          borderColor: getColor(theme, ecL),
+          boxShadow: `0px 1px 0px 0px ${getColor(theme, ecL)}`,
+        },
+        _dark: {
+          borderColor: getColor(theme, ecD),
+          boxShadow: `0px 1px 0px 0px ${getColor(theme, ecD)}`,
+        },
       },
       _focus: {
-        borderColor: getColor(theme, fc),
-        boxShadow: `0px 1px 0px 0px ${getColor(theme, fc)}`,
+        _light: {
+          borderColor: getColor(theme, fcL),
+          boxShadow: `0px 1px 0px 0px ${getColor(theme, fcL)}`,
+        },
+        _dark: {
+          borderColor: getColor(theme, fcD),
+          boxShadow: `0px 1px 0px 0px ${getColor(theme, fcD)}`,
+        },
       },
     },
     addon: {

--- a/packages/theme/src/components/kbd.ts
+++ b/packages/theme/src/components/kbd.ts
@@ -1,18 +1,23 @@
-import type { SystemStyleFunction } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
-const baseStyle: SystemStyleFunction = (props) => {
-  return {
-    bg: mode("gray.100", "whiteAlpha")(props),
-    borderRadius: "md",
-    borderWidth: "1px",
-    borderBottomWidth: "3px",
-    fontSize: "0.8em",
-    fontWeight: "bold",
-    lineHeight: "normal",
-    px: "0.4em",
-    whiteSpace: "nowrap",
-  }
+const baseStyle: SystemStyleObject = {
+  borderRadius: "md",
+  borderWidth: "1px",
+  borderBottomWidth: "3px",
+  fontSize: "0.8em",
+  fontWeight: "bold",
+  lineHeight: "normal",
+  px: "0.4em",
+  whiteSpace: "nowrap",
+
+  _light: {
+    bg: "gray.100",
+  },
+
+  _dark: {
+    bg: "whiteAlpha",
+  },
 }
 
 export default {

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -1,45 +1,64 @@
 import { menuAnatomy as parts } from "@chakra-ui/anatomy"
 import type {
-  PartsStyleFunction,
-  SystemStyleFunction,
+  PartsStyleObject,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
-const baseStyleList: SystemStyleFunction = (props) => {
-  return {
-    bg: mode("#fff", "gray.700")(props),
-    boxShadow: mode("sm", "dark-lg")(props),
-    color: "inherit",
-    minW: "3xs",
-    py: "2",
-    zIndex: 1,
-    borderRadius: "md",
-    borderWidth: "1px",
-  }
+const baseStyleList: SystemStyleObject = {
+  color: "inherit",
+  minW: "3xs",
+  py: "2",
+  zIndex: 1,
+  borderRadius: "md",
+  borderWidth: "1px",
+  _light: {
+    bg: "#fff",
+    boxShadow: "sm",
+  },
+  _dark: {
+    bg: "gray.700",
+    boxShadow: "dark-lg",
+  },
 }
 
-const baseStyleItem: SystemStyleFunction = (props) => {
-  return {
-    py: "0.4rem",
-    px: "0.8rem",
-    transitionProperty: "background",
-    transitionDuration: "ultra-fast",
-    transitionTimingFunction: "ease-in",
-    _focus: {
-      bg: mode("gray.100", "whiteAlpha.100")(props),
+const baseStyleItem: SystemStyleObject = {
+  py: "0.4rem",
+  px: "0.8rem",
+  transitionProperty: "background",
+  transitionDuration: "ultra-fast",
+  transitionTimingFunction: "ease-in",
+  _focus: {
+    _light: {
+      bg: "gray.100",
     },
-    _active: {
-      bg: mode("gray.200", "whiteAlpha.200")(props),
+
+    _dark: {
+      bg: "whiteAlpha.100",
     },
-    _expanded: {
-      bg: mode("gray.100", "whiteAlpha.100")(props),
+  },
+  _active: {
+    _light: {
+      bg: "gray.200",
     },
-    _disabled: {
-      opacity: 0.4,
-      cursor: "not-allowed",
+
+    _dark: {
+      bg: "whiteAlpha.200",
     },
-  }
+  },
+  _expanded: {
+    _light: {
+      bg: "gray.100",
+    },
+
+    _dark: {
+      bg: "whiteAlpha.100",
+    },
+  },
+  _disabled: {
+    opacity: 0.4,
+    cursor: "not-allowed",
+  },
 }
 
 const baseStyleGroupTitle: SystemStyleObject = {
@@ -66,14 +85,14 @@ const baseStyleButton: SystemStyleObject = {
   transitionDuration: "normal",
 }
 
-const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+const baseStyle: PartsStyleObject<typeof parts> = {
   button: baseStyleButton,
-  list: baseStyleList(props),
-  item: baseStyleItem(props),
+  list: baseStyleList,
+  item: baseStyleItem,
   groupTitle: baseStyleGroupTitle,
   command: baseStyleCommand,
   divider: baseStyleDivider,
-})
+}
 
 export default {
   parts: parts.keys,

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -5,7 +5,7 @@ import type {
   SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
 const baseStyleOverlay: SystemStyleObject = {
   bg: "blackAlpha.600",
@@ -29,12 +29,18 @@ const baseStyleDialog: SystemStyleFunction = (props) => {
 
   return {
     borderRadius: "md",
-    bg: mode("white", "gray.700")(props),
     color: "inherit",
     my: "3.75rem",
     zIndex: "modal",
     maxH: scrollBehavior === "inside" ? "calc(100% - 7.5rem)" : undefined,
-    boxShadow: mode("lg", "dark-lg")(props),
+    _light: {
+      bg: "white",
+      boxShadow: "lg",
+    },
+    _dark: {
+      bg: "gray.700",
+      boxShadow: "dark-lg",
+    },
   }
 }
 

--- a/packages/theme/src/components/number-input.ts
+++ b/packages/theme/src/components/number-input.ts
@@ -1,11 +1,9 @@
 import { numberInputAnatomy as parts } from "@chakra-ui/anatomy"
 import type {
-  PartsStyleFunction,
   PartsStyleObject,
-  SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { calc, cssVar, mode } from "@chakra-ui/theme-tools"
+import { calc, cssVar } from "@chakra-ui/theme-tools"
 import typography from "../foundations/typography"
 import Input from "./input"
 
@@ -27,27 +25,37 @@ const baseStyleStepperGroup: SystemStyleObject = {
   width: [$stepperWidth.reference],
 }
 
-const baseStyleStepper: SystemStyleFunction = (props) => {
-  return {
-    borderStart: "1px solid",
-    borderStartColor: mode("inherit", "whiteAlpha.300")(props),
-    color: mode("inherit", "whiteAlpha.800")(props),
-    _active: {
-      bg: mode("gray.200", "whiteAlpha.300")(props),
+const baseStyleStepper: SystemStyleObject = {
+  borderStart: "1px solid",
+  _active: {
+    _light: {
+      bg: "gray.200",
     },
-    _disabled: {
-      opacity: 0.4,
-      cursor: "not-allowed",
+
+    _dark: {
+      bg: "whiteAlpha.300",
     },
-  }
+  },
+  _disabled: {
+    opacity: 0.4,
+    cursor: "not-allowed",
+  },
+  _light: {
+    borderStartColor: "inherit",
+    color: "inherit",
+  },
+  _dark: {
+    borderStartColor: "whiteAlpha.300",
+    color: "whiteAlpha.800",
+  },
 }
 
-const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+const baseStyle: PartsStyleObject<typeof parts> = {
   root: baseStyleRoot,
   field: baseStyleField,
   stepperGroup: baseStyleStepperGroup,
-  stepper: baseStyleStepper(props),
-})
+  stepper: baseStyleStepper,
+}
 
 type Size = "xs" | "sm" | "md" | "lg"
 

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -1,10 +1,9 @@
 import { popoverAnatomy as parts } from "@chakra-ui/anatomy"
 import type {
-  PartsStyleFunction,
-  SystemStyleFunction,
+  PartsStyleObject,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { cssVar, mode } from "@chakra-ui/theme-tools"
+import { cssVar } from "@chakra-ui/theme-tools"
 
 const $popperBg = cssVar("popper-bg")
 
@@ -15,26 +14,36 @@ const baseStylePopper: SystemStyleObject = {
   zIndex: 10,
 }
 
-const baseStyleContent: SystemStyleFunction = (props) => {
-  const bg = mode("white", "gray.700")(props)
-  const shadowColor = mode("gray.200", "whiteAlpha.300")(props)
+const contentBgLight = "white"
+const contentBgDark = "gray.700"
+const contentShadowColorLight = "whiteAlpha.300"
+const contentShadowColorDark = "gray.200"
 
-  return {
-    [$popperBg.variable]: `colors.${bg}`,
-    bg: $popperBg.reference,
-    [$arrowBg.variable]: $popperBg.reference,
-    [$arrowShadowColor.variable]: `colors.${shadowColor}`,
-    width: "xs",
-    border: "1px solid",
-    borderColor: "inherit",
-    borderRadius: "md",
-    boxShadow: "sm",
-    zIndex: "inherit",
-    _focus: {
-      outline: 0,
-      boxShadow: "outline",
-    },
-  }
+const baseStyleContent: SystemStyleObject = {
+  [$arrowBg.variable]: $popperBg.reference,
+  width: "xs",
+  border: "1px solid",
+  borderColor: "inherit",
+  borderRadius: "md",
+  boxShadow: "sm",
+  zIndex: "inherit",
+
+  _focus: {
+    outline: 0,
+    boxShadow: "outline",
+  },
+
+  _light: {
+    bg: contentBgLight,
+    [$popperBg.variable]: `colors.${contentBgLight}`,
+    [$arrowShadowColor.variable]: `colors.${contentShadowColorDark}`,
+  },
+
+  _dark: {
+    bg: contentBgDark,
+    [$popperBg.variable]: `colors.${contentBgDark}`,
+    [$arrowShadowColor.variable]: `colors.${contentShadowColorLight}`,
+  },
 }
 
 const baseStyleHeader: SystemStyleObject = {
@@ -62,15 +71,15 @@ const baseStyleCloseButton: SystemStyleObject = {
   padding: 2,
 }
 
-const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+const baseStyle: PartsStyleObject<typeof parts> = {
   popper: baseStylePopper,
-  content: baseStyleContent(props),
+  content: baseStyleContent,
   header: baseStyleHeader,
   body: baseStyleBody,
   footer: baseStyleFooter,
   arrow: {},
   closeButton: baseStyleCloseButton,
-})
+}
 
 export default {
   parts: parts.keys,

--- a/packages/theme/src/components/progress.ts
+++ b/packages/theme/src/components/progress.ts
@@ -2,7 +2,6 @@ import { progressAnatomy as parts } from "@chakra-ui/anatomy"
 import {
   generateStripe,
   getColor,
-  mode,
   PartsStyleFunction,
   PartsStyleObject,
   StyleFunctionProps,
@@ -15,14 +14,12 @@ import type {
 function filledStyle(props: StyleFunctionProps): SystemStyleObject {
   const { colorScheme: c, theme: t, isIndeterminate, hasStripe } = props
 
-  const stripeStyle = mode(
-    generateStripe(),
-    generateStripe("1rem", "rgba(0,0,0,0.1)"),
-  )(props)
+  const stripeStyleLight = generateStripe()
+  const stripeStyleDark = generateStripe("1rem", "rgba(0,0,0,0.1)")
+  const bgColorDark = `${c}.200`
+  const bgColorLight = `${c}.500`
 
-  const bgColor = mode(`${c}.500`, `${c}.200`)(props)
-
-  const gradient = `linear-gradient(
+  const gradient = (bgColor: string) => `linear-gradient(
     to right,
     transparent 0%,
     ${getColor(t, bgColor)} 50%,
@@ -32,8 +29,26 @@ function filledStyle(props: StyleFunctionProps): SystemStyleObject {
   const addStripe = !isIndeterminate && hasStripe
 
   return {
-    ...(addStripe && stripeStyle),
-    ...(isIndeterminate ? { bgImage: gradient } : { bgColor }),
+    ...(isIndeterminate
+      ? {
+          _dark: {
+            bgImage: gradient(bgColorDark),
+          },
+          _light: {
+            bgImage: gradient(bgColorLight),
+          },
+        }
+      : {
+          _light: {
+            bgColor: bgColorLight,
+            ...(addStripe && stripeStyleLight),
+          },
+
+          _dark: {
+            bgColor: bgColorDark,
+            ...(addStripe && stripeStyleDark),
+          },
+        }),
   }
 }
 
@@ -44,10 +59,14 @@ const baseStyleLabel: SystemStyleObject = {
   color: "white",
 }
 
-const baseStyleTrack: SystemStyleFunction = (props) => {
-  return {
-    bg: mode("gray.100", "whiteAlpha.300")(props),
-  }
+const baseStyleTrack: SystemStyleObject = {
+  _light: {
+    bg: "gray.100",
+  },
+
+  _dark: {
+    bg: "whiteAlpha.300",
+  },
 }
 
 const baseStyleFilledTrack: SystemStyleFunction = (props) => {
@@ -61,7 +80,7 @@ const baseStyleFilledTrack: SystemStyleFunction = (props) => {
 const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   label: baseStyleLabel,
   filledTrack: baseStyleFilledTrack(props),
-  track: baseStyleTrack(props),
+  track: baseStyleTrack,
 })
 
 const sizes: Record<string, PartsStyleObject<typeof parts>> = {

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -1,25 +1,35 @@
 import { selectAnatomy as parts } from "@chakra-ui/anatomy"
 import type {
-  PartsStyleFunction,
   PartsStyleObject,
-  SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
 import { mergeWith } from "@chakra-ui/utils"
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 import Input from "./input"
 
-const baseStyleField: SystemStyleFunction = (props) => {
-  return {
-    ...Input.baseStyle.field,
-    bg: mode("white", "gray.700")(props),
-    appearance: "none",
-    paddingBottom: "1px",
-    lineHeight: "normal",
-    "> option, > optgroup": {
-      bg: mode("white", "gray.700")(props),
+const baseStyleField: SystemStyleObject = {
+  ...Input.baseStyle.field,
+  appearance: "none",
+  paddingBottom: "1px",
+  lineHeight: "normal",
+
+  "> option, > optgroup": {
+    _light: {
+      bg: "white",
     },
-  }
+
+    _dark: {
+      bg: "gray.700",
+    },
+  },
+
+  _light: {
+    bg: "white",
+  },
+
+  _dark: {
+    bg: "gray.700",
+  },
 }
 
 const baseStyleIcon: SystemStyleObject = {
@@ -34,10 +44,10 @@ const baseStyleIcon: SystemStyleObject = {
   },
 }
 
-const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
-  field: baseStyleField(props),
+const baseStyle: PartsStyleObject<typeof parts> = {
+  field: baseStyleField,
   icon: baseStyleIcon,
-})
+}
 
 const iconSpacing = { paddingInlineEnd: "2rem" }
 

--- a/packages/theme/src/components/skeleton.ts
+++ b/packages/theme/src/components/skeleton.ts
@@ -1,6 +1,6 @@
 import { keyframes } from "@chakra-ui/system"
 import type { SystemStyleFunction } from "@chakra-ui/theme-tools"
-import { getColor, mode } from "@chakra-ui/theme-tools"
+import { getColor } from "@chakra-ui/theme-tools"
 
 const fade = (startColor: string, endColor: string) =>
   keyframes({
@@ -8,26 +8,38 @@ const fade = (startColor: string, endColor: string) =>
     to: { borderColor: endColor, background: endColor },
   })
 
+const defaultStartColorLight = "gray.100"
+const defaultStartColorDark = "gray.800"
+const defaultEndColorDark = "gray.600"
+const defaultEndColorLight = "gray.400"
+
 const baseStyle: SystemStyleFunction = (props) => {
-  const defaultStartColor = mode("gray.100", "gray.800")(props)
-  const defaultEndColor = mode("gray.400", "gray.600")(props)
+  const { startColor, endColor, speed, theme } = props
 
-  const {
-    startColor = defaultStartColor,
-    endColor = defaultEndColor,
-    speed,
-    theme,
-  } = props
-
-  const start = getColor(theme, startColor)
-  const end = getColor(theme, endColor)
+  const startDark = getColor(theme, startColor ?? defaultStartColorDark)
+  const endDark = getColor(theme, endColor ?? defaultEndColorDark)
+  const startLight = getColor(theme, startColor ?? defaultStartColorLight)
+  const endLight = getColor(theme, endColor ?? defaultEndColorLight)
 
   return {
     opacity: 0.7,
     borderRadius: "2px",
-    borderColor: start,
-    background: end,
-    animation: `${speed}s linear infinite alternate ${fade(start, end)}`,
+    _light: {
+      borderColor: startLight,
+      background: endLight,
+      animation: `${speed}s linear infinite alternate ${fade(
+        startLight,
+        endLight,
+      )}`,
+    },
+    _dark: {
+      borderColor: startDark,
+      background: endDark,
+      animation: `${speed}s linear infinite alternate ${fade(
+        startDark,
+        endDark,
+      )}`,
+    },
   }
 }
 

--- a/packages/theme/src/components/skip-link.ts
+++ b/packages/theme/src/components/skip-link.ts
@@ -1,7 +1,7 @@
-import type { SystemStyleFunction } from "@chakra-ui/theme-tools"
-import { mode } from "@chakra-ui/theme-tools"
+import type { SystemStyleObject } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 
-const baseStyle: SystemStyleFunction = (props) => ({
+const baseStyle: SystemStyleObject = {
   borderRadius: "md",
   fontWeight: "semibold",
   _focus: {
@@ -10,9 +10,16 @@ const baseStyle: SystemStyleFunction = (props) => ({
     position: "fixed",
     top: "1.5rem",
     insetStart: "1.5rem",
-    bg: mode("white", "gray.700")(props),
+
+    _light: {
+      bg: "white",
+    },
+
+    _dark: {
+      bg: "gray.700",
+    },
   },
-})
+}
 
 export default {
   baseStyle,

--- a/packages/theme/src/components/slider.ts
+++ b/packages/theme/src/components/slider.ts
@@ -5,7 +5,7 @@ import type {
   SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { mode, orient } from "@chakra-ui/theme-tools"
+import { orient } from "@chakra-ui/theme-tools"
 
 function thumbOrientation(props: StyleFunctionProps): SystemStyleObject {
   return orient({
@@ -47,15 +47,27 @@ const baseStyleContainer: SystemStyleFunction = (props) => {
   }
 }
 
-const baseStyleTrack: SystemStyleFunction = (props) => {
-  return {
-    overflow: "hidden",
-    borderRadius: "sm",
-    bg: mode("gray.200", "whiteAlpha.200")(props),
-    _disabled: {
-      bg: mode("gray.300", "whiteAlpha.300")(props),
+const baseStyleTrack: SystemStyleObject = {
+  overflow: "hidden",
+  borderRadius: "sm",
+
+  _disabled: {
+    _light: {
+      bg: "gray.300",
     },
-  }
+
+    _dark: {
+      bg: "whiteAlpha.300",
+    },
+  },
+
+  _light: {
+    bg: "gray.200",
+  },
+
+  _dark: {
+    bg: "whiteAlpha.200",
+  },
 }
 
 const baseStyleThumb: SystemStyleFunction = (props) => {
@@ -85,13 +97,20 @@ const baseStyleFilledTrack: SystemStyleFunction = (props) => {
   return {
     width: "inherit",
     height: "inherit",
-    bg: mode(`${c}.500`, `${c}.200`)(props),
+
+    _light: {
+      bg: `${c}.500`,
+    },
+
+    _dark: {
+      bg: `${c}.200`,
+    },
   }
 }
 
 const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   container: baseStyleContainer(props),
-  track: baseStyleTrack(props),
+  track: baseStyleTrack,
   thumb: baseStyleThumb(props),
   filledTrack: baseStyleFilledTrack(props),
 })

--- a/packages/theme/src/components/switch.ts
+++ b/packages/theme/src/components/switch.ts
@@ -5,7 +5,7 @@ import type {
   SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { calc, cssVar, mode } from "@chakra-ui/theme-tools"
+import { calc, cssVar } from "@chakra-ui/theme-tools"
 
 const $width = cssVar("switch-track-width")
 const $height = cssVar("switch-track-height")
@@ -25,16 +25,32 @@ const baseStyleTrack: SystemStyleFunction = (props) => {
     height: [$height.reference],
     transitionProperty: "common",
     transitionDuration: "fast",
-    bg: mode("gray.300", "whiteAlpha.400")(props),
+
     _focus: {
       boxShadow: "outline",
     },
+
     _disabled: {
       opacity: 0.4,
       cursor: "not-allowed",
     },
+
     _checked: {
-      bg: mode(`${c}.500`, `${c}.200`)(props),
+      _light: {
+        bg: `${c}.500`,
+      },
+
+      _dark: {
+        bg: `${c}.200`,
+      },
+    },
+
+    _light: {
+      bg: "gray.300",
+    },
+
+    _dark: {
+      bg: "whiteAlpha.400",
     },
   }
 }

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -1,6 +1,6 @@
 import { tableAnatomy as parts } from "@chakra-ui/anatomy"
 
-import { mode } from "@chakra-ui/theme-tools"
+import "@chakra-ui/theme-tools"
 import type {
   PartsStyleFunction,
   PartsStyleObject,
@@ -42,18 +42,39 @@ const variantSimple: PartsStyleFunction<typeof parts> = (props) => {
 
   return {
     th: {
-      color: mode("gray.600", "gray.400")(props),
       borderBottom: "1px",
-      borderColor: mode(`${c}.100`, `${c}.700`)(props),
       ...numericStyles,
+
+      _light: {
+        color: "gray.600",
+        borderColor: `${c}.100`,
+      },
+
+      _dark: {
+        color: "gray.400",
+        borderColor: `${c}.700`,
+      },
     },
     td: {
       borderBottom: "1px",
-      borderColor: mode(`${c}.100`, `${c}.700`)(props),
       ...numericStyles,
+
+      _light: {
+        borderColor: `${c}.100`,
+      },
+
+      _dark: {
+        borderColor: `${c}.700`,
+      },
     },
     caption: {
-      color: mode("gray.600", "gray.100")(props),
+      _light: {
+        color: "gray.600",
+      },
+
+      _dark: {
+        color: "gray.100",
+      },
     },
     tfoot: {
       tr: {
@@ -70,28 +91,62 @@ const variantStripe: PartsStyleFunction<typeof parts> = (props) => {
 
   return {
     th: {
-      color: mode("gray.600", "gray.400")(props),
       borderBottom: "1px",
-      borderColor: mode(`${c}.100`, `${c}.700`)(props),
       ...numericStyles,
+
+      _light: {
+        color: "gray.600",
+        borderColor: `${c}.100`,
+      },
+
+      _dark: {
+        color: "gray.400",
+        borderColor: `${c}.700`,
+      },
     },
     td: {
       borderBottom: "1px",
-      borderColor: mode(`${c}.100`, `${c}.700`)(props),
       ...numericStyles,
+
+      _light: {
+        borderColor: `${c}.100`,
+      },
+
+      _dark: {
+        borderColor: `${c}.700`,
+      },
     },
     caption: {
-      color: mode("gray.600", "gray.100")(props),
+      _light: {
+        color: "gray.600",
+      },
+
+      _dark: {
+        color: "gray.100",
+      },
     },
     tbody: {
       tr: {
         "&:nth-of-type(odd)": {
           "th, td": {
             borderBottomWidth: "1px",
-            borderColor: mode(`${c}.100`, `${c}.700`)(props),
+
+            _light: {
+              borderColor: `${c}.100`,
+            },
+
+            _dark: {
+              borderColor: `${c}.700`,
+            },
           },
           td: {
-            background: mode(`${c}.100`, `${c}.700`)(props),
+            _light: {
+              background: `${c}.100`,
+            },
+
+            _dark: {
+              background: `${c}.700`,
+            },
           },
         },
       },

--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -6,7 +6,7 @@ import type {
   SystemStyleFunction,
   SystemStyleObject,
 } from "@chakra-ui/theme-tools"
-import { getColor, mode } from "@chakra-ui/theme-tools"
+import { getColor } from "@chakra-ui/theme-tools"
 
 const baseStyleRoot: SystemStyleFunction = (props) => {
   const { orientation } = props
@@ -95,11 +95,24 @@ const variantLine: PartsStyleFunction<typeof parts> = (props) => {
       borderColor: "transparent",
       [marginProp]: "-2px",
       _selected: {
-        color: mode(`${c}.600`, `${c}.300`)(props),
         borderColor: "currentColor",
+
+        _light: {
+          color: `${c}.600`,
+        },
+
+        _dark: {
+          color: `${c}.300`,
+        },
       },
       _active: {
-        bg: mode("gray.200", "whiteAlpha.300")(props),
+        _light: {
+          bg: "gray.200",
+        },
+
+        _dark: {
+          bg: "whiteAlpha.300",
+        },
       },
       _disabled: {
         opacity: 0.4,
@@ -118,9 +131,15 @@ const variantEnclosed: PartsStyleFunction<typeof parts> = (props) => {
       borderColor: "transparent",
       mb: "-1px",
       _selected: {
-        color: mode(`${c}.600`, `${c}.300`)(props),
         borderColor: "inherit",
-        borderBottomColor: mode(`white`, `gray.800`)(props),
+        _light: {
+          color: `${c}.600`,
+          borderBottomColor: `white`,
+        },
+        _dark: {
+          color: `${c}.300`,
+          borderBottomColor: `gray.800`,
+        },
       },
     },
     tablist: {
@@ -137,17 +156,32 @@ const variantEnclosedColored: PartsStyleFunction<typeof parts> = (props) => {
     tab: {
       border: "1px solid",
       borderColor: "inherit",
-      bg: mode(`gray.50`, `whiteAlpha.50`)(props),
       mb: "-1px",
+
       _notLast: {
         marginEnd: "-1px",
       },
+
       _selected: {
-        bg: mode("#fff", "gray.800")(props),
-        color: mode(`${c}.600`, `${c}.300`)(props),
         borderColor: "inherit",
         borderTopColor: "currentColor",
         borderBottomColor: "transparent",
+        _light: {
+          bg: "#fff",
+          color: `${c}.600`,
+        },
+        _dark: {
+          bg: "gray.800",
+          color: `${c}.300`,
+        },
+      },
+
+      _light: {
+        bg: `gray.50`,
+      },
+
+      _dark: {
+        bg: `whiteAlpha.50`,
       },
     },
     tablist: {
@@ -179,10 +213,24 @@ const variantSolidRounded: PartsStyleFunction<typeof parts> = (props) => {
     tab: {
       borderRadius: "full",
       fontWeight: "semibold",
-      color: mode("gray.600", "inherit")(props),
+
       _selected: {
-        color: mode(`#fff`, "gray.800")(props),
-        bg: mode(`${c}.600`, `${c}.300`)(props),
+        _light: {
+          color: `#fff`,
+          bg: `${c}.600`,
+        },
+        _dark: {
+          color: "gray.800",
+          bg: `${c}.300`,
+        },
+      },
+
+      _light: {
+        color: "gray.600",
+      },
+
+      _dark: {
+        color: "inherit",
       },
     },
   }

--- a/packages/theme/src/components/tooltip.ts
+++ b/packages/theme/src/components/tooltip.ts
@@ -1,24 +1,31 @@
-import { mode, cssVar, SystemStyleFunction } from "@chakra-ui/theme-tools"
+import { cssVar, SystemStyleObject } from "@chakra-ui/theme-tools"
 
 const $bg = cssVar("tooltip-bg")
 const $arrowBg = cssVar("popper-arrow-bg")
 
-const baseStyle: SystemStyleFunction = (props) => {
-  const bg = mode("gray.700", "gray.300")(props)
-  return {
-    [$bg.variable]: `colors.${bg}`,
-    px: "8px",
-    py: "2px",
-    bg: [$bg.reference],
-    [$arrowBg.variable]: [$bg.reference],
-    color: mode("whiteAlpha.900", "gray.900")(props),
-    borderRadius: "sm",
-    fontWeight: "medium",
-    fontSize: "sm",
-    boxShadow: "md",
-    maxW: "320px",
-    zIndex: "tooltip",
-  }
+const bgLight = "gray.700"
+const bgDark = "gray.300"
+
+const baseStyle: SystemStyleObject = {
+  px: "8px",
+  py: "2px",
+  [$arrowBg.variable]: [$bg.reference],
+  borderRadius: "sm",
+  fontWeight: "medium",
+  fontSize: "sm",
+  boxShadow: "md",
+  maxW: "320px",
+  zIndex: "tooltip",
+  _light: {
+    bg: bgLight,
+    color: "whiteAlpha.900",
+    [$bg.variable]: `colors.${bgLight}`,
+  },
+  _dark: {
+    bg: bgDark,
+    color: "gray.900",
+    [$bg.variable]: `colors.${bgDark}`,
+  },
 }
 
 export default {


### PR DESCRIPTION
## 📝 Description

Currently working on a codemod to migrate from `mode` in our components to `_dark` and `_light` pseudo selectors

This represents the current result.

See codemod implementation: https://github.com/chakra-ui/chakra-codemod/pull/22