### PR TITLE
revert: use-style-config types

### DIFF
--- a/.changeset/six-eyes-sniff.md
+++ b/.changeset/six-eyes-sniff.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/system": patch
+---
+
+Revert type updates for use-style-config

--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -11,22 +11,9 @@ import isEqual from "react-fast-compare"
 import { useChakra } from "./hooks"
 import { ThemingProps } from "./system.types"
 
-export function useStyleConfig(
-  themeKey: string,
-  props: ThemingProps & Dict,
-  opts: { isMultiPart: true },
-): Record<string, SystemStyleObject>
+type StylesRef = SystemStyleObject | Record<string, SystemStyleObject>
 
-export function useStyleConfig(
-  themeKey: string,
-  props?: ThemingProps & Dict,
-  opts?: { isMultiPart?: boolean },
-): SystemStyleObject
-
-export function useStyleConfig(
-  themeKey: string,
-  props: ThemingProps & Dict = {},
-) {
+function useStyleConfigImpl(themeKey: string, props: ThemingProps & Dict = {}) {
   const { styleConfig: styleConfigProp, ...rest } = props
 
   const { theme, colorMode } = useChakra()
@@ -42,7 +29,6 @@ export function useStyleConfig(
   /**
    * Store the computed styles in a `ref` to avoid unneeded re-computation
    */
-  type StylesRef = SystemStyleObject | Record<string, SystemStyleObject>
   const stylesRef = useRef<StylesRef>({})
 
   if (styleConfig) {
@@ -59,9 +45,19 @@ export function useStyleConfig(
   return stylesRef.current
 }
 
+export function useStyleConfig(
+  themeKey: string,
+  props: ThemingProps & Dict = {},
+) {
+  return useStyleConfigImpl(themeKey, props) as SystemStyleObject
+}
+
 export function useMultiStyleConfig(
   themeKey: string,
   props: ThemingProps & Dict = {},
 ) {
-  return useStyleConfig(themeKey, props, { isMultiPart: true })
+  return useStyleConfigImpl(themeKey, props) as Record<
+    string,
+    SystemStyleObject
+  >
 }

--- a/packages/system/src/use-style-config.ts
+++ b/packages/system/src/use-style-config.ts
@@ -13,6 +13,18 @@ import { ThemingProps } from "./system.types"
 
 export function useStyleConfig(
   themeKey: string,
+  props: ThemingProps & Dict,
+  opts: { isMultiPart: true },
+): Record<string, SystemStyleObject>
+
+export function useStyleConfig(
+  themeKey: string,
+  props?: ThemingProps & Dict,
+  opts?: { isMultiPart?: boolean },
+): SystemStyleObject
+
+export function useStyleConfig(
+  themeKey: string,
   props: ThemingProps & Dict = {},
 ) {
   const { styleConfig: styleConfigProp, ...rest } = props
@@ -47,4 +59,9 @@ export function useStyleConfig(
   return stylesRef.current
 }
 
-export const useMultiStyleConfig = useStyleConfig
+export function useMultiStyleConfig(
+  themeKey: string,
+  props: ThemingProps & Dict = {},
+) {
+  return useStyleConfig(themeKey, props, { isMultiPart: true })
+}


### PR DESCRIPTION
## 📝 Description

Due to past PR for responsive variant and size support, there was a regression in the types.

## ⛳️ Current behavior (updates)

Throws a TS error

## 🚀 New behavior

Works

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
