### PR TITLE
WIP: feat(theme): add color scheme hues to theme

### DIFF
--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -6,16 +6,16 @@ import {
   SearchIcon,
 } from "@chakra-ui/icons"
 import { Container, HStack, Stack } from "@chakra-ui/layout"
+import { getThemingArgTypes } from "@chakra-ui/storybook-addon"
+import { ThemingProps } from "@chakra-ui/system"
+import { theme } from "@chakra-ui/theme"
+import { pick } from "@chakra-ui/utils"
+import { Meta, StoryFn } from "@storybook/react"
+import { motion } from "framer-motion"
 import * as React from "react"
 import { FaFacebook, FaTwitter } from "react-icons/fa"
 import { MdBuild, MdCall } from "react-icons/md"
 import { BeatLoader } from "react-spinners"
-import { motion } from "framer-motion"
-import { Meta, StoryFn } from "@storybook/react"
-import { ThemingProps } from "@chakra-ui/system"
-import { theme } from "@chakra-ui/theme"
-import { getThemingArgTypes } from "@chakra-ui/storybook-addon"
-import { pick } from "@chakra-ui/utils"
 import { Button, ButtonGroup, IconButton } from "../src"
 
 export default {
@@ -44,15 +44,22 @@ basic.args = {
 
 export const outlines: StoryFn<StoryProps> = (props) => (
   <>
-    <Button {...props} variant="outline" colorScheme="red" />
-    <Button {...props} variant="outline" colorScheme="green" />
+    <Button
+      {...props}
+      variant="outline"
+      colorScheme="red"
+      colorSchemeHues={{
+        color: ["900", "700"],
+      }}
+    />
+    {/* <Button {...props} variant="outline" colorScheme="green" />
     <Button {...props} variant="outline" colorScheme="blue" />
     <Button {...props} variant="outline" colorScheme="teal" />
     <Button {...props} variant="outline" colorScheme="pink" />
     <Button {...props} variant="outline" colorScheme="purple" />
     <Button {...props} variant="outline" colorScheme="cyan" />
     <Button {...props} variant="outline" colorScheme="orange" />
-    <Button {...props} variant="outline" colorScheme="yellow" />
+    <Button {...props} variant="outline" colorScheme="yellow" /> */}
   </>
 )
 outlines.argTypes = {

--- a/packages/styled-system/src/theme.types.ts
+++ b/packages/styled-system/src/theme.types.ts
@@ -1,3 +1,4 @@
+import { SystemStyleObject } from "./system.types"
 import type { ThemeTypings as GeneratedThemeTypings } from "./theming.types"
 
 export interface BaseThemeTypings {
@@ -5,6 +6,7 @@ export interface BaseThemeTypings {
   colors: string
   breakpoints: string
   colorSchemes: string
+  colorSchemeHues: SystemStyleObject
   fonts: string
   fontSizes: string
   fontWeights: string

--- a/packages/system/src/system.types.tsx
+++ b/packages/system/src/system.types.tsx
@@ -20,6 +20,7 @@ export interface ThemingProps<ThemeComponent extends string = any> {
       : string
   >
   colorScheme?: ThemeTypings["colorSchemes"]
+  colorSchemeHues?: ThemeTypings["colorSchemeHues"]
   orientation?: "vertical" | "horizontal"
   styleConfig?: Dict
 }

--- a/packages/system/src/system.utils.ts
+++ b/packages/system/src/system.utils.ts
@@ -9,7 +9,13 @@ import { ThemingProps } from "./system.types"
 export type DOMElements = keyof JSX.IntrinsicElements
 
 export function omitThemingProps<T extends ThemingProps>(props: T) {
-  return omit(props, ["styleConfig", "size", "variant", "colorScheme"])
+  return omit(props, [
+    "styleConfig",
+    "size",
+    "variant",
+    "colorScheme",
+    "colorSchemeHues",
+  ])
 }
 
 export default function isTag(target: any) {

--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -36,6 +36,7 @@ export type { SystemStyleObject }
 
 export type StyleFunctionProps = {
   colorScheme: string
+  colorSchemeHues: Dict
   colorMode: "light" | "dark"
   orientation?: "horizontal" | "vertical"
   theme: Dict

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -26,7 +26,9 @@ const baseStyle: SystemStyleObject = {
 }
 
 const variantGhost: SystemStyleFunction = (props) => {
-  const { colorScheme: c, theme } = props
+  const { colorScheme: c, colorSchemeHues: ch, theme } = props
+
+  console.log("ch", ch)
 
   if (c === "gray") {
     return {
@@ -38,17 +40,17 @@ const variantGhost: SystemStyleFunction = (props) => {
     }
   }
 
-  const darkHoverBg = transparentize(`${c}.200`, 0.12)(theme)
-  const darkActiveBg = transparentize(`${c}.200`, 0.24)(theme)
+  const darkHoverBg = transparentize(`${c}.${ch._hover.bg[1]}`, 0.12)(theme)
+  const darkActiveBg = transparentize(`${c}.${ch._active.bg[1]}`, 0.24)(theme)
 
   return {
-    color: mode(`${c}.600`, `${c}.200`)(props),
+    color: mode(`${c}.${ch.color[0]}`, `${c}.${ch.color[1]}`)(props),
     bg: "transparent",
     _hover: {
-      bg: mode(`${c}.50`, darkHoverBg)(props),
+      bg: mode(`${c}.${ch._hover.bg[0]}`, darkHoverBg)(props),
     },
     _active: {
-      bg: mode(`${c}.100`, darkActiveBg)(props),
+      bg: mode(`${c}.${ch._active.bg[0]}`, darkActiveBg)(props),
     },
   }
 }
@@ -197,6 +199,15 @@ const defaultProps = {
   variant: "solid",
   size: "md",
   colorScheme: "gray",
+  colorSchemeHues: {
+    color: ["600", "200"],
+    _hover: {
+      bg: ["50", "200"],
+    },
+    _active: {
+      bg: ["100", "200"],
+    },
+  },
 }
 
 export default {


### PR DESCRIPTION
Closes #5716

## 📝 Description

This is an attempt to add `colorSchemeHues` to the theme that allows users to overwrite hues used in conjunction with the `colorScheme` prop.

## ⛳️ Current behavior (updates)

Color Scheme hues are preset and can't be modified. This makes colorScheme property not too useful for any use cases outside of prototyping.

## 🚀 New behavior
```
    <Button
      {...props}
      variant="outline"
      colorScheme="red"
      colorSchemeHues={{
        color: ["900", "700"],
      }}
    />
```

The new prop `colorSchemeHues` allows users to overwrite the color hue for both light and dark mode through props and theme. 


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

