### PR TITLE
refactor(theme-tools): replace tinycolor functionality

### DIFF
--- a/packages/avatar/stories/avatar.stories.tsx
+++ b/packages/avatar/stories/avatar.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
-import { Avatar, AvatarBadge, AvatarGroup } from "../src"
 import { Stack, Box } from "@chakra-ui/layout"
 import { PropsOf } from "@chakra-ui/system"
+import { Avatar, AvatarBadge, AvatarGroup } from "../src"
 
 export default {
   title: "Components / Media and Icons / Avatar",
@@ -19,6 +19,14 @@ export const Basic = () => (
     <Avatar name="Dan Abrahmov" src="https://bit.ly/dan-abramov" />
     <Avatar name="Christian Nwamba" src="https://bit.ly/code-beast" />
     <Avatar name="Segun Adebayo" src="https://bit.ly/sage-adebayo" />
+  </Stack>
+)
+
+export const BasicWithoutSrc = () => (
+  <Stack direction="row">
+    <Avatar name="Dan Abrahmov" />
+    <Avatar name="Christian Nwamba" />
+    <Avatar name="Segun Adebayo" />
   </Stack>
 )
 

--- a/packages/theme-tools/src/color.ts
+++ b/packages/theme-tools/src/color.ts
@@ -1,10 +1,4 @@
-import {
-  TinyColor,
-  readability,
-  isReadable,
-  random,
-  WCAG2Parms,
-} from "@ctrl/tinycolor"
+import { TinyColor, readability, isReadable, WCAG2Parms } from "@ctrl/tinycolor"
 import { memoizedGet as get, Dict, isEmptyObject } from "@chakra-ui/utils"
 
 const value = `(?:[-\\+]?\\d*\\.\\d+%?)|(?:[-\\+]?\\d+%?)`
@@ -50,22 +44,27 @@ export const getColor = (theme: Dict, color: string, fallback?: string) => {
 /**
  * Determines if the tone of given color is "light" or "dark"
  *
- * @deprecated This will be removed in the next major release.
- *
- * @param color - the color in hex, rgb, or hsl
+ * @param color - the color in hex
  */
 export const tone = (color: string) => (theme: Dict) => {
-  const hex = getColor(theme, color)
-  const isDark = new TinyColor(hex).isDark() // TODO replace by brightness < 128
-  return isDark ? "dark" : "light"
+  const hex: string = getColor(theme, color)
+
+  const hexArray = Array.from(hex).slice(1)
+  const rgb = [...hexArray.slice(0, 3).map((x) => parseInt(x, 16))] as [
+    number,
+    number,
+    number,
+  ]
+
+  const brightness = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000
+
+  return brightness > 128 ? "dark" : "light"
 }
 
 /**
  * Determines if a color tone is "dark"
  *
- * @deprecated This will be removed in the next major release.
- *
- * @param color - the color in hex, rgb, or hsl
+ * @param color - the color in hex
  */
 export const isDark = (color: string) => (theme: Dict) =>
   tone(color)(theme) === "dark"
@@ -73,9 +72,7 @@ export const isDark = (color: string) => (theme: Dict) =>
 /**
  * Determines if a color tone is "light"
  *
- * @deprecated This will be removed in the next major release.
- *
- * @param color - the color in hex, rgb, or hsl
+ * @param color - the color in hex
  */
 export const isLight = (color: string) => (theme: Dict) =>
   tone(color)(theme) === "light"
@@ -208,13 +205,8 @@ interface RandomColorOptions {
   colors?: string[]
 }
 
-/**
- *
- * @deprecated This will be removed in the next major release.
- *
- */
 export function randomColor(opts?: RandomColorOptions) {
-  const fallback = random().toHexString()
+  const fallback = randomHex()
 
   if (!opts || isEmptyObject(opts)) {
     return fallback
@@ -263,4 +255,8 @@ function randomColorFromList(str: string, list: string[]) {
 
 function randomFromList(list: string[]) {
   return list[Math.floor(Math.random() * list.length)]
+}
+
+function randomHex() {
+  return Math.floor(Math.random() * 16777215).toString(16)
 }

--- a/packages/theme-tools/src/color.ts
+++ b/packages/theme-tools/src/color.ts
@@ -7,6 +7,34 @@ import {
 } from "@ctrl/tinycolor"
 import { memoizedGet as get, Dict, isEmptyObject } from "@chakra-ui/utils"
 
+const value = `(?:[-\\+]?\\d*\\.\\d+%?)|(?:[-\\+]?\\d+%?)`
+
+const threeValues = `[\\s|\\(]+(${value})[,|\\s]+(${value})[,|\\s]+(${value})\\s*\\)?`
+const fourValues = `[\\s|\\(]+(${value})[,|\\s]+(${value})[,|\\s]+(${value})[,|\\s]+(${value})\\s*\\)?`
+
+const matchers: Record<string, RegExp> = {
+  name: /^[a-z]+$/,
+  rgb: new RegExp(String("rgb").concat(threeValues)),
+  rgba: new RegExp(String("rgba").concat(fourValues)),
+  hsl: new RegExp(String("hsl").concat(threeValues)),
+  hsla: new RegExp(String("hsla").concat(fourValues)),
+  hsv: new RegExp(String("hsv").concat(threeValues)),
+  hsva: new RegExp(String("hsva").concat(fourValues)),
+  hex3: /^#?([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
+  hex6: /^#?([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
+}
+
+const colorIsValid = (color: string) => {
+  const trimmedColor = color.trim()
+
+  for (const key in matchers) {
+    if (matchers[key].exec(trimmedColor)) {
+      return true
+    }
+    return false
+  }
+}
+
 /**
  * Get the color raw value from theme
  * @param theme - the theme object
@@ -14,23 +42,29 @@ import { memoizedGet as get, Dict, isEmptyObject } from "@chakra-ui/utils"
  * @param fallback - the fallback color
  */
 export const getColor = (theme: Dict, color: string, fallback?: string) => {
-  const hex = get(theme, `colors.${color}`, color)
-  const { isValid } = new TinyColor(hex)
-  return isValid ? hex : fallback
+  const value = get(theme, `colors.${color}`, color)
+  const isValid = colorIsValid(value)
+  return isValid ? value : fallback
 }
 
 /**
  * Determines if the tone of given color is "light" or "dark"
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  */
 export const tone = (color: string) => (theme: Dict) => {
   const hex = getColor(theme, color)
-  const isDark = new TinyColor(hex).isDark()
+  const isDark = new TinyColor(hex).isDark() // TODO replace by brightness < 128
   return isDark ? "dark" : "light"
 }
 
 /**
  * Determines if a color tone is "dark"
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  */
 export const isDark = (color: string) => (theme: Dict) =>
@@ -38,6 +72,9 @@ export const isDark = (color: string) => (theme: Dict) =>
 
 /**
  * Determines if a color tone is "light"
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  */
 export const isLight = (color: string) => (theme: Dict) =>
@@ -45,17 +82,23 @@ export const isLight = (color: string) => (theme: Dict) =>
 
 /**
  * Make a color transparent
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  * @param opacity - the amount of opacity the color should have (0-1)
  */
 export const transparentize =
   (color: string, opacity: number) => (theme: Dict) => {
     const raw = getColor(theme, color)
-    return new TinyColor(raw).setAlpha(opacity).toRgbString()
+    return new TinyColor(raw).setAlpha(opacity).toRgbString() // TODO replace with return rgba(r, b, g , opacity)
   }
 
 /**
  * Add white to a color
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  * @param amount - the amount white to add (0-100)
  */
@@ -66,6 +109,9 @@ export const whiten = (color: string, amount: number) => (theme: Dict) => {
 
 /**
  * Add black to a color
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  * @param amount - the amount black to add (0-100)
  */
@@ -76,6 +122,9 @@ export const blacken = (color: string, amount: number) => (theme: Dict) => {
 
 /**
  * Darken a specified color
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  * @param amount - the amount to darken (0-100)
  */
@@ -86,6 +135,9 @@ export const darken = (color: string, amount: number) => (theme: Dict) => {
 
 /**
  * Lighten a specified color
+ *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param color - the color in hex, rgb, or hsl
  * @param amount - the amount to lighten (0-100)
  */
@@ -95,6 +147,8 @@ export const lighten = (color: string, amount: number) => (theme: Dict) =>
 /**
  * Checks the contract ratio of between 2 colors,
  * based on the Web Content Accessibility Guidelines (Version 2.0).
+ *
+ * @deprecated This will be removed in the next major release.
  *
  * @param fg - the foreground or text color
  * @param bg - the background color
@@ -106,6 +160,8 @@ export const contrast = (fg: string, bg: string) => (theme: Dict) =>
  * Checks if a color meets the Web Content Accessibility
  * Guidelines (Version 2.0) for contrast ratio.
  *
+ * @deprecated This will be removed in the next major release.
+ *
  * @param textColor - the foreground or text color
  * @param bgColor - the background color
  * @param options
@@ -114,6 +170,10 @@ export const isAccessible =
   (textColor: string, bgColor: string, options?: WCAG2Parms) => (theme: Dict) =>
     isReadable(getColor(theme, bgColor), getColor(theme, textColor), options)
 
+/**
+ *
+ * @deprecated This will be removed in the next major release.
+ */
 export const complementary = (color: string) => (theme: Dict) =>
   new TinyColor(getColor(theme, color)).complement().toHexString()
 
@@ -148,6 +208,11 @@ interface RandomColorOptions {
   colors?: string[]
 }
 
+/**
+ *
+ * @deprecated This will be removed in the next major release.
+ *
+ */
 export function randomColor(opts?: RandomColorOptions) {
   const fallback = random().toHexString()
 

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -1,5 +1,5 @@
 import { alertAnatomy as parts } from "@chakra-ui/anatomy"
-import { getColor, mode, transparentize } from "@chakra-ui/theme-tools"
+import { getColor, mode } from "@chakra-ui/theme-tools"
 import type {
   PartsStyleObject,
   PartsStyleFunction,
@@ -36,7 +36,7 @@ const baseStyle: PartsStyleObject<typeof parts> = {
 function getBg(props: StyleFunctionProps): string {
   const { theme, colorScheme: c } = props
   const lightBg = getColor(theme, `${c}.100`, c)
-  const darkBg = transparentize(`${c}.200`, 0.16)(theme)
+  const darkBg = getColor(theme, `${c}.900`, c)
   return mode(lightBg, darkBg)(props)
 }
 

--- a/packages/theme/src/components/avatar.ts
+++ b/packages/theme/src/components/avatar.ts
@@ -1,5 +1,5 @@
 import { avatarAnatomy as parts } from "@chakra-ui/anatomy"
-import { isDark, mode, randomColor } from "@chakra-ui/theme-tools"
+import { mode } from "@chakra-ui/theme-tools"
 import type {
   PartsStyleFunction,
   PartsStyleObject,
@@ -23,18 +23,27 @@ const baseStyleExcessLabel: SystemStyleFunction = (props) => {
 }
 
 const baseStyleContainer: SystemStyleFunction = (props) => {
-  const { name, theme } = props
-  const bg = name ? randomColor({ string: name }) : "gray.400"
-  const isBgDark = isDark(bg)(theme)
+  const { theme } = props
 
-  let color = "white"
-  if (!isBgDark) color = "gray.800"
+  const colors = Object.keys(theme.colors).filter(
+    (c) =>
+      ![
+        "whiteAlpha",
+        "blackAlpha",
+        "white",
+        "black",
+        "transparent",
+        "current",
+      ].includes(c),
+  )
+
+  const bgColor = colors[Math.floor(Math.random() * colors.length)]
 
   const borderColor = mode("white", "gray.800")(props)
 
   return {
-    bg,
-    color,
+    bg: mode(`${bgColor}.300`, `${bgColor}.700`)(props),
+    color: mode("gray.800", "white")(props),
     borderColor,
     verticalAlign: "top",
   }

--- a/packages/theme/src/components/avatar.ts
+++ b/packages/theme/src/components/avatar.ts
@@ -1,5 +1,5 @@
 import { avatarAnatomy as parts } from "@chakra-ui/anatomy"
-import { mode } from "@chakra-ui/theme-tools"
+import { isDark, mode, randomColor } from "@chakra-ui/theme-tools"
 import type {
   PartsStyleFunction,
   PartsStyleObject,
@@ -23,27 +23,19 @@ const baseStyleExcessLabel: SystemStyleFunction = (props) => {
 }
 
 const baseStyleContainer: SystemStyleFunction = (props) => {
-  const { theme } = props
+  const { name, theme } = props
 
-  const colors = Object.keys(theme.colors).filter(
-    (c) =>
-      ![
-        "whiteAlpha",
-        "blackAlpha",
-        "white",
-        "black",
-        "transparent",
-        "current",
-      ].includes(c),
-  )
+  const bg = name ? randomColor({ string: name }) : "gray.400"
+  const isBgDark = isDark(bg)(theme)
 
-  const bgColor = colors[Math.floor(Math.random() * colors.length)]
+  let color = "white"
+  if (!isBgDark) color = "gray.800"
 
   const borderColor = mode("white", "gray.800")(props)
 
   return {
-    bg: mode(`${bgColor}.300`, `${bgColor}.700`)(props),
-    color: mode("gray.800", "white")(props),
+    bg,
+    color,
     borderColor,
     verticalAlign: "top",
   }

--- a/packages/theme/src/components/badge.ts
+++ b/packages/theme/src/components/badge.ts
@@ -1,4 +1,4 @@
-import { getColor, mode, transparentize } from "@chakra-ui/theme-tools"
+import { getColor, mode } from "@chakra-ui/theme-tools"
 import type {
   SystemStyleFunction,
   SystemStyleObject,
@@ -13,26 +13,32 @@ const baseStyle: SystemStyleObject = {
 }
 
 const variantSolid: SystemStyleFunction = (props) => {
-  const { colorScheme: c, theme } = props
-  const dark = transparentize(`${c}.500`, 0.6)(theme)
+  const { colorScheme: c } = props
   return {
-    bg: mode(`${c}.500`, dark)(props),
+    bg: mode(`${c}.500`, `${c}.700`)(props),
     color: mode(`white`, `whiteAlpha.800`)(props),
   }
 }
 
 const variantSubtle: SystemStyleFunction = (props) => {
-  const { colorScheme: c, theme } = props
-  const darkBg = transparentize(`${c}.200`, 0.16)(theme)
+  const { colorScheme: c } = props
+
+  if (c === "gray") {
+    return {
+      bg: mode(`${c}.100`, `${c}.600`)(props),
+      color: mode(`${c}.800`, `${c}.100`)(props),
+    }
+  }
+
   return {
-    bg: mode(`${c}.100`, darkBg)(props),
+    bg: mode(`${c}.100`, `${c}.800`)(props),
     color: mode(`${c}.800`, `${c}.200`)(props),
   }
 }
 
 const variantOutline: SystemStyleFunction = (props) => {
   const { colorScheme: c, theme } = props
-  const darkColor = transparentize(`${c}.200`, 0.8)(theme)
+  const darkColor = getColor(theme, `${c}.300`)
   const lightColor = getColor(theme, `${c}.500`)
   const color = mode(lightColor, darkColor)(props)
 

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -1,4 +1,4 @@
-import { mode, transparentize } from "@chakra-ui/theme-tools"
+import { mode } from "@chakra-ui/theme-tools"
 import type {
   SystemStyleObject,
   SystemStyleFunction,
@@ -26,7 +26,7 @@ const baseStyle: SystemStyleObject = {
 }
 
 const variantGhost: SystemStyleFunction = (props) => {
-  const { colorScheme: c, theme } = props
+  const { colorScheme: c } = props
 
   if (c === "gray") {
     return {
@@ -38,17 +38,14 @@ const variantGhost: SystemStyleFunction = (props) => {
     }
   }
 
-  const darkHoverBg = transparentize(`${c}.200`, 0.12)(theme)
-  const darkActiveBg = transparentize(`${c}.200`, 0.24)(theme)
-
   return {
     color: mode(`${c}.600`, `${c}.200`)(props),
     bg: "transparent",
     _hover: {
-      bg: mode(`${c}.50`, darkHoverBg)(props),
+      bg: mode(`${c}.50`, `${c}.900`)(props),
     },
     _active: {
-      bg: mode(`${c}.100`, darkActiveBg)(props),
+      bg: mode(`${c}.100`, `${c}.800`)(props),
     },
   }
 }

--- a/packages/theme/src/components/progress.ts
+++ b/packages/theme/src/components/progress.ts
@@ -1,6 +1,5 @@
 import { progressAnatomy as parts } from "@chakra-ui/anatomy"
 import {
-  generateStripe,
   getColor,
   mode,
   PartsStyleFunction,
@@ -11,6 +10,22 @@ import type {
   SystemStyleObject,
   SystemStyleFunction,
 } from "@chakra-ui/theme-tools"
+
+function generateStripe(size = "1rem", color = "rgba(255, 255, 255, 0.15)") {
+  return {
+    backgroundImage: `linear-gradient(
+    45deg,
+    ${color} 25%,
+    transparent 25%,
+    transparent 50%,
+    ${color} 50%,
+    ${color} 75%,
+    transparent 75%,
+    transparent
+  )`,
+    backgroundSize: `${size} ${size}`,
+  }
+}
 
 function filledStyle(props: StyleFunctionProps): SystemStyleObject {
   const { colorScheme: c, theme: t, isIndeterminate, hasStripe } = props

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,9 +2375,9 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@ctrl/tinycolor@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
-  integrity sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz#75b4c27948c81e88ccd3a8902047bcd797f38d32"
+  integrity sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==
 
 "@discordjs/collection@^0.1.6":
   version "0.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6584,7 +6584,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.1", "@types/react@^18.0.0", "@types/react@^18.0.1":
+"@types/react@*", "@types/react@18.0.1", "@types/react@^18.0.1":
   version "18.0.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.1.tgz#1b2e02fb7613212518733946e49fb963dfc66e19"
   integrity sha512-VnWlrVgG0dYt+NqlfMI0yUYb8Rdl4XUROyH+c6gq/iFCiZ805Vi//26UW38DHnxQkbDhnrIWTBiy6oKZqL11cw==


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Relates to #4975 <!-- Github issue # here -->

## 📝 Description

The goal of this PR is to remove the dependency to `@ctrl/tinycolor`. Which would shrink the bundle size by quite a bit.

Most of our color utility functions in `theme-tools` are not used internally in the codebase of Chakra UI. The tradeoff here for the higher bundle size is not worth the little usage. Also removing those functions simplifies the code to maintain.

Users that want to work with advanced color functions should pick their library of choice and overwrite the theme.

Let me know what you think.

Steps after discussion:
- [ ] write tests
- [ ] cleanup
- [ ] changesets

## ⛳️ Current behavior (updates)

Currently we have `@ctrl/tinycolor` as dependency and use some of its functionality for our color utility functions.

## 🚀 New behavior

All the functionality of `@ctrl/tinycolor` is either replaced by custom functions or removed / deprecated completely.

## 💣 Is this a breaking change (Yes/No):

Yes if we remove everything. No if we deprecated in a first step.

## 📝 Additional Information

I wasn't sure if removing everything directly is a good call, as we shipped those functions. So I chose to mark all the functions as deprecated to inform potential users. Let me know what's best here.

Also the getColor function could possibly be removed. It is not used consistently in the theme. This would lead to even less code to be maintained and no new code needed to replace the functionality from `@ctrl/tinycolor`