### PR TITLE
fix(popper): match-width behavior

### DIFF
--- a/.changeset/thirty-ghosts-lick.md
+++ b/.changeset/thirty-ghosts-lick.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/popper": patch
+---
+
+Fix issue where matchWidth doesn't work as expected due to the fixed
+`min-width: max-content` style attached to the element

--- a/examples/nextjs-typescript/components/PropertySummary.tsx
+++ b/examples/nextjs-typescript/components/PropertySummary.tsx
@@ -15,7 +15,7 @@ export const PropertySummary = ({ property }: { property: Property }) => {
     <Box maxW="sm" borderWidth="1px" borderRadius="lg" overflow="hidden">
       <Image src={property.imageUrl} alt={property.imageAlt} />
       <Box p="6">
-        <Box d="flex" alignItems="baseline">
+        <Box display="flex" alignItems="baseline">
           {property.isNew && (
             <Badge borderRadius="full" px="2" colorScheme="teal" mr="2">
               New
@@ -37,7 +37,7 @@ export const PropertySummary = ({ property }: { property: Property }) => {
           fontWeight="semibold"
           as="h4"
           lineHeight="tight"
-          isTruncated
+          noOfLines={1}
         >
           {property.title}
         </Box>

--- a/packages/popover/stories/popover.stories.tsx
+++ b/packages/popover/stories/popover.stories.tsx
@@ -240,3 +240,19 @@ export function WithPopoverAnchor() {
     </Popover>
   )
 }
+
+export const WithMatchWidth = () => (
+  <Popover matchWidth>
+    <PopoverTrigger>
+      <Button w="400px">Long Content</Button>
+    </PopoverTrigger>
+    <PopoverContent w="full">
+      <PopoverBody>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </PopoverBody>
+    </PopoverContent>
+  </Popover>
+)

--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -141,7 +141,10 @@ export function usePopper(props: UsePopperProps = {}) {
         customModifiers.innerArrow,
         customModifiers.positionArrow,
         customModifiers.transformOrigin,
-        { ...customModifiers.matchWidth, enabled: !!matchWidth },
+        {
+          ...customModifiers.matchWidth,
+          enabled: !!matchWidth,
+        },
         {
           name: "eventListeners",
           ...getEventListenerOptions(eventListeners),
@@ -235,11 +238,11 @@ export function usePopper(props: UsePopperProps = {}) {
       style: {
         ...props.style,
         position: strategy,
-        minWidth: "max-content",
+        minWidth: matchWidth ? undefined : "max-content",
         inset: "0 auto auto 0",
       },
     }),
-    [strategy, popperRef],
+    [strategy, popperRef, matchWidth],
   )
 
   const getArrowProps = useCallback<PropGetterV2<"div", ArrowCSSVarProps>>(

--- a/packages/popper/stories/popper.stories.tsx
+++ b/packages/popper/stories/popper.stories.tsx
@@ -92,3 +92,50 @@ declare module "csstype" {
     [k: string]: any
   }
 }
+
+export const WithMatchWidth = () => {
+  const { onToggle } = useDisclosure()
+
+  const { getPopperProps, getReferenceProps } = usePopper({
+    placement: "bottom-start",
+    matchWidth: true,
+  })
+
+  const popperProps = getPopperProps()
+
+  return (
+    <>
+      <button
+        {...getReferenceProps()}
+        onClick={onToggle}
+        style={{ width: "400px", margin: 400 }}
+      >
+        Toggle
+      </button>
+      <div
+        {...popperProps}
+        style={{
+          ...popperProps,
+          background: "red",
+        }}
+      >
+        <div style={{ width: "100%" }}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum
+          dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+          commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+          velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+          occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+          mollit anim id est laborum.
+        </div>
+      </div>
+    </>
+  )
+}

--- a/packages/system/src/should-forward-prop.ts
+++ b/packages/system/src/should-forward-prop.ts
@@ -9,7 +9,6 @@ const allPropNames = new Set([
   "textStyle",
   "layerStyle",
   "apply",
-  "isTruncated",
   "noOfLines",
   "focusBorderColor",
   "errorBorderColor",

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -22,10 +22,6 @@ export interface ThemingProps<ThemeComponent extends string = any> {
 
 export interface ChakraProps extends SystemProps {
   /**
-   * if `true`, it'll render an ellipsis when the text exceeds the width of the viewport or maxWidth set.
-   */
-  isTruncated?: boolean
-  /**
    * Used to truncate text at a specific number of lines
    */
   noOfLines?: ResponsiveValue<number>

--- a/packages/tag/src/tag.tsx
+++ b/packages/tag/src/tag.tsx
@@ -49,7 +49,7 @@ export interface TagLabelProps extends HTMLChakraProps<"span"> {}
 
 export const TagLabel = forwardRef<TagLabelProps, "span">((props, ref) => {
   const styles = useStyles()
-  return <chakra.span ref={ref} isTruncated {...props} __css={styles.label} />
+  return <chakra.span ref={ref} noOfLines={1} {...props} __css={styles.label} />
 })
 
 if (__DEV__) {


### PR DESCRIPTION
Closes #5865

## 📝 Description

ix issue where` matchWidth` doesn't work as expected due to the fixed `min-width: max-content` style attached to the element

## ⛳️ Current behavior (updates)

- If the content length is shorter than the trigger, the matchWidth property works as expected
- If the content length is longer than the trigger, due to the `min-width: max-content`, the min-width becomes the length of the content and gets longer than the trigger.

## 🚀 New behavior

We don't apply `min-width: max-content` when `matchWidth` is set to `true`

## 💣 Is this a breaking change (Yes/No):

No
