### PR TITLE
fix(media-query): get correct first render value for csr apps

### DIFF
--- a/.changeset/hip-wombats-lie.md
+++ b/.changeset/hip-wombats-lie.md
@@ -1,0 +1,31 @@
+---
+"@chakra-ui/media-query": minor
+---
+
+Add support for client-side rendered (CSR) apps to get the correct value on
+first render.
+
+> Affected hooks: `useMediaQuery`, `useBreakpoint`, `useBreakpointValue`.
+
+These hooks are built work in server-side rendering (SSR) applications by
+default. You might notice a quick flash of incorrect media query value when you
+use them.
+
+If you're creating a CSR-only app, you can now leverage the `ssr` argument to
+get the correct value on first render.
+
+```jsx live=false
+const [isMobile] = useMediaQuery("(max-width: 768px)", {
+  // you can now pass `ssr: false`
+  ssr: false,
+})
+
+const buttonSize = useBreakpointValue(
+  { base: "sm", lg: "md" },
+  // you can now pass `ssr: false`
+  { ssr: false },
+)
+
+// you can now pass `ssr: false`
+const breakpoint = useBreakpoint({ ssr: false })
+```

--- a/packages/media-query/src/media-query.hook.tsx
+++ b/packages/media-query/src/media-query.hook.tsx
@@ -1,11 +1,14 @@
-import { useMediaQuery } from "./use-media-query"
+import { useMediaQuery, UseMediaQueryOptions } from "./use-media-query"
 
 /**
  * React hook used to get the user's animation preference.
  */
