### PR TITLE
fix: simple grid

### DIFF
--- a/.changeset/friendly-terms-cover.md
+++ b/.changeset/friendly-terms-cover.md
@@ -2,4 +2,5 @@
 "@chakra-ui/system": minor
 ---
 
-Extract and export `getToken` function from `useToken`
+- Extract and export `getToken` function from `useToken`
+- Improve parameter types for `useToken`

--- a/.changeset/friendly-terms-cover.md
+++ b/.changeset/friendly-terms-cover.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/system": minor
+---
+
+Extract and export `getToken` function from `useToken`

--- a/.changeset/perfect-icons-exist.md
+++ b/.changeset/perfect-icons-exist.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+SimpleGrid: Fix issue where `minChildWidth` doesn't work with size tokens

--- a/packages/layout/src/simple-grid.tsx
+++ b/packages/layout/src/simple-grid.tsx
@@ -1,5 +1,16 @@
-import { ResponsiveValue, forwardRef } from "@chakra-ui/system"
-import { mapResponsive, isNumber, isNull, __DEV__ } from "@chakra-ui/utils"
+import {
+  forwardRef,
+  getToken,
+  ResponsiveValue,
+  useTheme,
+} from "@chakra-ui/system"
+import {
+  Dict,
+  isNull,
+  isNumber,
+  mapResponsive,
+  __DEV__,
+} from "@chakra-ui/utils"
 import * as React from "react"
 import { Grid, GridProps } from "./grid"
 
@@ -33,7 +44,7 @@ export interface SimpleGridProps extends GridProps, SimpleGridOptions {}
  *
  * React component that uses the `Grid` component and provides
  * a simpler interface to create responsive grid layouts.
- * 
+ *
  * Provides props that easily define columns and spacing.
  *
  * @see Docs https://chakra-ui.com/simplegrid
