### PR TITLE
Apply the same constraint to this type parameter as the place it's used

### DIFF
--- a/.changeset/pretty-pandas-cover.md
+++ b/.changeset/pretty-pandas-cover.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/descendant": patch
+---
+
+Apply type constraints to `useDescendants` hook for improved TypeScript 4.8 support

--- a/packages/descendant/src/use-descendant.ts
+++ b/packages/descendant/src/use-descendant.ts
@@ -7,7 +7,7 @@ import { useSafeLayoutEffect, cast } from "./utils"
  * @internal
  * React hook that initializes the DescendantsManager
  */
-function useDescendants<T extends HTMLElement = HTMLElement, K = {}>() {
+function useDescendants<T extends HTMLElement = HTMLElement, K extends Record<string, any> = {}>() {
   const descendants = useRef(new DescendantsManager<T, K>())
   useSafeLayoutEffect(() => {
     return () => descendants.current.destroy()
@@ -81,7 +81,7 @@ function useDescendant<T extends HTMLElement = HTMLElement, K = {}>(
 
 export function createDescendantContext<
   T extends HTMLElement = HTMLElement,
-  K = {},
+  K extends Record<string, any> = {},
 >() {
   type ContextProviderType = React.Provider<DescendantsManager<T, K>>
   const ContextProvider = cast<ContextProviderType>(DescendantsContextProvider)


### PR DESCRIPTION
Mitigates an upcoming correctness improvement in TypeScript 4.8

## 📝 Description

TypeScript 4.8 has improved checking around unconstrained type parameters and now correctly identifies potentially-unsafe instantiations of generic types with `null` and `undefined`

See https://github.com/microsoft/TypeScript/issues/49489

## ⛳️ Current behavior (updates)

This code will not build in TypeScript 4.8

## 🚀 New behavior

Now it will

## 💣 Is this a breaking change (Yes/No):

Sort of? Code that invoked this with `null` or `undefined` will now correctly see an error, but this code presumably already crashed

## 📝 Additional Information
