### PR TITLE
feat(modal): add border radius of zero on full size

### DIFF
--- a/.changeset/soft-ducks-reply.md
+++ b/.changeset/soft-ducks-reply.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Add border radius of none to the default full size modal

--- a/.changeset/soft-ducks-reply.md
+++ b/.changeset/soft-ducks-reply.md
@@ -2,4 +2,4 @@
 "@chakra-ui/theme": patch
 ---
 
-Add border radius of none to the default full size modal
+Add border radius of zero to the default full size modal

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -90,6 +90,7 @@ function getSize(value: string): PartsStyleObject<typeof parts> {
           minH: "-webkit-fill-available",
         },
         my: 0,
+        borderRadius: "none",
       },
     }
   }

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -90,7 +90,7 @@ function getSize(value: string): PartsStyleObject<typeof parts> {
           minH: "-webkit-fill-available",
         },
         my: 0,
-        borderRadius: "none",
+        borderRadius: 0,
       },
     }
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6066 

## 📝 Description
Add `borderRadius` of `none` to the default style of `full` size modal.

## ⛳️ Current behavior (updates)
Current full size modal has a border radius by default.

## 🚀 New behavior
Now the full size modal has no border radius by default.

## 💣 Is this a breaking change (Yes/No):
No.

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
