### PR TITLE
 feat(color-mode): add option to specify domain

### DIFF
--- a/.changeset/lovely-grapes-develop.md
+++ b/.changeset/lovely-grapes-develop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/color-mode": minor
+---
+
+Add option to specify domain.

--- a/packages/color-mode/src/color-mode-script.tsx
+++ b/packages/color-mode/src/color-mode-script.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 export type ColorModeScriptProps = {
   type?: "localStorage" | "cookie"
   initialColorMode?: "light" | "dark" | "system"
+  cookieDomain?: string
   storageKey?: string
 }
 
@@ -22,6 +23,7 @@ export function getScriptSrc(props: ColorModeScriptProps = {}) {
     initialColorMode = "light",
     type = "localStorage",
     storageKey: key = "chakra-ui-color-mode",
+    cookieDomain
   } = props
 
   // runtime safe-guard against invalid color mode values
@@ -29,7 +31,7 @@ export function getScriptSrc(props: ColorModeScriptProps = {}) {
 
   const isCookie = type === "cookie"
 
-  const cookieScript = `(function(){try{var a=function(o){var l="(prefers-color-scheme: dark)",v=window.matchMedia(l).matches?"dark":"light",e=o==="system"?v:o,d=document.documentElement,m=document.body,i="chakra-ui-light",n="chakra-ui-dark",s=e==="dark";return m.classList.add(s?n:i),m.classList.remove(s?i:n),d.style.colorScheme=e,d.dataset.theme=e,e},u=a,h="${init}",r="${key}",t=document.cookie.match(new RegExp("(^| )".concat(r,"=([^;]+)"))),c=t?t[2]:null;c?a(c):document.cookie="".concat(r,"=").concat(a(h),"; max-age=31536000; path=/")}catch(a){}})();
+  const cookieScript = `(function(){try{var a=function(o){var l="(prefers-color-scheme: dark)",v=window.matchMedia(l).matches?"dark":"light",e=o==="system"?v:o,d=document.documentElement,m=document.body,i="chakra-ui-light",n="chakra-ui-dark",s=e==="dark";return m.classList.add(s?n:i),m.classList.remove(s?i:n),d.style.colorScheme=e,d.dataset.theme=e,e},u=a,h="${init}",r="${key}",t=document.cookie.match(new RegExp("(^| )".concat(r,"=([^;]+)"))),c=t?t[2]:null;c?a(c):document.cookie="".concat(r,"=").concat(a(h),";${cookieDomain ? ` domain=${cookieDomain};` : ''} max-age=31536000; path=/")}catch(a){}})();
   `
 
   const localStorageScript = `(function(){try{var a=function(c){var v="(prefers-color-scheme: dark)",h=window.matchMedia(v).matches?"dark":"light",r=c==="system"?h:c,o=document.documentElement,s=document.body,l="chakra-ui-light",d="chakra-ui-dark",i=r==="dark";return s.classList.add(i?d:l),s.classList.remove(i?l:d),o.style.colorScheme=r,o.dataset.theme=r,r},n=a,m="${init}",e="${key}",t=localStorage.getItem(e);t?a(t):localStorage.setItem(e,a(m))}catch(a){}})();

--- a/packages/color-mode/src/storage-manager.ts
+++ b/packages/color-mode/src/storage-manager.ts
@@ -47,6 +47,7 @@ function parseCookie(cookie: string, key: string): MaybeColorMode {
 export function createCookieStorageManager(
   key: string,
   cookie?: string,
+  domain?: string,
 ): StorageManager {
   return {
     ssr: !!cookie,
@@ -57,7 +58,7 @@ export function createCookieStorageManager(
       return parseCookie(document.cookie, key) || init
     },
     set(value) {
-      document.cookie = `${key}=${value}; max-age=31536000; path=/`
+      document.cookie = `${key}=${value};${domain ? ` domain=${domain};` : ''} max-age=31536000; path=/`
     },
   }
 }


### PR DESCRIPTION
## 📝 Description

Add option to specify domain in the `createCookieStorageManager` function.

## ⛳️ Current behavior (updates)

Defaults to current domain.

## 🚀 New behavior

Allows domain to be specified.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This is a feature I would find extremely useful as I use an app that uses multiple sub-domains.

```js
createCookieStorageManager('themeMode', undefined, '.example.com')
                                                 // ^^ Adds this option
```