-export function usePrefersReducedMotion(): boolean {
+export function usePrefersReducedMotion(
+  options?: UseMediaQueryOptions,
+): boolean {
   const [prefersReducedMotion] = useMediaQuery(
     "(prefers-reduced-motion: reduce)",
+    options,
   )
   return prefersReducedMotion
 }
@@ -13,11 +16,13 @@ export function usePrefersReducedMotion(): boolean {
 /**
  * React hook for getting the user's color mode preference.
  */
-export function useColorModePreference(): "dark" | "light" | undefined {
-  const [isLight, isDark] = useMediaQuery([
-    "(prefers-color-scheme: light)",
-    "(prefers-color-scheme: dark)",
-  ])
+export function useColorModePreference(
+  options?: UseMediaQueryOptions,
+): "dark" | "light" | undefined {
+  const [isLight, isDark] = useMediaQuery(
+    ["(prefers-color-scheme: light)", "(prefers-color-scheme: dark)"],
+    options,
+  )
 
   if (isLight) return "light"
   if (isDark) return "dark"

--- a/packages/media-query/src/media-query.tsx
+++ b/packages/media-query/src/media-query.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { useMediaQuery } from "./use-media-query"
 
 interface VisibilityProps {
+  ssr?: boolean
   breakpoint: string
   hide?: boolean
   children: React.ReactNode
@@ -16,8 +17,8 @@ interface VisibilityProps {
  * children based on the current breakpoint
  */
 const Visibility: React.FC<VisibilityProps> = (props) => {
-  const { breakpoint, hide, children } = props
-  const [show] = useMediaQuery(breakpoint)
+  const { breakpoint, hide, children, ssr } = props
+  const [show] = useMediaQuery(breakpoint, { ssr })
   const isVisible = hide ? !show : show
 
   const rendered = isVisible ? children : null
@@ -27,10 +28,10 @@ const Visibility: React.FC<VisibilityProps> = (props) => {
 export type HideProps = ShowProps
 
 export const Hide: React.FC<HideProps> = (props) => {
-  const { children } = props
+  const { children, ssr } = props
   const query = useQuery(props)
   return (
-    <Visibility breakpoint={query} hide>
+    <Visibility breakpoint={query} hide ssr={ssr}>
       {children}
     </Visibility>
   )
@@ -56,13 +57,18 @@ export interface ShowProps {
    * from that breakpoint and above. Default breakpoint values: `sm`, `md`, `lg`, `xl`, `2xl`.
    */
   above?: string
+  ssr?: boolean
   children?: React.ReactNode
 }
 
 export const Show: React.FC<ShowProps> = (props) => {
-  const { children } = props
+  const { children, ssr } = props
   const query = useQuery(props)
-  return <Visibility breakpoint={query}>{children}</Visibility>
+  return (
+    <Visibility breakpoint={query} ssr={ssr}>
+      {children}
+    </Visibility>
+  )
 }
 
 if (__DEV__) {

--- a/packages/media-query/src/use-breakpoint-value.ts
+++ b/packages/media-query/src/use-breakpoint-value.ts
@@ -1,15 +1,16 @@
 import { useTheme } from "@chakra-ui/system"
-import { arrayToObjectNotation, fromEntries, isArray } from "@chakra-ui/utils"
+import {
+  arrayToObjectNotation,
+  fromEntries,
+  isArray,
+  isObject,
+} from "@chakra-ui/utils"
 import { getClosestValue } from "./media-query.utils"
-import { useBreakpoint } from "./use-breakpoint"
+import { useBreakpoint, UseBreakpointOptions } from "./use-breakpoint"
 
 /**
  * React hook for getting the value for the current breakpoint from the
  * provided responsive values object.
- *
- * @param values
- * @param [defaultBreakpoint] default breakpoint name
- * (in non-window environments like SSR)
  *
  * For SSR, you can use a package like [is-mobile](https://github.com/kaimallea/isMobile)
  * to get the default breakpoint value from the user-agent
@@ -19,12 +20,13 @@ import { useBreakpoint } from "./use-breakpoint"
  */
 export function useBreakpointValue<T = any>(
   values: Partial<Record<string, T>> | T[],
-  defaultBreakpoint?: string,
+  arg?: UseBreakpointOptions | string,
 ): T | undefined {
-  const breakpoint = useBreakpoint(defaultBreakpoint)
+  const opts = isObject(arg) ? arg : { fallback: arg ?? "base" }
+  const breakpoint = useBreakpoint(opts)
   const theme = useTheme()
 
-  if (!breakpoint) return undefined
+  if (!breakpoint) return
 
   /**
    * Get the sorted breakpoint keys from the provided breakpoints

--- a/packages/media-query/src/use-breakpoint.ts
+++ b/packages/media-query/src/use-breakpoint.ts
@@ -1,18 +1,20 @@
 import { useTheme } from "@chakra-ui/system"
+import { isObject } from "@chakra-ui/utils"
 import { useMediaQuery } from "./use-media-query"
+
+export type UseBreakpointOptions = {
+  ssr?: boolean
+  fallback?: string
+}
 
 /**
  * React hook used to get the current responsive media breakpoint.
  *
- * @param [defaultBreakpoint="base"] default breakpoint name
- * (in non-window environments like SSR)
- *
  * For SSR, you can use a package like [is-mobile](https://github.com/kaimallea/isMobile)
- * to get the default breakpoint value from the user-agent
+ * to get the default breakpoint value from the user-agent.
  */
-export function useBreakpoint(
-  defaultBreakpoint = "base", // default value ensures SSR+CSR consistency
-) {
+export function useBreakpoint(arg?: string | UseBreakpointOptions) {
+  const opts = isObject(arg) ? arg : { fallback: arg ?? "base" }
   const theme = useTheme()
 
   const breakpoints = theme.__breakpoints!.details.map(
@@ -22,11 +24,12 @@ export function useBreakpoint(
     }),
   )
 
+  const fallback = breakpoints.map((bp) => bp.breakpoint === opts.fallback)
   const values = useMediaQuery(
     breakpoints.map((bp) => bp.query),
-    breakpoints.map((bp) => bp.breakpoint === defaultBreakpoint),
+    { fallback, ssr: opts.ssr },
   )
 
   const index = values.findIndex((value) => value == true)
-  return breakpoints[index]?.breakpoint ?? defaultBreakpoint
+  return breakpoints[index]?.breakpoint ?? opts.fallback
 }


### PR DESCRIPTION
Closes #6130

## 📝 Description

Add support for client-side rendered (CSR) apps to get the correct value on the first render.

> Affected hooks: `useMediaQuery`, `useBreakpoint`, `useBreakpointValue`.

These hooks are built to work in server-side rendering (SSR) applications by default. You might notice a quick flash of incorrect media query values when you use them.

If you're creating a CSR-only app, you can now leverage the `ssr` argument to get the correct value on the first render.

```jsx live=false
const [isMobile] = useMediaQuery("(max-width: 768px)", {
  // you can now pass `ssr: false`
  ssr: false,
})
const buttonSize = useBreakpointValue(
  { base: "sm", lg: "md" },
  // you can now pass `ssr: false`
  { ssr: false },
)
// you can now pass `ssr: false`
const breakpoint = useBreakpoint({ ssr: false })
```

## ⛳️ Current behavior (updates)

CSR only apps still face the Incorrect value on first render

## 🚀 New behavior

With the new option, this doesn't happen anymore

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
