### PR TITLE
feat: export use-drawer-context

### DIFF
--- a/.changeset/yellow-ligers-trade.md
+++ b/.changeset/yellow-ligers-trade.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": minor
+---
+
+Export `useDrawerContext` hook

--- a/packages/modal/src/drawer.tsx
+++ b/packages/modal/src/drawer.tsx
@@ -159,5 +159,6 @@ export {
   ModalFooter as DrawerFooter,
   ModalHeader as DrawerHeader,
   ModalOverlay as DrawerOverlay,
-  useDrawerContext,
 } from "./modal"
+
+export { useDrawerContext };

--- a/packages/modal/src/drawer.tsx
+++ b/packages/modal/src/drawer.tsx
@@ -159,4 +159,5 @@ export {
   ModalFooter as DrawerFooter,
   ModalHeader as DrawerHeader,
   ModalOverlay as DrawerOverlay,
+  useDrawerContext,
 } from "./modal"


### PR DESCRIPTION

## 📝 Description

This PR exports the useDrawerContext hook. This is useful for when you want to implement a swipe to close functionality further down the stack, like on the DrawerContent.

## 💣 Is this a breaking change (Yes/No):

Not a breaking change, but an extension of the API
