### PR TITLE
docs: update ZEIT references to Vercel

### DIFF
--- a/examples/next-js/README.md
+++ b/examples/next-js/README.md
@@ -1,5 +1,5 @@
 This is a [Next.js](https://nextjs.org/) project bootstrapped with
-[`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app).
+[`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started
 
@@ -26,13 +26,13 @@ To learn more about Next.js, take a look at the following resources:
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out
-[the Next.js GitHub repository](https://github.com/zeit/next.js/) - your
+[the Next.js GitHub repository](https://github.com/vercel/next.js) - your
 feedback and contributions are welcome!
 
-## Deploy on ZEIT Now
+## Deploy on Vercel Now
 
 The easiest way to deploy your Next.js app is to use the
-[ZEIT Now Platform](https://zeit.co/import?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)
+[Vercel Platform](https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&filter=next.js&utm_campaign=create-next-app-readme)
 from the creators of Next.js.
 
 Check out our


### PR DESCRIPTION
- Updated ZEIT references to Vercel (new name of the organisation)
- Added direct links instead of redirecting links referencing ZEIT

## 📝 Description

> Vercel incorrectly referenced as ZEIT.

## ⛳️ Current behavior (updates)

> Vercel incorrectly referenced as ZEIT.

## 🚀 New behavior

> Updated the docs and links to correctly reference Vercel.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
None.