### PR TITLE
refactor: add type for `use-radio` returned state

### DIFF
--- a/.changeset/tall-candles-deny.md
+++ b/.changeset/tall-candles-deny.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Add type for state returned by use-radio hook

--- a/packages/radio/src/use-radio.ts
+++ b/packages/radio/src/use-radio.ts
@@ -76,6 +76,17 @@ export interface UseRadioProps {
   "aria-describedby"?: string
 }
 
+export interface RadioState {
+  isInvalid: boolean | undefined
+  isFocused: boolean
+  isChecked: boolean
+  isActive: boolean
+  isHovered: boolean
+  isDisabled: boolean | undefined
+  isReadOnly: boolean | undefined
+  isRequired: boolean | undefined
+}
+
 export function useRadio(props: UseRadioProps = {}) {
   const {
     defaultIsChecked,
@@ -163,7 +174,7 @@ export function useRadio(props: UseRadioProps = {}) {
     [setActive],
   )
 
-  const getCheckboxProps: PropGetter = useCallback(
+  const getRadioProps: PropGetter = useCallback(
     (props = {}, ref = null) => ({
       ...props,
       ref,
@@ -263,18 +274,21 @@ export function useRadio(props: UseRadioProps = {}) {
     "data-invalid": dataAttr(isInvalid),
   })
 
+  const state: RadioState = {
+    isInvalid,
+    isFocused,
+    isChecked,
+    isActive,
+    isHovered,
+    isDisabled,
+    isReadOnly,
+    isRequired,
+  }
+
   return {
-    state: {
-      isInvalid,
-      isFocused,
-      isChecked,
-      isActive,
-      isHovered,
-      isDisabled,
-      isReadOnly,
-      isRequired,
-    },
-    getCheckboxProps,
+    state,
+    // the function is renamed to getRadioProps to make the code more consistent. It is renamed towards outside because otherwise this would produce a breaking change
+    getCheckboxProps: getRadioProps,
     getInputProps,
     getLabelProps,
     getRootProps,
@@ -283,7 +297,7 @@ export function useRadio(props: UseRadioProps = {}) {
 }
 
 /**
- * Prevent `onBlur` being fired when the checkbox label is touched
+ * Prevent `onBlur` being fired when the radio label is touched
  */
 function stop(event: SyntheticEvent) {
   event.preventDefault()


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

No Issue

## 📝 Description

This PR adds a type for the state returned by the `use-radio` hook. The purpose of this is to improve documentation and readability. Also in this Pr 

## ⛳️ Current behavior (updates)

This was the returned type:
![image](https://user-images.githubusercontent.com/21695702/157515481-6841ee0c-f548-4627-980d-0f5fb3477d59.png)


## 🚀 New behavior

The new type:
![image](https://user-images.githubusercontent.com/21695702/157515538-d465ac37-1a3c-4f75-8405-1ab23f061c64.png)
![image](https://user-images.githubusercontent.com/21695702/157515573-90b337e8-3d08-48dd-af94-f3de9415a114.png)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->No
## 📝 Additional Information
-