### PR TITLE
fix(popover): check related target onMouseLeave to prevent unexpected closing

### DIFF
--- a/.changeset/modern-dogs-ring.md
+++ b/.changeset/modern-dogs-ring.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popover": patch
+---
+
+Fixed an issue where the Popover closes if the selection overflows the Popover size

--- a/packages/popover/src/use-popover.ts
+++ b/packages/popover/src/use-popover.ts
@@ -242,10 +242,17 @@ export function usePopover(props: UsePopoverProps = {}) {
         popoverProps.onMouseEnter = callAllHandlers(props.onMouseEnter, () => {
           isHoveringRef.current = true
         })
-        popoverProps.onMouseLeave = callAllHandlers(props.onMouseLeave, () => {
-          isHoveringRef.current = false
-          setTimeout(onClose, closeDelay)
-        })
+        popoverProps.onMouseLeave = callAllHandlers(
+          props.onMouseLeave,
+          (event) => {
+            // https://stackoverflow.com/questions/46831247/select-triggers-mouseleave-event-on-parent-element-in-mozilla-firefox
+            if (event.nativeEvent.relatedTarget === null) {
+              return
+            }
+            isHoveringRef.current = false
+            setTimeout(onClose, closeDelay)
+          },
+        )
       }
 
       return popoverProps


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5658

## 📝 Description

In certain browsers and OS, the popover component was closing unexpectedly due to [this known issue with the select element](https://stackoverflow.com/questions/46831247/select-triggers-mouseleave-event-on-parent-element-in-mozilla-firefox).

For more details on the research behind this PR, please see my [comment](https://github.com/chakra-ui/chakra-ui/issues/5658#issuecomment-1080024524) within the original issue.

## ⛳️ Current behavior (updates)

The `onMouseLeave` handler does not check for the native `relatedTarget` before mutating the hovering status and calling the `onClose` handler.

## 🚀 New behavior

Checks the `relatedTarget` on the native event inside of the `onMouseLeave` synthetic event handler before invoking any close handlers.

## 💣 Is this a breaking change (Yes/No):

No