### PR TITLE
fix(CHANGELOG.md): fix jsx snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ experience.
 - Expose `cookieStorageManagerSSR` for users who prefer to manage color mode
   server-side. If you use this, there's no need for the `ColorModeScript`
 
-````jsx live=false
+```jsx live=false
 function App({ Component, pageProps }) {
   // get the `cookie` from each page `getServerSideProps` return value
   // Note: the implementation is up to you
@@ -48,7 +48,9 @@ function App({ Component, pageProps }) {
     </ChakraProvider>
   )
 }
-```- We now provide a way to customize the localStorage / cookie storage key
+```
+
+- We now provide a way to customize the localStorage / cookie storage key
 
 ```jsx live=false
 import { createLocalStorageManager } from "@chakra-ui/react"
@@ -64,7 +66,7 @@ function App() {
 function Document() {
   return <ColorModeScript storageKey="my-key" />
 }
-````
+```
 
 - Fix inconsistent handling across provider and script
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ function Document() {
 
 - The `AlertIcon` component accepts custom icons as React children
 
-```jsx
+```jsx live=false
 <AlertIcon>
   <MyCustomIcon />
 </AlertIcon>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,9 @@ https://www.conventionalcommits.org/ or check out the
    [Learn more about Changeset](https://github.com/atlassian/changesets/tree/master/packages/cli).
    Please note that you might have to run `git fetch origin main:master` (where
    origin will be your fork on GitHub) before `yarn changeset` works.
+5. Also, if you provide `jsx` snippets to the changeset, please turn off the
+   live preview by doing the following at the beginning of the snippet:
+   ` ```jsx live=false`
 
 > If you made minor changes like CI config, prettier, etc, you can run
 > `yarn changeset add --empty` to generate an empty changeset file to document


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

_Addresses ChakraUI Docs Issue [#632](https://github.com/chakra-ui/chakra-ui-docs/issues/632)_

Update `CHANGELOG.md` to add `live=false` to any jsx snippets that were missing it.

Also, this PR fixes some formatting as well as adding a note in `CONTRIBUTING.md` about always adding `live=false` when including jsx snippets in a changeset.

