### PR TITLE
feat(cli): include semantic tokens in generated theme typings

### DIFF
--- a/.changeset/lemon-jobs-impress.md
+++ b/.changeset/lemon-jobs-impress.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": minor
+---
+
+The CLI tokens command now includes semantic tokens in the generated
+ThemeTypings

--- a/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
+++ b/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
@@ -19,7 +19,7 @@ export interface ThemeKeyOptions {
    * @example
    * union: gray.500
    * level: 1---|2--|
-   * @default 1
+   * @default 3
    */
   maxScanDepth?: number
   /**
@@ -52,13 +52,24 @@ export async function createThemeTypingsInterface(
       { key, maxScanDepth, filter = () => true, flatMap = (value) => value },
     ) => {
       const target = theme[key]
+
+      allUnions[key] = []
+
       if (isObject(target) || Array.isArray(target)) {
         allUnions[key] = extractPropertyPaths(target, maxScanDepth)
           .filter(filter)
           .flatMap(flatMap)
-      } else {
-        allUnions[key] = []
       }
+
+      if (isObject(theme.semanticTokens)) {
+        // semantic tokens do not allow nesting, we just need to extract the keys
+        const semanticTokenKeys = extractPropertyKeys(theme.semanticTokens, key)
+          .filter(filter)
+          .flatMap(flatMap)
+
+        allUnions[key].push(...semanticTokenKeys)
+      }
+
       return allUnions
     },
     {} as Record<string, string[]>,

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -221,4 +221,72 @@ describe("Theme typings", () => {
       "
     `)
   })
+
+  it("should include semantic tokens", async () => {
+    const themeInterface = await createThemeTypingsInterface(
+      {
+        colors: {
+          gray: {
+            50: "lightgray",
+            900: "darkgray",
+          },
+          red: {
+            400: "lightred",
+            500: "red",
+          },
+        },
+        semanticTokens: {
+          colors: {
+            text: {
+              default: "gray.900",
+              _dark: "gray.50",
+            },
+            "feedback.error": {
+              default: "red.500",
+              _dark: "red.400",
+            },
+          },
+        },
+      },
+      {
+        config: themeKeyConfiguration,
+      },
+    )
+
+    expect(themeInterface).toMatchInlineSnapshot(`
+      "// regenerate by running
+      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+      export interface ThemeTypings {
+        blur: string & {}
+        borders: string & {}
+        borderStyles: string & {}
+        borderWidths: string & {}
+        breakpoints: string & {}
+        colors:
+          | \\"gray.50\\"
+          | \\"gray.900\\"
+          | \\"red.400\\"
+          | \\"red.500\\"
+          | \\"text\\"
+          | \\"feedback.error\\"
+          | (string & {})
+        colorSchemes: string & {}
+        fonts: string & {}
+        fontSizes: string & {}
+        fontWeights: string & {}
+        layerStyles: string & {}
+        letterSpacings: string & {}
+        lineHeights: string & {}
+        radii: string & {}
+        shadows: string & {}
+        sizes: string & {}
+        space: string & {}
+        textStyles: string & {}
+        transition: string & {}
+        zIndices: string & {}
+        components: {}
+      }
+      "
+    `)
+  })
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5585

## 📝 Description

The CLI tokens command now includes semantic tokens in the generated ThemeTypings

## ⛳️ Current behavior (updates)

ThemeTypings only included "normal" tokens.

## 🚀 New behavior

CLI scans `theme.semanticTokens` too.

## 💣 Is this a breaking change (Yes/No):

No
