### PR TITLE
fix(TabIndicator): avoid bg flash when long tab text 

### DIFF
--- a/.changeset/brave-emus-mate.md
+++ b/.changeset/brave-emus-mate.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tabs": patch
+---
+
+Include width in TabIndicator transition properties

--- a/.changeset/brave-emus-mate.md
+++ b/.changeset/brave-emus-mate.md
@@ -2,4 +2,4 @@
 "@chakra-ui/tabs": patch
 ---
 
-Include width in TabIndicator transition properties
+Add height & width to the TabIndicator transition properties

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -276,7 +276,7 @@ export interface UseTabProps
  */
 export function useTab<P extends UseTabProps>(props: P) {
   const { isDisabled, isFocusable, ...htmlProps } = props
-
+  // test
   const { setSelectedIndex, isManual, id, setFocusedIndex, selectedIndex } =
     useTabsContext()
 
@@ -444,7 +444,7 @@ export function useTabIndicator(): React.CSSProperties {
 
   return {
     position: "absolute",
-    transitionProperty: "left, right, top, bottom, width",
+    transitionProperty: "left, right, top, bottom, height, width",
     transitionDuration: hasMeasured ? "200ms" : "0ms",
     transitionTimingFunction: "cubic-bezier(0, 0, 0.2, 1)",
     ...rect,

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -276,7 +276,7 @@ export interface UseTabProps
  */
 export function useTab<P extends UseTabProps>(props: P) {
   const { isDisabled, isFocusable, ...htmlProps } = props
-  // test
+
   const { setSelectedIndex, isManual, id, setFocusedIndex, selectedIndex } =
     useTabsContext()
 

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -277,13 +277,8 @@ export interface UseTabProps
 export function useTab<P extends UseTabProps>(props: P) {
   const { isDisabled, isFocusable, ...htmlProps } = props
 
-  const {
-    setSelectedIndex,
-    isManual,
-    id,
-    setFocusedIndex,
-    selectedIndex,
-  } = useTabsContext()
+  const { setSelectedIndex, isManual, id, setFocusedIndex, selectedIndex } =
+    useTabsContext()
 
   const { index, register } = useTabsDescendant({
     disabled: isDisabled && !isFocusable,
@@ -449,7 +444,7 @@ export function useTabIndicator(): React.CSSProperties {
 
   return {
     position: "absolute",
-    transitionProperty: "left, right, top, bottom",
+    transitionProperty: "left, right, top, bottom, width",
     transitionDuration: hasMeasured ? "200ms" : "0ms",
     transitionTimingFunction: "cubic-bezier(0, 0, 0.2, 1)",
     ...rect,

--- a/packages/tabs/stories/tabs.stories.tsx
+++ b/packages/tabs/stories/tabs.stories.tsx
@@ -95,6 +95,26 @@ export const withIndicator = () => (
   </Tabs>
 )
 
+export const withIndicatorAndLongTabText = () => (
+  <>
+    <Tabs variant="unstyled" isManual>
+      <TabList>
+        <Tab>Tab with long text</Tab>
+        <Tab>Billings</Tab>
+        <Tab>Preferences</Tab>
+        <Tab>Shut Down</Tab>
+      </TabList>
+      <TabIndicator mt="-36px" zIndex={-1} height="34px" bg="green.200" />
+      <TabPanels>
+        <TabPanel>Tab with long text</TabPanel>
+        <TabPanel>Billings</TabPanel>
+        <TabPanel>Preferences</TabPanel>
+        <TabPanel>Shut Down</TabPanel>
+      </TabPanels>
+    </Tabs>
+  </>
+)
+
 export const withVerticalTabs = () => (
   <Tabs orientation="vertical">
     <TabList>


### PR DESCRIPTION
Closes (https://github.com/chakra-ui/chakra-ui/issues/5664)

## 📝 Description

Add "width" to the list of transitionProperties of the TabIndicator to prevent the background from overlapping adjacent tabs. This issue occurs when one tab's width is larger than the other tabs.

## ⛳️ Current behavior (updates)

The transition behavior when the selected tab changes.

## 🚀 New behavior

Including "width" as a transition property of the TabIndicator prevents any overlapping when the selected tab changes (assuming the tabs differ in width so the issue shows itself)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Example of the issue:
https://codesandbox.io/s/pedantic-dawn-ds3hfu?file=/src/index.tsx

I did not include a test since the nature of the issue is more visual/timing related -- it seemed hard to create a test to capture that.