### PR TITLE
fix: add reference to popover close button

### DIFF
--- a/.changeset/quick-worms-retire.md
+++ b/.changeset/quick-worms-retire.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/popover": patch
+---
+
+Add a reference to popover close button

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -202,19 +202,22 @@ if (__DEV__) {
 
 export type PopoverCloseButtonProps = CloseButtonProps
 
-export const PopoverCloseButton: React.FC<CloseButtonProps> = (props) => {
-  const { onClose } = usePopoverContext()
-  const styles = useStyles()
-  return (
-    <CloseButton
-      size="sm"
-      onClick={onClose}
-      className={cx("chakra-popover__close-btn", props.className)}
-      __css={styles.closeButton}
-      {...props}
-    />
-  )
-}
+export const PopoverCloseButton = forwardRef<CloseButtonProps, "button">(
+  (props, ref) => {
+    const { onClose } = usePopoverContext()
+    const styles = useStyles()
+    return (
+      <CloseButton
+        size="sm"
+        onClick={onClose}
+        className={cx("chakra-popover__close-btn", props.className)}
+        __css={styles.closeButton}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
 
 if (__DEV__) {
   PopoverCloseButton.displayName = "PopoverCloseButton"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add a `reference` to popover close button, as it is already done in other component.

Using Popover component, I wanted to bring the focus on the `PopoverCloseButton`, using `initialFocusRef`.
However, as opposed to the `CloseButton` component, I do not have access to the reference. 
This led me to add a reference directly in the PopoverCloseButton component.
