### PR TITLE
refactor: Fix unsafe any in theme tools mode()

### DIFF
--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -78,7 +78,7 @@ export { runIfFn }
 
 export type Styles = GlobalStyles & JSXElementStyles
 
-export function mode(light: any, dark: any) {
+export function mode(light: string, dark: string) {
   return (props: Dict | StyleFunctionProps) =>
     props.colorMode === "dark" ? dark : light
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/5960

## 📝 Description

This PR increases the accuracy & safety of `mode()` arg/return types

## ⛳️ Current behavior (updates)

Currently, using `mode()` returns `any`, which causes TypeScript ESLint to throw an unsafe assignment error:
```
Unsafe assignment of an `any` value. (@typescript-eslint/no-unsafe-assignment)
 FILE  /Users/mc/Sites/saber/client/src/theme/global.ts:9:7

     7 |   global: (props) => ({
     8 |     '*, *::before, &::after': {
  >  9 |       borderColor: mode('gray.300', 'whiteAlpha.300')(props),
       |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    10 |     },
    11 |   }),
    12 | }
```

## 🚀 New behavior

Looking at the value of `SystemStyleObject`, I believe the return value needs to be a string:
```ts
type CSSDefinition<D> = D | string | RecursiveCSSSelector<D | string>

export interface RecursiveCSSSelector<D> {
  [selector: string]: CSSDefinition<D> & D
}

export type RecursiveCSSObject<D> = D &
  (D | RecursivePseudo<D> | RecursiveCSSSelector<D>)

export type CSSObject = RecursiveCSSObject<CSSWithMultiValues>

export type SystemStyleObject = CSSObject
```

This commit updates `mode()`'s `light` and `dark` args to be `string`, instead of `any`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
