### PR TITLE
fix(avatar): __css prop does not work on Avatar #6188

### DIFF
--- a/.changeset/lucky-tigers-juggle.md
+++ b/.changeset/lucky-tigers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/avatar": patch
+---
+
+\_\_css prop doesn't work on Avatar since it's not being properly passed down

--- a/packages/avatar/src/avatar.tsx
+++ b/packages/avatar/src/avatar.tsx
@@ -199,6 +199,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
     children,
     borderColor,
     ignoreFallback,
+    __css,
     ...rest
   } = omitThemingProps(props)
 
@@ -207,6 +208,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
     borderWidth: showBorder ? "2px" : undefined,
     ...baseStyle,
     ...styles.container,
+    ...__css,
   }
 
   if (borderColor) {


### PR DESCRIPTION
Closes #6188 

## 📝 Description

`__css` prop doesn't work on Avatar since it's not being properly passed down to component. This PR gets `__css` working by spreading its value into **avatarStyles** variable.

## ⛳️ Current behavior (updates)

`__css` prop doesn't work on **Avatar** component since its being ignored

## 🚀 New behavior

`__css` prop works as expected on **Avatar** component just as `sx` prop does.

## 💣 Is this a breaking change (Yes/No):

No
