### PR TITLE
fix: focus visible in radio

### DIFF
--- a/.changeset/wet-cobras-call.md
+++ b/.changeset/wet-cobras-call.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Fix issue where radio doesn't show focus when interacting with keyboard

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -36,7 +36,8 @@
     "@chakra-ui/hooks": "2.0.2",
     "@chakra-ui/react-utils": "2.0.1",
     "@chakra-ui/utils": "2.0.2",
-    "@chakra-ui/visually-hidden": "2.0.2"
+    "@chakra-ui/visually-hidden": "2.0.2",
+    "@zag-js/focus-visible": "0.1.0"
   },
   "devDependencies": {
     "@chakra-ui/system": "2.1.3",

--- a/packages/radio/src/use-radio.ts
+++ b/packages/radio/src/use-radio.ts
@@ -3,7 +3,14 @@ import { useBoolean, useControllableProp, useId } from "@chakra-ui/hooks"
 import { PropGetter } from "@chakra-ui/react-utils"
 import { ariaAttr, callAllHandlers, dataAttr } from "@chakra-ui/utils"
 import { visuallyHiddenStyle } from "@chakra-ui/visually-hidden"
-import { ChangeEvent, SyntheticEvent, useCallback, useState } from "react"
+import { trackFocusVisible } from "@zag-js/focus-visible"
+import {
+  ChangeEvent,
+  SyntheticEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react"
 import { useRadioGroupContext } from "./radio-group"
 
 /**
@@ -114,6 +121,7 @@ export function useRadio(props: UseRadioProps = {}) {
   const isRequired = isRequiredProp ?? formControl?.isRequired
   const isInvalid = isInvalidProp ?? formControl?.isInvalid
 
+  const [isFocusVisible, setIsFocusVisible] = useState(false)
   const [isFocused, setFocused] = useBoolean()
   const [isHovered, setHovering] = useBoolean()
   const [isActive, setActive] = useBoolean()
@@ -124,6 +132,10 @@ export function useRadio(props: UseRadioProps = {}) {
     isCheckedProp,
     isCheckedState,
   )
+
+  useEffect(() => {
+    return trackFocusVisible(setIsFocusVisible)
+  }, [])
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -169,6 +181,7 @@ export function useRadio(props: UseRadioProps = {}) {
       "data-invalid": dataAttr(isInvalid),
       "data-checked": dataAttr(isChecked),
       "data-focus": dataAttr(isFocused),
+      "data-focus-visible": dataAttr(isFocused && isFocusVisible),
       "data-readonly": dataAttr(isReadOnly),
       "aria-hidden": true,
       onMouseDown: callAllHandlers(props.onMouseDown, setActive.on),
@@ -188,6 +201,7 @@ export function useRadio(props: UseRadioProps = {}) {
       setActive.off,
       setHovering.on,
       setHovering.off,
+      isFocusVisible,
     ],
   )
 


### PR DESCRIPTION
Closes #6166

## 📝 Description

Fix issue where radio component doesn't show focus visible outlines.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
