### PR TITLE
fix zIndex of a elevated link in a linkoverlay

### DIFF
--- a/packages/layout/src/link-box.tsx
+++ b/packages/layout/src/link-box.tsx
@@ -57,7 +57,7 @@ export const LinkBox = forwardRef<LinkBoxProps, "div">((props, ref) => {
         /* Elevate the links, abbreviations and buttons up */
         "a[href]:not(.chakra-linkbox__overlay), abbr[title], button": {
           position: "relative",
-          zIndex: 1,
+          zIndex: 2,
         },
       }}
     />


### PR DESCRIPTION
#5632 was solved by changing the zIndex of the linkbox, however the elevated link it self was not updated. This breaks if the elevated link is before the overlay link in the DOM.

For example:
```
<LinkBox as='article'>
  <a href='#notworking'>
    Link not working
  </a>
  <Heading>
    <LinkOverlay href='#overlay'>
      Overlay link
    </LinkOverlay>
  </Heading>
  <a href='#working'>
    Link working
  </a>
</LinkBox>
```