### PR TITLE
refactor: remove internal usage of deprecated createBreakpoints function

### DIFF
--- a/.changeset/many-seas-chew.md
+++ b/.changeset/many-seas-chew.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/media-query": patch
+"@chakra-ui/react": patch
+"@chakra-ui/skeleton": patch
+"@chakra-ui/styled-system": patch
+"@chakra-ui/system": patch
+"@chakra-ui/theme": patch
+"@chakra-ui/theme-tools": patch
+---
+
+Remove internal usage of createBreakpoints function

--- a/packages/media-query/tests/test-data.ts
+++ b/packages/media-query/tests/test-data.ts
@@ -1,7 +1,6 @@
 import { extendTheme } from "@chakra-ui/react"
-import { createBreakpoints } from "@chakra-ui/theme-tools"
 
-export const breakpoints = createBreakpoints({
+export const breakpoints = {
   base: "0px",
   sm: "100px",
   md: "200px",
@@ -9,7 +8,7 @@ export const breakpoints = createBreakpoints({
   xl: "400px",
   "2xl": "500px",
   customBreakpoint: "600px",
-})
+}
 
 export const theme = extendTheme({ breakpoints })
 

--- a/packages/react/tests/extend-theme.test.tsx
+++ b/packages/react/tests/extend-theme.test.tsx
@@ -1,4 +1,3 @@
-import { createBreakpoints } from "@chakra-ui/theme-tools"
 import { extendTheme, ThemeOverride } from "../src/extend-theme"
 
 describe("extendTheme", () => {
@@ -256,12 +255,12 @@ describe("extendTheme", () => {
     Array.prototype["customFunction"] = () => {}
 
     const override = {
-      breakpoints: createBreakpoints({
+      breakpoints: {
         sm: "1",
         md: "1",
         lg: "1",
         xl: "1",
-      }),
+      },
     }
 
     const customTheme = extendTheme(override)
@@ -273,13 +272,13 @@ describe("extendTheme", () => {
 
   it("should allow custom breakpoints", () => {
     const override = {
-      breakpoints: createBreakpoints({
+      breakpoints: {
         sm: "1px",
         md: "2px",
         lg: "3px",
         xl: "4px",
         phone: "5px",
-      }),
+      },
     }
 
     const customTheme = extendTheme(override)

--- a/packages/skeleton/tests/test-data.ts
+++ b/packages/skeleton/tests/test-data.ts
@@ -1,6 +1,4 @@
-import { createBreakpoints } from "@chakra-ui/theme-tools"
-
-export const breakpoints = createBreakpoints({
+export const breakpoints = {
   base: "0px",
   sm: "100px",
   md: "200px",
@@ -8,7 +6,7 @@ export const breakpoints = createBreakpoints({
   xl: "400px",
   "2xl": "600px",
   customBreakpoint: "500px",
-})
+}
 
 export const theme = { breakpoints }
 

--- a/packages/styled-system/tests/css.test.ts
+++ b/packages/styled-system/tests/css.test.ts
@@ -1,5 +1,5 @@
-import { css } from "../src/css"
 import { toCSSVar } from "../src/create-theme-vars"
+import { css } from "../src/css"
 
 const theme = toCSSVar({
   breakpoints: {
@@ -349,30 +349,6 @@ test("padding shorthand does not collide with nested p selector", () => {
     }
   `)
 })
-
-// test.skip("ignores array values longer than breakpoints", () => {
-//   // intentionally not using createBreakpoints here
-//   // because you can't just slice off it
-//   const customBreakpoints: any = ["0em", "32em", "40em"]
-//   customBreakpoints.base = customBreakpoints[0]
-//   customBreakpoints.sm = customBreakpoints[1]
-//   customBreakpoints.lg = customBreakpoints[2]
-
-//   const result = css({
-//     width: [32, 64, 128, 256, 512],
-//   })({
-//     breakpoints: customBreakpoints,
-//   })
-//   expect(result).toEqual({
-//     width: 32,
-//     "@media screen and (min-width: 32em)": {
-//       width: 64,
-//     },
-//     "@media screen and (min-width: 40em)": {
-//       width: 128,
-//     },
-//   })
-// })
 
 test("functional values can return responsive arrays", () => {
   const result = css({

--- a/packages/styled-system/tests/interpolation.test.ts
+++ b/packages/styled-system/tests/interpolation.test.ts
@@ -1,13 +1,12 @@
-import { createBreakpoints } from "@chakra-ui/theme-tools"
 import { css, toCSSVar } from "../src"
 
 test("should handle array interpolations", () => {
-  const customBreakpoints = createBreakpoints({
+  const customBreakpoints = {
     sm: "40em",
     md: "50em",
     lg: "60em",
     xl: "70em",
-  })
+  }
 
   // @ts-ignore
   const result = css({ "&": [{ bg: "red" }, { bg: "green" }] })(

--- a/packages/system/tests/hooks.test.ts
+++ b/packages/system/tests/hooks.test.ts
@@ -1,5 +1,4 @@
 import { hooks } from "@chakra-ui/test-utils"
-import { createBreakpoints } from "../../theme-tools"
 import { toCSSVar, useToken } from "../src"
 import * as system from "../src/providers"
 
@@ -23,13 +22,13 @@ const mockSpace = {
   "1.5": "0.375rem",
 }
 
-const mockBreakpoints = createBreakpoints({
+const mockBreakpoints = {
   sm: "30em",
   md: "48em",
   lg: "62em",
   xl: "80em",
   "2xl": "96em",
-})
+}
 
 const setupMock = () => {
   jest.spyOn(system, "useTheme").mockReturnValueOnce(

--- a/packages/theme-tools/src/create-breakpoints.ts
+++ b/packages/theme-tools/src/create-breakpoints.ts
@@ -11,6 +11,9 @@ export interface BaseBreakpointConfig {
 
 export type Breakpoints<T> = T & { base: "0em" }
 
+/**
+ * @deprecated will be deprecated pretty soon, simply pass the breakpoints as an object
+ */
 export const createBreakpoints = <T extends BaseBreakpointConfig>(
   config: T,
 ): Breakpoints<T> => {
@@ -18,7 +21,7 @@ export const createBreakpoints = <T extends BaseBreakpointConfig>(
     condition: true,
     message: [
       `[chakra-ui]: createBreakpoints(...) will be deprecated pretty soon`,
-      `simply pass the breakpoints as an object. Remove the createBreakpoint(..) call`,
+      `simply pass the breakpoints as an object. Remove the createBreakpoints(..) call`,
     ].join(""),
   })
   return { base: "0em", ...config }

--- a/packages/theme/src/foundations/breakpoints.ts
+++ b/packages/theme/src/foundations/breakpoints.ts
@@ -1,14 +1,12 @@
-import { createBreakpoints } from "@chakra-ui/theme-tools"
-
 /**
  * Breakpoints for responsive design
  */
-const breakpoints = createBreakpoints({
+const breakpoints = {
   sm: "30em",
   md: "48em",
   lg: "62em",
   xl: "80em",
   "2xl": "96em",
-})
+}
 
 export default breakpoints

--- a/packages/theme/src/foundations/breakpoints.ts
+++ b/packages/theme/src/foundations/breakpoints.ts
@@ -2,6 +2,7 @@
  * Breakpoints for responsive design
  */
 const breakpoints = {
+  base: "0em",
   sm: "30em",
   md: "48em",
   lg: "62em",

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -9,7 +9,6 @@ import type {
   ThemingProps,
 } from "@chakra-ui/system"
 import type {
-  Breakpoints,
   PartsStyleInterpolation,
   Styles,
   SystemStyleInterpolation,
@@ -108,7 +107,7 @@ interface Typography {
 
 interface Foundations extends Typography {
   borders: RecursiveObject
-  breakpoints: Breakpoints<Dict>
+  breakpoints: Dict
   colors: Colors
   radii: RecursiveObject
   shadows: RecursiveObject<string>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes -> no current issue

## 📝 Description

The `createBreakpoints` function has a warning regarding deprecation, see [create-breakpoints.ts](https://github.com/chakra-ui/chakra-ui/blob/8e201b9f84a914e58cdc9ee90b3e03269fabf4d7/packages/theme-tools/src/create-breakpoints.ts#L20). According to that this PR removes all occurences in the repo (except in [responsive.test.ts](https://github.com/chakra-ui/chakra-ui/blob/8e201b9f84a914e58cdc9ee90b3e03269fabf4d7/packages/utils/tests/responsive.test.ts#L130) as long as the function is in the repo).

## ⛳️ Current behavior (updates)

Internal usage of deprecated `createBreakpoints` function

## 🚀 New behavior

- Internal usage of objects with the breakpoints
- JSDoc deprecation warning for the function

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information

- Occurances of the function in the docs repo are already removed: https://github.com/chakra-ui/chakra-ui-docs/pull/460
- Maybe we can remove the createBreakpoints function in v2.2 or v3 -> only thing to do is to remove the function is to remove the [createBreakpoints.ts](https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme-tools/src/create-breakpoints.ts) and the [test](https://github.com/chakra-ui/chakra-ui/blob/main/packages/utils/tests/responsive.test.ts) with the usage of the function