### PR TITLE
feat(modal): introduce useImperativeModal

### DIFF
--- a/.changeset/beige-bikes-wait.md
+++ b/.changeset/beige-bikes-wait.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Add a possibility to open a modal imperatively inside a function with
+`useImperativeModal`

--- a/packages/modal/src/use-modal.ts
+++ b/packages/modal/src/use-modal.ts
@@ -2,7 +2,7 @@ import { useIds } from "@chakra-ui/hooks"
 import { callAllHandlers } from "@chakra-ui/utils"
 import { mergeRefs, PropGetter } from "@chakra-ui/react-utils"
 import { hideOthers } from "aria-hidden"
-import {
+import React, {
   KeyboardEvent,
   MouseEvent,
   RefObject,
@@ -213,4 +213,42 @@ export function useAriaHidden(
 
     return hideOthers(ref.current)
   }, [shouldHide, ref, currentElement])
+}
+
+/**
+ * A function that takes a result of a variable type and returns nothing.
+ * This will close our modal and return to the caller of `openModal`.
+ */
+type CloseModal<ResultType> = (result: ResultType) => void
+
+/**
+ * A function that builds the UI for a modal dialog.
+ * It takes the close function as a parameter and returns a `ReactNode`
+ * that we can display.
+ */
+type ModalFactory<ResultType> = (actions: {
+  onClose: CloseModal<ResultType>
+}) => React.ReactNode
+
+export function useImperativeModal() {
+  // The React node has to be stored somewhere
+  const [modalNode, setModalNode] = useState<React.ReactNode>(null)
+
+  function openModal<ModalResult>(modalFactory: ModalFactory<ModalResult>) {
+    return new Promise<ModalResult>((resolve) => {
+      function onClose(value: ModalResult) {
+        resolve(value)
+
+        // When the modal should be closed, we set our state to null
+        // to stop rendering a dialog
+        setModalNode(null)
+      }
+
+      // To open the dialog, we store the resulting jsx in our state
+      setModalNode(modalFactory({ onClose }))
+    })
+  }
+
+  // We return the modalNode (or null) and the openModal function
+  return [modalNode, openModal] as const
 }

