### PR TITLE
fix(toast): add getServerSnapshot function for ssr

### DIFF
--- a/.changeset/sixty-dragons-smell.md
+++ b/.changeset/sixty-dragons-smell.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Fix SSR errors with toast and `use-sync-external-store` due to lack of `getServerSnapshot`

--- a/packages/toast/src/toast.provider.tsx
+++ b/packages/toast/src/toast.provider.tsx
@@ -95,6 +95,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
   const state = React.useSyncExternalStore(
     toastStore.subscribe,
     toastStore.getState,
+    toastStore.getState,
   )
 
   const {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6096

## 📝 Description

`useSyncExternalStore` requires the `getServerSnapshot` argument for ssr, but I forgot to pass it in #6091 .
Add `getServerSnapshot` to fix the toast.

## ⛳️ Current behavior (updates)

Toast doesn't work with ssr

## 🚀 New behavior

Toast work with ssr

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
