### PR TITLE
fix: add manager call to colorMode default state

### DIFF
--- a/.changeset/cuddly-countries-sip.md
+++ b/.changeset/cuddly-countries-sip.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/color-mode": patch
+---
+
+Improve SSR for color mode by adding `manager.get()` in the default state

--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -60,7 +60,8 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   const defaultColorMode = initialColorMode === "dark" ? "dark" : "light"
 
   const [colorMode, rawSetColorMode] = React.useState<ColorMode | undefined>(
-    colorModeManager.get() || defaultColorMode,
+    colorModeManager.type === "cookie"
+      ? colorModeManager.get(defaultColorMode) : defaultColorMode
   )
 
   const { document } = useEnvironment()

--- a/packages/color-mode/src/color-mode-provider.tsx
+++ b/packages/color-mode/src/color-mode-provider.tsx
@@ -60,7 +60,7 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   const defaultColorMode = initialColorMode === "dark" ? "dark" : "light"
 
   const [colorMode, rawSetColorMode] = React.useState<ColorMode | undefined>(
-    defaultColorMode,
+    colorModeManager.get() || defaultColorMode,
   )
 
   const { document } = useEnvironment()


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Add `StorageManager.get` call in `colorMode`'s default state for better SSR behavior.

## ⛳️ Current behavior (updates)

`StorageManager` isn't able to read cookies on the server side.

## 🚀 New behavior

Allows for a custom `StorageManager` to be created that'll read cookies on the server side.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
