### PR TITLE
Make `leastDestructiveRef` property non-nullable

### DIFF
--- a/.changeset/nervous-keys-look.md
+++ b/.changeset/nervous-keys-look.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Make `leastDestructiveRef` non-nullable

--- a/packages/modal/src/alert-dialog.tsx
+++ b/packages/modal/src/alert-dialog.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { Modal, ModalContent, ModalContentProps, ModalProps } from "./modal"
 
 export interface AlertDialogProps extends Omit<ModalProps, "initialFocusRef"> {
-  leastDestructiveRef?: ModalProps["initialFocusRef"]
+  leastDestructiveRef: NonNullable<ModalProps["initialFocusRef"]>
 }
 
 export function AlertDialog(props: AlertDialogProps) {

--- a/packages/modal/src/alert-dialog.tsx
+++ b/packages/modal/src/alert-dialog.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { Modal, ModalContent, ModalContentProps, ModalProps } from "./modal"
 
 export interface AlertDialogProps extends Omit<ModalProps, "initialFocusRef"> {
-  leastDestructiveRef: ModalProps["initialFocusRef"]
+  leastDestructiveRef?: ModalProps["initialFocusRef"]
 }
 
 export function AlertDialog(props: AlertDialogProps) {


### PR DESCRIPTION
## 📝 Description

There was likely an oversight when creating the type definition for `AlertDialog`. `AlertDialogProps` requires the `leastDestructiveRef` property to be present, even though the property can be trivially set to `undefined`. This makes the property effectively optional, but the types don't (currently) allow this.

## ⛳️ Current behavior (updates)

When creating a `AlertDialog` in a TS project, the elements requires the `leastDestructiveRef` property. However, the property can trivially be set to `undefined`.

```tsx
      <AlertDialog
        isOpen
        onClose={() => { ... }}
        leastDestructiveRef={undefined}
      >
```

## 🚀 New behavior

When creating a `AlertDialog` in a TS project, the `leastDestructiveRef` property is now optional and can be omitted.

```tsx
      <AlertDialog
        isOpen
        onClose={() => { ... }}
      >
```

The behavior is identical to setting `leastDestructiveRef` to undefined.

## 💣 Is this a breaking change (Yes/No):

No.
