### PR TITLE
feat(theme-utils): fallback to semanticToken-value when calling `getColor`

### DIFF
--- a/.changeset/nice-beans-invent.md
+++ b/.changeset/nice-beans-invent.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme-tools": patch
+---
+
+Fallback to semantic token colors when calling `getColor`

--- a/packages/theme-tools/src/color.ts
+++ b/packages/theme-tools/src/color.ts
@@ -14,7 +14,11 @@ import { memoizedGet as get, Dict, isEmptyObject } from "@chakra-ui/utils"
  * @param fallback - the fallback color
  */
 export const getColor = (theme: Dict, color: string, fallback?: string) => {
-  const hex = get(theme, `colors.${color}`, color)
+  let hex = get(theme, `colors.${color}`, color)
+  // we didnt resolve a color value
+  if (hex === color) {
+    hex = get(theme, `semanticTokens.colors.${color}`, color)
+  }
   const { isValid } = new TinyColor(hex)
   return isValid ? hex : fallback
 }
@@ -48,12 +52,11 @@ export const isLight = (color: string) => (theme: Dict) =>
  * @param color - the color in hex, rgb, or hsl
  * @param opacity - the amount of opacity the color should have (0-1)
  */
-export const transparentize = (color: string, opacity: number) => (
-  theme: Dict,
-) => {
-  const raw = getColor(theme, color)
-  return new TinyColor(raw).setAlpha(opacity).toRgbString()
-}
+export const transparentize =
+  (color: string, opacity: number) => (theme: Dict) => {
+    const raw = getColor(theme, color)
+    return new TinyColor(raw).setAlpha(opacity).toRgbString()
+  }
 
 /**
  * Add white to a color
@@ -110,12 +113,9 @@ export const contrast = (fg: string, bg: string) => (theme: Dict) =>
  * @param fg - the foreground or text color
  * @param bg - the background color
  */
-export const isAccessible = (
-  textColor: string,
-  bgColor: string,
-  options?: WCAG2Parms,
-) => (theme: Dict) =>
-  isReadable(getColor(theme, bgColor), getColor(theme, textColor), options)
+export const isAccessible =
+  (textColor: string, bgColor: string, options?: WCAG2Parms) => (theme: Dict) =>
+    isReadable(getColor(theme, bgColor), getColor(theme, textColor), options)
 
 export const complementary = (color: string) => (theme: Dict) =>
   new TinyColor(getColor(theme, color)).complement().toHexString()

--- a/packages/theme-tools/test/color.test.ts
+++ b/packages/theme-tools/test/color.test.ts
@@ -1,0 +1,30 @@
+import { getColor } from "../src"
+
+test("gets color from theme", () => {
+  expect(
+    getColor({ colors: { red: { 200: "#ff0000" } } }, "red.200", "red.200"),
+  ).toBe("#ff0000")
+})
+
+test("can get semantic token from theme", () => {
+  expect(
+    getColor(
+      { semanticTokens: { colors: { error: { 200: "#ff0000" } } } },
+      "error.200",
+      "error.200",
+    ),
+  ).toBe("#ff0000")
+})
+
+test("takes color over semanticToken", () => {
+  expect(
+    getColor(
+      {
+        colors: { red: { 200: "#dd0000" } },
+        semanticTokens: { colors: { red: { 200: "#ff0000" } } },
+      },
+      "red.200",
+      "red.200",
+    ),
+  ).toBe("#dd0000")
+})


### PR DESCRIPTION
## 📝 Description

When you are defining custom components-themes with semantic tokens and need to resolve your color value on your own (.e.g. `box-shadow`) you can't resolve the token as usual with `getColor` since `getColor` only supports a lookup into `colors.${tokenValue}` 

## 🚀 New behavior

`getColor` now also tries to resolve the color from  `semanticTokens` before returning the fallback
