### PR TITLE
chore(toast): remove dependency to @reach-ui/alert

### DIFF
--- a/.changeset/forty-plums-attend.md
+++ b/.changeset/forty-plums-attend.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Removed dependency to @reach-ui/alert

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -8,9 +8,7 @@
     "ui mode",
     "ui"
   ],
-  "sideEffects": [
-    "./src/toast.manager.tsx"
-  ],
+  "sideEffects": false,
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
   "license": "MIT",
@@ -38,19 +36,17 @@
     "@chakra-ui/hooks": "1.9.1",
     "@chakra-ui/portal": "1.3.10",
     "@chakra-ui/react-utils": "1.2.3",
+    "@chakra-ui/system": "1.12.1",
     "@chakra-ui/theme": "1.14.1",
     "@chakra-ui/transition": "1.4.8",
-    "@chakra-ui/utils": "1.10.4",
-    "@reach/alert": "0.13.2"
+    "@chakra-ui/utils": "1.10.4"
   },
   "devDependencies": {
-    "@chakra-ui/system": "1.12.1",
     "framer-motion": "^4.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "@chakra-ui/system": ">=1.0.0",
     "framer-motion": "3.x || 4.x || 5.x || 6.x",
     "react": ">=16.8.6",
     "react-dom": ">=16.8.6"

--- a/packages/toast/src/index.ts
+++ b/packages/toast/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./use-toast"
 export * from "./toast.provider"
 export * from "./toast.types"
-export type { ToastPosition, ToastPositionWithLogical } from "./toast.placement"
+export * from "./toast.placement"
 export * from "./create-standalone-toast"
 export * from "./toast"

--- a/packages/toast/src/toast.component.tsx
+++ b/packages/toast/src/toast.component.tsx
@@ -115,7 +115,6 @@ export const ToastComponent = React.memo((props: ToastComponentProps) => {
     >
       <chakra.div
         role="status"
-        aria-live="polite"
         aria-atomic="true"
         className="chakra-toast__inner"
         __css={containerStyles}

--- a/packages/toast/src/toast.provider.tsx
+++ b/packages/toast/src/toast.provider.tsx
@@ -105,6 +105,8 @@ export const ToastProvider = React.forwardRef<ToastMethods, ToastProviderProps>(
 
       return (
         <ul
+          role="region"
+          aria-live="polite"
           key={position}
           id={`chakra-toast-manager-${position}`}
           style={getStyle(position)}

--- a/packages/toast/src/toast.types.ts
+++ b/packages/toast/src/toast.types.ts
@@ -1,11 +1,13 @@
 import type * as React from "react"
-import { ToastPosition } from "./toast.placement"
+import type { CSSObject } from "@chakra-ui/system"
+import type { ToastPosition } from "./toast.placement"
 
 export interface RenderProps {
   /**
    * The auto-generated or passed `id` of the toast
    */
   id: ToastId
+
   /**
    * Function to close the toast
    */
@@ -34,10 +36,12 @@ export interface ToastOptions {
    * The status of the toast's alert component.
    */
   status: Status
+
   /**
    * Function that removes the toast from manager's state.
    */
   onRequestRemove(): void
+
   /**
    * Whether a toast is currently in view or not
    */
@@ -46,10 +50,12 @@ export interface ToastOptions {
    * The position of the toast
    */
   position: ToastPosition
+
   /**
    * Callback function to run side effects after the toast has closed.
    */
   onCloseComplete?(): void
+
   /**
    * Internally used to queue closing a toast. Should probably not be used by
    * anyone else, but documented regardless.
@@ -58,7 +64,7 @@ export interface ToastOptions {
   /**
    * Optional style overrides for the toast component.
    */
-  containerStyle?: React.CSSProperties
+  containerStyle?: CSSObject
 }
 
 export type ToastState = {
@@ -72,3 +78,5 @@ export type UpdateFn = (state: ToastState) => void
 export type CloseAllToastsOptions = {
   positions?: ToastPosition[]
 }
+
+export {}

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -1,21 +1,18 @@
 import * as React from "react"
-import { theme as base } from "@chakra-ui/theme"
+import {
+  createStandaloneToast,
+  ToastId,
+  useToast,
+  theme as base,
+} from "@chakra-ui/react"
 import { Button, ButtonGroup } from "@chakra-ui/button"
 import { chakra, useColorMode } from "@chakra-ui/system"
 import { Alert } from "@chakra-ui/alert"
 import { Text } from "@chakra-ui/layout"
 import { useLatestRef } from "@chakra-ui/hooks"
-import { createStandaloneToast, ToastId, ToastProvider, useToast } from "../src"
 
 export default {
   title: "Components / Feedback / Toast",
-  decorators: [
-    (Story: Function) => (
-      <ToastProvider>
-        <Story />
-      </ToastProvider>
-    ),
-  ],
 }
 
 export function ToastExample() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3547,16 +3547,6 @@
     pirates "^4.0.1"
     source-map-support "^0.5.16"
 
-"@reach/alert@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.13.2.tgz#71c4a848d51341f1d6d9eaae060975391c224870"
-  integrity sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==
-  dependencies:
-    "@reach/utils" "0.13.2"
-    "@reach/visually-hidden" "0.13.2"
-    prop-types "^15.7.2"
-    tslib "^2.1.0"
-
 "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -3566,23 +3556,6 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
-
-"@reach/utils@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.13.2.tgz#87e8fef8ebfe583fa48250238a1a3ed03189fcc8"
-  integrity sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==
-  dependencies:
-    "@types/warning" "^3.0.0"
-    tslib "^2.1.0"
-    warning "^4.0.3"
-
-"@reach/visually-hidden@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.13.2.tgz#ee21de376a7e57e60dc92d95a671073796caa17e"
-  integrity sha512-sPZwNS0/duOuG0mYwE5DmgEAzW9VhgU3aIt1+mrfT/xiT9Cdncqke+kRBQgU708q/Ttm9tWsoHni03nn/SuPTQ==
-  dependencies:
-    prop-types "^15.7.2"
-    tslib "^2.1.0"
 
 "@rollup/plugin-alias@^3.1.1":
   version "3.1.8"
@@ -5560,11 +5533,6 @@
   dependencies:
     "@types/configstore" "*"
     boxen "^4.2.0"
-
-"@types/warning@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
-  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
 "@types/webpack-env@^1.16.0":
   version "1.16.3"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR removes the dependency to @reach-ui/alert, because it is not compatible with React 18. 
It uses `ReactDOM.render` to announce the toast message.
According to this reach-ui PR https://github.com/reach/reach-ui/pull/906 it may not be necessary to reattach the message for a11y reasons.

## ⛳️ Current behavior (updates)

The toast package wraps the toast message in Reach UIs Alert component.
This leads to a ReactDOM error:
> Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot

## 🚀 New behavior

Replaced the Reach Alert with a div element with following properties:

```ts
<chakra.div 
  role="status"
  aria-live="polite" // do not interrupt current announcements
  aria-atomic="true" // announce whole alert
  />
```

The ReactDOM error is not showing anymore.
The alert is still announced by VoiceOver, on macOS. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
