### PR TITLE
fix: use-outside-click register clicks on document

### DIFF
--- a/packages/hooks/src/use-outside-click.ts
+++ b/packages/hooks/src/use-outside-click.ts
@@ -81,7 +81,7 @@ function isValidEvent(event: any, ref: React.RefObject<HTMLElement>) {
   // if the event target is no longer in the document
   if (target) {
     const doc = getOwnerDocument(target)
-    if (!doc.body.contains(target)) return false
+    if (!doc.contains(target)) return false
   }
 
   return !ref.current?.contains(target)

--- a/packages/hooks/tests/use-outside-click.test.tsx
+++ b/packages/hooks/tests/use-outside-click.test.tsx
@@ -2,8 +2,8 @@ import { render, fireEvent } from "@chakra-ui/test-utils"
 import * as React from "react"
 import { useOutsideClick } from "../src"
 
-const OutsideClicker = ({ onOutsideClick }) => {
-  const ref = React.useRef()
+const OutsideClicker = ({ onOutsideClick }: { onOutsideClick: () => void }) => {
+  const ref = React.useRef<HTMLDivElement>(null)
   useOutsideClick({
     ref,
     handler: onOutsideClick,
@@ -24,7 +24,7 @@ test("should register clicks on other elements, the body, and the document", asy
   const element = getByText("Element")
   const outsideElement = getByText("Outside")
 
-  const click = (el) => {
+  const click = (el: Node) => {
     fireEvent.mouseDown(el)
     fireEvent.mouseUp(el)
   }

--- a/packages/hooks/tests/use-outside-click.test.tsx
+++ b/packages/hooks/tests/use-outside-click.test.tsx
@@ -1,0 +1,45 @@
+import { render, fireEvent } from "@chakra-ui/test-utils"
+import * as React from "react"
+import { useOutsideClick } from "../src"
+
+const OutsideClicker = ({ onOutsideClick }) => {
+  const ref = React.useRef()
+  useOutsideClick({
+    ref,
+    handler: onOutsideClick,
+  })
+  return (
+    <>
+      <div ref={ref}>Element</div>
+      <div>Outside</div>
+    </>
+  )
+}
+
+test("should register clicks on other elements, the body, and the document", async () => {
+  let outsideClicks = 0
+  const { getByText } = render(
+    <OutsideClicker onOutsideClick={() => outsideClicks++} />,
+  )
+  const element = getByText("Element")
+  const outsideElement = getByText("Outside")
+
+  const click = (el) => {
+    fireEvent.mouseDown(el)
+    fireEvent.mouseUp(el)
+  }
+
+  expect(outsideClicks).toEqual(0)
+
+  click(element)
+  expect(outsideClicks).toEqual(0)
+
+  click(outsideElement)
+  expect(outsideClicks).toEqual(1)
+
+  click(document.body)
+  expect(outsideClicks).toEqual(2)
+
+  click(document)
+  expect(outsideClicks).toEqual(3)
+})


### PR DESCRIPTION
Closes #5837

## 📝 Description

I expect `useOutsideClick()` to respond to clicks anywhere on the page,     
but it was ignoring clicks outside `<body>`. There can be space below the   
end of the body for `<body>` elements who's height is less than the         
browsers height.                                                          
                                                                          
Now, we respond to events on document too. the test added in the prior    
commit now passes.                                                        

## ⛳️ Current behavior (updates)

`useOutsideClick()` ignores clicks on `document`

## 🚀 New behavior

`useOutsideClick()` responds to clicks on `document`

## 💣 Is this a breaking change (Yes/No):

Not a breaking change.