### PR TITLE
fix: update csstype and typings

### DIFF
--- a/.changeset/tender-pugs-sniff.md
+++ b/.changeset/tender-pugs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Update `csstype` package to fix typings error for `colorAdjust` property

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "chart.js": "^3.6.0",
     "commitizen": "4.2.4",
     "cross-env": "7.0.3",
-    "csstype": "3.0.9",
+    "csstype": "^3.0.11",
     "cz-conventional-changelog": "3.3.0",
     "discord.js": "^12.5.3",
     "dotenv-cli": "4.1.0",

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@chakra-ui/utils": "2.0.0-next.1",
-    "csstype": "3.0.9"
+    "csstype": "^3.0.11"
   },
   "sideEffects": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6584,7 +6584,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.1", "@types/react@^18.0.0", "@types/react@^18.0.1":
+"@types/react@*", "@types/react@18.0.1", "@types/react@^18.0.1":
   version "18.0.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.1.tgz#1b2e02fb7613212518733946e49fb963dfc66e19"
   integrity sha512-VnWlrVgG0dYt+NqlfMI0yUYb8Rdl4XUROyH+c6gq/iFCiZ805Vi//26UW38DHnxQkbDhnrIWTBiy6oKZqL11cw==
@@ -10667,15 +10667,15 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@3.0.9, csstype@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
-  integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
-
 csstype@^2.5.7:
   version "2.6.18"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.18.tgz#980a8b53085f34af313410af064f2bd241784218"
   integrity sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==
+
+csstype@^3.0.11, csstype@^3.0.2:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
+  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
 
 csv-generate@^3.4.3:
   version "3.4.3"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5714 <!-- Github issue # here -->

## 📝 Description

`Property.ColorAdjust` is replaced with `Property.PrintColorAdjust` in csstype 3.0.11 and type errors occur.
Update csstype to 3.0.11 or higher to fix this.

## ⛳️ Current behavior (updates)

```ts
// menu/dist/declarations/src/use-menu.d.ts:480
colorAdjust?: import("csstype").Property.ColorAdjust | undefined;

// menu/dist/declarations/src/use-menu.d.ts:986
WebkitPrintColorAdjust?: import("csstype").Property.ColorAdjust | undefined;
```

## 🚀 New behavior

```ts
// menu/dist/declarations/src/use-menu.d.ts:481
colorAdjust?: import("csstype").Property.PrintColorAdjust | undefined;

// menu/dist/declarations/src/use-menu.d.ts:993
WebkitPrintColorAdjust?: import("csstype").Property.PrintColorAdjust | undefined;
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information

12212162f267ed34720e6482e5ffa8a7a21d4a7f cause errors because both 3.0.9 and 3.0.11 are present.
You need to install 3.0.11 or higher only.