### PR TITLE
fix(toast): #5692 provide default options when passing options to useToast

### DIFF
--- a/.changeset/nasty-lobsters-hope.md
+++ b/.changeset/nasty-lobsters-hope.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+use default options as well when providing options to useToast

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -217,7 +217,7 @@ export function useToast(options?: UseToastOptions) {
       colorMode,
       setColorMode,
       toggleColorMode,
-      defaultOptions: toastOptions.current,
+      defaultOptions: { ...defaults, ...toastOptions.current },
     })
   }, [theme, setColorMode, toggleColorMode, colorMode, toastOptions])
 }


### PR DESCRIPTION
Closes #5692

## 📝 Description

> Add a brief description

spreading `defaultOptions`  aswell as `option` to `createStandaloneToast` when passing `options` to `useToast` 

## 💣 Is this a breaking change (Yes/No):

No
