### PR TITLE
fix: wrap spacing collapse with zero value

### DIFF
--- a/.changeset/small-hats-raise.md
+++ b/.changeset/small-hats-raise.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/layout": patch
+---
+
+Fix issue where setting zero value for either x or y causes all spacing to be
+collapse (and not work)

--- a/packages/layout/src/wrap.tsx
+++ b/packages/layout/src/wrap.tsx
@@ -45,6 +45,10 @@ export interface WrapProps extends HTMLChakraProps<"div"> {
   shouldWrapChildren?: boolean
 }
 
+function px(value: number | string | null): string | null {
+  return typeof value === "number" ? `${value}px` : value
+}
+
 /**
  * Layout component used to stack elements that differ in length
  * and are liable to wrap.
@@ -76,9 +80,9 @@ export const Wrap = forwardRef<WrapProps, "div">((props, ref) => {
     }
     return {
       "--chakra-wrap-x-spacing": (theme: Dict) =>
-        mapResponsive(x, (value) => tokenToCSSVar("space", value)(theme)),
+        mapResponsive(x, (value) => px(tokenToCSSVar("space", value)(theme))),
       "--chakra-wrap-y-spacing": (theme: Dict) =>
-        mapResponsive(y, (value) => tokenToCSSVar("space", value)(theme)),
+        mapResponsive(y, (value) => px(tokenToCSSVar("space", value)(theme))),
       "--wrap-x-spacing": "calc(var(--chakra-wrap-x-spacing) / 2)",
       "--wrap-y-spacing": "calc(var(--chakra-wrap-y-spacing) / 2)",
       display: "flex",
@@ -103,7 +107,12 @@ export const Wrap = forwardRef<WrapProps, "div">((props, ref) => {
     : children
 
   return (
-    <chakra.div ref={ref} className={cx("chakra-wrap", className)} {...rest}>
+    <chakra.div
+      ref={ref}
+      className={cx("chakra-wrap", className)}
+      overflow="hidden"
+      {...rest}
+    >
       <chakra.ul className="chakra-wrap__list" __css={styles}>
         {childrenToRender}
       </chakra.ul>

--- a/packages/layout/stories/wrap.stories.tsx
+++ b/packages/layout/stories/wrap.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Badge, Wrap, WrapItem } from "../src"
+import { Badge, Box, Text, Wrap, WrapItem } from "../src"
 
 export default {
   title: "Components / Layout / Wrap",
@@ -31,7 +31,7 @@ const Placeholder = (props: any) => (
 )
 
 export const placeholder = () => (
-  <Wrap spacing={5}>
+  <Wrap bg="pink" spacing={5}>
     <Placeholder />
     <Placeholder />
     <Placeholder />
@@ -63,7 +63,7 @@ export const responsive = () => (
 )
 
 export const horizontalAndVertical = () => (
-  <Wrap spacingY={["0px", "24px"]} spacingX={["4px", "12px"]}>
+  <Wrap bg="pink" spacingY={["0px", "24px"]} spacingX={["4px", "12px"]}>
     <Placeholder />
     <Placeholder />
     <Placeholder />
@@ -76,4 +76,26 @@ export const horizontalAndVertical = () => (
     <Placeholder />
     <Placeholder />
   </Wrap>
+)
+
+export const withZeroXSpacing = () => (
+  <Box>
+    <Text>Welcome</Text>
+    <Box bg="pink">
+      <Wrap maxW="200px" spacingX={20} spacingY={4}>
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </Wrap>
+    </Box>
+    <Text>Welcome</Text>
+  </Box>
 )


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5907

## 📝 Description

Fix issue where setting zero value for either x or y causes all spacing to be collapse (and not work)

## ⛳️ Current behavior (updates)

See attached issue

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
