### PR TITLE
fix: button dom mutation

### DIFF
--- a/.changeset/dirty-buttons-fold.md
+++ b/.changeset/dirty-buttons-fold.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/button": patch
+---
+
+Fix issue where react throws when dom is mutated by external chrome extensions
+(e.g. Google Translate)

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import { useMergeRefs } from "@chakra-ui/hooks"
 import {
   chakra,
@@ -142,17 +141,17 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
         </ButtonSpinner>
       )}
 
-      {isLoading ? (
-        loadingText ? (
-          <span className="chakra-button__loading-text">{loadingText}</span>
-        ) : (
-          <chakra.span opacity={0}>
-            <ButtonContent {...contentProps} />
-          </chakra.span>
-        )
-      ) : (
-        <ButtonContent {...contentProps} />
+      {isLoading && loadingText && (
+        <span className="chakra-button__loading-text">{loadingText}</span>
       )}
+
+      {isLoading && !loadingText && (
+        <chakra.span opacity={0}>
+          <ButtonContent {...contentProps} />
+        </chakra.span>
+      )}
+
+      {!isLoading && <ButtonContent {...contentProps} />}
 
       {isLoading && spinnerPlacement === "end" && (
         <ButtonSpinner

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -142,7 +142,9 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       )}
 
       {isLoading && loadingText && (
-        <span className="chakra-button__loading-text">{loadingText}</span>
+        <chakra.span className="chakra-button__loading-text" display="contents">
+          {loadingText}
+        </chakra.span>
       )}
 
       {isLoading && !loadingText && (
@@ -181,7 +183,9 @@ function ButtonContent(props: ButtonContentProps) {
   return (
     <>
       {leftIcon && <ButtonIcon marginEnd={iconSpacing}>{leftIcon}</ButtonIcon>}
-      <span className="chakra-button__content">{children}</span>
+      <chakra.span className="chakra-button__content" display="contents">
+        {children}
+      </chakra.span>
       {rightIcon && (
         <ButtonIcon marginStart={iconSpacing}>{rightIcon}</ButtonIcon>
       )}

--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import { useMergeRefs } from "@chakra-ui/hooks"
 import {
   chakra,
@@ -142,7 +143,9 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       )}
 
       {isLoading ? (
-        loadingText || (
+        loadingText ? (
+          <span className="chakra-button__loading-text">{loadingText}</span>
+        ) : (
           <chakra.span opacity={0}>
             <ButtonContent {...contentProps} />
           </chakra.span>
@@ -179,7 +182,7 @@ function ButtonContent(props: ButtonContentProps) {
   return (
     <>
       {leftIcon && <ButtonIcon marginEnd={iconSpacing}>{leftIcon}</ButtonIcon>}
-      {children}
+      <span className="chakra-button__content">{children}</span>
       {rightIcon && (
         <ButtonIcon marginStart={iconSpacing}>{rightIcon}</ButtonIcon>
       )}

--- a/packages/button/tests/button-group.test.tsx
+++ b/packages/button/tests/button-group.test.tsx
@@ -14,16 +14,18 @@ it("passes a11y test", async () => {
 })
 
 test("Should apply spacing", () => {
-  const { getByText } = render(
+  const { getByRole } = render(
     <ButtonGroup spacing="4rem">
       <Button>Button 1</Button>
       <Button>Button 2</Button>
     </ButtonGroup>,
   )
-  expect(getByText(/Button 2/i)).toHaveStyle({ marginInlineStart: "4rem" })
+  expect(getByRole("button", { name: "Button 2" })).toHaveStyle({
+    marginInlineStart: "4rem",
+  })
 })
 test("Should flush button", () => {
-  const { getByText } = render(
+  const { getByRole } = render(
     <ButtonGroup isAttached>
       <Button>Button 1</Button>
       <Button>Button 2</Button>
@@ -31,24 +33,24 @@ test("Should flush button", () => {
       <Button>Button 4</Button>
     </ButtonGroup>,
   )
-  expect(getByText(/Button 1/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 1" })).toHaveStyle({
     borderTopRightRadius: "0",
     borderBottomRightRadius: "0",
   })
-  expect(getByText(/Button 2/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 2" })).toHaveStyle({
     borderRadius: "0px",
   })
-  expect(getByText(/Button 3/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 3" })).toHaveStyle({
     borderRadius: "0px",
   })
-  expect(getByText(/Button 4/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 4" })).toHaveStyle({
     borderTopLeftRadius: "0",
     borderBottomLeftRadius: "0",
   })
 })
 
 test("Should flush outline button", () => {
-  const { getByText } = render(
+  const { getByRole } = render(
     <ButtonGroup isAttached variant="outline">
       <Button>Button 1</Button>
       <Button>Button 2</Button>
@@ -56,16 +58,16 @@ test("Should flush outline button", () => {
       <Button>Button 4</Button>
     </ButtonGroup>,
   )
-  expect(getByText(/Button 1/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 1" })).toHaveStyle({
     marginInlineEnd: "-1px",
   })
-  expect(getByText(/Button 2/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 2" })).toHaveStyle({
     marginInlineEnd: "-1px",
   })
-  expect(getByText(/Button 3/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 3" })).toHaveStyle({
     marginInlineEnd: "-1px",
   })
-  expect(getByText(/Button 4/i)).toHaveStyle({
+  expect(getByRole("button", { name: "Button 4" })).toHaveStyle({
     marginInlineEnd: "",
   })
 })


### PR DESCRIPTION
Closes #6004 

## 📝 Description

Fix issue where button throws when its content is mutated by external chrome extensions (Google Translate)

## ⛳️ Current behavior (updates)

After translation, it throws

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
