### PR TITLE
feat: support `portalProps` in toast provider

### DIFF
--- a/.changeset/funny-moose-move.md
+++ b/.changeset/funny-moose-move.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/toast": patch
+---
+
+- Fix issue where toast portal are rendered in test even if they are not used.
+- Add support for `portalProps` in toast provider. When using with the
+  `ChakraProvider`, this can be configure in the `toastOptions`

--- a/.changeset/funny-moose-move.md
+++ b/.changeset/funny-moose-move.md
@@ -1,7 +1,6 @@
 ---
-"@chakra-ui/toast": patch
+"@chakra-ui/toast": minor
 ---
 
-- Fix issue where toast portal are rendered in test even if they are not used.
 - Add support for `portalProps` in toast provider. When using with the
   `ChakraProvider`, this can be configure in the `toastOptions`

--- a/packages/toast/src/toast.provider.tsx
+++ b/packages/toast/src/toast.provider.tsx
@@ -2,7 +2,7 @@ import { objectKeys } from "@chakra-ui/utils"
 import { AnimatePresence, Variants } from "framer-motion"
 import type { CSSProperties } from "react"
 import * as React from "react"
-import { Portal } from "@chakra-ui/portal"
+import { Portal, PortalProps } from "@chakra-ui/portal"
 import { ToastComponent, ToastComponentProps } from "./toast.component"
 import type {
   CloseAllToastsOptions,
@@ -85,6 +85,10 @@ export type ToastProviderProps = React.PropsWithChildren<{
    * @default 0.5rem
    */
   toastSpacing?: CSSProperties["margin"]
+  /**
+   * Props to be forwarded to the portal component
+   */
+  portalProps?: Pick<PortalProps, "appendToParentPortal" | "containerRef">
 }>
 
 /**
@@ -101,8 +105,13 @@ export const ToastProvider = (props: ToastProviderProps) => {
   const {
     children,
     motionVariants,
-    component: CustomToastComponent = ToastComponent,
+    component: Component = ToastComponent,
+    portalProps,
   } = props
+
+  const isAnyToastActive = React.useMemo(() => {
+    return objectKeys(state).some((position) => state[position].length > 0)
+  }, [state])
 
   const toastList = objectKeys(state).map((position) => {
     const toasts = state[position]
@@ -117,7 +126,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
       >
         <AnimatePresence initial={false}>
           {toasts.map((toast) => (
-            <CustomToastComponent
+            <Component
               key={toast.id}
               motionVariants={motionVariants}
               {...toast}
@@ -131,7 +140,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
   return (
     <>
       {children}
-      <Portal>{toastList}</Portal>
+      {isAnyToastActive && <Portal {...portalProps}>{toastList}</Portal>}
     </>
   )
 }

--- a/packages/toast/src/toast.provider.tsx
+++ b/packages/toast/src/toast.provider.tsx
@@ -109,10 +109,6 @@ export const ToastProvider = (props: ToastProviderProps) => {
     portalProps,
   } = props
 
-  const isAnyToastActive = React.useMemo(() => {
-    return objectKeys(state).some((position) => state[position].length > 0)
-  }, [state])
-
   const toastList = objectKeys(state).map((position) => {
     const toasts = state[position]
 
@@ -140,7 +136,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
   return (
     <>
       {children}
-      {isAnyToastActive && <Portal {...portalProps}>{toastList}</Portal>}
+      <Portal {...portalProps}>{toastList}</Portal>
     </>
   )
 }


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description

Add support for `portalProps` in the toast component.

## ⛳️ Current behavior (updates)

Toasts are always appended to `document.body`

## 🚀 New behavior

User can now define where they'd like the toast to live

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
