### PR TITLE
fix: add cursor not-allowed for disabled checkbox and radio

### DIFF
--- a/.changeset/wet-rules-speak.md
+++ b/.changeset/wet-rules-speak.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/checkbox": patch
+"@chakra-ui/theme": patch
+---
+
+Fix radio cursor when disabled

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -33,9 +33,6 @@ const Label = chakra("label", {
     alignItems: "center",
     verticalAlign: "top",
     position: "relative",
-    _disabled: {
-      cursor: "not-allowed",
-    },
   },
 })
 

--- a/packages/theme/src/components/checkbox.ts
+++ b/packages/theme/src/components/checkbox.ts
@@ -57,6 +57,10 @@ const baseStyleControl: SystemStyleFunction = (props) => {
   }
 }
 
+const baseStyleContainer: SystemStyleObject = {
+  _disabled: { cursor: "not-allowed" },
+}
+
 const baseStyleLabel: SystemStyleObject = {
   userSelect: "none",
   _disabled: { opacity: 0.4 },
@@ -69,6 +73,7 @@ const baseStyleIcon: SystemStyleObject = {
 
 const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   icon: baseStyleIcon,
+  container: baseStyleContainer,
   control: baseStyleControl(props),
   label: baseStyleLabel,
 })

--- a/packages/theme/src/components/radio.ts
+++ b/packages/theme/src/components/radio.ts
@@ -29,6 +29,7 @@ const baseStyleControl: SystemStyleFunction = (props) => {
 
 const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   label: Checkbox.baseStyle(props).label,
+  container: Checkbox.baseStyle(props).container,
   control: baseStyleControl(props),
 })
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

Previously, the cursor was **not** set to `not-allowed` when a `Radio` was disabled

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

![CleanShot 2022-03-29 at 15 12 14](https://user-images.githubusercontent.com/5040476/160619369-a12d8666-8739-40f8-a603-fbe0304df12a.gif)

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

This is now fixed by updating and reusing the `Checkbox` base style

![CleanShot 2022-03-29 at 15 14 37](https://user-images.githubusercontent.com/5040476/160619573-796ae2e5-0d30-440c-bb64-62a2a8eaece2.gif)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information

By moving the cursor style to the `container` part, we are now sure that the whole component will inherit from it
