### PR TITLE
chore: do not publish src files

### DIFF
--- a/.changeset/thirty-trains-brush.md
+++ b/.changeset/thirty-trains-brush.md
@@ -71,4 +71,5 @@
 "@chakra-ui/test-utils": major
 ---
 
-Bump peer depencency to React and ReactDOM to >=18
+- Bump peer dependency to React and ReactDOM to >=18
+- Omit `src` directory from being published to npm

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -22,8 +22,7 @@
   "module": "dist/chakra-ui-accordion.esm.js",
   "types": "dist/chakra-ui-accordion.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-alert.esm.js",
   "types": "dist/chakra-ui-alert.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/anatomy/package.json
+++ b/packages/anatomy/package.json
@@ -16,8 +16,7 @@
   "types": "dist//chakra-ui-anatomy.cjs.d.ts",
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -20,8 +20,7 @@
   "module": "dist/chakra-ui-avatar.esm.js",
   "types": "dist/chakra-ui-avatar.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-breadcrumb.esm.js",
   "types": "dist/chakra-ui-breadcrumb.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-button.esm.js",
   "types": "dist/chakra-ui-button.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -23,8 +23,7 @@
   "module": "dist/chakra-ui-checkbox.esm.js",
   "types": "dist/chakra-ui-checkbox.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/clickable/package.json
+++ b/packages/clickable/package.json
@@ -17,8 +17,7 @@
   "module": "dist/chakra-ui-clickable.esm.js",
   "types": "dist/chakra-ui-clickable.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -17,8 +17,7 @@
   "module": "dist/chakra-ui-close-button.esm.js",
   "types": "dist/chakra-ui-close-button.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/color-mode/package.json
+++ b/packages/color-mode/package.json
@@ -23,8 +23,7 @@
   "module": "dist/chakra-ui-color-mode.esm.js",
   "types": "dist/chakra-ui-color-mode.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/control-box/package.json
+++ b/packages/control-box/package.json
@@ -16,8 +16,7 @@
   "module": "dist/chakra-ui-control-box.esm.js",
   "types": "dist/chakra-ui-control-box.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -21,8 +21,7 @@
   "module": "dist/chakra-ui-counter.esm.js",
   "types": "dist/chakra-ui-counter.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/css-reset/package.json
+++ b/packages/css-reset/package.json
@@ -17,8 +17,7 @@
   "module": "dist/chakra-ui-css-reset.esm.js",
   "types": "dist/chakra-ui-css-reset.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/descendant/package.json
+++ b/packages/descendant/package.json
@@ -20,8 +20,7 @@
   "module": "dist/chakra-ui-descendant.esm.js",
   "types": "dist/chakra-ui-descendant.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/editable/package.json
