### PR TITLE
Fix hydration issue and fix useMediaQuery behavior on first render

### DIFF
--- a/.changeset/selfish-plants-hug.md
+++ b/.changeset/selfish-plants-hug.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/media-query": patch
+"@chakra-ui/portal": patch
+---
+
+fix hydration issue when using suspense and fix `useMediaQuery` to return actual
+values on first render

--- a/packages/env/src/env.tsx
+++ b/packages/env/src/env.tsx
@@ -1,11 +1,5 @@
 import { isBrowser, __DEV__ } from "@chakra-ui/utils"
-import React, {
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-  startTransition,
-} from "react"
+import React, { createContext, useContext, useMemo } from "react"
 import { ssrDocument } from "./mock-document"
 import { ssrWindow } from "./mock-window"
 
@@ -37,29 +31,12 @@ export interface EnvironmentProviderProps {
 }
 
 export function EnvironmentProvider(props: EnvironmentProviderProps) {
-  const { children, environment: environmentProp } = props
-  const [node, setNode] = useState<HTMLElement | null>(null)
-
-  const context = useMemo(() => {
-    const doc = node?.ownerDocument
-    const win = node?.ownerDocument.defaultView
-    const nodeEnv = doc ? { document: doc, window: win } : undefined
-    const env = environmentProp ?? nodeEnv ?? defaultEnv
-    return env as Environment
-  }, [node, environmentProp])
+  const { children, environment } = props
+  const context = useMemo(() => environment ?? defaultEnv, [environment])
 
   return (
     <EnvironmentContext.Provider value={context}>
       {children}
-      <span
-        hidden
-        className="chakra-env"
-        ref={(el) => {
-          startTransition(() => {
-            if (el) setNode(el)
-          })
-        }}
-      />
     </EnvironmentContext.Provider>
   )
 }

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -22,10 +22,7 @@ export function useBreakpoint(
     }),
   )
 
-  const values = useMediaQuery(
-    breakpoints.map((bp) => bp.query),
-    breakpoints.map((bp) => bp.breakpoint === defaultBreakpoint),
-  )
+  const values = useMediaQuery(breakpoints.map((bp) => bp.query))
 
   const index = values.findIndex((value) => value == true)
   return breakpoints[index]?.breakpoint ?? defaultBreakpoint

--- a/packages/media-query/src/use-media-query.ts
+++ b/packages/media-query/src/use-media-query.ts
@@ -8,35 +8,20 @@ const useSafeLayoutEffect = isBrowser ? useLayoutEffect : useEffect
  * React hook that tracks state of a CSS media query
  *
  * @param query the media query to match
- * @param defaultValues the default values to match
  */
-export function useMediaQuery(
-  query: string | string[],
-  defaultValues?: boolean | boolean[],
-): boolean[] {
+export function useMediaQuery(query: string | string[]): boolean[] {
   const env = useEnvironment()
 
   const queries = Array.isArray(query) ? query : [query]
 
-  let defaults = Array.isArray(defaultValues) ? defaultValues : [defaultValues]
-  defaults = defaults.filter((v) => v != null) as boolean[]
-
   const [value, setValue] = useState(() => {
-    return queries.map((query, index) => ({
+    return queries.map((query) => ({
       media: query,
-      matches: defaults[index] ?? false,
+      matches: env.window.matchMedia(query).matches,
     }))
   })
 
   useSafeLayoutEffect(() => {
-    // set initial matches
-    setValue(
-      queries.map((query) => ({
-        media: query,
-        matches: env.window.matchMedia(query).matches,
-      })),
-    )
-
     const mql = queries.map((query) => env.window.matchMedia(query))
 
     const handler = (evt: MediaQueryListEvent) => {

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@chakra-ui/hooks": "2.0.1",
+    "@chakra-ui/react-env": "2.0.1",
     "@chakra-ui/react-utils": "2.0.0",
     "@chakra-ui/utils": "2.0.1"
   },

--- a/packages/portal/src/portal.tsx
+++ b/packages/portal/src/portal.tsx
@@ -3,6 +3,7 @@ import { isBrowser, __DEV__ } from "@chakra-ui/utils"
 import { createContext } from "@chakra-ui/react-utils"
 import * as React from "react"
 import { createPortal } from "react-dom"
+import { useEnvironment } from "@chakra-ui/react-env"
 import { usePortalManager } from "./portal-manager"
 
 type PortalContext = HTMLDivElement | null
@@ -40,23 +41,20 @@ const DefaultPortal = (
 ) => {
   const { appendToParentPortal, children } = props
 
-  const tempNode = React.useRef<HTMLDivElement | null>(null)
   const portal = React.useRef<HTMLDivElement | null>(null)
-
   const forceUpdate = useForceUpdate()
-
   const parentPortal = usePortalContext()
+  const { document } = useEnvironment()
   const manager = usePortalManager()
 
   useSafeLayoutEffect(() => {
-    if (!tempNode.current) return
-
-    const doc = tempNode.current!.ownerDocument
-    const host = appendToParentPortal ? parentPortal ?? doc.body : doc.body
+    const host = appendToParentPortal
+      ? parentPortal ?? document.body
+      : document.body
 
     if (!host) return
 
-    portal.current = doc.createElement("div")
+    portal.current = document.createElement("div")
     portal.current.className = PORTAL_CLASSNAME
 
     host.appendChild(portal.current)
@@ -76,15 +74,14 @@ const DefaultPortal = (
     children
   )
 
-  return portal.current ? (
+  return (
+    portal.current &&
     createPortal(
       <PortalContextProvider value={portal.current}>
         {_children}
       </PortalContextProvider>,
       portal.current,
     )
-  ) : (
-    <span ref={tempNode} />
   )
 }
 

--- a/packages/system/tests/style-config.test.tsx
+++ b/packages/system/tests/style-config.test.tsx
@@ -123,7 +123,7 @@ test("should resolve multipart styles in theme", async () => {
   `)
 })
 
-test.skip("should resolve props and styles", async () => {
+test("should resolve props and styles", async () => {
   const Component = (props: any) => {
     const res = useProps("Tabs", props, true)
     return (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6129
Closes #6130

## 📝 Description

This PR fixes two issues.

1. Fix hydration issue when using ChakraProvider and React Suspense in Next.js
2. Fix `useMediaQuery` to return actual values on first render

These two issues are separate issues. However, to fix 1, we need to fix 2 as well.

The cause of the hydration issue is explained at https://github.com/chakra-ui/chakra-ui/issues/5842#issuecomment-1127363672
> setNode(el) in EnvironmentProvider will cause it re-render,
> and the context value has changed from defaultEnv to { document, window }
> React recived an update during streaming rendering
> react doesn't know if this update will affect the <ComponentThatSuspend /> component
> 
> So react will have to replace the server HTML with the suspense fallback.
> This is because it is stale

Like `EnvironmentProvider`, `setValue` in `useMediaQuery` and `ref` in `DefaultPortal` causes this hydration issue.

## ⛳️ Current behavior (updates)

1. Error when using ChakraProvider and React Suspense in Next.js
2. `useMediaQuery` always returns `false` on first render.

## 🚀 New behavior

1. ChakraProvider and Suspense in Next.js doesn't cause an error
2. `useMediaQuery` returns actual values on first render

## 💣 Is this a breaking change (Yes/No):

Yes

I removed `defaultValues` argument of `useMediaQuery`.
But it is an internal api, undocumented, and just recently introduced (from v2.0.0), so I don't think it's a problem.

## 📝 Additional Information
