### PR TITLE
feat(form-control): add optional indicator for `FormLabel`

### DIFF
--- a/.changeset/sharp-crews-wave.md
+++ b/.changeset/sharp-crews-wave.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/form-control": minor
+---
+
+Introduced `optionalIndicator` for `FormLabel`
+
+Similar to the `RequiredIndicator` the `OptionalIndicator` signalizes when a
+field is optional.

--- a/packages/form-control/src/form-label.tsx
+++ b/packages/form-control/src/form-label.tsx
@@ -18,6 +18,10 @@ export interface FormLabelProps
    * @type React.ReactElement
    */
   requiredIndicator?: React.ReactElement
+  /**
+   * @type React.ReactNode
+   */
+  optionalIndicator?: React.ReactNode
 }
 
 /**
@@ -37,6 +41,7 @@ export const FormLabel = forwardRef<FormLabelProps, "label">(
       className,
       children,
       requiredIndicator = <RequiredIndicator />,
+      optionalIndicator = null,
       ...rest
     } = props
 
@@ -54,7 +59,7 @@ export const FormLabel = forwardRef<FormLabelProps, "label">(
         }}
       >
         {children}
-        {field?.isRequired ? requiredIndicator : null}
+        {field?.isRequired ? requiredIndicator : optionalIndicator}
       </chakra.label>
     )
   },

--- a/packages/form-control/tests/form-control.test.tsx
+++ b/packages/form-control/tests/form-control.test.tsx
@@ -245,3 +245,14 @@ test("can provide a custom aria-describedby reference", () => {
     "name-expanded-helptext name-helptext",
   )
 })
+
+test("it renders the optionalIndicator in FormLabel if it is provided", () => {
+  render(
+    <FormControl isRequired={false}>
+      <FormLabel optionalIndicator=" (optional)">Test</FormLabel>
+      <Input />
+    </FormControl>,
+  )
+
+  expect(screen.getByText("Test (optional)")).toBeInTheDocument()
+})


### PR DESCRIPTION
## 📝 Description

Added `optionalIndicator` to `FormLabel` to provide a way to signalize if a field is optional

## ⛳️ Current behavior (updates)

Currently, we only show `<RequiredIndicator/>` if a field is `required` to do the same for the inverse side the `Indicator has to be passed to the `children`

## 🚀 New behavior

made `optionalIndicator` a prop which can be passed to `<FormLabel/>` with default value `null` which renders if the field is not required. 

