### PR TITLE
fix: remove no referrer

### DIFF
--- a/.changeset/loud-crews-help.md
+++ b/.changeset/loud-crews-help.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+Remove `noreferrer` attribute from link component

--- a/packages/layout/src/link.tsx
+++ b/packages/layout/src/link.tsx
@@ -37,7 +37,7 @@ export const Link = forwardRef<LinkProps, "a">((props, ref) => {
   return (
     <chakra.a
       target={isExternal ? "_blank" : undefined}
-      rel={isExternal ? "noopener noreferrer" : undefined}
+      rel={isExternal ? "noopener" : undefined}
       ref={ref}
       className={cx("chakra-link", className)}
       {...rest}


### PR DESCRIPTION
Closes #4243

## 📝 Description

Remove `noreferrer` attribute from `<Link isExternal />` as described in the linked issue