### PR TITLE
fix: allow use-menu to specify button type

### DIFF
--- a/.changeset/plenty-mails-juggle.md
+++ b/.changeset/plenty-mails-juggle.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fix issue where menu items cannot type `type=submit`

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -211,20 +211,23 @@ const StyledMenuItem = forwardRef<StyledMenuItemProps, "button">(
      * Else, use no type to avoid invalid html, e.g. <a type="button" />
      * Else, fall back to "button"
      */
-    const btnType = rest.as ? type ?? undefined : "button"
+    const btnType = rest.as || type ? type ?? undefined : "button"
 
-    const buttonStyles: SystemStyleObject = {
-      textDecoration: "none",
-      color: "inherit",
-      userSelect: "none",
-      display: "flex",
-      width: "100%",
-      alignItems: "center",
-      textAlign: "start",
-      flex: "0 0 auto",
-      outline: 0,
-      ...styles.item,
-    }
+    const buttonStyles: SystemStyleObject = React.useMemo(
+      () => ({
+        textDecoration: "none",
+        color: "inherit",
+        userSelect: "none",
+        display: "flex",
+        width: "100%",
+        alignItems: "center",
+        textAlign: "start",
+        flex: "0 0 auto",
+        outline: 0,
+        ...styles.item,
+      }),
+      [styles.item],
+    )
 
     return (
       <chakra.button ref={ref} type={btnType} {...rest} __css={buttonStyles} />

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -336,7 +336,7 @@ export interface MenuItemOptionProps
 export const MenuItemOption = forwardRef<MenuItemOptionProps, "button">(
   (props, ref) => {
     // menu option item should always be `type=button`, so we omit `type`
-    const { icon, iconSpacing = "0.75rem", type: _, ...rest } = props
+    const { icon, iconSpacing = "0.75rem", ...rest } = props
 
     const optionProps = useMenuOption(rest, ref) as HTMLAttributes
 

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -335,7 +335,8 @@ export interface MenuItemOptionProps
 
 export const MenuItemOption = forwardRef<MenuItemOptionProps, "button">(
   (props, ref) => {
-    const { icon, iconSpacing = "0.75rem", ...rest } = props
+    // menu option item should always be `type=button`, so we omit `type`
+    const { icon, iconSpacing = "0.75rem", type: _, ...rest } = props
 
     const optionProps = useMenuOption(rest, ref) as HTMLAttributes
 

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -668,7 +668,7 @@ export interface UseMenuOptionOptions {
 }
 
 export interface UseMenuOptionProps
-  extends UseMenuItemProps,
+  extends Omit<UseMenuItemProps, "type">,
     UseMenuOptionOptions {}
 
 export function useMenuOption(

--- a/packages/menu/src/use-menu.ts
+++ b/packages/menu/src/use-menu.ts
@@ -532,6 +532,10 @@ export interface UseMenuItemProps
    * Overrides the parent menu's `closeOnSelect` prop.
    */
   closeOnSelect?: boolean
+  /**
+   * The type of the menuitem.
+   */
+  type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"]
 }
 
 export function useMenuItem(
@@ -546,6 +550,7 @@ export function useMenuItem(
     isDisabled,
     isFocusable,
     closeOnSelect,
+    type: typeProp,
     ...htmlProps
   } = props
 
@@ -644,6 +649,7 @@ export function useMenuItem(
   return {
     ...htmlProps,
     ...clickableProps,
+    type: typeProp ?? (clickableProps as any).type,
     id,
     role: "menuitem",
     tabIndex: isFocused ? 0 : -1,

--- a/packages/menu/tests/menu.test.tsx
+++ b/packages/menu/tests/menu.test.tsx
@@ -463,3 +463,23 @@ test("MenuList direction flips in rtl", () => {
     "top-start",
   )
 })
+
+test("can override menu item type", async () => {
+  render(
+    <Menu>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        <MenuItem type="submit">Submit</MenuItem>
+        <MenuItem as={Button}>Button</MenuItem>
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByText("Open menu")
+  fireEvent.click(button)
+
+  const submitOption = screen.getByText("Submit")
+  await waitFor(() => expect(submitOption).toHaveFocus())
+
+  expect(submitOption).toHaveAttribute("type", "submit")
+})


### PR DESCRIPTION
Closes #5462

## 📝 Description

Fix issue where menu items cannot type `type=submit`