--- a/packages/modal/stories/modal.stories.tsx
+++ b/packages/modal/stories/modal.stories.tsx
@@ -10,6 +10,8 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  ModalProps,
+  useImperativeModal,
 } from "../src"
 
 const Button = chakra("button", {
@@ -193,6 +195,58 @@ export const FullWithLongContent = () => {
           </ModalFooter>
         </ModalContent>
       </Modal>
+    </>
+  )
+}
+
+export const ImperativeModal = () => {
+  const ExampleModal: React.FC<
+    Omit<ModalProps, "children"> & {
+      onCancel: () => void
+      onConfirm: () => void
+    }
+  > = (props) => {
+    return (
+      <Modal {...props}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal Title</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>Just an example Body</ModalBody>
+
+          <ModalFooter>
+            <Button mr={3} onClick={props.onConfirm}>
+              Confirm
+            </Button>
+            <Button onClick={props.onCancel}>Cancel</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    )
+  }
+
+  const [modalNode, openModal] = useImperativeModal()
+
+  const onClick = async () => {
+    // render a modal inside a function and get the result back from it
+    const modalResult = await openModal<boolean>(({ onClose }) => (
+      <ExampleModal
+        isOpen
+        onClose={() => onClose(false)}
+        onCancel={() => onClose(false)}
+        onConfirm={() => onClose(true)}
+      />
+    ))
+    if (modalResult) {
+      alert("user confirmed alert")
+    } else {
+      alert("user canceled alert")
+    }
+  }
+  return (
+    <>
+      {modalNode}
+      <Button onClick={onClick}>Click me to open a modal imperatively</Button>
     </>
   )
 }

--- a/packages/modal/tests/use-modal.test.tsx
+++ b/packages/modal/tests/use-modal.test.tsx
@@ -1,7 +1,24 @@
 import { renderHook } from "@testing-library/react-hooks"
 import { hideOthers } from "aria-hidden"
 import { MutableRefObject } from "react"
-import { useAriaHidden } from "../src"
+import { Button } from "@chakra-ui/button"
+import * as React from "react"
+import {
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalProps,
+  useAriaHidden,
+  useImperativeModal,
+} from "../src"
+import { forwardRef } from "@chakra-ui/system"
+import { render, screen } from "@testing-library/react"
+import { waitFor } from "@chakra-ui/test-utils"
+import userEvent from "@testing-library/user-event"
 
 jest.mock("aria-hidden")
 
@@ -32,5 +49,83 @@ describe("useAriaHidden", () => {
 
     renderHook(() => useAriaHidden(ref, false))
     expect(hideOthers).not.toBeCalled()
+  })
+})
+
+describe("useImperativeModal", () => {
+  const ExampleModal: React.FC<
+    Omit<ModalProps, "children"> & {
+      onCancel: () => void
+      onConfirm: () => void
+    }
+  > = (props) => {
+    return (
+      <Modal {...props}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal Title</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>Just an example Body</ModalBody>
+
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3} onClick={props.onConfirm}>
+              Confirm
+            </Button>
+            <Button variant="ghost" onClick={props.onCancel}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    )
+  }
+  const TestComponent: React.FC<{
+    clickedConfirm: () => void
+    clickedCancelOrClose: () => void
+  }> = ({ clickedConfirm, clickedCancelOrClose }) => {
+    const [modalNode, openModal] = useImperativeModal()
+
+    const onClick = async () => {
+      // render a modal inside a function and get the result back from it
+      const modalResult = await openModal<boolean>(({ onClose }) => (
+        <ExampleModal
+          isOpen
+          onClose={() => onClose(false)}
+          onCancel={() => onClose(false)}
+          onConfirm={() => onClose(true)}
+        />
+      ))
+      if (modalResult) {
+        clickedConfirm()
+      } else {
+        clickedCancelOrClose()
+      }
+    }
+    return (
+      <>
+        {modalNode}
+        <Button onClick={onClick}>Do some action</Button>
+      </>
+    )
+  }
+  it("renders modal imperatively", async () => {
+    const clickedConfirmMock = jest.fn()
+    const clickedCancelOrCloseMock = jest.fn()
+    render(
+      <TestComponent
+        clickedConfirm={clickedConfirmMock}
+        clickedCancelOrClose={clickedCancelOrCloseMock}
+      />,
+    )
+    userEvent.click(screen.getByText("Do some action"))
+    await waitFor(() => {
+      expect(screen.getByText("Modal Title")).toBeInTheDocument()
+    })
+    userEvent.click(screen.getByText("Confirm"))
+    await waitFor(() => {
+      expect(clickedConfirmMock).toHaveBeenCalled()
+    })
+    // Modal should be closed after wards
+    expect(screen.queryByText("Modal Title")).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 📝 Description

Added `useImperativeModal` to display a Modal and await its result inside a function call.

this makes the following possible:

```tsx
const Component: React.FC = ()=>{
  const [modalNode, openModal] = useImperativeModal()

  const onClick = async () => {
    // render a modal inside a function and get the result back from it
    const modalResult = await openModal<boolean>(({ onClose }) => (
      <ExampleModal
        isOpen
        onClose={() => onClose(false)}
        onCancel={() => onClose(false)}
        onConfirm={() => onClose(true)}
      />
    ))
    if (modalResult) {
      alert("user confirmed alert")
    } else {
      alert("user canceled alert")
    }
  }
  return (
    <>
      {modalNode}
      <Button onClick={onClick}>Click me to open a modal imperatively</Button>
    </>
  )
}
```


take a look at this CSB to checkout the feature: https://codesandbox.io/s/useimperativemodal-oxgwym?file=/src/App.tsx