### PR TITLE
Fix/focus issue in checkbox switch

### DIFF
--- a/.changeset/serious-dragons-glow.md
+++ b/.changeset/serious-dragons-glow.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+fixed issue where switch cannot be toggled when text is selectedd

--- a/packages/checkbox/src/use-checkbox.ts
+++ b/packages/checkbox/src/use-checkbox.ts
@@ -272,7 +272,9 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       const onPressDown = (event: React.MouseEvent) => {
         // On mousedown, the input blurs and returns focus to the `body`,
         // we need to prevent this. Native checkboxes keeps focus on `input`
-        event.preventDefault()
+        if (isFocused) {
+          event.preventDefault()
+        }
         setActive.on()
       }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #4216

## 📝 Description

You cannot toggle a switch on a single click if you have text that is highlighted (selected) on the screen.

## ⛳️ Current behavior (updates)

On mousedown, the input usually blurs and returns focus to the `body`, we do to prevent this

## 🚀 New behavior

We only prevent the default event if the input is already focused

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

 