### PR TITLE
Add option to specify initially focused menu item

### DIFF
--- a/.changeset/lemon-trees-relate.md
+++ b/.changeset/lemon-trees-relate.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": minor
+---
+
+Initial focus item for menu can be specified

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -119,6 +119,12 @@ export interface UseMenuProps
    * as it might affect scrolling performance.
    */
   computePositionOnMount?: boolean
+  /**
+   * If set, the initially focused item will be the item with the given index.
+   * Keyboard navigation will start out at this item. If not set, the first item
+   * will be focused.
+   */
+  initialFocusIndex?: number;
 }
 
 /**
@@ -142,6 +148,7 @@ export function useMenu(props: UseMenuProps = {}) {
     lazyBehavior = "unmount",
     direction,
     computePositionOnMount = false,
+    initialFocusIndex = -1,
     ...popperProps
   } = props
   /**
@@ -214,7 +221,7 @@ export function useMenu(props: UseMenuProps = {}) {
     direction,
   })
 
-  const [focusedIndex, setFocusedIndex] = React.useState(-1)
+  const [focusedIndex, setFocusedIndex] = React.useState(initialFocusIndex)
 
   /**
    * Focus the button when we close the menu

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -124,7 +124,7 @@ export interface UseMenuProps
    * Keyboard navigation will start out at this item. If not set, the first item
    * will be focused.
    */
-  initialFocusIndex?: number;
+  initialFocusIndex?: number
 }
 
 /**
@@ -148,7 +148,7 @@ export function useMenu(props: UseMenuProps = {}) {
     lazyBehavior = "unmount",
     direction,
     computePositionOnMount = false,
-    initialFocusIndex = -1,
+    initialFocusIndex,
     ...popperProps
   } = props
   /**
@@ -169,13 +169,13 @@ export function useMenu(props: UseMenuProps = {}) {
     })
   }, [])
 
-  const focusFirstItem = React.useCallback(() => {
+  const focusInitialItem = React.useCallback(() => {
     const id = setTimeout(() => {
-      const first = descendants.firstEnabled()
-      if (first) setFocusedIndex(first.index)
+      const itemIndex = initialFocusIndex ?? descendants.firstEnabled()?.index
+      if (itemIndex) setFocusedIndex(itemIndex)
     })
     timeoutIds.current.add(id)
-  }, [descendants])
+  }, [descendants, initialFocusIndex])
 
   const focusLastItem = React.useCallback(() => {
     const id = setTimeout(() => {
@@ -188,11 +188,11 @@ export function useMenu(props: UseMenuProps = {}) {
   const onOpenInternal = React.useCallback(() => {
     onOpenProp?.()
     if (autoSelect) {
-      focusFirstItem()
+      focusInitialItem()
     } else {
       focusMenu()
     }
-  }, [autoSelect, focusFirstItem, focusMenu, onOpenProp])
+  }, [autoSelect, focusInitialItem, focusMenu, onOpenProp])
 
   const { isOpen, onOpen, onClose, onToggle } = useDisclosure({
     isOpen: isOpenProp,
@@ -221,7 +221,7 @@ export function useMenu(props: UseMenuProps = {}) {
     direction,
   })
 
-  const [focusedIndex, setFocusedIndex] = React.useState(initialFocusIndex)
+  const [focusedIndex, setFocusedIndex] = React.useState(-1)
 
   /**
    * Focus the button when we close the menu
@@ -259,8 +259,8 @@ export function useMenu(props: UseMenuProps = {}) {
 
   const openAndFocusFirstItem = React.useCallback(() => {
     onOpen()
-    focusFirstItem()
-  }, [focusFirstItem, onOpen])
+    focusInitialItem()
+  }, [focusInitialItem, onOpen])
 
   const openAndFocusLastItem = React.useCallback(() => {
     onOpen()
@@ -305,6 +305,7 @@ export function useMenu(props: UseMenuProps = {}) {
     setFocusedIndex,
     isLazy,
     lazyBehavior,
+    initialFocusIndex,
   }
 }
 
@@ -566,6 +567,7 @@ export function useMenuItem(
     menuRef,
     isOpen,
     menuId,
+    initialFocusIndex,
   } = menu
 
   const ref = React.useRef<HTMLDivElement>(null)
@@ -603,7 +605,7 @@ export function useMenuItem(
       if (isDisabled) return
       setFocusedIndex(-1)
     },
-    [setFocusedIndex, isDisabled, onMouseLeaveProp],
+    [onMouseLeaveProp, isDisabled, setFocusedIndex],
   )
 
   const onClick = React.useCallback(

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -567,7 +567,6 @@ export function useMenuItem(
     menuRef,
     isOpen,
     menuId,
-    initialFocusIndex,
   } = menu
 
   const ref = React.useRef<HTMLDivElement>(null)

--- a/packages/menu/stories/menu.stories.tsx
+++ b/packages/menu/stories/menu.stories.tsx
@@ -128,6 +128,20 @@ export const WithDisabledButFocusableItem = () => (
   </Menu>
 )
 
+export const WithInitialFocus = () => (
+  <Menu initialFocusIndex={2}>
+    <MenuButton as={Button} variant="solid" colorScheme="green" size="sm">
+      Open menu
+    </MenuButton>
+    <MenuList>
+      <MenuItem>Menu 1</MenuItem>
+      <MenuItem>Menu 2</MenuItem>
+      <MenuItem>Menu 3 (initially focused)</MenuItem>
+      <MenuItem>Menu 4</MenuItem>
+    </MenuList>
+  </Menu>
+)
+
 export const WithTogglableMenuItems = () => {
   const [items, setItems] = React.useState<
     {

--- a/packages/menu/tests/menu.test.tsx
+++ b/packages/menu/tests/menu.test.tsx
@@ -463,3 +463,22 @@ test("MenuList direction flips in rtl", () => {
     "top-start",
   )
 })
+
+test("supports initial focus", async () => {
+  render(
+    <Menu initialFocusIndex={2}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        <MenuItem>Menu 0</MenuItem>
+        <MenuItem>Menu 1</MenuItem>
+        <MenuItem>Menu 2</MenuItem>
+        <MenuItem>Menu 3</MenuItem>
+      </MenuList>
+    </Menu>,
+  )
+
+  const openMenuButton = screen.getByRole("button")
+  const focusItem = screen.getByText("Menu 2")
+  fireEvent.click(openMenuButton)
+  await waitFor(() => expect(focusItem).toHaveAttribute("tabindex", "0"))
+})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5598

## 📝 Description

Adds the option to specify which menu item is focused initially when the menu is opened.

## ⛳️ Current behavior (updates)

Always focuses the first item when `autoSelect` is true.

## 🚀 New behavior

Behavior remains the same if `initialFocusIndex` is undefined, and focuses the item at index `initialFocusIndex` if provided and `autoSelect` is true.

## 💣 Is this a breaking change (Yes/No):

No. The new behavior is controlled by a new prop.

## 📝 Additional Information

-