### PR TITLE
[useDisclosure] Return a dynamic "aria-expanded" value from getButtonProps #5939

### DIFF
--- a/.changeset/pink-hotels-carry.md
+++ b/.changeset/pink-hotels-carry.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/hooks": patch
+---
+
+[useDisclosure] Return a dynamic "aria-hidden" value from getButtonProps #5939

--- a/packages/hooks/src/use-disclosure.ts
+++ b/packages/hooks/src/use-disclosure.ts
@@ -54,7 +54,7 @@ export function useDisclosure(props: UseDisclosureProps = {}) {
     isControlled,
     getButtonProps: (props: any = {}) => ({
       ...props,
-      "aria-expanded": "true",
+      "aria-expanded": isOpen,
       "aria-controls": id,
       onClick: callAllHandlers(props.onClick, onToggle),
     }),


### PR DESCRIPTION
Closes #5939

## 📝 Description

This PR improves the accessibility of components using the `useDisclosure()` hook in tandem with `getButtonProps()` and `useDisclosureProps()`.

## ⛳️ Current behavior (updates)

At the moment, the `getButtonProps()` function returned by the `useDisclosure()` hook returns a static `"aria-expanded": true` prop.

## 🚀 New behavior

It now returns a dynamic `"aria-expanded": isOpen` to match the `useDisclosure` state.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

See [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded#buttons)