### PR TITLE
feature: support for adding custom icons

### DIFF
--- a/.changeset/empty-cats-sin.md
+++ b/.changeset/empty-cats-sin.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/alert": patch
+---
+
+The `AlertIcon` component accepts custom icons as React children
+
+```jsx
+<AlertIcon>
+  <MyCustomIcon />
+</AlertIcon>
+```

--- a/.changeset/rotten-zoos-train.md
+++ b/.changeset/rotten-zoos-train.md
@@ -1,0 +1,21 @@
+---
+"@chakra-ui/toast": minor
+---
+
+Added support for custom icons in a toast:
+
+```tsx
+const toast = useToast()
+return (
+  <Button
+    onClick={() => {
+      toast({
+        title: "Message me",
+        icon: "💬",
+      })
+    }}
+  >
+    Show Toast with custom icon
+  </Button>
+)
+```

--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -132,7 +132,7 @@ export const AlertIcon: React.FC<AlertIconProps> = (props) => {
       className={cx("chakra-alert__icon", props.className)}
       __css={css}
     >
-      <BaseIcon h="100%" w="100%" />
+      {props.children || <BaseIcon h="100%" w="100%" />}
     </chakra.span>
   )
 }

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -19,7 +19,7 @@ export interface ToastProps
 }
 
 export const Toast: React.FC<ToastProps> = (props) => {
-  const { status, variant, id, title, isClosable, onClose, description } = props
+  const { status, variant, id, title, isClosable, onClose, description, icon } = props
 
   const alertTitleId =
     typeof id !== "undefined" ? `toast-${id}-title` : undefined
@@ -37,7 +37,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
       width="auto"
       aria-labelledby={alertTitleId}
     >
-      <AlertIcon />
+      {icon || <AlertIcon />}
       <chakra.div flex="1" maxWidth="100%">
         {title && <AlertTitle id={alertTitleId}>{title}</AlertTitle>}
         {description && (

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -37,7 +37,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
       width="auto"
       aria-labelledby={alertTitleId}
     >
-      {icon || <AlertIcon />}
+      <AlertIcon>{icon}</AlertIcon>
       <chakra.div flex="1" maxWidth="100%">
         {title && <AlertTitle id={alertTitleId}>{title}</AlertTitle>}
         {description && (

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -46,6 +46,10 @@ export interface UseToastOptions extends ThemingProps<"Alert"> {
    */
   status?: AlertStatus
   /**
+  * A custom icon that will be displayed by the toast.
+  */
+  icon?: React.ReactNode
+  /**
    * The `id` of the toast.
    *
    * Mostly used when you need to prevent duplicate.

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -381,7 +381,7 @@ export const AsyncToast = () => {
   )
 }
 
-export const ToastWidthCustomIcon = () => {
+export const ToastWithCustomIcon = () => {
   const toast = useToast()
   const id = "toast-with-custom-icon"
 

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -409,8 +409,8 @@ export const ToastWidthCustomIcon = () => {
       <Button
         onClick={() =>
           toast.update(id, {
-            title: "You have reached me 🥳!!!",
-            description: "You now have permissions to perform this action.",
+            title: "You have reached me!!!",
+            icon: <span>🥳</span>,
             duration: 3000,
           })
         }

--- a/packages/toast/stories/toast.stories.tsx
+++ b/packages/toast/stories/toast.stories.tsx
@@ -380,3 +380,44 @@ export const AsyncToast = () => {
     </ButtonGroup>
   )
 }
+
+export const ToastWidthCustomIcon = () => {
+  const toast = useToast()
+  const id = "toast-with-custom-icon"
+
+  return (
+    <ButtonGroup>
+      <Button
+        onClick={() => {
+          if (toast.isActive(id)) return
+          toast({
+            id,
+            position: "top-left",
+            title: "Message me",
+            icon: <span>💬</span>,
+            duration: null,
+            isClosable: true,
+            onCloseComplete: () => {
+              console.log("hello")
+            },
+          })
+        }}
+      >
+        Show Toast
+      </Button>
+      <Button onClick={() => toast.closeAll()}>Close all</Button>
+      <Button
+        onClick={() =>
+          toast.update(id, {
+            title: "You have reached me 🥳!!!",
+            description: "You now have permissions to perform this action.",
+            duration: 3000,
+          })
+        }
+      >
+        Update
+      </Button>
+      <Button onClick={() => toast.close(id)}>Close One</Button>
+    </ButtonGroup>
+  )
+} 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5930

## 📝 Description

> Adds support for passing in custom icons into toasts. 

## ⛳️ Current behavior (updates)

> we do not have a possibility to render custom icons on the toast element.

## 🚀 New behavior

> The toasts elements will now render custom icons, if they are passed into their props. If there are no icons passed in, we will render the Default `<AlertIcon />` component. The icon is a React Node that will be passed into the component using the prop `icon`, which is `optional`.

## 💣 Is this a breaking change (Yes/No):

No, this does not break anything instead adds a new feature.

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
This would be a great feature for devs who want to customise their toast's UI. So, I just need to know that if this feature will fit match UI perfectly.