### PR TITLE
fix(color-mode): check if mediaQueryList.addEventListener is supported

### DIFF
--- a/.changeset/clever-shrimps-whisper.md
+++ b/.changeset/clever-shrimps-whisper.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/color-mode": minor
+---
+
+Check if the MediaQueryList object supports the addEventListener() method, else
+fallback to the legacy .addListener() method.

--- a/packages/color-mode/src/color-mode.utils.ts
+++ b/packages/color-mode/src/color-mode.utils.ts
@@ -1,3 +1,5 @@
+import { isFunction } from "@chakra-ui/utils"
+
 export type ColorMode = "light" | "dark"
 
 const classNames = {
@@ -35,8 +37,14 @@ export function getColorModeUtils(options: UtilOptions = {}) {
       const listener = (e: MediaQueryListEvent) => {
         fn(e.matches ? "dark" : "light")
       }
-      mql.addEventListener("change", listener)
-      return () => mql.removeEventListener("change", listener)
+
+      if (isFunction(mql.addListener)) mql.addListener(listener)
+      else mql.addEventListener("change", listener)
+
+      return () => {
+        if (isFunction(mql.removeListener)) mql.removeListener(listener)
+        else mql.removeEventListener("change", listener)
+      }
     },
     preventTransition() {
       const css = document.createElement("style")


### PR DESCRIPTION
Closes #5197

## 📝 Description

Support color mode for older browsers. Conditionally check if the
MediaQueryList object supports the addEventListener() method, else fallback to
the legacy .addListener() method.

## ⛳️ Current behavior (updates)

crashes on Safari browsers < v13 with error `mediaQueryList.addEventListener is not a function` 

## 🚀 New behavior

the method `addListener()` is used instead of `addEventListener()` for older browsers

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
