### PR TITLE
fix(number-input): add theme typings for NumberInputField

### DIFF
--- a/.changeset/thick-cherries-fail.md
+++ b/.changeset/thick-cherries-fail.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/number-input": patch
+---
+
+Add ThemeTypings for NumberInputField

--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -24,14 +24,12 @@ interface NumberInputContext extends Omit<UseNumberInputReturn, "htmlProps"> {}
 /**
  * React context used to communicate between components
  */
-const [
-  NumberInputProvider,
-  useNumberInputContext,
-] = createContext<NumberInputContext>({
-  name: "NumberInputContext",
-  errorMessage:
-    "useNumberInputContext: `context` is undefined. Seems you forgot to wrap number-input's components within <NumberInput />",
-})
+const [NumberInputProvider, useNumberInputContext] =
+  createContext<NumberInputContext>({
+    name: "NumberInputContext",
+    errorMessage:
+      "useNumberInputContext: `context` is undefined. Seems you forgot to wrap number-input's components within <NumberInput />",
+  })
 
 interface InputOptions {
   /**
@@ -143,7 +141,9 @@ if (__DEV__) {
   NumberInputStepper.displayName = "NumberInputStepper"
 }
 
-export interface NumberInputFieldProps extends HTMLChakraProps<"input"> {}
+export interface NumberInputFieldProps
+  extends Omit<HTMLChakraProps<"input">, "size">,
+    ThemingProps<"NumberInput"> {}
 
 /**
  * NumberInputField


### PR DESCRIPTION
Closes #5682

## 📝 Description

Added typings to support theming-props for `NumberInputField`

## 💣 Is this a breaking change (Yes/No):

No
