### PR TITLE
fix: Added type number for text underline offset

### DIFF
--- a/.changeset/modern-snails-remember.md
+++ b/.changeset/modern-snails-remember.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+added type number for text underline offset of text decoration props of styled-system

--- a/packages/styled-system/src/config/text-decoration.ts
+++ b/packages/styled-system/src/config/text-decoration.ts
@@ -41,7 +41,7 @@ export interface TextDecorationProps {
   /**
    * The CSS `text-underline-offset` property
    */
-  textUnderlineOffset?: ResponsiveValue<CSS.Property.TextUnderlineOffset>
+  textUnderlineOffset?: ResponsiveValue<CSS.Property.TextUnderlineOffset | number>
   /**
    * The `text-shadow` property
    */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5592 

## 📝 Description
added the type number for textUnderlineOffset property of TextDecorationProps.
When using the Heading component and passing property textUnderlineOffset with a numerical value. typescript doesn't allow you to use a numerical value to it and shows error.

## ⛳️ Current behavior (updates)
When using the Heading component and passing property textUnderlineOffset with a numerical value. Typescript doesn't allow you to use a numerical value to it.
it throws error : `Type error: Type '6' is not assignable to type 'ResponsiveValue<TextUnderlineOffset<0 | (string & {})>>'`.

## 🚀 Please describe the behavior or changes this PR adds  
with these changes, it is possible to pass numerical values to the textUnderlineOffset property for the Heading component, it won't throw any typescript error 
## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