+++ b/packages/editable/package.json
@@ -21,8 +21,7 @@
   "module": "dist/chakra-ui-editable.esm.js",
   "types": "dist/chakra-ui-editable.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -18,8 +18,7 @@
   "types": "dist/chakra-ui-react-env.cjs.d.ts",
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/focus-lock/package.json
+++ b/packages/focus-lock/package.json
@@ -17,8 +17,7 @@
   "module": "dist/chakra-ui-focus-lock.esm.js",
   "types": "dist/chakra-ui-focus-lock.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -21,8 +21,7 @@
   "module": "dist/chakra-ui-form-control.esm.js",
   "types": "dist/chakra-ui-form-control.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -17,7 +17,6 @@
   "types": "dist/chakra-ui-hooks.cjs.d.ts",
   "files": [
     "dist",
-    "src",
     "use-animation-state"
   ],
   "preconstruct": {

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -17,8 +17,7 @@
   "module": "dist/chakra-ui-icon.esm.js",
   "types": "dist/chakra-ui-icon.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,8 +10,7 @@
   "module": "dist/chakra-ui-icons.esm.js",
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-image.esm.js",
   "types": "dist/chakra-ui-image.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-input.esm.js",
   "types": "dist/chakra-ui-input.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -24,8 +24,7 @@
   "module": "dist/chakra-ui-layout.esm.js",
   "types": "dist/chakra-ui-layout.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/live-region/package.json
+++ b/packages/live-region/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-live-region.esm.js",
   "types": "dist/chakra-ui-live-region.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/media-query/package.json
+++ b/packages/media-query/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-media-query.esm.js",
   "types": "dist/chakra-ui-media-query.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -20,8 +20,7 @@
   "module": "dist/chakra-ui-menu.esm.js",
   "types": "dist/chakra-ui-menu.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -25,8 +25,7 @@
   "module": "dist/chakra-ui-modal.esm.js",
   "types": "dist/chakra-ui-modal.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/number-input/package.json
+++ b/packages/number-input/package.json
@@ -24,8 +24,7 @@
   "module": "dist/chakra-ui-number-input.esm.js",
   "types": "dist/chakra-ui-number-input.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/pin-input/package.json
+++ b/packages/pin-input/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-pin-input.esm.js",
   "types": "dist/chakra-ui-pin-input.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-popover.esm.js",
   "types": "dist/chakra-ui-popover.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -22,8 +22,7 @@
   "module": "dist/chakra-ui-popper.esm.js",
   "types": "dist/chakra-ui-popper.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-portal.esm.js",
   "types": "dist/chakra-ui-portal.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -17,8 +17,7 @@
   "module": "dist/chakra-ui-progress.esm.js",
   "types": "dist/chakra-ui-progress.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -6,8 +6,7 @@
   "module": "dist/chakra-ui-provider.esm.js",
   "types": "dist/chakra-ui-provider.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-radio.esm.js",
   "types": "dist/chakra-ui-radio.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -16,8 +16,7 @@
   "types": "dist/chakra-ui-react-utils.cjs.d.ts",
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,8 +6,7 @@
   "module": "dist/chakra-ui-react.esm.js",
   "types": "dist/chakra-ui-react.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-select.esm.js",
   "types": "dist/chakra-ui-select.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -20,8 +20,7 @@
   "module": "dist/chakra-ui-skeleton.esm.js",
   "types": "dist/chakra-ui-skeleton.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/skip-nav/package.json
+++ b/packages/skip-nav/package.json
@@ -21,8 +21,7 @@
   "module": "dist/chakra-ui-skip-nav.esm.js",
   "types": "dist/chakra-ui-skip-nav.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -27,8 +27,7 @@
   "module": "dist/chakra-ui-slider.esm.js",
   "types": "dist/chakra-ui-slider.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -16,8 +16,7 @@
   "module": "dist/chakra-ui-spinner.esm.js",
   "types": "dist/chakra-ui-spinner.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/stat/package.json
+++ b/packages/stat/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-stat.esm.js",
   "types": "dist/chakra-ui-stat.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -21,8 +21,7 @@
   "module": "dist/chakra-ui-styled-system.esm.js",
   "types": "dist/chakra-ui-styled-system.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-switch.esm.js",
   "types": "dist/chakra-ui-switch.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -20,8 +20,7 @@
   "module": "dist/chakra-ui-system.esm.js",
   "types": "dist/chakra-ui-system.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -27,8 +27,7 @@
   "module": "dist/chakra-ui-table.esm.js",
   "types": "dist/chakra-ui-table.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -27,8 +27,7 @@
   "module": "dist/chakra-ui-tabs.esm.js",
   "types": "dist/chakra-ui-tabs.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-tag.esm.js",
   "types": "dist/chakra-ui-tag.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-textarea.esm.js",
   "types": "dist/chakra-ui-textarea.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/theme-tools/package.json
+++ b/packages/theme-tools/package.json
@@ -16,8 +16,7 @@
   "module": "dist/chakra-ui-theme-tools.esm.js",
   "types": "dist/chakra-ui-theme-tools.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,7 +17,6 @@
   "types": "dist/chakra-ui-theme.cjs.d.ts",
   "files": [
     "dist",
-    "src",
     "components",
     "foundations",
     "foundations/blur",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -16,8 +16,7 @@
   "module": "dist/chakra-ui-toast.esm.js",
   "types": "dist/chakra-ui-toast.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -19,8 +19,7 @@
   "module": "dist/chakra-ui-tooltip.esm.js",
   "types": "dist/chakra-ui-tooltip.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/transition/package.json
+++ b/packages/transition/package.json
@@ -18,8 +18,7 @@
   "module": "dist/chakra-ui-transition.esm.js",
   "types": "dist/chakra-ui-transition.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,8 +10,7 @@
   "module": "dist/chakra-ui-utils.esm.js",
   "types": "dist/chakra-ui-utils.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -24,8 +24,7 @@
   "module": "dist/chakra-ui-visually-hidden.esm.js",
   "types": "dist/chakra-ui-visually-hidden.cjs.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/plop-templates/component/package.json.hbs
+++ b/plop-templates/component/package.json.hbs
@@ -13,8 +13,7 @@
   "types": "dist/chakra-ui-{{componentName}}.cjs.d.ts",
   "sideEffects": false,
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "preconstruct": {},
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6584,7 +6584,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.1", "@types/react@^18.0.0", "@types/react@^18.0.1":
+"@types/react@*", "@types/react@18.0.1", "@types/react@^18.0.1":
   version "18.0.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.1.tgz#1b2e02fb7613212518733946e49fb963dfc66e19"
   integrity sha512-VnWlrVgG0dYt+NqlfMI0yUYb8Rdl4XUROyH+c6gq/iFCiZ805Vi//26UW38DHnxQkbDhnrIWTBiy6oKZqL11cw==


### PR DESCRIPTION
Relates to #5855

## 📝 Description

This PR removes the `src` directory from the npm files array to omit those files from being published.
This change aims to fix multiple TS errors reported in the #5855 issue.

## ⛳️ Current behavior (updates)

`src` files of our packages are published

## 🚀 New behavior

`src` files are not getting published

## 💣 Is this a breaking change (Yes/No):

Yes - it impacts the files we are publishing