### PR TITLE
fix: conflicting zindex of linkoverlay with opacity

### DIFF
--- a/.changeset/nine-cars-sneeze.md
+++ b/.changeset/nine-cars-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/layout": patch
+---
+
+Fixed zIndex in LinkOverlay so that content in LinkBox can have an opacity below
+1

--- a/packages/layout/src/link-box.tsx
+++ b/packages/layout/src/link-box.tsx
@@ -27,7 +27,7 @@ export const LinkOverlay = forwardRef<LinkOverlayProps, "a">((props, ref) => {
           position: "absolute",
           top: 0,
           left: 0,
-          zIndex: 0,
+          zIndex: 1,
           width: "100%",
           height: "100%",
         },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5630 

## 📝 Description

Fixed an issue regarding the zIndex of the LinkOverlay in LinkBox.

## ⛳️ Current behavior (updates)

Content outside the LinkOverlay can not be clicked when having an opacity below 1.\
Codesandbox from the issue: https://codesandbox.io/s/laughing-sun-q1qjmw?file=/src/index.tsx

## 🚀 New behavior

Content outside the LinkOverlay can be clicked when having an opacity below 1.
Codesandbox with an override of the changed zIndex of this PR: https://codesandbox.io/s/elegant-varahamihira-9zuwk6?file=/src/index.tsx

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
