### PR TITLE
feat(StyleProvider): style provider factory w/ helpful error message

### DIFF
--- a/.changeset/nervous-bulldogs-cheer.md
+++ b/.changeset/nervous-bulldogs-cheer.md
@@ -1,0 +1,23 @@
+---
+"@chakra-ui/accordion": patch
+"@chakra-ui/alert": patch
+"@chakra-ui/avatar": patch
+"@chakra-ui/breadcrumb": patch
+"@chakra-ui/editable": patch
+"@chakra-ui/form-control": patch
+"@chakra-ui/input": patch
+"@chakra-ui/layout": patch
+"@chakra-ui/menu": patch
+"@chakra-ui/modal": patch
+"@chakra-ui/number-input": patch
+"@chakra-ui/popover": patch
+"@chakra-ui/progress": patch
+"@chakra-ui/slider": patch
+"@chakra-ui/stat": patch
+"@chakra-ui/system": patch
+"@chakra-ui/table": patch
+"@chakra-ui/tabs": patch
+"@chakra-ui/tag": patch
+---
+
+Improve error messaging around style provider factory

--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -3,12 +3,11 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { Collapse } from "@chakra-ui/transition"
 import { cx, Omit, runIfFn, __DEV__ } from "@chakra-ui/utils"
@@ -24,6 +23,8 @@ import {
   UseAccordionProps,
   AccordionDescendantsProvider,
 } from "./use-accordion"
