### PR TITLE
fix(modal): fix modal not to change position when the radio button is focused

### DIFF
--- a/.changeset/quick-fans-act.md
+++ b/.changeset/quick-fans-act.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Fix a bug in chromium browsers where the modal position would change when
+focusing on the radio button in the modal which has some long content.

--- a/.changeset/quick-fans-act.md
+++ b/.changeset/quick-fans-act.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/modal": patch
+"@chakra-ui/radio": patch
 ---
 
 Fix a bug in chromium browsers where the modal position would change when

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -114,7 +114,9 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
 
   return (
     <chakra.label className="chakra-radio" {...rootProps} __css={rootStyles}>
-      <input className="chakra-radio__input" {...inputProps} />
+      <chakra.div position="relative">
+        <input className="chakra-radio__input" {...inputProps} />
+      </chakra.div>
       <chakra.span
         className="chakra-radio__control"
         {...checkboxProps}

--- a/packages/radio/src/radio.tsx
+++ b/packages/radio/src/radio.tsx
@@ -95,6 +95,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
     alignItems: "center",
     verticalAlign: "top",
     cursor: "pointer",
+    position: "relative",
     ...styles.container,
   }
 
@@ -114,9 +115,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
 
   return (
     <chakra.label className="chakra-radio" {...rootProps} __css={rootStyles}>
-      <chakra.div position="relative">
-        <input className="chakra-radio__input" {...inputProps} />
-      </chakra.div>
+      <input className="chakra-radio__input" {...inputProps} />
       <chakra.span
         className="chakra-radio__control"
         {...checkboxProps}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5926

## 📝 Description

Fix a bug in chromium browsers where the modal position would change when focusing on the radio button in the modal.

## ⛳️ Current behavior (updates)

When a radio button is focused inside a modal which has some long content, the modal position is affected in chromium browsers.
This is caused by `position: absolute` of the [`visuallyHiddenStyle`](https://github.com/chakra-ui/chakra-ui/blob/d26c7d7aa2ca8951794cdfdc5c340bf8ff0866ec/packages/visually-hidden/src/visually-hidden.tsx#L18) used by [`<input type="radio">`](https://github.com/chakra-ui/chakra-ui/blob/d26c7d7aa2ca8951794cdfdc5c340bf8ff0866ec/packages/radio/src/radio.tsx#L117).

## 🚀 New behavior

Wrap the `<input type="radio">` with `position: relative` and fix it so that the modal doesn't move when focusing on the radio button.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- Checkbox also uses `visuallyHiddenStyle`, but this issue doesn't occur because [it's already wrapped with `position: relative`](https://github.com/chakra-ui/chakra-ui/blob/d26c7d7aa2ca8951794cdfdc5c340bf8ff0866ec/packages/checkbox/src/checkbox.tsx#L35).
- Testable sandbox https://codesandbox.io/s/jolly-margulis-uftvky