### PR TITLE
ci: run PR workflow on next branch as target

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, ready_for_review, edited, closed]
     branches:
       - main
+      - next
 
 jobs:
   build:


### PR DESCRIPTION
## 📝 Description

When creating a PR targeting the next branch our PR workflow is not getting started

## ⛳️ Current behavior (updates)

PR workflow only runs on target main

## 🚀 New behavior

PR workflow runs on target main and next

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
