### PR TITLE
Fix: ts no unchecked index access

### DIFF
--- a/.changeset/purple-coins-punch.md
+++ b/.changeset/purple-coins-punch.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Fixed typescript errors when using `noUncheckedIndexedAccess` inside your
+project.

--- a/.changeset/rude-parrots-fry.md
+++ b/.changeset/rude-parrots-fry.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Fixed typescript errors when using `noUncheckedIndexedAccess` inside your
+project.

--- a/packages/theme/src/components/number-input.ts
+++ b/packages/theme/src/components/number-input.ts
@@ -61,12 +61,12 @@ function getSize(size: FontSize): PartsStyleObject<typeof parts> {
     xs: "sm",
   }
 
-  const _fontSize = (sizeStyle.field?.fontSize ?? "md") as FontSize
+  const _fontSize = (sizeStyle?.field?.fontSize ?? "md") as FontSize
   const fontSize = typography.fontSizes[_fontSize]
 
   return {
     field: {
-      ...sizeStyle.field,
+      ...sizeStyle?.field,
       paddingInlineEnd: $inputPadding.reference,
       verticalAlign: "top",
     },

--- a/packages/theme/src/components/textarea.ts
+++ b/packages/theme/src/components/textarea.ts
@@ -20,10 +20,10 @@ const variants: Record<string, SystemStyleInterpolation> = {
 }
 
 const sizes: Record<string, SystemStyleObject> = {
-  xs: Input.sizes.xs.field ?? {},
-  sm: Input.sizes.sm.field ?? {},
-  md: Input.sizes.md.field ?? {},
-  lg: Input.sizes.lg.field ?? {},
+  xs: Input.sizes.xs?.field ?? {},
+  sm: Input.sizes.sm?.field ?? {},
+  md: Input.sizes.md?.field ?? {},
+  lg: Input.sizes.lg?.field ?? {},
 }
 
 const defaultProps = {

--- a/packages/toast/src/use-toast-provider.tsx
+++ b/packages/toast/src/use-toast-provider.tsx
@@ -109,10 +109,11 @@ export function useToastProvider(
       setAreas((prevState) => {
         const nextState = { ...prevState }
         const { position, index } = findToast(nextState, id)
+        const toast = nextState[position][index]
 
-        if (position && index !== -1) {
+        if (position && index !== -1 && toast) {
           nextState[position][index] = {
-            ...nextState[position][index],
+            ...toast,
             ...options,
           }
         }


### PR DESCRIPTION
## 📝 Description

When using `noUncheckedIndexAccess` in your tsconfig file and having a single import of `@chakra-ui/react` in your project, `tsc` command will fail.
Added checks to some variables where this issue is happening.

## ⛳️ Current behavior (updates)

Errors about undefined properties when using the `tsc` to build or check typescript inside your project.

## 🚀 New behavior

No more errors about undefined properties when using the `tsc` to build or check typescript.
