### PR TITLE
feat(wrap): separate x and y margins

### DIFF
--- a/.changeset/ten-turkeys-drop.md
+++ b/.changeset/ten-turkeys-drop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": minor
+---
+
+Adds vertical and horizontal spacing options to the Wrap component.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -61,9 +61,10 @@ Wrap is used to manage the distribution of child elements that are liable to
 wrap. It is mostly used for button groups, tag group, badge group, and chips.
 
 ```jsx
-<AspectRatio ratio={16 / 9}>
-  <img src="./some-ig-story" alt="Instagram story" />
-</AspectRatio>
+<Wrap spacing={3}>
+  <Box>Box 1</Box>
+  <Box>Box 2</Box>
+</Wrap>
 ```
 
 Badge is used to render a badge. It can comes in different variants and color

--- a/packages/layout/src/wrap.tsx
+++ b/packages/layout/src/wrap.tsx
@@ -76,9 +76,9 @@ export const Wrap = forwardRef<WrapProps, "div">((props, ref) => {
     }
     return {
       "--chakra-wrap-x-spacing": (theme: Dict) =>
-        mapResponsive(y, (value) => tokenToCSSVar("space", value)(theme)),
-      "--chakra-wrap-y-spacing": (theme: Dict) =>
         mapResponsive(x, (value) => tokenToCSSVar("space", value)(theme)),
+      "--chakra-wrap-y-spacing": (theme: Dict) =>
+        mapResponsive(y, (value) => tokenToCSSVar("space", value)(theme)),
       "--wrap-x-spacing": "calc(var(--chakra-wrap-x-spacing) / 2)",
       "--wrap-y-spacing": "calc(var(--chakra-wrap-y-spacing) / 2)",
       display: "flex",

--- a/packages/layout/src/wrap.tsx
+++ b/packages/layout/src/wrap.tsx
@@ -10,10 +10,20 @@ import * as React from "react"
 
 export interface WrapProps extends HTMLChakraProps<"div"> {
   /**
-   * The space between the each child (even if it wraps)
+   * The horizontal and vertical space between the each child (even if it wraps)
    * @type SystemProps["margin"]
    */
   spacing?: SystemProps["margin"]
+  /**
+   * The horizontal space between the each child (even if it wraps). Defaults to `spacing` if not defined.
+   * @type SystemProps["margin"]
+   */
+  spacingX?: SystemProps["margin"]
+  /**
+   * The vertical space between the each child (even if it wraps). Defaults to `spacing` if not defined.
+   * @type SystemProps["margin"]
+   */
+  spacingY?: SystemProps["margin"]
   /**
    * The `justify-content` value (for cross-axis alignment)
    * @type SystemProps["justifyContent"]
@@ -48,6 +58,8 @@ export interface WrapProps extends HTMLChakraProps<"div"> {
 export const Wrap = forwardRef<WrapProps, "div">((props, ref) => {
   const {
     spacing = "0.5rem",
+    spacingX,
+    spacingY,
     children,
     justify,
     direction,
@@ -57,11 +69,18 @@ export const Wrap = forwardRef<WrapProps, "div">((props, ref) => {
     ...rest
   } = props
 
-  const styles = React.useMemo(
-    () => ({
-      "--chakra-wrap-spacing": (theme: Dict) =>
-        mapResponsive(spacing, (value) => tokenToCSSVar("space", value)(theme)),
-      "--wrap-spacing": "calc(var(--chakra-wrap-spacing) / 2)",
+  const styles = React.useMemo(() => {
+    const { spacingX: x = spacing, spacingY: y = spacing } = {
+      spacingX,
+      spacingY,
+    }
+    return {
+      "--chakra-wrap-x-spacing": (theme: Dict) =>
+        mapResponsive(y, (value) => tokenToCSSVar("space", value)(theme)),
+      "--chakra-wrap-y-spacing": (theme: Dict) =>
+        mapResponsive(x, (value) => tokenToCSSVar("space", value)(theme)),
+      "--wrap-x-spacing": "calc(var(--chakra-wrap-x-spacing) / 2)",
+      "--wrap-y-spacing": "calc(var(--chakra-wrap-y-spacing) / 2)",
       display: "flex",
       flexWrap: "wrap",
       justifyContent: justify,
@@ -69,13 +88,13 @@ export const Wrap = forwardRef<WrapProps, "div">((props, ref) => {
       flexDirection: direction,
       listStyleType: "none",
       padding: "0",
-      margin: "calc(var(--wrap-spacing) * -1)",
+      margin:
+        "calc(var(--wrap-y-spacing) * -1) calc(var(--wrap-x-spacing) * -1)",
       "& > *:not(style)": {
-        margin: "var(--wrap-spacing)",
+        margin: "var(--wrap-y-spacing) var(--wrap-x-spacing)",
       },
-    }),
-    [spacing, justify, align, direction],
-  )
+    }
+  }, [spacing, spacingX, spacingY, justify, align, direction])
 
   const childrenToRender = shouldWrapChildren
     ? React.Children.map(children, (child, index) => (

--- a/packages/layout/stories/wrap.stories.tsx
+++ b/packages/layout/stories/wrap.stories.tsx
@@ -61,3 +61,19 @@ export const responsive = () => (
     <Placeholder />
   </Wrap>
 )
+
+export const horizontalAndVertical = () => (
+  <Wrap spacingY={["0px", "24px"]} spacingX={["4px", "12px"]}>
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+    <Placeholder />
+  </Wrap>
+)


### PR DESCRIPTION
## 📝 Description

* Adds the option to specify vertical and horizontal spacing options for the `<Wrap>` component, should the user choose. 
* Falls back to the `spacing` prop for defaults or to set both h and v at the same time.
* Also fixes the code example of Wrap in the layout package.

## ⛳️ Current behavior (updates)

The Wrap component adds the `spacing` prop to both horizontal and vertical margins, with no opportunity for the user to specify anything else.

## 🚀 New behavior

Users can optionally specify `hSpacing` and/or `vSpacing` to choose a specific margin for that axis.

Example:

```jsx
<Wrap vSpacing={0} hSpacing={['8px', '12px', '24px']}>
  <Box/>
  <Box/>
  <Box/>
  <Box/>
</Wrap>
```

## 💣 Is this a breaking change (Yes/No):

No, intentionally made backwards compatible.

## 📝 Additional Information
Happy to rename if this prop naming is not preferred.
I recognize that there could be room for improvements on `spacing`-only implementations, but wasn't sure what the best way to conditionally use one or two css values in the styles memo without mostly duplicating the return object.