### PR TITLE
fix(tooltip): don't show tooltips after opening a modal

### DIFF
--- a/.changeset/twelve-years-lie.md
+++ b/.changeset/twelve-years-lie.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/tooltip": patch
+---
+
+Avoid rendering multiple tooltips so that they are not appeared after opening a
+modal

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -117,7 +117,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
   const exitTimeout = React.useRef<number>()
 
   const openWithDelay = React.useCallback(() => {
-    if (!isDisabled) {
+    if (!isDisabled && !enterTimeout.current) {
       enterTimeout.current = window.setTimeout(onOpen, openDelay)
     }
   }, [isDisabled, onOpen, openDelay])
@@ -125,6 +125,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
   const closeWithDelay = React.useCallback(() => {
     if (enterTimeout.current) {
       clearTimeout(enterTimeout.current)
+      enterTimeout.current = undefined
     }
     exitTimeout.current = window.setTimeout(onClose, closeDelay)
   }, [closeDelay, onClose])

--- a/packages/tooltip/src/use-tooltip.ts
+++ b/packages/tooltip/src/use-tooltip.ts
@@ -131,16 +131,16 @@ export function useTooltip(props: UseTooltipProps = {}) {
   }, [closeDelay, onClose])
 
   const onClick = React.useCallback(() => {
-    if (closeOnClick) {
+    if (isOpen && closeOnClick) {
       closeWithDelay()
     }
-  }, [closeOnClick, closeWithDelay])
+  }, [closeOnClick, closeWithDelay, isOpen])
 
   const onMouseDown = React.useCallback(() => {
-    if (closeOnMouseDown) {
+    if (isOpen && closeOnMouseDown) {
       closeWithDelay()
     }
-  }, [closeOnMouseDown, closeWithDelay])
+  }, [closeOnMouseDown, closeWithDelay, isOpen])
 
   const onKeyDown = React.useCallback(
     (event: KeyboardEvent) => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #2503

## 📝 Description

Avoid rendering multiple tooltips so that they are not appeared after opening a modal

## ⛳️ Current behavior (updates)

If the user clicks the modal trigger button before opening the tooltip, `openWithDelay` will be called twice by `onMouseEnter` and `onFocus`. `openWithDelay` using `setTimeout` to open a tooltip.
#2503 is caused by this double `setTimeout` .

When the user click the trigger button, `onClick` or `onMouseDown` is called, and they call `closeWithDelay` to close a tooltip and clear an enter timer.
However, `enterTimeout` ref stores only the latest timer id, so `closeWithDelay` clears only the latest timer and the previous timer displays a tooltip after opening the modal.

## 🚀 New behavior

Don't show tooltips after opening a modal

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information

Testable sandbox https://codesandbox.io/s/serene-worker-i9mpqg
