### PR TITLE
fix(slider): Updated the styling for the _disabled states.

### DIFF
--- a/.changeset/fast-tips-matter.md
+++ b/.changeset/fast-tips-matter.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/slider": patch
+"@chakra-ui/theme": patch
+---
+
+Slider: Add visual styles for disabled state.

--- a/packages/slider/stories/slider.stories.tsx
+++ b/packages/slider/stories/slider.stories.tsx
@@ -112,3 +112,22 @@ export function SteppedHorizontalSlider() {
     </Slider>
   )
 }
+
+export function WithDisabled() {
+  const [value, setValue] = React.useState<number>(1)
+  return (
+    <Slider
+      value={value}
+      onChange={setValue}
+      min={1}
+      max={7}
+      step={2}
+      isDisabled
+    >
+      <SliderTrack>
+        <SliderFilledTrack />
+      </SliderTrack>
+      <SliderThumb children={value} boxSize="30px" color="black" />
+    </Slider>
+  )
+}

--- a/packages/slider/tests/slider.test.tsx
+++ b/packages/slider/tests/slider.test.tsx
@@ -1,5 +1,5 @@
 import { extendTheme, ThemeProvider } from "@chakra-ui/react"
-import { screen, render, testA11y } from "@chakra-ui/test-utils"
+import { screen, render, testA11y, fireEvent } from "@chakra-ui/test-utils"
 import * as React from "react"
 import styled from "@emotion/styled"
 import {
@@ -202,4 +202,34 @@ test("should have colors from styled", async () => {
   styles = getComputedStyle(sliderElement)
 
   expect(styles.backgroundColor).toBe("red")
+})
+
+const DisabledSlider = (props: {
+  defaultValue?: number
+  isReversed?: boolean
+  orientation?: UseSliderProps["orientation"]
+}) => (
+  <Slider
+    data-testid="slider"
+    aria-label="slider-2"
+    colorScheme="red"
+    orientation={props.orientation}
+    isReversed={props.isReversed || undefined}
+    defaultValue={props.defaultValue || defaultValue}
+    isDisabled
+  >
+    <SliderTrack>
+      <SliderFilledTrack />
+    </SliderTrack>
+    <SliderThumb />
+  </Slider>
+)
+
+test("should have a `not-allowed` cursor when disabled", async () => {
+  const { getByTestId } = render(<DisabledSlider />)
+  const sliderElement = getByTestId("slider")
+
+  fireEvent.mouseDown(sliderElement)
+  const styles = getComputedStyle(sliderElement)
+  expect(styles.cursor).toBe("not-allowed")
 })

--- a/packages/theme/src/components/slider.ts
+++ b/packages/theme/src/components/slider.ts
@@ -15,6 +15,9 @@ function thumbOrientation(props: StyleFunctionProps): SystemStyleObject {
       transform: `translateX(-50%)`,
       _active: {
         transform: `translateX(-50%) scale(1.15)`,
+        _disabled: {
+          transform: `translateX(-50%)`,
+        },
       },
     },
     horizontal: {
@@ -22,6 +25,9 @@ function thumbOrientation(props: StyleFunctionProps): SystemStyleObject {
       transform: `translateY(-50%)`,
       _active: {
         transform: `translateY(-50%) scale(1.15)`,
+        _disabled: {
+          transform: `translateY(-50%)`,
+        },
       },
     },
   })
@@ -36,8 +42,8 @@ const baseStyleContainer: SystemStyleFunction = (props) => {
     cursor: "pointer",
     _disabled: {
       opacity: 0.6,
-      cursor: "default",
-      pointerEvents: "none",
+      cursor: "not-allowed",
+      pointerEvents: "auto",
     },
     ...orient({
       orientation,


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6060 

## 📝 Description

Updating the styling of the `slider` component to add the `not-allowed` cursor on hover when `isDisabled`.

## ⛳️ Current behavior (updates)

Currently, there is no cursor displayed when hovering the `slider` component when it is disabled.
See live example here: https://codesandbox.io/s/fix-slider-add-disabled-state-cd8q66

## 🚀 New behavior

When hover, the cursor will display as `not-allowed`.

## 💣 Is this a breaking change (Yes/No):

No, not a breaking change.

## 📝 Additional Information

(1) Updated baseStyleContainer to show the "not-allowed" cursor when disabled.
(2) Updated thumbOrientation _active -> _disabled state to translateY when active and disabled.
    This update was necessary, because the pointerEvents on baseStyleContainer needed to be turned
    to "auto" from "none" or else the "not-allowed" cursor would not be shown.