### PR TITLE
ci: adding dispatch event to docs repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,11 @@ jobs:
         run: |
           yarn changelog:write
           yarn changelog:commit
+
+      - name: Send a dispatch event to chakra-ui-docs
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          curl -X POST -u "segunadebayo:${{ secrets.SAGE_PAT }}"
+          -H "Accept: application/vnd.github.everest-preview+json"
+          -H "Content-Type: application/json" https://api.github.com/repos/chakra-ui/chakra-ui-docs/dispatches
+          --data '{"event_type": "build_application"}'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui-docs/issues/481

Sibling PR on the docs repo: 
- https://github.com/chakra-ui/chakra-ui-docs/pull/508

## 📝 Description
Upon release, I've added one more step where it sends a dispatch event to the docs repo.

## ⛳️ Current behavior (updates)
I think this job is manual if I'm not wrong or there is a cron job. Not entirely sure.

## 🚀 New behavior
No need for a cron job or for manual generation, upon new release the dispatch event will be sent to the docs repo and the changelog will be generated & a PR will be opened.

## 💣 Is this a breaking change (Yes/No):
No.
