### PR TITLE
fix: baseStyle borderRadius on Tag component

### DIFF
--- a/.changeset/nasty-cows-begin.md
+++ b/.changeset/nasty-cows-begin.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Tag component variants borderRadius was overwriting baseStyle eventhough
+borderRadius was same for all variants. borderRadius is now part of the
+baseStyle

--- a/packages/theme/src/components/tag.ts
+++ b/packages/theme/src/components/tag.ts
@@ -10,6 +10,7 @@ const baseStyleContainer: SystemStyleObject = {
   fontWeight: "medium",
   lineHeight: 1.2,
   outline: 0,
+  borderRadius: "md",
   _focus: {
     boxShadow: "outline",
   },
@@ -54,7 +55,6 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
       minW: "1.25rem",
       fontSize: "xs",
       px: 2,
-      borderRadius: "md",
     },
     closeButton: {
       marginEnd: "-2px",
@@ -66,7 +66,6 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
       minH: "1.5rem",
       minW: "1.5rem",
       fontSize: "sm",
-      borderRadius: "md",
       px: 2,
     },
   },
@@ -75,7 +74,6 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
       minH: 8,
       minW: 8,
       fontSize: "md",
-      borderRadius: "md",
       px: 3,
     },
   },


### PR DESCRIPTION
Closes [6054](https://github.com/chakra-ui/chakra-ui/issues/6054)

## 📝 Description

Tag component variants borderRadius was overwriting baseStyle eventhough
borderRadius was same for all variants. borderRadius is now part of the
baseStyle, so it can be overwritten by a custom theme on the baseStyle instead of variants. 

## 💣 Is this a breaking change (Yes/No):

No