### PR TITLE
revert: use-styles regression

### DIFF
--- a/.changeset/strong-bottles-compare.md
+++ b/.changeset/strong-bottles-compare.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/system": patch
+---
+
+Fixed a regression where useStyles and StylesProvider was removed from
+`@chakra-ui/system`

--- a/packages/system/src/providers.tsx
+++ b/packages/system/src/providers.tsx
@@ -61,6 +61,25 @@ export function useTheme<T extends object = Dict>() {
 }
 
 /**
+ * @deprecated - Prefer to use `createStylesContext` to provide better error messages
+ *
+ * @example
+ *
+ * ```jsx
+ * import { createStylesContext } from "@chakra-ui/react"
+ *
+ * const [StylesProvider, useStyles] = createStylesContext("Component")
+ * ```
+ */
+const [StylesProvider, useStyles] = createContext<Dict<SystemStyleObject>>({
+  name: "StylesContext",
+  errorMessage:
+    "useStyles: `styles` is undefined. Seems you forgot to wrap the components in `<StylesProvider />` ",
+})
+
+export { StylesProvider, useStyles }
+
+/**
  * Helper function that creates context with a standardized errorMessage related to the component
  * @param componentName
  * @returns [StylesProvider, useStyles]


### PR DESCRIPTION
## 📝 Description

Fixed a regression where useStyles and StylesProvider were removed from `@chakra-ui/system`

## ⛳️ Current behavior (updates)

The last release introduced this breaking change from [this PR](https://github.com/chakra-ui/chakra-ui/commit/391f51221fd1fca1ec40bed1f41d163b66731ce3#diff-895ce969e1d1346a8856aa25b2e2bc87efd71a2c14a5734b850e6b7ef45553d5L63-L68). Thanks for the heads-up @TimKolberger 

## 🚀 New behavior

We've now reverted this regression and marked it as deprecated

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
