### PR TITLE
docs: Add typescript details to `AlertDialog`

### DIFF
--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -194,7 +194,7 @@ function AlertDialogExample() {
 Using the above example will throw a typescript error. You'll want to modify the type of the `useRef` hook to the HTML element you're placing the focus on and default the value to null.
 
 
-```jsx
+```tsx
   const cancelRef = React.useRef<HTMLButtonElement>(null)
 ```
 

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -189,6 +189,16 @@ function AlertDialogExample() {
 }
 ```
 
+## Usage with Typescript
+
+Using the above example will throw a typescript error. You'll want to modify the type of the `useRef` hook to the HTML element you're placing the focus on and default the value to null.
+
+
+```jsx
+  const cancelRef = React.useRef<HTMLButtonElement>(null)
+```
+
+
 # Drawer
 
 The Drawer component is a panel that slides out from the edge of the screen. It


### PR DESCRIPTION
## 📝 Description

> The `AlertDialog` component currently has an example that Typescript throws an error for. This PR provides a reference point for people hitting the same issue.

## 💣 Is this a breaking change (Yes/No): **No**
