### PR TITLE
fix: toast position

### DIFF
--- a/.changeset/pink-goats-give.md
+++ b/.changeset/pink-goats-give.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Fix regression with the default toast position. It now defaults to `bottom` as described in docs

--- a/packages/toast/src/create-standalone-toast.tsx
+++ b/packages/toast/src/create-standalone-toast.tsx
@@ -20,7 +20,6 @@ import { getToastPlacement } from "./toast.placement"
 
 const defaults: UseToastOptions = {
   duration: 5000,
-  position: "bottom",
   variant: "solid",
 }
 

--- a/packages/toast/src/create-standalone-toast.tsx
+++ b/packages/toast/src/create-standalone-toast.tsx
@@ -79,7 +79,10 @@ export function createStandaloneToast({
   const normalizeToastOptions = (options?: UseToastOptions) => ({
     ...defaultOptions,
     ...options,
-    position: getToastPlacement(options?.position, theme.direction),
+    position: getToastPlacement(
+      options?.position ?? defaultOptions?.position,
+      theme.direction,
+    ),
   })
 
   const toast = (options?: UseToastOptions) => {

--- a/packages/toast/src/toast.placement.ts
+++ b/packages/toast/src/toast.placement.ts
@@ -24,9 +24,10 @@ type LogicalPlacementMap = Record<
 >
 
 export function getToastPlacement(
-  position: ToastPosition = "bottom",
+  position: ToastPosition | undefined,
   dir: "ltr" | "rtl",
 ): ToastPosition | undefined {
+  const computedPosition = position ?? "bottom"
   const logicals: LogicalPlacementMap = {
     "top-start": { ltr: "top-left", rtl: "top-right" },
     "top-end": { ltr: "top-right", rtl: "top-left" },
@@ -34,6 +35,6 @@ export function getToastPlacement(
     "bottom-end": { ltr: "bottom-right", rtl: "bottom-left" },
   }
 
-  const logical = logicals[position as keyof typeof logicals]
-  return logical?.[dir] ?? position
+  const logical = logicals[computedPosition as keyof typeof logicals]
+  return logical?.[dir] ?? computedPosition
 }

--- a/packages/toast/src/toast.placement.ts
+++ b/packages/toast/src/toast.placement.ts
@@ -24,10 +24,9 @@ type LogicalPlacementMap = Record<
 >
 
 export function getToastPlacement(
-  position: ToastPosition | undefined,
+  position: ToastPosition = "bottom",
   dir: "ltr" | "rtl",
 ): ToastPosition | undefined {
-  if (!position) return
   const logicals: LogicalPlacementMap = {
     "top-start": { ltr: "top-left", rtl: "top-right" },
     "top-end": { ltr: "top-right", rtl: "top-left" },

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -46,8 +46,8 @@ export interface UseToastOptions extends ThemingProps<"Alert"> {
    */
   status?: AlertStatus
   /**
-  * A custom icon that will be displayed by the toast.
-  */
+   * A custom icon that will be displayed by the toast.
+   */
   icon?: React.ReactNode
   /**
    * The `id` of the toast.

--- a/packages/toast/src/use-toast.tsx
+++ b/packages/toast/src/use-toast.tsx
@@ -81,7 +81,10 @@ export function useToast(defaultOptions?: UseToastOptions) {
     const normalizeToastOptions = (options?: UseToastOptions) => ({
       ...defaultOptions,
       ...options,
-      position: getToastPlacement(options?.position, theme.direction),
+      position: getToastPlacement(
+        options?.position ?? defaultOptions?.position,
+        theme.direction,
+      ),
     })
 
     const toast = (options?: UseToastOptions) => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I fixed two toast issues.

1. Fix toast default position to bottom
2. Fix to be able to use the position passed by the `useToast` argument

## ⛳️ Current behavior (updates)

1. According to the [official docs](https://chakra-ui.com/docs/components/feedback/toast#props) and [types](https://github.com/chakra-ui/chakra-ui/blob/32db866119e831dbc38d92c706a67f87d8a3a946/packages/toast/src/use-toast.tsx#L15), the default position is bottom, but for now it is top
2. The position passed by the `useToast` argument does nothing

## 🚀 New behavior

1. Fix toast default position to bottom
2. Fix to be able to use the position passed by the `useToast` argument

## 💣 Is this a breaking change (Yes/No): Yes

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
