### PR TITLE
fix(types): missing type exports

### DIFF
--- a/.changeset/cuddly-houses-worry.md
+++ b/.changeset/cuddly-houses-worry.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/descendant": patch
+"@chakra-ui/react": patch
+"@chakra-ui/theme": patch
+---
+
+Make sure that types used by other chakra packages are properly exported and
+imported so that `src` directory is not referenced in the emitted type
+declarations. Fixes #6021

--- a/.changeset/lucky-eels-hunt.md
+++ b/.changeset/lucky-eels-hunt.md
@@ -1,7 +1,0 @@
----
-"@chakra-ui/descendant": patch
-"@chakra-ui/theme": patch
----
-
-Make sure that the types used by other chackra packages are properly exported so
-that there isn't reference to \`src\` in type declarations. Fixes #6021

--- a/.changeset/lucky-eels-hunt.md
+++ b/.changeset/lucky-eels-hunt.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/descendant": patch
+"@chakra-ui/theme": patch
+---
+
+Make sure that the types used by other chackra packages are properly exported so
+that there isn't reference to \`src\` in type declarations. Fixes #6021

--- a/packages/descendant/src/index.ts
+++ b/packages/descendant/src/index.ts
@@ -3,5 +3,6 @@ export type {
   Descendant,
   DescendantOptions,
 } from "./descendant"
+export type { UseDescendantsReturn } from "./use-descendant"
 export { createDescendantContext } from "./use-descendant"
 export { createDescendantContext as default } from "./use-descendant"

--- a/packages/react/src/chakra-provider.tsx
+++ b/packages/react/src/chakra-provider.tsx
@@ -4,8 +4,7 @@ import {
   ChakraProviderProps as BaseChakraProviderProps,
 } from "@chakra-ui/provider"
 import { theme } from "@chakra-ui/theme"
-import { ToastProvider } from "@chakra-ui/toast"
-import { ToastProviderProps } from "@chakra-ui/toast/src"
+import { ToastProvider, ToastProviderProps } from "@chakra-ui/toast"
 
 export interface ChakraProviderProps extends BaseChakraProviderProps {
   /**

--- a/packages/theme/src/components/index.ts
+++ b/packages/theme/src/components/index.ts
@@ -1,3 +1,44 @@
+import Accordion from "./accordion"
+import Alert from "./alert"
+import Avatar from "./avatar"
+import Badge from "./badge"
+import Breadcrumb from "./breadcrumb"
+import Button from "./button"
+import Checkbox from "./checkbox"
+import CloseButton from "./close-button"
+import Code from "./code"
+import Container from "./container"
+import Divider from "./divider"
+import Drawer from "./drawer"
+import Editable from "./editable"
+import Form from "./form"
+import FormError from "./form-error"
+import FormLabel from "./form-label"
+import Heading from "./heading"
+import Input from "./input"
+import Kbd from "./kbd"
+import Link from "./link"
+import List from "./list"
+import Menu from "./menu"
+import Modal from "./modal"
+import NumberInput from "./number-input"
+import PinInput from "./pin-input"
+import Popover from "./popover"
+import Progress from "./progress"
+import Radio from "./radio"
+import Select from "./select"
+import Skeleton from "./skeleton"
+import SkipLink from "./skip-link"
+import Slider from "./slider"
+import Spinner from "./spinner"
+import Stat from "./stat"
+import Switch from "./switch"
+import Table from "./table"
+import Tabs from "./tabs"
+import Tag from "./tag"
+import Textarea from "./textarea"
+import Tooltip from "./tooltip"
+
 export { default as Accordion } from "./accordion"
 export { default as Alert } from "./alert"
 export { default as Avatar } from "./avatar"
@@ -38,4 +79,45 @@ export { default as Tabs } from "./tabs"
 export { default as Tag } from "./tag"
 export { default as Textarea } from "./textarea"
 export { default as Tooltip } from "./tooltip"
-
+export default {
+  Accordion,
+  Alert,
+  Avatar,
+  Badge,
+  Breadcrumb,
+  Button,
+  Checkbox,
+  CloseButton,
+  Code,
+  Container,
+  Divider,
+  Drawer,
+  Editable,
+  Form,
+  FormError,
+  FormLabel,
+  Heading,
+  Input,
+  Kbd,
+  Link,
+  List,
+  Menu,
+  Modal,
+  NumberInput,
+  PinInput,
+  Popover,
+  Progress,
+  Radio,
+  Select,
+  Skeleton,
+  SkipLink,
+  Slider,
+  Spinner,
+  Stat,
+  Switch,
+  Table,
+  Tabs,
+  Tag,
+  Textarea,
+  Tooltip,
+}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,4 +1,4 @@
-import * as components from "./components"
+import components from "./components"
 import foundations from "./foundations"
 import styles from "./styles"
 import type { ThemeConfig, ThemeDirection } from "./theme.types"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6021

## 📝 Description

- type `UseDescendantsReturn` wasn't exported from `@chakra-ui/descendants`
- bundle import was used `@chakra-ui/theme` for `Components`
- type `ToastProviderProps` was imported from `src` in `@chakra-ui/react`

## ⛳️ Current behavior (updates)

This resulted in `src` directory being referenced in type declarations of consumers of those packages, which resulted in a failed typecheck in typescript projects not configuring `"skipLibCheck": true` in their `tsconfig.json`

## 🚀 New behavior

- exports `UseDescendantsReturn` type from `@chakra-ui/descendants`
- switches to use default import over bundled import for `Components` in `@chakra-ui/theme`
- `ToastProviderProps` is imported from `@chakra-ui/toast`

This makes sure that `src` directories are no longer referenced in the emitted tye declarations.

## 💣 Is this a breaking change (Yes/No): No
