### PR TITLE
feat(image): add imageFallbackStrategies

### DIFF
--- a/.changeset/chatty-hornets-shake.md
+++ b/.changeset/chatty-hornets-shake.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/image": patch
+---
+
+Added `fallbackStrategies` for `Image` to provide different behaviors when to
+display/load the `fallback`
+
+- `beforeLoadOrError` is the default strategy and previous behaviour of `Image`
+  which displays/loads the placeholder when `loading` the `src`/`srcSet` and on
+  `error`
+- `onError` strategy displays/loads the fallback image only on `error`

--- a/packages/image/src/use-image.ts
+++ b/packages/image/src/use-image.ts
@@ -44,6 +44,8 @@ export interface UseImageProps {
 
 type Status = "loading" | "failed" | "pending" | "loaded"
 
+export type FallbackStrategy = "onError" | "beforeLoadOrError"
+
 type ImageEvent = React.SyntheticEvent<HTMLImageElement, Event>
 
 /**
@@ -137,5 +139,12 @@ export function useImage(props: UseImageProps) {
    */
   return ignoreFallback ? "loaded" : status
 }
+
+export const shouldShowFallbackImage = (
+  status: Status,
+  fallbackStrategy: FallbackStrategy,
+) =>
+  (status !== "loaded" && fallbackStrategy === "beforeLoadOrError") ||
+  (status === "failed" && fallbackStrategy === "onError")
 
 export type UseImageReturn = ReturnType<typeof useImage>

--- a/packages/image/stories/image.stories.tsx
+++ b/packages/image/stories/image.stories.tsx
@@ -117,3 +117,24 @@ export const WithSrcSet = () => {
     </>
   )
 }
+
+export const FallbackStrategies = () => {
+  return (
+    <>
+      <Image
+        src="https://via.placeholder.com/240"
+        w={240}
+        h={240}
+        fallbackStrategy="onError"
+        fallbackSrc="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+      />
+      <Image
+        w={240}
+        h={240}
+        src="https://via.placeholder.com/240"
+        fallbackStrategy="beforeLoadOrError"
+        fallbackSrc="https://bit.ly/dan-abramov"
+      />
+    </>
+  )
+}

--- a/packages/image/tests/use-image.test.tsx
+++ b/packages/image/tests/use-image.test.tsx
@@ -1,0 +1,20 @@
+import { FallbackStrategy, shouldShowFallbackImage } from "../src"
+
+type Status = "loading" | "failed" | "pending" | "loaded"
+describe("shouldShowFallbackImage", () => {
+  it.each<{ status: Status; strategy: FallbackStrategy; result: boolean }>([
+    { status: "loading", strategy: "beforeLoadOrError", result: true },
+    { status: "loaded", strategy: "beforeLoadOrError", result: false },
+    { status: "failed", strategy: "beforeLoadOrError", result: true },
+    { status: "pending", strategy: "beforeLoadOrError", result: true },
+    { status: "loading", strategy: "onError", result: false },
+    { status: "loaded", strategy: "onError", result: false },
+    { status: "failed", strategy: "onError", result: true },
+    { status: "pending", strategy: "onError", result: false },
+  ])(
+    "shouldShowFallbackImage with status: $status strategy:$strategy returns $result",
+    ({ status, result, strategy }) => {
+      expect(shouldShowFallbackImage(status, strategy)).toBe(result)
+    },
+  )
+})


### PR DESCRIPTION
Closes #5581 #5288

## 📝 Description

added fallback strategies to the image component

Currently unsure in a few points how to write a useful test for this since I'm not sure how to verify resource loads in jest

Also, not sure how to handle this specific case:

`fallbackStrategy==="onError" && Boolean(fallbackSrc) && status==="loading"`

In this case, I currently render `null` as `fallbackImage` which could lead to unexpected behaviour in the layout.

**The main problem is:** when `fallbackStrategy==='onError'` I want to load the `fallbackSrc` only if `status==='error'` therefor we don't have a resource to display when `status==='loading'`  



Possible Alternatives:
- render an `img` without the `src`-Attribute, but this doesn't comply to html5 standards since `src` is a required attribute`
- remove unnecessary `img` attributes and render a `Box` as a placeholder with the same props as the image component to just take the same space.

This showcases the current behavior: https://codesandbox.io/s/create-react-app-ts-forked-9zv672?file=/src/App.tsx to see the `loading`-case set throttling to `fast 3G`

What do you think @TimKolberger?

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

 