### PR TITLE
fix(collapse): #5778 remove explicit overflow hidden/initial on exit/enter animation

### DIFF
--- a/.changeset/young-items-return.md
+++ b/.changeset/young-items-return.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/transition": patch
+---
+
+Fix intermittent Collapse component overflow initial/hidden issue

--- a/packages/transition/src/collapse.tsx
+++ b/packages/transition/src/collapse.tsx
@@ -54,7 +54,6 @@ const variants: Variants<CollapseOptions> = {
     delay,
   }) => ({
     ...(animateOpacity && { opacity: isNumeric(startingHeight) ? 1 : 0 }),
-    overflow: "hidden",
     height: startingHeight,
     transitionEnd: transitionEnd?.exit,
     transition:
@@ -123,7 +122,6 @@ export const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
       animateOpacity,
       transition: !mounted ? { enter: { duration: 0 } } : transition,
       transitionEnd: mergeWith(transitionEnd, {
-        enter: { overflow: "initial" },
         exit: unmountOnExit
           ? undefined
           : {


### PR DESCRIPTION
Closes #5778

## 📝 Description

Fix intermittent Collapse component overflow initial/hidden issue.

## ⛳️ Current behavior (updates)

Collapse component sometimes doesn't collapse.

## 🚀 New behavior

Collapse component always collapses.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Read: https://github.com/chakra-ui/chakra-ui/issues/5778

This is my first PR here—please let me know if I'm doing anything wrong!