### PR TITLE
fix(storybook-addon): use default theme as fallback

### DIFF
--- a/.changeset/five-dots-own.md
+++ b/.changeset/five-dots-own.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/storybook-addon": patch
+---
+
+Fixed an issue where the storybook addon did not use the default theme if none
+was provided

--- a/examples/storybook-addon/.storybook/main.js
+++ b/examples/storybook-addon/.storybook/main.js
@@ -1,11 +1,14 @@
 module.exports = {
-  "stories": [
+  stories: [
     "../../../packages/**/stories/**/*.stories.mdx",
-    "../../../packages/**/stories/**/*.stories.@(js|jsx|ts|tsx)"
+    "../../../packages/**/stories/**/*.stories.@(js|jsx|ts|tsx)",
   ],
-  "addons": [
+  addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "../../../tooling/storybook-addon/"
-  ]
+    "@chakra-ui/storybook-addon",
+  ],
+  features: {
+    emotionAlias: false,
+  },
 }

--- a/examples/storybook-addon/package.json
+++ b/examples/storybook-addon/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.16.0",
+    "@chakra-ui/storybook-addon": "2.0.0-next.4",
     "@storybook/addon-actions": "~6.5.0-alpha.64",
     "@storybook/react": "~6.5.0-alpha.64"
   },

--- a/tooling/storybook-addon/src/feature/decorator/ChakraProviderDecorator.tsx
+++ b/tooling/storybook-addon/src/feature/decorator/ChakraProviderDecorator.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { StoryContext, StoryFn } from "@storybook/addons"
-import { ChakraProvider, extendTheme } from "@chakra-ui/react"
+import { ChakraProvider, extendTheme, theme } from "@chakra-ui/react"
 import { ColorModeSync } from "../color-mode/ColorModeSync"
 import { useDirection } from "../direction/useDirection"
 import { DIRECTION_TOOL_ID } from "../../constants"
@@ -13,12 +13,11 @@ export const ChakraProviderDecorator = (
     parameters: { chakra: chakraParams },
     globals: { [DIRECTION_TOOL_ID]: globalDirection },
   } = context
-  const direction = useDirection(
-    globalDirection ?? chakraParams.theme?.direction,
-  )
+  const chakraTheme = chakraParams?.theme ?? theme
+  const direction = useDirection(globalDirection ?? chakraTheme?.direction)
   const themeWithDirectionOverride = React.useMemo(
-    () => extendTheme({ direction }, chakraParams.theme),
-    [chakraParams.theme, direction],
+    () => extendTheme({ direction }, chakraTheme),
+    [chakraTheme, direction],
   )
 
   return (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5977

## 📝 Description

This PR fixes the usage of our storybook addon with no custom theme.

## ⛳️ Current behavior (updates)

The storybook-addon expected a custom theme to be set via `parameters`.

## 🚀 New behavior

The storybook-addon uses the default theme as fallback

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
