### PR TITLE
fix(ButtonGroup): collapse borders with isAttached enabled

### DIFF
--- a/.changeset/polite-planets-travel.md
+++ b/.changeset/polite-planets-travel.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/button": patch
+---
+
+Fix `ButtonGroup` to collapse borders when using `isAttached` with
+`variant="outline"`

--- a/packages/button/src/button-group.tsx
+++ b/packages/button/src/button-group.tsx
@@ -73,6 +73,9 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">((props, ref) => {
       "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
       "> *:not(:first-of-type):last-of-type": { borderStartRadius: 0 },
     }
+    if (variant === "outline") {
+      groupStyles["> *:not(:last-of-type)"] = { marginEnd: "-1px" }
+    }
   } else {
     groupStyles = {
       ...groupStyles,

--- a/packages/button/src/button-group.tsx
+++ b/packages/button/src/button-group.tsx
@@ -87,7 +87,7 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">((props, ref) => {
         role="group"
         __css={groupStyles}
         className={_className}
-        data-attached={isAttached ? true : undefined}
+        data-attached={isAttached ? "" : undefined}
         {...rest}
       />
     </ButtonGroupProvider>

--- a/packages/button/src/button-group.tsx
+++ b/packages/button/src/button-group.tsx
@@ -73,9 +73,6 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">((props, ref) => {
       "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
       "> *:not(:first-of-type):last-of-type": { borderStartRadius: 0 },
     }
-    if (variant === "outline") {
-      groupStyles["> *:not(:last-of-type)"] = { marginEnd: "-1px" }
-    }
   } else {
     groupStyles = {
       ...groupStyles,
@@ -90,6 +87,7 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">((props, ref) => {
         role="group"
         __css={groupStyles}
         className={_className}
+        data-attached={isAttached ? true : undefined}
         {...rest}
       />
     </ButtonGroupProvider>

--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -236,7 +236,8 @@ export const WithButtonGroup = () => (
 
 export const attachedButtons = () => (
   <ButtonGroup size="sm" isAttached variant="outline">
-    <Button marginEnd="-px">Save</Button>
+    <Button>Save</Button>
+    <Button>Cancel</Button>
     <IconButton
       fontSize="2xl"
       aria-label="Add to friends"

--- a/packages/button/tests/button-group.test.tsx
+++ b/packages/button/tests/button-group.test.tsx
@@ -45,6 +45,27 @@ test("Should flush button", () => {
     borderTopLeftRadius: "0",
     borderBottomLeftRadius: "0",
   })
+})
 
-  // expect(getByText(/Button 1/i)).toHaveStyle({ borderStartRadius: "0" })
+test("Should flush outline button", () => {
+  const { getByText } = render(
+    <ButtonGroup isAttached variant="outline">
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+      <Button>Button 4</Button>
+    </ButtonGroup>,
+  )
+  expect(getByText(/Button 1/i)).toHaveStyle({
+    marginInlineEnd: "-1px",
+  })
+  expect(getByText(/Button 2/i)).toHaveStyle({
+    marginInlineEnd: "-1px",
+  })
+  expect(getByText(/Button 3/i)).toHaveStyle({
+    marginInlineEnd: "-1px",
+  })
+  expect(getByText(/Button 4/i)).toHaveStyle({
+    marginInlineEnd: "",
+  })
 })

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -59,6 +59,9 @@ const variantOutline: SystemStyleFunction = (props) => {
   return {
     border: "1px solid",
     borderColor: c === "gray" ? borderColor : "currentColor",
+    ".chakra-button__group[data-attached] > &:not(:last-of-type)": {
+      marginEnd: "-1px",
+    },
     ...variantGhost(props),
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4531

## 📝 Description

Collapse borders in outlined buttons inside `ButtonGroup` with `isAttached`.

Reinstates the behavior of https://github.com/chakra-ui/chakra-ui/pull/230

## ⛳️ Current behavior (updates)

Currently the `ButtonGroup` requires manually adding `mr="-px"` to each outlined button when using `isAttached` to get rid of the double border.

## 🚀 New behavior

`ButtonGroup` applies the negative margin automatically when using `isAttached` with `variant="outline"`

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

Before:
![image](https://user-images.githubusercontent.com/1596280/159199448-d2216295-ad92-4867-9872-90e328a37335.png)

After:
![image](https://user-images.githubusercontent.com/1596280/159199463-06af5efc-1e75-4f02-b8d5-0495e610ff50.png)

