### PR TITLE
fix: checkbox reset to defaultCheck

### DIFF
--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -249,6 +249,18 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     }
   }, [inputRef.current])
 
+  /**
+   * HTMLFormElement.reset() should reset the checkbox state
+   */
+  useSafeLayoutEffect(() => {
+    if (!inputRef.current) return
+    if (inputRef.current.form) {
+      inputRef.current.form.onreset = () => {
+        setCheckedState(!!defaultChecked)
+      }
+    }
+  }, [inputRef.current])
+
   const getCheckboxProps: PropGetter = useCallback(
     (props = {}, forwardedRef = null) => {
       const onPressDown = (event: React.MouseEvent) => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

In issue #5820 checkbox was on resetting to its default state when `HTMLFormElement.reset() `is triggered

## ⛳️ Current behavior (updates)

Currently, no change happens in the checkbox when we call `form.reset()`

## 🚀 New behavior

Now it's resetting to its default state.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
