### PR TITLE
fix: buttons zIndex in linkbox with usage of link overlay

### DIFF
--- a/.changeset/happy-ads-confess.md
+++ b/.changeset/happy-ads-confess.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+Fix buttons zIndex within LinkBox and usage of LinkOverlay

--- a/packages/layout/src/link-box.tsx
+++ b/packages/layout/src/link-box.tsx
@@ -54,8 +54,8 @@ export const LinkBox = forwardRef<LinkBoxProps, "div">((props, ref) => {
       {...rest}
       className={cx("chakra-linkbox", className)}
       __css={{
-        /* Elevate the links and abbreviations up */
-        "a[href]:not(.chakra-linkbox__overlay), abbr[title]": {
+        /* Elevate the links, abbreviations and buttons up */
+        "a[href]:not(.chakra-linkbox__overlay), abbr[title], button": {
           position: "relative",
           zIndex: 1,
         },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5673 

## 📝 Description

This fixes a problem that buttons are no longer clickable within a `LinkBox` with a `LinkOverlay`  because of the zIndex. This is a result of the changes of https://github.com/chakra-ui/chakra-ui/pull/5632.

## ⛳️ Current behavior (updates)

Buttons are not clickable if they are within a `LinkBox` with a `LinkOverlay`, see e.g. the CSB from the issue: https://codesandbox.io/s/bold-leaf-rhjbxj?file=/src/index.tsx

## 🚀 New behavior

Buttons are clickable again, this should represent the fix: https://codesandbox.io/s/stoic-glitter-9em593

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

It worked also with `zIndex: 1` on Firefox 97.0 and Chromium 99.0.4844.51 but it feels wrong so that I set it to 2 to avoid unexpected behavior on other browsers/versions.