+
+const [StylesProvider, useStyles] = createStylesProvider("Accordion")
 
 /* -------------------------------------------------------------------------------------------------
  * Accordion - The wrapper that provides context for all accordion items

--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -2,18 +2,19 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { cx } from "@chakra-ui/utils"
 import { createContext } from "@chakra-ui/react-utils"
 import * as React from "react"
 import { Spinner } from "@chakra-ui/spinner"
 import { CheckIcon, InfoIcon, WarningIcon } from "./icons"
+
+const [StylesProvider, useStyles] = createStylesProvider("Alert")
 
 const STATUSES = {
   info: { icon: InfoIcon, colorScheme: "blue" },

--- a/packages/avatar/src/avatar.tsx
+++ b/packages/avatar/src/avatar.tsx
@@ -1,22 +1,21 @@
 import type { ImageProps } from "@chakra-ui/image"
 import { useImage } from "@chakra-ui/image"
-import type {
+import {
   ChakraComponent,
   SystemProps,
   SystemStyleObject,
   ThemingProps,
   HTMLChakraProps,
-} from "@chakra-ui/system"
-import {
+  createStylesProvider,
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   useMultiStyleConfig,
-  useStyles,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createStylesProvider("Avatar")
 
 interface AvatarOptions {
   /**

--- a/packages/breadcrumb/src/breadcrumb.tsx
+++ b/packages/breadcrumb/src/breadcrumb.tsx
@@ -2,17 +2,18 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   SystemProps,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import { getValidChildren } from "@chakra-ui/react-utils"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createStylesProvider("Breadcrumb")
 
 export interface BreadcrumbSeparatorProps extends HTMLChakraProps<"div"> {
   /**

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -2,12 +2,11 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { cx, runIfFn, __DEV__ } from "@chakra-ui/utils"
 import { createContext, MaybeRenderProp } from "@chakra-ui/react-utils"
@@ -17,6 +16,8 @@ import {
   UseEditableProps,
   UseEditableReturn,
 } from "./use-editable"
+
+const [StylesProvider, useStyles] = createStylesProvider("Editable")
 
 type EditableContext = Omit<UseEditableReturn, "htmlProps">
 

--- a/packages/form-control/src/form-control.tsx
+++ b/packages/form-control/src/form-control.tsx
@@ -1,13 +1,12 @@
 import { useBoolean, useId } from "@chakra-ui/hooks"
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
 } from "@chakra-ui/system"
 import { cx, dataAttr, __DEV__ } from "@chakra-ui/utils"
 import {
@@ -17,6 +16,10 @@ import {
   PropGetterV2,
 } from "@chakra-ui/react-utils"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createStylesProvider("FormControl")
+
+export const useFormControlStyles = useStyles
 
 export interface FormControlOptions {
   /**

--- a/packages/form-control/src/form-error.tsx
+++ b/packages/form-control/src/form-error.tsx
@@ -1,17 +1,18 @@
 import Icon, { IconProps } from "@chakra-ui/icon"
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 import { useFormControlContext } from "./form-control"
+
+const [StylesProvider, useStyles] = createStylesProvider("FormError")
 
 export interface FormErrorMessageProps
   extends HTMLChakraProps<"div">,

--- a/packages/form-control/src/form-label.tsx
+++ b/packages/form-control/src/form-label.tsx
@@ -5,11 +5,10 @@ import {
   omitThemingProps,
   ThemingProps,
   useStyleConfig,
-  useStyles,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
-import { useFormControlContext } from "./form-control"
+import { useFormControlContext, useFormControlStyles } from "./form-control"
 
 export interface FormLabelProps
   extends HTMLChakraProps<"label">,
@@ -78,7 +77,7 @@ export interface RequiredIndicatorProps extends HTMLChakraProps<"span"> {}
 export const RequiredIndicator = forwardRef<RequiredIndicatorProps, "span">(
   (props, ref) => {
     const field = useFormControlContext()
-    const styles = useStyles()
+    const styles = useFormControlStyles()
 
     if (!field?.isRequired) return null
 

--- a/packages/form-control/tests/form-control.test.tsx
+++ b/packages/form-control/tests/form-control.test.tsx
@@ -63,8 +63,8 @@ test("only displays error icon and message when invalid", () => {
       <RequiredIndicator />
       <Input placeholder="Name" />
       <FormHelperText>Enter your name please!</FormHelperText>
-      <FormErrorIcon data-testid="icon" />
       <FormErrorMessage data-testid="message">
+        <FormErrorIcon data-testid="icon" />
         Your name is invalid
       </FormErrorMessage>
     </FormControl>,
@@ -79,8 +79,8 @@ test("only displays error icon and message when invalid", () => {
       <RequiredIndicator />
       <Input placeholder="Name" />
       <FormHelperText>Enter your name please!</FormHelperText>
-      <FormErrorIcon data-testid="icon" />
       <FormErrorMessage data-testid="message">
+        <FormErrorIcon data-testid="icon" />
         Your name is invalid
       </FormErrorMessage>
     </FormControl>,

--- a/packages/input/src/input-addon.tsx
+++ b/packages/input/src/input-addon.tsx
@@ -1,11 +1,7 @@
-import {
-  chakra,
-  forwardRef,
-  useStyles,
-  HTMLChakraProps,
-} from "@chakra-ui/system"
+import { chakra, forwardRef, HTMLChakraProps } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
+import { useInputGroupStyles } from "./input-group"
 
 type Placement = "left" | "right"
 
@@ -44,7 +40,7 @@ export interface InputAddonProps extends HTMLChakraProps<"div"> {
 export const InputAddon = forwardRef<InputAddonProps, "div">((props, ref) => {
   const { placement = "left", ...rest } = props
   const placementStyles = placements[placement] ?? {}
-  const styles = useStyles()
+  const styles = useInputGroupStyles()
 
   return (
     <StyledAddon

--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -2,11 +2,11 @@ import {
   chakra,
   forwardRef,
   SystemStyleObject,
-  useStyles,
   HTMLChakraProps,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
+import { useInputGroupStyles } from "./input-group"
 
 export interface InputElementProps extends HTMLChakraProps<"div"> {
   placement?: "left" | "right"
@@ -26,7 +26,7 @@ const StyledElement = chakra("div", {
 const InputElement = forwardRef<InputElementProps, "div">((props, ref) => {
   const { placement = "left", ...rest } = props
 
-  const styles = useStyles()
+  const styles = useInputGroupStyles()
   const input: any = styles.field
 
   const attr = placement === "left" ? "insetStart" : "insetEnd"

--- a/packages/input/src/input-group.tsx
+++ b/packages/input/src/input-group.tsx
@@ -2,14 +2,18 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { cx, filterUndefined, __DEV__ } from "@chakra-ui/utils"
 import { getValidChildren } from "@chakra-ui/react-utils"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createStylesProvider("InputGroup")
+
+export const useInputGroupStyles = useStyles
 
 export interface InputGroupProps
   extends HTMLChakraProps<"div">,

--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -1,8 +1,8 @@
 import { Icon, IconProps } from "@chakra-ui/icon"
-import { createContext, getValidChildren } from "@chakra-ui/react-utils"
-import { SystemStyleObject } from "@chakra-ui/styled-system"
+import { getValidChildren } from "@chakra-ui/react-utils"
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
@@ -10,14 +10,10 @@ import {
   ThemingProps,
   useMultiStyleConfig,
 } from "@chakra-ui/system"
-import { Dict, __DEV__ } from "@chakra-ui/utils"
+import { __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
-const [StylesProvider, useStyles] = createContext<Dict<SystemStyleObject>>({
-  name: "StylesContext",
-  errorMessage:
-    "useStyles: `styles` is undefined. Seems you forgot to wrap the components in a `<*List />` ",
-})
+const [StylesProvider, useStyles] = createStylesProvider("List")
 
 interface ListOptions {
   /**

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -2,16 +2,15 @@ import { MaybeRenderProp } from "@chakra-ui/react-utils"
 import {
   chakra,
   ChakraComponent,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
   PropsOf,
-  StylesProvider,
   SystemProps,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   useTheme,
 } from "@chakra-ui/system"
 import { callAll, cx, runIfFn, __DEV__ } from "@chakra-ui/utils"
@@ -33,6 +32,8 @@ import {
   useMenuPositioner,
   UseMenuProps,
 } from "./use-menu"
+
+const [StylesProvider, useStyles] = createStylesProvider("Menu")
 
 export interface MenuProps extends UseMenuProps, ThemingProps<"Menu"> {
   children: MaybeRenderProp<{

--- a/packages/modal/src/drawer.tsx
+++ b/packages/modal/src/drawer.tsx
@@ -5,13 +5,18 @@ import {
   HTMLChakraProps,
   SystemStyleObject,
   ThemingProps,
-  useStyles,
   useTheme,
 } from "@chakra-ui/system"
 import { Slide, SlideOptions } from "@chakra-ui/transition"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
-import { Modal, ModalFocusScope, ModalProps, useModalContext } from "./modal"
+import {
+  Modal,
+  ModalFocusScope,
+  ModalProps,
+  useModalContext,
+  useModalStyles,
+} from "./modal"
 
 const [DrawerContextProvider, useDrawerContext] = createContext<DrawerOptions>()
 
@@ -104,7 +109,7 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
 
     const _className = cx("chakra-modal__content", className)
 
-    const styles = useStyles()
+    const styles = useModalStyles()
 
     const dialogStyles: SystemStyleObject = {
       display: "flex",

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -1,16 +1,16 @@
 import { CloseButton, CloseButtonProps } from "@chakra-ui/close-button"
 import { FocusLock, FocusLockProps } from "@chakra-ui/focus-lock"
 import { Portal, PortalProps } from "@chakra-ui/portal"
+import { createContext } from "@chakra-ui/react-utils"
 import {
   chakra,
   ChakraProps,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
 } from "@chakra-ui/system"
 import { fadeConfig } from "@chakra-ui/transition"
 import {
@@ -19,7 +19,6 @@ import {
   FocusableElement,
   __DEV__,
 } from "@chakra-ui/utils"
-import { createContext } from "@chakra-ui/react-utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
@@ -27,10 +26,13 @@ import {
   usePresence,
 } from "framer-motion"
 import * as React from "react"
-import { RemoveScroll } from "react-remove-scroll"
 import { MouseEvent } from "react"
+import { RemoveScroll } from "react-remove-scroll"
 import { ModalTransition } from "./modal-transition"
 import { useModal, UseModalProps, UseModalReturn } from "./use-modal"
+
+const [StylesProvider, useStyles] = createStylesProvider("Modal")
+export const useModalStyles = useStyles
 
 interface ModalOptions extends Pick<FocusLockProps, "lockFocusAcrossFrames"> {
   /**

--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -1,13 +1,12 @@
 import { useFormControlProps } from "@chakra-ui/form-control"
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
 } from "@chakra-ui/system"
 import { __DEV__, cx } from "@chakra-ui/utils"
 import { createContext } from "@chakra-ui/react-utils"
@@ -18,6 +17,8 @@ import {
   UseNumberInputProps,
   UseNumberInputReturn,
 } from "./use-number-input"
+
+const [StylesProvider, useStyles] = createStylesProvider("NumberInput")
 
 interface NumberInputContext extends Omit<UseNumberInputReturn, "htmlProps"> {}
 

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -2,14 +2,13 @@ import { CloseButton, CloseButtonProps } from "@chakra-ui/close-button"
 import { MaybeRenderProp } from "@chakra-ui/react-utils"
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   useTheme,
 } from "@chakra-ui/system"
 import { callAll, cx, runIfFn, __DEV__ } from "@chakra-ui/utils"
@@ -19,6 +18,8 @@ import { PopoverTransition, PopoverTransitionProps } from "./popover-transition"
 import { usePopover, UsePopoverProps } from "./use-popover"
 
 export { usePopoverContext }
+
+const [StylesProvider, useStyles] = createStylesProvider("Popover")
 
 export interface PopoverProps extends UsePopoverProps, ThemingProps<"Popover"> {
   /**

--- a/packages/progress/src/progress.tsx
+++ b/packages/progress/src/progress.tsx
@@ -2,12 +2,11 @@ import {
   chakra,
   Interpolation,
   omitThemingProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -17,6 +16,8 @@ import {
   progress,
   stripe,
 } from "./progress.utils"
+
+const [StylesProvider, useStyles] = createStylesProvider("Progress")
 
 export interface ProgressLabelProps extends HTMLChakraProps<"div"> {}
 

--- a/packages/slider/src/range-slider.tsx
+++ b/packages/slider/src/range-slider.tsx
@@ -1,13 +1,12 @@
 import { createContext } from "@chakra-ui/react-utils"
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   useTheme,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
@@ -29,6 +28,8 @@ const [RangeSliderProvider, useRangeSliderContext] =
     errorMessage:
       "useSliderContext: `context` is undefined. Seems you forgot to wrap all slider components within <RangeSlider />",
   })
+
+const [StylesProvider, useStyles] = createStylesProvider("RangeSlider")
 
 export { RangeSliderProvider, useRangeSliderContext }
 

--- a/packages/slider/src/slider.tsx
+++ b/packages/slider/src/slider.tsx
@@ -1,13 +1,12 @@
 import { createContext } from "@chakra-ui/react-utils"
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   useTheme,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
@@ -22,6 +21,8 @@ const [SliderProvider, useSliderContext] = createContext<SliderContext>({
   errorMessage:
     "useSliderContext: `context` is undefined. Seems you forgot to wrap all slider components within <Slider />",
 })
+
+const [StylesProvider, useStyles] = createStylesProvider("Slider")
 
 export { SliderProvider, useSliderContext }
 

--- a/packages/stat/src/stat.tsx
+++ b/packages/stat/src/stat.tsx
@@ -3,16 +3,17 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
   SystemStyleObject,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import { VisuallyHidden } from "@chakra-ui/visually-hidden"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createStylesProvider("Stat")
 
 export interface StatLabelProps extends HTMLChakraProps<"dt"> {}
 

--- a/packages/system/src/providers.tsx
+++ b/packages/system/src/providers.tsx
@@ -60,12 +60,16 @@ export function useTheme<T extends object = Dict>() {
   return theme as WithCSSVar<T>
 }
 
-const [StylesProvider, useStyles] = createContext<Dict<SystemStyleObject>>({
-  name: "StylesContext",
-  errorMessage:
-    "useStyles: `styles` is undefined. Seems you forgot to wrap the components in `<StylesProvider />` ",
-})
-export { StylesProvider, useStyles }
+/**
+ * Helper function that creates context with a standardized errorMessage related to the component
+ * @param componentName
+ * @returns [StylesProvider, useStyles]
+ */
+export const createStylesProvider = (componentName: string) =>
+  createContext<Dict<SystemStyleObject>>({
+    name: `${componentName}StylesContext`,
+    errorMessage: `useStyles: "styles" is undefined. Seems you forgot to wrap the components in "<${componentName} />" `,
+  })
 
 /**
  * Applies styles defined in `theme.styles.global` globally

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1,15 +1,16 @@
 import {
   chakra,
+  createStylesProvider,
   forwardRef,
   HTMLChakraProps,
   omitThemingProps,
-  StylesProvider,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
 } from "@chakra-ui/system"
 import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createStylesProvider("Table")
 
 export interface TableContainerProps extends HTMLChakraProps<"div"> {}
 

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -2,12 +2,11 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { cx, omit, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
@@ -24,6 +23,8 @@ import {
   useTabs,
   UseTabsProps,
 } from "./use-tabs"
+
+const [StylesProvider, useStyles] = createStylesProvider("Tabs")
 
 interface TabsOptions {
   /**

--- a/packages/tag/src/tag.tsx
+++ b/packages/tag/src/tag.tsx
@@ -3,15 +3,16 @@ import {
   chakra,
   forwardRef,
   omitThemingProps,
-  StylesProvider,
   SystemStyleObject,
   ThemingProps,
   useMultiStyleConfig,
-  useStyles,
   HTMLChakraProps,
+  createStylesProvider,
 } from "@chakra-ui/system"
 import { __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
+
+const [StylesProvider, useStyles] = createStylesProvider("Tag")
 
 export interface TagProps
   extends HTMLChakraProps<"span">,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5119

## 📝 Description

As outlined in the issue, because all components share a pre created StyleContext, the error message was not very descriptive. This PR replaces the current implementation with a helper to create a consistent StyleProvider in every component. This will ensure that the error message is:
1. Consistent
2. Helpful

## ⛳️ Current behavior (updates)

Currently the error message when missing wrapping a component in the correct parent component with the correct StyleProvider reads:
```
useStyles: `styles` is undefined. Seems you forgot to wrap the components in `<StylesProvider />` 
```

## 🚀 New behavior

```useStyles: "styles" is undefined. Seems you forgot to wrap the components in "<__COMPONENT_NAME__" />"```

![Screen Shot 2022-06-02 at 9 33 13 AM](https://user-images.githubusercontent.com/6193042/171666968-8278a318-0736-411c-a7ff-a7e174f18fe3.png)

The context name now also includes the component name.
>> <StyleProvider to <__COMPONENT_NAME__StyleProvider>

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
