### PR TITLE
fix(modal): add size to modal with reference to theme.sizes

### DIFF
--- a/.changeset/serious-panthers-brake.md
+++ b/.changeset/serious-panthers-brake.md
@@ -1,6 +1,6 @@
 ---
-"@chakra-ui/modal": major
-"@chakra-ui/theme": major
+"@chakra-ui/modal": minor
+"@chakra-ui/theme": minor
 ---
 
 add size to modal with reference to theme.sizes

--- a/.changeset/serious-panthers-brake.md
+++ b/.changeset/serious-panthers-brake.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": major
+"@chakra-ui/theme": major
+---
+
+add size to modal with reference to theme.sizes

--- a/packages/modal/stories/modal.stories.tsx
+++ b/packages/modal/stories/modal.stories.tsx
@@ -175,6 +175,28 @@ export const AnimationDisabled = () => {
   )
 }
 
+export const MaxSpecifiedSizeWithLongContent = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  return (
+    <>
+      <button onClick={onOpen}>Open</button>
+      <Modal onClose={onClose} isOpen={isOpen} size="8xl">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal Title2</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Lorem count={30} />
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={onClose}>Close</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}
+
 export const FullWithLongContent = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   return (

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -109,6 +109,8 @@ const sizes = {
   "4xl": getSize("4xl"),
   "5xl": getSize("5xl"),
   "6xl": getSize("6xl"),
+  "7xl": getSize("7xl"),
+  "8xl": getSize("8xl"),
   full: getSize("full"),
 }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

no issues.

## 📝 Description

- add size to modal with reference to theme.sizes.

## ⛳️ Current behavior (updates)

modal is able to set size until ‘6xl’. 

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

in theme.sizes, there are the size until ‘8xl’.

## 💣 Is this a breaking change (Yes/No):

No.
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
