### PR TITLE
fix(CHANGELOG.md): fix jsx snippets #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,7 +314,7 @@ return (
 Allow user configure the storage key for the provider and script. We now export
 a `createLocalStorageManager` and `createCookieStorageManager` functions.
 
-```jsx
+```jsx live=false
 const manager = createLocalStorageManager("{storageKey}")
 
 function App({ Component, pageProps }) {
@@ -331,7 +331,7 @@ cookie script, you can set `type=cookie`.
 
 > Pro tip: You can also configure the `storageKey` from script as well
 
-```jsx
+```jsx live=false
 import { ColorModeScript } from "@chakra-ui/react"
 function Document() {
   return (

--- a/scripts/changelog-write.ts
+++ b/scripts/changelog-write.ts
@@ -4,11 +4,16 @@ const cwd = process.cwd()
 
 async function main() {
   const content = fs.readFileSync(`${cwd}/.changelogrc`).toString()
+  // If "live=false" is missing in jsx snippet, add it!
+  const noLiveContent = content.replace(
+    /^(```jsx)(\s?)+$/gim,
+    "```jsx live=false",
+  )
   const changelogPath = `${cwd}/CHANGELOG.md`
   const changelog = await fs.promises.readFile(changelogPath, "utf8")
   const newChangelog = changelog.replace(
     "<!-- CHANGELOG:INSERT -->",
-    `<!-- CHANGELOG:INSERT -->\n\n${content}`,
+    `<!-- CHANGELOG:INSERT -->\n\n${noLiveContent}`,
   )
   // write new changelog
   await fs.promises.writeFile(changelogPath, newChangelog)


### PR DESCRIPTION
Extends merged PR #6073 and further addresses Docs Issue [#632](https://github.com/chakra-ui/chakra-ui-docs/issues/632)

This PR adds `live=false` to jsx snippets that were missing in `CHANGELOG.md`

Also adds a script to take the incoming string from `.changelogrc` and add `live=false` if missing from the jsx snippet, should the contributor provide any.

The regex in the added `replace()` method searches for any line that begins with ` ```jsx ` and checks if there are only spaces (or nothing) after it. I would not expect to need more complexity here since there should only be the `live=false` option to include. Else there are probably formatting issues that would need to be addressed on a case-by-case basis.