### PR TITLE
fix: memoize switch object in useBoolean

### DIFF
--- a/.changeset/spicy-dolphins-tickle.md
+++ b/.changeset/spicy-dolphins-tickle.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+Improve stability of `useBoolean` hook to ensure setter object reference stays
+the same

--- a/packages/hooks/src/use-boolean.ts
+++ b/packages/hooks/src/use-boolean.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
 type InitialState = boolean | (() => boolean)
 
@@ -9,11 +9,13 @@ type InitialState = boolean | (() => boolean)
  */
 export function useBoolean(initialState: InitialState = false) {
   const [value, setValue] = useState(initialState)
-  const [switches] = useState(() => ({
-    on: () => setValue(true),
-    off: () => setValue(false),
-    toggle: () => setValue(prev => !prev),
-  }))
-
-  return [value, switches] as const
+  const callbacks = useMemo(
+    () => ({
+      on: () => setValue(true),
+      off: () => setValue(false),
+      toggle: () => setValue((prev) => !prev),
+    }),
+    [],
+  )
+  return [value, callbacks] as const
 }

--- a/packages/hooks/src/use-boolean.ts
+++ b/packages/hooks/src/use-boolean.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useState } from "react"
 
 type InitialState = boolean | (() => boolean)
 
@@ -9,18 +9,11 @@ type InitialState = boolean | (() => boolean)
  */
 export function useBoolean(initialState: InitialState = false) {
   const [value, setValue] = useState(initialState)
+  const [switches] = useState(() => ({
+    on: () => setValue(true),
+    off: () => setValue(false),
+    toggle: () => setValue(prev => !prev),
+  }))
 
-  const on = useCallback(() => {
-    setValue(true)
-  }, [])
-
-  const off = useCallback(() => {
-    setValue(false)
-  }, [])
-
-  const toggle = useCallback(() => {
-    setValue((prev) => !prev)
-  }, [])
-
-  return [value, { on, off, toggle }] as const
+  return [value, switches] as const
 }


### PR DESCRIPTION
This allows us to use it in hook deps:

```js
const [flag, setFlag] = useBoolean();

useEffect(() => {}, [setFlag]);
```