### PR TITLE
fix: add color mode script runtime safeguard

### DIFF
--- a/.changeset/poor-llamas-obey.md
+++ b/.changeset/poor-llamas-obey.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+Adds a runtime safeguard for `ColorModeScript`.

--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -52,7 +52,14 @@ interface ColorModeScriptProps {
  * to help prevent flash of color mode that can happen during page load.
  */
 export const ColorModeScript = (props: ColorModeScriptProps) => {
-  const { initialColorMode = "light" } = props
+  let { initialColorMode = "light" } = props
+
+  // Runtime safeguard against invalid color mode values.
+  const validColorModeValues = ["dark", "light", "system"] as const
+  if (!validColorModeValues.includes(initialColorMode)) {
+    initialColorMode = "light"
+  }
+
   const html = `(${String(setScript)})('${initialColorMode}')`
   return (
     <script nonce={props.nonce} dangerouslySetInnerHTML={{ __html: html }} />


### PR DESCRIPTION
## 📝 Description

This PR adds a runtime safeguard to `ColorModeScript` since there's no need for the values to be dynamic and it's creating a `script` with `dangerouslySetInnerHTML`.

## ⛳️ Current behavior (updates)

The `initialColorMode` passed to `ColorModeScript` is currently only guarded via TypeScript typing. Setting `initialColorMode` to evil values like `(() => { console.log('hello'); return 'light'; })()` is possible.

This security issue is obviously far fetched but it is nevertheless there, and made worst since `ColorModeScript` obscures the fact that it's using `dangerouslySetInnerHTML`. 

## 🚀 New behavior

Adds hardening to `ColorModeScript` by runtime checking for three specific color mode values: `dark`, `light` and `system`.

## 💣 Is this a breaking change (Yes/No):

No
