### PR TITLE
fix: disabled state in editable

### DIFF
--- a/.changeset/quiet-items-eat.md
+++ b/.changeset/quiet-items-eat.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/editable": patch
+---
+
+Fix issue where editable preview remains interactive even when
+`isDisabled: true` is passed.

--- a/packages/editable/src/use-editable.ts
+++ b/packages/editable/src/use-editable.ts
@@ -132,7 +132,7 @@ export function useEditable(props: UseEditableProps = {}) {
     elements: [cancelButtonRef, submitButtonRef],
   })
 
-  const isInteractive = !isEditing || !isDisabled
+  const isInteractive = !isEditing && !isDisabled
 
   useSafeLayoutEffect(() => {
     if (isEditing) {
@@ -332,8 +332,9 @@ export function useEditable(props: UseEditableProps = {}) {
       type: "button",
       onClick: callAllHandlers(props.onClick, onEdit),
       ref: mergeRefs(ref, editButtonRef),
+      disabled: isDisabled,
     }),
-    [onEdit],
+    [onEdit, isDisabled],
   )
 
   const getSubmitButtonProps: PropGetter = useCallback(
@@ -343,8 +344,9 @@ export function useEditable(props: UseEditableProps = {}) {
       ref: mergeRefs(submitButtonRef, ref),
       type: "button",
       onClick: callAllHandlers(props.onClick, onSubmit),
+      disabled: isDisabled,
     }),
-    [onSubmit],
+    [onSubmit, isDisabled],
   )
 
   const getCancelButtonProps: PropGetter = useCallback(
@@ -355,8 +357,9 @@ export function useEditable(props: UseEditableProps = {}) {
       ref: mergeRefs(cancelButtonRef, ref),
       type: "button",
       onClick: callAllHandlers(props.onClick, onCancel),
+      disabled: isDisabled,
     }),
-    [onCancel],
+    [onCancel, isDisabled],
   )
 
   return {

--- a/packages/editable/stories/editable.stories.tsx
+++ b/packages/editable/stories/editable.stories.tsx
@@ -160,3 +160,11 @@ export const EditableEventHandler = () => {
     </>
   )
 }
+
+export const Disabled = () => (
+  <Editable isDisabled defaultValue="Rasengan ⚡️" fontSize="xl">
+    <EditablePreview />
+    <EditableInput />
+    <EditableControls />
+  </Editable>
+)

--- a/packages/editable/tests/editable.test.tsx
+++ b/packages/editable/tests/editable.test.tsx
@@ -287,5 +287,5 @@ test("should not be interactive when disabled", () => {
   )
 
   userEvent.click(screen.getByText(/editable/))
-  expect(screen.findByTestId("input")).not.toBeVisible()
+  expect(screen.getByTestId("input")).not.toBeVisible()
 })

--- a/packages/editable/tests/editable.test.tsx
+++ b/packages/editable/tests/editable.test.tsx
@@ -214,7 +214,7 @@ test("can submit on blur", () => {
 
 test("startWithEditView when true focuses on the input ", () => {
   render(
-    <Editable startWithEditView={true} defaultValue="Chakra testing">
+    <Editable startWithEditView defaultValue="Chakra testing">
       <EditablePreview />
       <EditableInput data-testid="input" />
     </Editable>,
@@ -277,3 +277,15 @@ test.each([
     expect(preview).toHaveTextContent("John")
   },
 )
+
+test("should not be interactive when disabled", () => {
+  render(
+    <Editable defaultValue="editable" isDisabled>
+      <EditablePreview data-testid="preview" />
+      <EditableInput data-testid="input" />
+    </Editable>,
+  )
+
+  userEvent.click(screen.getByText(/editable/))
+  expect(screen.findByTestId("input")).not.toBeVisible()
+})

--- a/packages/editable/tests/editableTextarea.test.tsx
+++ b/packages/editable/tests/editableTextarea.test.tsx
@@ -6,12 +6,7 @@ import {
   userEvent,
 } from "@chakra-ui/test-utils"
 import * as React from "react"
-import {
-  Editable,
-  EditableInput,
-  EditablePreview,
-  EditableTextarea,
-} from "../src"
+import { Editable, EditablePreview, EditableTextarea } from "../src"
 
 test("matches snapshot", () => {
   render(


### PR DESCRIPTION
Closes #5758

## 📝 Description

Fix issue where editable preview remains interactive even when `isDisabled: true` is passed.

## ⛳️ Current behavior (updates)

Switches to edit mode because `tabindex: 0` is still set on it

## 🚀 New behavior

Works as expected