### PR TITLE
refactor: remove annoying focus outline

### DIFF
--- a/.changeset/breezy-boats-relax.md
+++ b/.changeset/breezy-boats-relax.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/checkbox": minor
+"@chakra-ui/styled-system": minor
+"@chakra-ui/theme": minor
+---
+
+Remove annoying focus outline by leveraging focus visible

--- a/.changeset/modern-parents-doubt.md
+++ b/.changeset/modern-parents-doubt.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Add support for styling `data-focus-visible` using the `_focusVisible` pseudo
+prop

--- a/.changeset/tender-mails-cry.md
+++ b/.changeset/tender-mails-cry.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/checkbox": minor
+---
+
+Track focus visible and add `data-focus-visible` to `getCheckboxProps`

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -41,7 +41,8 @@
     "@chakra-ui/hooks": "2.0.1",
     "@chakra-ui/react-utils": "2.0.0",
     "@chakra-ui/utils": "2.0.1",
-    "@chakra-ui/visually-hidden": "2.0.1"
+    "@chakra-ui/visually-hidden": "2.0.1",
+    "@zag-js/focus-visible": "dev"
   },
   "devDependencies": {
     "@chakra-ui/system": "2.1.1",

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -13,9 +13,11 @@ import React, {
   ChangeEvent,
   KeyboardEvent,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react"
+import { trackFocusVisible } from "@zag-js/focus-visible"
 
 export interface UseCheckboxProps {
   /**
@@ -157,9 +159,17 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   const onBlurProp = useCallbackRef(onBlur)
   const onFocusProp = useCallbackRef(onFocus)
 
+  const [isFocusVisible, setIsFocusVisible] = useState(false)
   const [isFocused, setFocused] = useBoolean()
   const [isHovered, setHovered] = useBoolean()
   const [isActive, setActive] = useBoolean()
+
+  useEffect(() => {
+    const cleanup = trackFocusVisible(setIsFocusVisible)
+    return () => {
+      cleanup()
+    }
+  }, [])
 
   const inputRef = useRef<HTMLInputElement>(null)
   const [rootIsLabelElement, setRootIsLabelElement] = useState(true)
@@ -276,6 +286,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
         "data-hover": dataAttr(isHovered),
         "data-checked": dataAttr(isChecked),
         "data-focus": dataAttr(isFocused),
+        "data-focus-visible": dataAttr(isFocused && isFocusVisible),
         "data-indeterminate": dataAttr(isIndeterminate),
         "data-disabled": dataAttr(isDisabled),
         "data-invalid": dataAttr(isInvalid),
@@ -292,6 +303,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       isChecked,
       isDisabled,
       isFocused,
+      isFocusVisible,
       isHovered,
       isIndeterminate,
       isInvalid,

--- a/packages/styled-system/src/pseudos.ts
+++ b/packages/styled-system/src/pseudos.ts
@@ -61,7 +61,7 @@ export const pseudoSelectors = {
    * Styles to apply when this element has received focus via tabbing
    * - CSS Selector `&:focus-visible`
    */
-  _focusVisible: "&:focus-visible",
+  _focusVisible: "&:focus-visible, &[data-focus-visible]",
   /**
    * Styles to apply when this element is disabled. The passed styles are applied to these CSS selectors:
    * - `&[aria-disabled=true]`

--- a/packages/theme/src/components/accordion.ts
+++ b/packages/theme/src/components/accordion.ts
@@ -16,7 +16,7 @@ const baseStyleButton: SystemStyleObject = {
   transitionProperty: "common",
   transitionDuration: "normal",
   fontSize: "1rem",
-  _focus: {
+  _focusVisible: {
     boxShadow: "outline",
   },
   _hover: {

--- a/packages/theme/src/components/breadcrumb.ts
+++ b/packages/theme/src/components/breadcrumb.ts
@@ -15,7 +15,7 @@ const baseStyleLink: SystemStyleObject = {
   _hover: {
     textDecoration: "underline",
   },
-  _focus: {
+  _focusVisible: {
     boxShadow: "outline",
   },
 }

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -10,7 +10,7 @@ const baseStyle: SystemStyleObject = {
   fontWeight: "semibold",
   transitionProperty: "common",
   transitionDuration: "normal",
-  _focus: {
+  _focusVisible: {
     boxShadow: "outline",
   },
   _disabled: {

--- a/packages/theme/src/components/checkbox.ts
+++ b/packages/theme/src/components/checkbox.ts
@@ -47,7 +47,7 @@ const baseStyleControl: SystemStyleFunction = (props) => {
       borderColor: mode("gray.100", "transparent")(props),
     },
 
-    _focus: {
+    _focusVisible: {
       boxShadow: "outline",
     },
 

--- a/packages/theme/src/components/close-button.ts
+++ b/packages/theme/src/components/close-button.ts
@@ -23,7 +23,7 @@ const baseStyle: SystemStyleFunction = (props) => {
     },
     _hover: { bg: hoverBg },
     _active: { bg: activeBg },
-    _focus: {
+    _focusVisible: {
       boxShadow: "outline",
     },
   }

--- a/packages/theme/src/components/editable.ts
+++ b/packages/theme/src/components/editable.ts
@@ -17,7 +17,7 @@ const baseStyleInput: SystemStyleObject = {
   transitionProperty: "common",
   transitionDuration: "normal",
   width: "full",
-  _focus: { boxShadow: "outline" },
+  _focusVisible: { boxShadow: "outline" },
   _placeholder: { opacity: 0.6 },
 }
 
@@ -27,7 +27,7 @@ const baseStyleTextarea: SystemStyleObject = {
   transitionProperty: "common",
   transitionDuration: "normal",
   width: "full",
-  _focus: { boxShadow: "outline" },
+  _focusVisible: { boxShadow: "outline" },
   _placeholder: { opacity: 0.6 },
 }
 

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -99,7 +99,7 @@ const variantOutline: PartsStyleFunction<typeof parts> = (props) => {
         borderColor: getColor(theme, ec),
         boxShadow: `0 0 0 1px ${getColor(theme, ec)}`,
       },
-      _focus: {
+      _focusVisible: {
         zIndex: 1,
         borderColor: getColor(theme, fc),
         boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
@@ -136,7 +136,7 @@ const variantFilled: PartsStyleFunction<typeof parts> = (props) => {
       _invalid: {
         borderColor: getColor(theme, ec),
       },
-      _focus: {
+      _focusVisible: {
         bg: "transparent",
         borderColor: getColor(theme, fc),
       },
@@ -168,7 +168,7 @@ const variantFlushed: PartsStyleFunction<typeof parts> = (props) => {
         borderColor: getColor(theme, ec),
         boxShadow: `0px 1px 0px 0px ${getColor(theme, ec)}`,
       },
-      _focus: {
+      _focusVisible: {
         borderColor: getColor(theme, fc),
         boxShadow: `0px 1px 0px 0px ${getColor(theme, fc)}`,
       },

--- a/packages/theme/src/components/link.ts
+++ b/packages/theme/src/components/link.ts
@@ -11,7 +11,7 @@ const baseStyle: SystemStyleObject = {
   _hover: {
     textDecoration: "underline",
   },
-  _focus: {
+  _focusVisible: {
     boxShadow: "outline",
   },
 }

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -30,7 +30,7 @@ const baseStyleContent: SystemStyleFunction = (props) => {
     borderRadius: "md",
     boxShadow: "sm",
     zIndex: "inherit",
-    _focus: {
+    _focusVisible: {
       outline: 0,
       boxShadow: "outline",
     },

--- a/packages/theme/src/components/skip-link.ts
+++ b/packages/theme/src/components/skip-link.ts
@@ -4,7 +4,7 @@ import { mode } from "@chakra-ui/theme-tools"
 const baseStyle: SystemStyleFunction = (props) => ({
   borderRadius: "md",
   fontWeight: "semibold",
-  _focus: {
+  _focusVisible: {
     boxShadow: "outline",
     padding: "1rem",
     position: "fixed",

--- a/packages/theme/src/components/slider.ts
+++ b/packages/theme/src/components/slider.ts
@@ -73,7 +73,7 @@ const baseStyleThumb: SystemStyleFunction = (props) => {
     borderColor: "transparent",
     transitionProperty: "transform",
     transitionDuration: "normal",
-    _focus: { boxShadow: "outline" },
+    _focusVisible: { boxShadow: "outline" },
     _disabled: { bg: "gray.300" },
     ...thumbOrientation(props),
   }

--- a/packages/theme/src/components/switch.ts
+++ b/packages/theme/src/components/switch.ts
@@ -26,7 +26,7 @@ const baseStyleTrack: SystemStyleFunction = (props) => {
     transitionProperty: "common",
     transitionDuration: "fast",
     bg: mode("gray.300", "whiteAlpha.400")(props),
-    _focus: {
+    _focusVisible: {
       boxShadow: "outline",
     },
     _disabled: {

--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -22,7 +22,7 @@ const baseStyleTab: SystemStyleFunction = (props) => {
     flex: isFitted ? 1 : undefined,
     transitionProperty: "common",
     transitionDuration: "normal",
-    _focus: {
+    _focusVisible: {
       zIndex: 1,
       boxShadow: "outline",
     },

--- a/packages/theme/src/components/tag.ts
+++ b/packages/theme/src/components/tag.ts
@@ -11,7 +11,7 @@ const baseStyleContainer: SystemStyleObject = {
   lineHeight: 1.2,
   outline: 0,
   borderRadius: "md",
-  _focus: {
+  _focusVisible: {
     boxShadow: "outline",
   },
 }
@@ -34,7 +34,7 @@ const baseStyleCloseButton: SystemStyleObject = {
   _disabled: {
     opacity: 0.4,
   },
-  _focus: {
+  _focusVisible: {
     boxShadow: "outline",
     bg: "rgba(0, 0, 0, 0.14)",
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7010,6 +7010,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zag-js/focus-visible@dev":
+  version "0.0.0-dev-20220604230945"
+  resolved "https://registry.yarnpkg.com/@zag-js/focus-visible/-/focus-visible-0.0.0-dev-20220604230945.tgz#b6427d3181b4c3089d279a96a7a159bae128807d"
+  integrity sha512-/iV4A51ImV8y5N6y5tuKzSIZATE0UsGMmnWDmLUyQ/46eKHxYzkVMeatfV1CHuMUOW/zRKgM2sUznjnrS+vomA==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
## 📝 Description

Removes the annoying focus outline by leveraging the `:focus-visible` pseudo-class and a `trackFocusVisible` helpers from Zag.js

## ⛳️ Current behavior (updates)

A focus outline is always shown because we use the `:focus` selector

## 🚀 New behavior

Focus outline shows only when the keyboard is used to interact with the component

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
