### PR TITLE
fix(toast): set a default variant of `solid`

### DIFF
--- a/.changeset/bright-news-retire.md
+++ b/.changeset/bright-news-retire.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Set default variant for the toast to `solid`

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -19,7 +19,16 @@ export interface ToastProps
 }
 
 export const Toast: React.FC<ToastProps> = (props) => {
-  const { status, variant, id, title, isClosable, onClose, description, icon } = props
+  const {
+    status,
+    variant = "solid",
+    id,
+    title,
+    isClosable,
+    onClose,
+    description,
+    icon,
+  } = props
 
   const alertTitleId =
     typeof id !== "undefined" ? `toast-${id}-title` : undefined


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6017

## 📝 Description

Provide a default variant to the `Alert` component rendered in [toast.tsx](https://github.com/chakra-ui/chakra-ui/blob/fed228c088bcecc9b367198f79231c98e0a1d29d/packages/toast/src/toast.tsx#L30)

## ⛳️ Current behavior (updates)

No default value is set, so without the user defining the `variant` pop passed into `toast` the default variant from `Alert` of `subtle` will be rendered instead. This can cause accessibility issues with contrast, as the `subtle` variant renders an opaque background.

## 🚀 New behavior

Give the `variant` prop passed into `toast` a default value of `solid` to render solid background colors.

## 💣 Is this a breaking change (Yes/No):

No
