### PR TITLE
feat: chakra-cli tokens --watch

### DIFF
--- a/.changeset/serious-otters-tell.md
+++ b/.changeset/serious-otters-tell.md
@@ -1,0 +1,21 @@
+---
+"@chakra-ui/cli": minor
+---
+
+New watch flag for the tokens command. You can specify a directory path to watch
+for changes. It defaults to the parent dir of `<source>`, e.g.
+`src/theme/theme.ts` => `src/theme`.
+
+```shell
+> chakra-cli tokens src/theme/theme.ts --watch
+
+> chakra-cli tokens --help
+Usage: chakra-cli tokens [options] <source>
+
+Options:
+  --out <path>              output file e.g. node_modules/@chakra-ui/styled-system/dist/declarations/src/theming.types.d.ts
+  --strict-component-types  Generate strict types for props variant and size
+  --watch [path]            Watch directory for changes and rebuild
+  -h, --help                display help for command
+
+```

--- a/.changeset/slow-kangaroos-accept.md
+++ b/.changeset/slow-kangaroos-accept.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Fixed an issue where the tokens command failed with
+`SyntaxError: Undefined label 'e'`.

--- a/tooling/cli/bin/tsconfig.json
+++ b/tooling/cli/bin/tsconfig.json
@@ -2,6 +2,7 @@
   // these options are used by ts-node
   "compilerOptions": {
     "module": "commonjs",
+    "baseUrl": "./",
     "allowJs": true,
     "strict": false,
     "noImplicitAny": false,

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@chakra-ui/utils": "^2.0.0",
     "@swc/core": "^1.2.177",
+    "chokidar": "^3.5.3",
     "cli-check-node": "^1.3.4",
     "cli-handle-unhandled": "^1.1.1",
     "cli-welcome": "^2.2.2",

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -46,10 +46,12 @@ export async function generateThemeTypings({
   themeFile,
   out,
   strictComponentTypes,
+  onError,
 }: {
   themeFile: string
   out: string
   strictComponentTypes?: boolean
+  onError?: () => void
 }) {
   const spinner = ora("Generating chakra theme typings").start()
   try {
@@ -70,7 +72,7 @@ export async function generateThemeTypings({
       console.error(e.message)
     }
     spinner.stop()
-    process.exit(1)
+    onError?.()
   } finally {
     spinner.stop()
   }

--- a/tooling/cli/src/index.ts
+++ b/tooling/cli/src/index.ts
@@ -1,6 +1,9 @@
 import "regenerator-runtime/runtime"
 import * as path from "path"
 import { Command, program } from "commander"
+import chokidar from "chokidar"
+import { isString } from "@chakra-ui/utils"
+import throttle from "lodash/throttle"
 import { initCLI } from "./utils/init-cli"
 import {
   generateThemeTypings,
@@ -20,12 +23,35 @@ export async function run() {
       "--strict-component-types",
       "Generate strict types for props variant and size",
     )
+    .option("--watch [path]", "Watch directory for changes and rebuild")
     .action(async (themeFile: string, command: Command) => {
-      const { out, strictComponentTypes } = command.opts()
+      const { out, strictComponentTypes, watch } = command.opts()
+
+      if (watch) {
+        const watchPath = isString(watch) ? watch : path.dirname(themeFile)
+        const throttledGenerateThemeTypings = throttle(async () => {
+          console.time("Duration")
+          await generateThemeTypings({
+            themeFile,
+            out,
+            strictComponentTypes,
+          })
+          console.timeEnd("Duration")
+          console.info(new Date().toLocaleString())
+        }, 1_000)
+
+        // run once to initialize
+        throttledGenerateThemeTypings()
+
+        chokidar.watch(watchPath).on("change", throttledGenerateThemeTypings)
+        return
+      }
+
       await generateThemeTypings({
         themeFile,
         out,
         strictComponentTypes,
+        onError: () => process.exit(1),
       })
     })
 

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -124,11 +124,13 @@ async function run() {
   }
 }
 
-run().catch((e) => {
+run().catch((e: Error) => {
+  const err = `${e.toString()}\n${e.stack}`
+
   if (process.send) {
-    process.send({ err: e.toString() })
+    process.send({ err })
   } else {
-    process.stderr.write(e.message)
+    process.stderr.write(err)
   }
   process.exit(1)
 })

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -40,6 +40,8 @@ async function readTheme(themeFilePath: string) {
       compilerOptions: {
         module: "CommonJS",
       },
+      transpileOnly: true,
+      swc: true,
     })
 
     /**

--- a/tooling/cli/src/utils/format-with-prettier.ts
+++ b/tooling/cli/src/utils/format-with-prettier.ts
@@ -1,13 +1,15 @@
 import { format, resolveConfig } from "prettier"
 
-async function createFormatFileWithPrettier(content: string) {
-  const prettierConfig = await resolveConfig(process.cwd())
-  return format(String(content), {
-    ...prettierConfig,
-    parser: "typescript",
-  })
-}
-
 export async function formatWithPrettierIfAvailable(content: string) {
-  return createFormatFileWithPrettier(content)
+  const prettierConfig = await resolveConfig(process.cwd())
+
+  try {
+    return format(String(content), {
+      ...prettierConfig,
+      parser: "typescript",
+    })
+  } catch {
+    // prettier fails when no tsconfig.json is found
+    return String(content)
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9757,7 +9757,7 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2:
+chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==


### PR DESCRIPTION
## 📝 Description

New watch flag for the tokens command. 
You can specify a directory path to watch for changes. 
It defaults to the parent dir of `<source>`, e.g.`src/theme/theme.ts` => `src/theme`.

```shell
> chakra-cli tokens src/theme/theme.ts --watch
> chakra-cli tokens --help
Usage: chakra-cli tokens [options] <source>
Options:
  --out <path>              output file e.g. node_modules/@chakra-ui/styled-system/dist/declarations/src/theming.types.d.ts
  --strict-component-types  Generate strict types for props variant and size
  --watch [path]            Watch directory for changes and rebuild
  -h, --help                display help for command
```

## ⛳️ Current behavior (updates)

No watch flag

## 🚀 New behavior

- The tokens command with `--watch` watches the parent dir of the theme file for changes and rebuilds the typings
- fixed an error where prettier could not format a file

## 💣 Is this a breaking change (Yes/No):

No