@@ -41,8 +52,9 @@ export interface SimpleGridProps extends GridProps, SimpleGridOptions {}
 export const SimpleGrid = forwardRef<SimpleGridProps, "div">((props, ref) => {
   const { columns, spacingX, spacingY, spacing, minChildWidth, ...rest } = props
 
+  const theme = useTheme()
   const templateColumns = minChildWidth
-    ? widthToColumns(minChildWidth)
+    ? widthToColumns(minChildWidth, theme)
     : countToColumns(columns)
 
   return (
@@ -65,10 +77,11 @@ function toPx(n: string | number) {
   return isNumber(n) ? `${n}px` : n
 }
 
-function widthToColumns(width: any) {
-  return mapResponsive(width, (value) =>
-    isNull(value) ? null : `repeat(auto-fit, minmax(${toPx(value)}, 1fr))`,
-  )
+function widthToColumns(width: any, theme: Dict) {
+  return mapResponsive(width, (value) => {
+    const _value = getToken("sizes", value, toPx(value))(theme)
+    return isNull(value) ? null : `repeat(auto-fit, minmax(${_value}, 1fr))`
+  })
 }
 
 function countToColumns(count: any) {

--- a/packages/layout/stories/simple-grid.stories.tsx
+++ b/packages/layout/stories/simple-grid.stories.tsx
@@ -16,7 +16,7 @@ export const WithColumns = () => (
 )
 
 export const WithAutofit = () => (
-  <SimpleGrid minChildWidth="300px" spacing="40px">
+  <SimpleGrid minChildWidth="sm" spacing="40px">
     <Box bg="tomato" height="200px" />
     <Box bg="tomato" height="200px" />
     <Box bg="tomato" height="200px" />

--- a/packages/system/src/hooks.ts
+++ b/packages/system/src/hooks.ts
@@ -8,25 +8,24 @@ export function useChakra<T extends Dict = Dict>() {
   return { ...colorModeResult, theme }
 }
 
-const resolveBreakpointValue = <T extends StringOrNumber>(
+function getBreakpointValue<T extends StringOrNumber>(
   theme: Dict,
-  tokenValue: T,
-  fallbackValue: any,
-) => {
-  if (tokenValue === null) return tokenValue
+  value: T,
+  fallback: any,
+) {
+  if (value === null) return value
   const getValue = (val: T) => theme.__breakpoints?.asArray?.[val]
-  return getValue(tokenValue) ?? getValue(fallbackValue) ?? fallbackValue
+  return getValue(value) ?? getValue(fallback) ?? fallback
 }
 
-// inspired from ./css.ts : resolveTokenValue
-const resolveTokenValue = <T extends StringOrNumber>(
+function getTokenValue<T extends StringOrNumber>(
   theme: Dict,
-  tokenValue: T,
-  fallbackValue: any,
-) => {
-  if (tokenValue == null) return tokenValue
+  value: T,
+  fallback: any,
+) {
+  if (value == null) return value
   const getValue = (val: T) => theme.__cssMap?.[val]?.value
-  return getValue(tokenValue) ?? getValue(fallbackValue) ?? fallbackValue
+  return getValue(value) ?? getValue(fallback) ?? fallback
 }
 
 export function useToken<T extends StringOrNumber>(
@@ -48,10 +47,10 @@ export function getToken<T extends StringOrNumber>(
     const fallbackArr = _fallback.filter(Boolean) as T[]
     return _token.map((token, index) => {
       if (scale === "breakpoints") {
-        return resolveBreakpointValue(theme, token, fallbackArr[index] ?? token)
+        return getBreakpointValue(theme, token, fallbackArr[index] ?? token)
       }
       const path = `${scale}.${token}`
-      return resolveTokenValue(theme, path, fallbackArr[index] ?? token)
+      return getTokenValue(theme, path, fallbackArr[index] ?? token)
     })
   }
 }

--- a/packages/system/src/hooks.ts
+++ b/packages/system/src/hooks.ts
@@ -1,17 +1,6 @@
 import { useColorMode } from "@chakra-ui/color-mode"
-import { SystemStyleObject } from "@chakra-ui/styled-system"
-import {
-  Dict,
-  filterUndefined,
-  mergeWith,
-  runIfFn,
-  StringOrNumber,
-} from "@chakra-ui/utils"
-import { useMemo, useRef } from "react"
-import isEqual from "react-fast-compare"
+import { Dict, StringOrNumber } from "@chakra-ui/utils"
 import { useTheme } from "./providers"
-import { ThemingProps } from "./system.types"
-import { omitThemingProps } from "./system.utils"
 
 export function useChakra<T extends Dict = Dict>() {
   const colorModeResult = useColorMode()
@@ -45,97 +34,24 @@ export function useToken<T extends StringOrNumber>(
   token: T | T[],
   fallback?: T | T[],
 ) {
-  const theme = useTheme()
+  return getToken(scale, token, fallback)(useTheme())
+}
 
-  if (Array.isArray(token)) {
-    let fallbackArr: T[] = []
-    if (fallback) {
-      fallbackArr = Array.isArray(fallback) ? fallback : [fallback]
-    }
-
-    return token.map((token, index) => {
+export function getToken<T extends StringOrNumber>(
+  scale: string,
+  token: T | T[],
+  fallback?: T | T[],
+) {
+  const _token = Array.isArray(token) ? token : [token]
+  const _fallback = Array.isArray(fallback) ? fallback : [fallback]
+  return (theme: Dict<any>) => {
+    const fallbackArr = _fallback.filter(Boolean) as T[]
+    return _token.map((token, index) => {
       if (scale === "breakpoints") {
         return resolveBreakpointValue(theme, token, fallbackArr[index] ?? token)
       }
       const path = `${scale}.${token}`
       return resolveTokenValue(theme, path, fallbackArr[index] ?? token)
     })
-  }
-
-  if (scale === "breakpoints") {
-    return resolveBreakpointValue(theme, token, fallback)
-  }
-
-  const path = `${scale}.${token}`
-  return resolveTokenValue(theme, path, fallback)
-}
-
-export function useProps<P extends ThemingProps>(
-  themeKey: string,
-  props: P,
-  isMulti: true,
-): {
-  styles: Record<string, SystemStyleObject>
-  props: Omit<P, keyof ThemingProps>
-}
-
-export function useProps<P extends ThemingProps>(
-  themeKey: string,
-  props?: P,
-  isMulti?: boolean,
-): {
-  styles: SystemStyleObject
-  props: Omit<P, keyof ThemingProps>
-}
-
-export function useProps(themeKey: string, props: Dict) {
-  const { theme, colorMode } = useChakra()
-
-  const styleConfig = (props.styleConfig || theme.components?.[themeKey]) as
-    | Dict
-    | undefined
-
-  const defaultProps = styleConfig?.defaultProps ?? {}
-  const propsWithDefault = { ...defaultProps, ...filterUndefined(props) }
-
-  const stylesRef = useRef<Dict>({})
-
-  const mergedProps = mergeWith({}, propsWithDefault, { theme, colorMode })
-
-  const memoizedStyles = useMemo(() => {
-    if (styleConfig) {
-      const baseStyles = runIfFn(styleConfig.baseStyle ?? {}, mergedProps)
-
-      const variants = runIfFn(
-        styleConfig.variants?.[mergedProps.variant as string] ?? {},
-        mergedProps,
-      )
-
-      const sizes = runIfFn(
-        styleConfig.sizes?.[mergedProps.size as string] ?? {},
-        mergedProps,
-      )
-
-      const styles = mergeWith(baseStyles, sizes, variants)
-
-      if (styleConfig.parts) {
-        styleConfig.parts.forEach((part: string) => {
-          styles[part] = styles[part] ?? {}
-        })
-      }
-
-      const isStyleEqual = isEqual(stylesRef.current, styles)
-
-      if (!isStyleEqual) {
-        stylesRef.current = styles
-      }
-    }
-
-    return stylesRef.current
-  }, [styleConfig, mergedProps])
-
-  return {
-    styles: memoizedStyles,
-    props: omitThemingProps(propsWithDefault),
   }
 }

--- a/packages/system/src/hooks.ts
+++ b/packages/system/src/hooks.ts
@@ -13,7 +13,7 @@ function getBreakpointValue<T extends StringOrNumber>(
   value: T,
   fallback: any,
 ) {
-  if (value === null) return value
+  if (value == null) return value
   const getValue = (val: T) => theme.__breakpoints?.asArray?.[val]
   return getValue(value) ?? getValue(fallback) ?? fallback
 }
@@ -28,29 +28,31 @@ function getTokenValue<T extends StringOrNumber>(
   return getValue(value) ?? getValue(fallback) ?? fallback
 }
 
-export function useToken<T extends StringOrNumber>(
+export function useToken<T extends StringOrNumber | StringOrNumber[]>(
   scale: string,
-  token: T | T[],
-  fallback?: T | T[],
+  token: T,
+  fallback?: T,
 ) {
-  return getToken(scale, token, fallback)(useTheme())
+  const theme = useTheme()
+  return getToken(scale, token, fallback)(theme)
 }
 
-export function getToken<T extends StringOrNumber>(
+export function getToken<T extends StringOrNumber | StringOrNumber[]>(
   scale: string,
-  token: T | T[],
-  fallback?: T | T[],
-) {
+  token: T,
+  fallback?: T,
+): (theme: Dict) => T {
   const _token = Array.isArray(token) ? token : [token]
   const _fallback = Array.isArray(fallback) ? fallback : [fallback]
   return (theme: Dict<any>) => {
     const fallbackArr = _fallback.filter(Boolean) as T[]
-    return _token.map((token, index) => {
+    const result = _token.map((token, index) => {
       if (scale === "breakpoints") {
         return getBreakpointValue(theme, token, fallbackArr[index] ?? token)
       }
       const path = `${scale}.${token}`
       return getTokenValue(theme, path, fallbackArr[index] ?? token)
     })
+    return Array.isArray(token) ? result : result[0]
   }
 }

--- a/packages/system/stories/system.stories.tsx
+++ b/packages/system/stories/system.stories.tsx
@@ -1,16 +1,9 @@
-import React from "react"
-import theme from "@chakra-ui/theme"
 import { Text } from "@chakra-ui/layout"
-import { motion } from "framer-motion"
 import { HTMLChakraProps } from "@chakra-ui/system"
-import {
-  chakra,
-  PropsOf,
-  ThemeProvider,
-  ThemingProps,
-  useProps,
-  useStyleConfig,
-} from "../src"
+import theme from "@chakra-ui/theme"
+import { motion } from "framer-motion"
+import React from "react"
+import { chakra, ThemeProvider, useStyleConfig } from "../src"
 
 export default {
   title: "System / Core",
@@ -79,25 +72,6 @@ export const withTextStyles = () => (
       Welcome text
     </Text>
   </ThemeProvider>
-)
-
-const Comp = (props: PropsOf<typeof chakra.div> & ThemingProps) => {
-  const res = useProps("Badge", props)
-  return <chakra.div {...res.props} __css={res.styles} />
-}
-
-export const WithUseProps = () => (
-  <Comp
-    bg="green.500"
-    d="inline-block"
-    color="white"
-    textTransform="lowercase"
-    onClick={() => {
-      console.log("welcome home")
-    }}
-  >
-    Welcome home
-  </Comp>
 )
 
 export const WithGradient = () => (

--- a/packages/system/tests/style-config.test.tsx
+++ b/packages/system/tests/style-config.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { render } from "@chakra-ui/test-utils"
-import { ThemeProvider, useStyleConfig, useProps } from "../src"
+import { ThemeProvider, useStyleConfig } from "../src"
 import { createTheme } from "./theme"
 
 test("should resolve styles in theme", async () => {
@@ -117,75 +117,6 @@ test("should resolve multipart styles in theme", async () => {
       "tablist": {
         "p": 4,
         "border": "1px solid"
-      }
-    }
-    </DocumentFragment>
-  `)
-})
-
-test.skip("should resolve props and styles", async () => {
-  const Component = (props: any) => {
-    const res = useProps("Tabs", props, true)
-    return (
-      <>
-        {JSON.stringify(
-          res,
-          (k, v) => (typeof v === "function" ? "[Function]" : v),
-          2,
-        )}
-      </>
-    )
-  }
-
-  const { asFragment } = render(
-    <Component
-      size="sm"
-      variant="outline"
-      aria-label="testing"
-      tabIndex={0}
-      styleConfig={{
-        baseStyle: {
-          fontFamily: "Inter",
-          color: "red.400",
-        },
-        sizes: {
-          sm: {
-            fontSize: 12,
-            color: "red.500",
-          },
-        },
-        variants: {
-          outline: {
-            border: "2px solid blue.400",
-          },
-          solid: {
-            bg: "blue.400",
-          },
-        },
-        defaultProps: {
-          focusBorderColor: "red.400",
-          variant: "solid",
-        },
-      }}
-      onClick={() => {
-        console.log("hello")
-      }}
-    />,
-  )
-  expect(asFragment()).toMatchInlineSnapshot(`
-    <DocumentFragment>
-      {
-      "styles": {
-        "fontFamily": "Inter",
-        "color": "red.500",
-        "fontSize": 12,
-        "border": "2px solid blue.400"
-      },
-      "props": {
-        "focusBorderColor": "red.400",
-        "aria-label": "testing",
-        "tabIndex": 0,
-        "onClick": "[Function]"
       }
     }
     </DocumentFragment>


### PR DESCRIPTION
Closes #6199

## 📝 Description

This PR fix issue where SimpleGrid's `minChildWidth` doesn't allow size tokens but the types hints so. I've also removed a couple of unused functions in the `system` package

## ⛳️ Current behavior (updates)

Doesn't support tokens

## 🚀 New behavior

Now supports tokens

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
