### PR TITLE
Fix/media query default breakpoint unused

### DIFF
--- a/.changeset/thick-swans-attend.md
+++ b/.changeset/thick-swans-attend.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+Fixed an issue that undefined is returned when calling the hook `useBreakpoint`
+with `defaultValue` specified in SSR

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -30,7 +30,9 @@ export function useBreakpoint(defaultBreakpoint?: string) {
       const matchingBreakpointDetail = queries.find(
         ({ query }) => env.window.matchMedia(query).matches,
       )
-      return matchingBreakpointDetail?.breakpoint
+      if (matchingBreakpointDetail) {
+        return matchingBreakpointDetail.breakpoint
+      }
     }
 
     if (defaultBreakpoint) {
@@ -38,7 +40,9 @@ export function useBreakpoint(defaultBreakpoint?: string) {
       const fallbackBreakpointDetail = queries.find(
         ({ breakpoint }) => breakpoint === defaultBreakpoint,
       )
-      return fallbackBreakpointDetail?.breakpoint
+      if (fallbackBreakpointDetail) {
+        return fallbackBreakpointDetail.breakpoint
+      }
     }
 
     return undefined

--- a/packages/media-query/tests/test-data.ts
+++ b/packages/media-query/tests/test-data.ts
@@ -1,3 +1,4 @@
+import { extendTheme } from "@chakra-ui/react"
 import { createBreakpoints } from "@chakra-ui/theme-tools"
 
 export const breakpoints = createBreakpoints({
@@ -9,7 +10,7 @@ export const breakpoints = createBreakpoints({
   customBreakpoint: "500px",
 })
 
-export const theme = { breakpoints }
+export const theme = extendTheme({ breakpoints })
 
 export const queries = {
   base: "(min-width: 0px) and (max-width: 99px)",

--- a/packages/media-query/tests/test-data.ts
+++ b/packages/media-query/tests/test-data.ts
@@ -7,7 +7,8 @@ export const breakpoints = createBreakpoints({
   md: "200px",
   lg: "300px",
   xl: "400px",
-  customBreakpoint: "500px",
+  "2xl": "500px",
+  customBreakpoint: "600px",
 })
 
 export const theme = extendTheme({ breakpoints })
@@ -18,5 +19,6 @@ export const queries = {
   md: "(min-width: 200px) and (max-width: 299px)",
   lg: "(min-width: 300px) and (max-width: 399px)",
   xl: "(min-width: 400px) and (max-width: 499px)",
-  customBreakpoint: "(min-width: 500px)",
+  "2xl": "(min-width: 500px) and (max-width: 599px)",
+  customBreakpoint: "(min-width: 600px)",
 }

--- a/packages/media-query/tests/use-breakpoint-value-ssr.test.tsx
+++ b/packages/media-query/tests/use-breakpoint-value-ssr.test.tsx
@@ -1,8 +1,17 @@
 import React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
-import { ThemeProvider } from "@chakra-ui/system"
+import { ChakraProvider } from "@chakra-ui/react"
 import { theme } from "./test-data"
 import { useBreakpointValue } from "../src"
+
+jest.mock("@chakra-ui/utils", () => ({
+  ...jest.requireActual("@chakra-ui/utils"),
+  isBrowser: false,
+}))
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
 
 describe("with defaultBreakpoint", () => {
   // To clean up erroneous console warnings from react, we temporarliy force
@@ -100,9 +109,9 @@ function ssrRenderWithDefaultBreakpoint(
   defaultBreakpoint: string,
 ) {
   return renderToStaticMarkup(
-    <ThemeProvider theme={theme}>
+    <ChakraProvider theme={theme}>
       <TestComponent values={values} defaultBreakpoint={defaultBreakpoint} />
-    </ThemeProvider>,
+    </ChakraProvider>,
   )
 }
 

--- a/packages/media-query/tests/use-breakpoint-value.test.tsx
+++ b/packages/media-query/tests/use-breakpoint-value.test.tsx
@@ -17,19 +17,20 @@ describe("with object", () => {
   })
 
   const values = {
-    base: "base",
-    sm: "sm",
-    md: "md",
-    lg: "lg",
-    xl: "xl",
-    customBreakpoint: "customBreakpoint",
+    base: "__base__",
+    sm: "__sm__",
+    md: "__md__",
+    lg: "__lg__",
+    xl: "__xl__",
+    "2xl": "__2xl__",
+    customBreakpoint: "__customBreakpoint__",
   }
 
   test("uses base value if smaller than sm", () => {
     renderWithQuery(values, queries.base)
 
     Object.keys(values).forEach((key) => {
-      if (key === "base") {
+      if (key === "__base__") {
         expect(screen.getByText(key)).toBeInTheDocument()
       } else {
         expect(screen.queryByText(key)).not.toBeInTheDocument()
@@ -41,7 +42,7 @@ describe("with object", () => {
     renderWithQuery(values, queries.sm)
 
     Object.keys(values).forEach((key) => {
-      if (key === "sm") {
+      if (key === "__sm__") {
         expect(screen.getByText(key)).toBeInTheDocument()
       } else {
         expect(screen.queryByText(key)).not.toBeInTheDocument()
@@ -53,7 +54,7 @@ describe("with object", () => {
     renderWithQuery(values, queries.md)
 
     Object.keys(values).forEach((key) => {
-      if (key === "md") {
+      if (key === "__md__") {
         expect(screen.getByText(key)).toBeInTheDocument()
       } else {
         expect(screen.queryByText(key)).not.toBeInTheDocument()
@@ -65,7 +66,7 @@ describe("with object", () => {
     renderWithQuery(values, queries.lg)
 
     Object.keys(values).forEach((key) => {
-      if (key === "lg") {
+      if (key === "__lg__") {
         expect(screen.getByText(key)).toBeInTheDocument()
       } else {
         expect(screen.queryByText(key)).not.toBeInTheDocument()
@@ -77,7 +78,19 @@ describe("with object", () => {
     renderWithQuery(values, queries.xl)
 
     Object.keys(values).forEach((key) => {
-      if (key === "xl") {
+      if (key === "__xl__") {
+        expect(screen.getByText(key)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(key)).not.toBeInTheDocument()
+      }
+    })
+  })
+
+  test("2xl", () => {
+    renderWithQuery(values, queries.xl)
+
+    Object.keys(values).forEach((key) => {
+      if (key === "__2xl__") {
         expect(screen.getByText(key)).toBeInTheDocument()
       } else {
         expect(screen.queryByText(key)).not.toBeInTheDocument()
@@ -89,7 +102,7 @@ describe("with object", () => {
     renderWithQuery(values, queries.customBreakpoint)
 
     Object.keys(values).forEach((key) => {
-      if (key === "customBreakpoint") {
+      if (key === "__customBreakpoint__") {
         expect(screen.getByText(key)).toBeInTheDocument()
       } else {
         expect(screen.queryByText(key)).not.toBeInTheDocument()
@@ -118,6 +131,7 @@ describe("with array", () => {
     "value2",
     "value3",
     "value4",
+    "value5",
     "anotherValue",
     "customBreakpoint",
   ]
@@ -165,6 +179,18 @@ describe("with array", () => {
 
   test("xl", () => {
     renderWithQuery(values, queries.xl)
+
+    values.forEach((value) => {
+      if (value === "value5") {
+        expect(screen.getByText(value)).toBeInTheDocument()
+      } else {
+        expect(screen.queryByText(value)).not.toBeInTheDocument()
+      }
+    })
+  })
+
+  test("2xl", () => {
+    renderWithQuery(values, queries["2xl"])
 
     values.forEach((value) => {
       if (value === "anotherValue") {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Since `matchMedia` always returns `false` during SSR, the code to check `defaultBreakpoint` was not reached by  [this refactor](https://github.com/chakra-ui/chakra-ui/pull/5576)
Also, the test was not able to set up the same situation as SSR, so it was not failed.

https://github.com/chakra-ui/chakra-ui/blob/60fc221f362c85a80d1534525dc45c499116433f/packages/media-query/src/use-breakpoint.ts#L27-L45

## ⛳️ Current behavior (updates)

Always return undefined during SSR

## 🚀 New behavior

return `defaultValue` when SSR

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
