### PR TITLE
fix(tabs): Adding disabled state for all variants.

### DIFF
--- a/.changeset/seven-swans-joke.md
+++ b/.changeset/seven-swans-joke.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Tab: Add visual feedback for disabled state in all variants.

--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -26,6 +26,10 @@ const baseStyleTab: SystemStyleFunction = (props) => {
       zIndex: 1,
       boxShadow: "outline",
     },
+    _disabled: {
+      cursor: "not-allowed",
+      opacity: 0.4,
+    },
   }
 }
 
@@ -102,8 +106,6 @@ const variantLine: PartsStyleFunction<typeof parts> = (props) => {
         bg: mode("gray.200", "whiteAlpha.300")(props),
       },
       _disabled: {
-        opacity: 0.4,
-        cursor: "not-allowed",
         _active: { bg: "none" },
       },
     },
@@ -122,10 +124,6 @@ const variantEnclosed: PartsStyleFunction<typeof parts> = (props) => {
         color: mode(`${c}.600`, `${c}.300`)(props),
         borderColor: "inherit",
         borderBottomColor: mode(`white`, `gray.800`)(props),
-      },
-      _disabled: {
-        cursor: "not-allowed",
-        opacity: 0.4,
       },
     },
     tablist: {
@@ -154,10 +152,6 @@ const variantEnclosedColored: PartsStyleFunction<typeof parts> = (props) => {
         borderTopColor: "currentColor",
         borderBottomColor: "transparent",
       },
-      _disabled: {
-        cursor: "not-allowed",
-        opacity: 0.4,
-      },
     },
     tablist: {
       mb: "-1px",
@@ -178,10 +172,6 @@ const variantSoftRounded: PartsStyleFunction<typeof parts> = (props) => {
         color: getColor(theme, `${c}.700`),
         bg: getColor(theme, `${c}.100`),
       },
-      _disabled: {
-        cursor: "not-allowed",
-        opacity: 0.4,
-      },
     },
   }
 }
@@ -196,10 +186,6 @@ const variantSolidRounded: PartsStyleFunction<typeof parts> = (props) => {
       _selected: {
         color: mode(`#fff`, "gray.800")(props),
         bg: mode(`${c}.600`, `${c}.300`)(props),
-      },
-      _disabled: {
-        cursor: "not-allowed",
-        opacity: 0.4,
       },
     },
   }

--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -104,6 +104,7 @@ const variantLine: PartsStyleFunction<typeof parts> = (props) => {
       _disabled: {
         opacity: 0.4,
         cursor: "not-allowed",
+        _active: { bg: "none" },
       },
     },
   }
@@ -121,6 +122,10 @@ const variantEnclosed: PartsStyleFunction<typeof parts> = (props) => {
         color: mode(`${c}.600`, `${c}.300`)(props),
         borderColor: "inherit",
         borderBottomColor: mode(`white`, `gray.800`)(props),
+      },
+      _disabled: {
+        cursor: "not-allowed",
+        opacity: 0.4,
       },
     },
     tablist: {
@@ -149,6 +154,10 @@ const variantEnclosedColored: PartsStyleFunction<typeof parts> = (props) => {
         borderTopColor: "currentColor",
         borderBottomColor: "transparent",
       },
+      _disabled: {
+        cursor: "not-allowed",
+        opacity: 0.4,
+      },
     },
     tablist: {
       mb: "-1px",
@@ -169,6 +178,10 @@ const variantSoftRounded: PartsStyleFunction<typeof parts> = (props) => {
         color: getColor(theme, `${c}.700`),
         bg: getColor(theme, `${c}.100`),
       },
+      _disabled: {
+        cursor: "not-allowed",
+        opacity: 0.4,
+      },
     },
   }
 }
@@ -183,6 +196,10 @@ const variantSolidRounded: PartsStyleFunction<typeof parts> = (props) => {
       _selected: {
         color: mode(`#fff`, "gray.800")(props),
         bg: mode(`${c}.600`, `${c}.300`)(props),
+      },
+      _disabled: {
+        cursor: "not-allowed",
+        opacity: 0.4,
       },
     },
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6062 

## 📝 Description

1. Adds disabled state to variants [`enclosed`, `enclosed-colored`, `soft-rounded`, `solid-rounded`] of the Tabs component. 
2. Also added a fix that prevents visual feedback of a successful click on the `_disabled` tabs of variant `line`.

## ⛳️ Current behavior (updates)
1. Previously there was no visual feedback if a tab was disabled to the end user.
2. Previously, when clicking the tab would show a background color that gave indication of a successful click, other components in the library such as Button, Checkbox, and Input do not display this.

## 🚀 New behavior

1. When a tab is `_disabled` the `cursor: 'not-allowed'` will be shown, also the `opacity: 0.4` will be displayed.
2. When clicking the `_disabled` tab, the background will be `background: none`.

## 💣 Is this a breaking change (Yes/No):

No, this is not a breaking change.

## 📝 Additional Information
(1) Added the disabled state to variantEnclosed, variantEnclosedColored, variantSoftRounded, variantSolidRounded
(2) Set bg to "none" in variantLine when _disabled. This new styling mimics that of other components such as the
    button, checkbox, and input which do not have styling changes on clicks when disabled. AKA it shouldn't look
    like a click when the tab button is disabled.