### PR TITLE
feat: add configurable parameters to the ColorModeSwitch of the storybook-addon package

### DIFF
--- a/.changeset/wicked-deers-hug.md
+++ b/.changeset/wicked-deers-hug.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/storybook-addon": minor
+---
+
+Add enable, position, zIndex and margin as parameters to modify the Color Mode
+Switch properties

--- a/tooling/storybook-addon/README.md
+++ b/tooling/storybook-addon/README.md
@@ -19,6 +19,8 @@ yarn add -D @chakra-ui/storybook-addon
 npm i -D @chakra-ui/storybook-addon
 ```
 
+## Usage
+
 Add the addon to your configuration in `.storybook/main.js`:
 
 ```js
@@ -27,7 +29,7 @@ module.exports = {
 }
 ```
 
-## Configuring `ChakraProvider`
+### Configuring `ChakraProvider`
 
 If you need to customize the props passed to `ChakraProvider` for your stories
 (to use a custom `theme`, for example), you'll need to create custom Storybook
@@ -50,7 +52,45 @@ The `chakra` parameters take the same shape as the `props` for `ChakraProvider`.
 [See the `ChakraProvider` props table][chakraprovider] to see the list of
 possible parameters.
 
-### Overriding `ChakraProvider` configuration for individual components or stories
+## Color Mode Switch
+
+You will be able to toggle your color mode with the button in the top right
+corner as you can see below:
+
+![dark-mode](https://user-images.githubusercontent.com/87735757/142751123-77a39f2f-9277-4b11-b030-8a879d4b909b.gif)
+
+## Configuring Color Mode Switch
+
+If you need to remove or change the switch's behavior you can pass the following
+values:
+
+### Example Usage
+
+```js
+//.storybook/preview.js
+export const parameters = {
+  chakra: {
+    ...
+    colorModeSwitch: { //default values
+      enable: true,
+      position: 'top-right',
+      margin: '1rem',
+      zIndex: 9999
+    }
+  }
+}
+```
+
+All the parameters are **optional**.
+
+| Parameter | Type             | Default       | Allowed values                                           | Description                                                                                                                                            |
+| --------- | ---------------- | ------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| enable    | boolean          | `true`        | `true\|false`                                            | Show or hide                                                                                                                                           |
+| position  | string           | `'top-right'` | `'top-left'\|'top-right'\|'bottom-left'\|'bottom-right'` | Change the position to a different corner                                                                                                              |
+| zIndex    | number \| string | `9999`        | any valid value to Chakra `zIndex` Style System          | This property goes directly to the `zIndex` of the [Style Props](https://chakra-ui.com/docs/styled-system/features/style-props#position)               |
+| margin    | number \| string | `1rem`        | any valid value to Chakra `position` Style System        | This property goes directly to `top\|right\|bottom\|left` of the [Style Props](https://chakra-ui.com/docs/styled-system/features/style-props#position) |
+
+### Overriding [`ChakraProvider`][chakraprovider] and Color Mode Switch configuration for individual components or stories
 
 Storybook allows you to define parameters at multiple levels: global, component,
 and story. We recommend setting default parameters at the global level, and
@@ -59,11 +99,4 @@ overriding them at the component or story when necessary. See the
 for more information.
 
 [chakraprovider]:
-  https://chakra-ui.com/docs/getting-started#chakraprovider-props
-
-## Color Mode Switch
-
-You will be able to toggle your color mode with the button in the top right
-corner as you can see below:
-
-![dark-mode](https://user-images.githubusercontent.com/87735757/142751123-77a39f2f-9277-4b11-b030-8a879d4b909b.gif)
+  https://chakra-ui.com/guides/getting-started/cra-guide#chakraprovider-props

--- a/tooling/storybook-addon/src/components/ChakraProviderWrapper.tsx
+++ b/tooling/storybook-addon/src/components/ChakraProviderWrapper.tsx
@@ -2,15 +2,72 @@ import * as React from "react"
 import { StoryContext, StoryFn } from "@storybook/addons"
 import { ChakraProvider } from "@chakra-ui/react"
 import { ColorModeSwitch } from "./ColorModeSwitch"
+import { ChakraOptions } from "../interfaces"
+import { positionAllowedValues } from "../constants"
 
 export const ChakraProviderWrapper = (
   Story: StoryFn<JSX.Element>,
   context: StoryContext,
 ) => {
   const { chakra } = context.parameters
+
+  const { theme, colorModeSwitch } = (chakra as ChakraOptions) ?? {}
+
+  const { enable, position, zIndex, margin } = colorModeSwitch ?? {}
+
+  let args = {}
+  let enableOpt: boolean
+  let zIndexOpt: any
+  const warnMessages = []
+
+  const positionOpt = positionAllowedValues[position]
+  const [yAxis, xAxis] = positionOpt ?? []
+
+  const marginOpt = margin ?? "1rem"
+
+  if (positionOpt) {
+    args = {
+      [yAxis]: marginOpt,
+      [xAxis]: marginOpt,
+    }
+  } else {
+    //default
+    warnMessages.push(
+      "[position] Invalid position parameter, using default values",
+    )
+    args = {
+      top: marginOpt,
+      right: marginOpt,
+    }
+  }
+
+  if (typeof enable === "undefined") {
+    warnMessages.push(
+      "[enable] Enable parameter not found, using default values",
+    )
+    enableOpt = true
+  } else {
+    enableOpt = enable
+  }
+
+  if (typeof zIndex === "undefined") {
+    warnMessages.push(
+      "[zIndex] zIndex parameter not found, using default values",
+    )
+    zIndexOpt = 9999
+  } else {
+    zIndexOpt = zIndex
+  }
+
+  if (warnMessages.length > 0) {
+    warnMessages.forEach((msg) =>
+      console.warn(`[@chakra-ui/storybook-addon] ${msg}`),
+    )
+  }
+
   return (
-    <ChakraProvider {...chakra}>
-      <ColorModeSwitch />
+    <ChakraProvider theme={theme}>
+      {enableOpt ? <ColorModeSwitch zIndex={zIndexOpt} {...args} /> : ""}
       <Story {...context} />
     </ChakraProvider>
   )

--- a/tooling/storybook-addon/src/components/ColorModeSwitch.tsx
+++ b/tooling/storybook-addon/src/components/ColorModeSwitch.tsx
@@ -16,8 +16,6 @@ export const ColorModeSwitch = (props: Partial<IconButtonProps>) => {
     <IconButton
       size="md"
       position="absolute"
-      top="1rem"
-      right="1rem"
       fontSize="lg"
       aria-label={`Switch to ${nextMode} mode`}
       variant="ghost"

--- a/tooling/storybook-addon/src/constants.ts
+++ b/tooling/storybook-addon/src/constants.ts
@@ -1,1 +1,18 @@
 export const ADDON_ID = "@chakra-ui/storybook-addon"
+
+export const topLeft = "top-left"
+export const topRight = "top-right"
+export const bottomLeft = "bottom-left"
+export const bottomRight = "bottom-right"
+
+export const top = "top"
+export const bottom = "bottom"
+export const left = "left"
+export const right = "right"
+
+export const positionAllowedValues = {
+  [topLeft]: [top, left],
+  [topRight]: [top, right],
+  [bottomLeft]: [bottom, left],
+  [bottomRight]: [bottom, right],
+}

--- a/tooling/storybook-addon/src/interfaces.ts
+++ b/tooling/storybook-addon/src/interfaces.ts
@@ -1,0 +1,13 @@
+import { ChakraTheme } from "@chakra-ui/react"
+
+export interface ChakraOptions {
+  theme: ChakraTheme
+  colorModeSwitch: ColorModeSwitchOptions
+}
+
+export interface ColorModeSwitchOptions {
+  enable: boolean
+  position: "top-left" | "top-right" | "bottom-left" | "bottom-right"
+  zIndex: number
+  margin: number
+}


### PR DESCRIPTION
Closes #5544 #5380 

## 📝 Description

This PR enhances the configuration of the [Storybook Addon](https://storybook.js.org/docs/react/addons/writing-addons/) for Chakra-UI. This will allow users to configure the Color Mode Switch with following parameters:

| Parameter | Type             | Default       | Allowed values                                           | Description                                                                                                                                            |
| --------- | ---------------- | ------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
| enable    | boolean          | `true`        | `true\|false`                                            | Show or hide                                                                                                                                           |
| position  | string           | `'top-right'` | `'top-left'\|'top-right'\|'bottom-left'\|'bottom-right'` | Change the position to a different corner                                                                                                              |
| zIndex    | number \| string | `9999`        | any valid value to Chakra `zIndex` Style System          | This property goes directly to the `zIndex` of the [Style Props](https://chakra-ui.com/docs/styled-system/features/style-props#position)               |
| margin    | number \| string | `1rem`        | any valid value to Chakra `position` Style System        | This property goes directly to `top\|right\|bottom\|left` of the [Style Props](https://chakra-ui.com/docs/styled-system/features/style-props#position) |

All the parameters are **optional**.

### Example Usage
```js
//.storybook/preview.js
export const parameters = {
  chakra: {
    ...
    colorModeSwitch: { //default values
      enable: true,
      position: 'top-right',
      margin: '1rem',
      zIndex: 9999
    }
  }
}
```


## ⛳️ Current behavior (updates)

The Color Mode Switch can't be modified

## 🚀 New behavior

This PR will include:
- New parameters to configure the Color Mode Switch and their properties
- Docs explaining the new parameters, example usage and allowed values

## 💣 Is this a breaking change (Yes/No):
No
