### PR TITLE
chore: update storybook instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,9 @@ end with `.stories.tsx`.
 
 ### Storybook
 
-Build components in isolation with Storybook using `yarn storybook`
+Build components in isolation with Storybook. When using Storybook, the build
+process needs to be run separately. Run `yarn build && yarn preconstruct watch`
+in one terminal and then `yarn storybook` in a second terminal.
 
 ## Think you found a bug?
 


### PR DESCRIPTION
No issue; prompted by https://github.com/chakra-ui/chakra-ui/pull/5571

## 📝 Description

Recent changes to entry points have caused the storybook build to be
inadequate resulting in errors like
`Can't resolve '@chakra-ui/hooks/use-animation-state'`.

## ⛳️ Current behavior (updates)

Following the instructions for running storybook results in a failed build.

## 🚀 New behavior

The instructions reflect the current requirements for running storybook

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Is this accurate? Or does `yarn build` only need to be run once when changing branches (and then you just need `yarn preconstruct` + `yarn storybook` to get SB running)?