### PR TITLE
fix(README): add new browser stack icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ specification. Contributions of any kind welcome!
 
 ## Testing supported by
 
-<img width="200" src="https://marker.io/vendor/img/logo/browserstack-logo.svg" alt="BrowserStack"/>
+<img width="200" src="https://i.imgur.com/eeuDARI.png" alt="BrowserStack"/>
 
 ## License
 


### PR DESCRIPTION

## 📝 Description

> Fixed the Browser Stack Logo in README, apparently, the previous logo was removed from marker.io, so I used imgur.
> ![image](https://user-images.githubusercontent.com/68690233/161872126-672f26c1-d54f-4e34-966f-2a9b218cf9e6.png)


## ⛳️ Current behavior (updates)

> The image alt text is displayed.
> ![image](https://user-images.githubusercontent.com/68690233/161872174-cb324e15-5e79-4f96-9603-9ed8d2c24f13.png)


## 🚀 New behavior

> Logo is displayed.
> ![image](https://user-images.githubusercontent.com/68690233/161872266-ccc040c4-f97a-4467-b8fe-0660727aa476.png)


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
