### PR TITLE
Allow opt-in for outline/shadow on focused elements

### DIFF
--- a/packages/css-reset/src/css-reset.tsx
+++ b/packages/css-reset/src/css-reset.tsx
@@ -271,7 +271,7 @@ export const CSSReset = () => (
         height: auto;
       }
 
-      [data-js-focus-visible] :focus:not([data-focus-visible-added]) {
+      [data-js-focus-visible] :focus:not([data-focus-visible-added]):not([data-chakra-allow-focus-highlights]) {
         outline: none;
         box-shadow: none;
       }

--- a/packages/css-reset/src/css-reset.tsx
+++ b/packages/css-reset/src/css-reset.tsx
@@ -271,7 +271,7 @@ export const CSSReset = () => (
         height: auto;
       }
 
-      [data-js-focus-visible] :focus:not([data-focus-visible-added]):not([data-chakra-allow-focus-highlights]) {
+      [data-js-focus-visible] :focus:not([data-focus-visible-added]):not([data-focus-visible-disabled]) {
         outline: none;
         box-shadow: none;
       }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5575
## 📝 Description

This will need to be documented, but ultimately this allows users to override the automatic focus style overrides applied when using focus-visible.

The focus-visible documentation suggests adding a get-out like this, so Chakra really needs to give us one!

## ⛳️ Current behavior (updates)

When using the focus-visible package, it is impossible to apply certain styles to certain focussed elements. For example, adding a shadow to a link when focussed is currently not possible.

## 🚀 New behavior

By adding a special `data-` attribute, we allow developers to opt-out of this override in certain cases.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The focus-visible docs are slightly confusing on this. It says first:

> We suggest that users selectively disable the default focus style by selecting for the case when the polyfill is loaded and .focus-visible is not applied to the element:

with this example

```css
.js-focus-visible :focus:not(.focus-visible) {
  outline: none;
}
```

Then they say:

> Alternatively, if you're using a framework which overwrites your classes ([#179](https://github.com/WICG/focus-visible/issues/179)), you can rely on the data-js-focus-visible and data-focus-visible-added attributes.

And give this example, which is what Chakra already has:

```css
[data-js-focus-visible] :focus:not([data-focus-visible-added]) {
  outline: none;
}
```

The problem is that you can't just add `data-focus-visible-added` or whatever to your element, because the focus-visible package goes around adding and removing that attribute - it can work for one render, then the attribute is removed by the library, and it's broken again.

I think their docs are wrong, or possibly just confusing. You do need an extra opt-out selector.