### PR TITLE
docs(use-dimensions): add props interface with descriptions to the `useDimensions` hook

### DIFF
--- a/.changeset/stale-tips-film.md
+++ b/.changeset/stale-tips-film.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+Added prop types interface with descriptions to the useDimensions hook

--- a/packages/hooks/src/use-dimensions.ts
+++ b/packages/hooks/src/use-dimensions.ts
@@ -20,9 +20,10 @@ export interface UseDimensionsProps {
  * @param ref ref of the component to measure
  * @param observe if `true`, resize and scroll observers will be turned on
  */
-export function useDimensions(props: UseDimensionsProps) {
-  const { ref, observe } = props
-
+export function useDimensions(
+  ref: UseDimensionsProps["ref"],
+  observe?: UseDimensionsProps["observe"],
+) {
   const [dimensions, setDimensions] = React.useState<BoxModel | null>(null)
   const rafId = React.useRef<number>()
 

--- a/packages/hooks/src/use-dimensions.ts
+++ b/packages/hooks/src/use-dimensions.ts
@@ -2,16 +2,27 @@ import * as React from "react"
 import { getBox, BoxModel } from "@chakra-ui/utils"
 import { useSafeLayoutEffect } from "./use-safe-layout-effect"
 
+export interface UseDimensionsProps {
+  /**
+   * Ref of the element/component to measure.
+   */
+  ref: React.RefObject<HTMLElement>
+  /**
+   * If true, "resize" and "scroll" observers will be turned on.
+   * Attaches events to the `window` object that update dimensions.
+   */
+  observe?: boolean
+}
+
 /**
- * Reack hook to measure a component's dimensions
+ * React hook to measure a component's dimensions
  *
  * @param ref ref of the component to measure
  * @param observe if `true`, resize and scroll observers will be turned on
  */
-export function useDimensions(
-  ref: React.RefObject<HTMLElement>,
-  observe?: boolean,
-) {
+export function useDimensions(props: UseDimensionsProps) {
+  const { ref, observe } = props
+
   const [dimensions, setDimensions] = React.useState<BoxModel | null>(null)
   const rafId = React.useRef<number>()
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add a props interface with descriptions to be able to render `PropsTable` when including a documentation page of `useDimensions` to the Chakra website.

## ⛳️ Current behavior (updates)

No interface with description for the props and the props are inline-typed

## 🚀 New behavior

Move the inline-typing of the props into an interface, and provide JSDoc for each prop.

## 💣 Is this a breaking change (Yes/No):

No
