### PR TITLE
feat(cli): add --no-format option

### DIFF
--- a/.changeset/cuddly-cars-sin.md
+++ b/.changeset/cuddly-cars-sin.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Add --no-format option

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -45,7 +45,7 @@
     "cli-check-node": "^1.3.4",
     "cli-handle-unhandled": "^1.1.1",
     "cli-welcome": "^2.2.2",
-    "commander": "^6.2.1",
+    "commander": "^9.3.0",
     "lodash.throttle": "^4.1.1",
     "module-alias": "^2.2.2",
     "ora": "^5.3.0",

--- a/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
+++ b/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
@@ -40,11 +40,16 @@ export interface ThemeKeyOptions {
 export interface CreateThemeTypingsInterfaceOptions {
   config: ThemeKeyOptions[]
   strictComponentTypes?: boolean
+  format?: boolean
 }
 
 export async function createThemeTypingsInterface(
   theme: Record<string, unknown>,
-  { config, strictComponentTypes = false }: CreateThemeTypingsInterfaceOptions,
+  {
+    config,
+    strictComponentTypes = false,
+    format = true,
+  }: CreateThemeTypingsInterfaceOptions,
 ) {
   const unions = config.reduce(
     (
@@ -91,5 +96,5 @@ export interface ThemeTypings {
 
 `
 
-  return formatWithPrettierIfAvailable(template)
+  return format ? formatWithPrettierIfAvailable(template) : template
 }

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -15,13 +15,17 @@ const writeFileAsync = promisify(writeFile)
 async function runTemplateWorker({
   themeFile,
   strictComponentTypes,
+  format,
 }: {
   themeFile: string
   strictComponentTypes?: boolean
+  format?: boolean
 }): Promise<string> {
   const worker = fork(
     path.join(__dirname, "..", "..", "scripts", "read-theme-file.worker.js"),
-    [themeFile].concat(strictComponentTypes ? "--strict-component-types" : []),
+    [themeFile]
+      .concat(strictComponentTypes ? "--strict-component-types" : [])
+      .concat(format ? "--format" : []),
     {
       stdio: ["pipe", "pipe", "pipe", "ipc"],
       cwd: process.cwd(),
@@ -46,11 +50,13 @@ export async function generateThemeTypings({
   themeFile,
   out,
   strictComponentTypes,
+  format,
   onError,
 }: {
   themeFile: string
   out: string
   strictComponentTypes?: boolean
+  format?: boolean
   onError?: () => void
 }) {
   const spinner = ora("Generating chakra theme typings").start()
@@ -58,6 +64,7 @@ export async function generateThemeTypings({
     const template = await runTemplateWorker({
       themeFile,
       strictComponentTypes,
+      format,
     })
     const outPath = await resolveOutputPath(out)
 

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -54,7 +54,7 @@ export async function generateThemeTypings({
   onError,
 }: {
   themeFile: string
-  out: string
+  out?: string
   strictComponentTypes?: boolean
   format?: boolean
   onError?: () => void

--- a/tooling/cli/src/command/tokens/resolve-output-path.ts
+++ b/tooling/cli/src/command/tokens/resolve-output-path.ts
@@ -45,7 +45,9 @@ async function resolveThemingDefinitionPath(): Promise<string | undefined> {
 /**
  * Find the location of the default target file or resolve the given path
  */
-export async function resolveOutputPath(overridePath: string): Promise<string> {
+export async function resolveOutputPath(
+  overridePath?: string,
+): Promise<string> {
   if (overridePath) {
     return path.resolve(process.cwd(), overridePath)
   }

--- a/tooling/cli/src/index.ts
+++ b/tooling/cli/src/index.ts
@@ -1,6 +1,6 @@
 import "regenerator-runtime/runtime"
 import * as path from "path"
-import { Command, program } from "commander"
+import { program } from "commander"
 import chokidar from "chokidar"
 import { isString } from "@chakra-ui/utils"
 import throttle from "lodash.throttle"
@@ -9,6 +9,13 @@ import {
   generateThemeTypings,
   themeInterfaceDestination,
 } from "./command/tokens"
+
+type OptionsType = {
+  out?: string
+  strictComponentTypes?: boolean
+  format: boolean
+  watch?: string
+}
 
 export async function run() {
   await initCLI()
@@ -25,8 +32,8 @@ export async function run() {
     )
     .option("--no-format", "Disable auto formatting")
     .option("--watch [path]", "Watch directory for changes and rebuild")
-    .action(async (themeFile, command) => {
-      const { out, strictComponentTypes, format, watch } = command.opts()
+    .action(async (themeFile: string, options: OptionsType) => {
+      const { out, strictComponentTypes, format, watch } = options
 
       if (watch) {
         const watchPath = isString(watch) ? watch : path.dirname(themeFile)

--- a/tooling/cli/src/index.ts
+++ b/tooling/cli/src/index.ts
@@ -23,9 +23,10 @@ export async function run() {
       "--strict-component-types",
       "Generate strict types for props variant and size",
     )
+    .option("--no-format", "Disable auto formatting")
     .option("--watch [path]", "Watch directory for changes and rebuild")
-    .action(async (themeFile: string, command: Command) => {
-      const { out, strictComponentTypes, watch } = command.opts()
+    .action(async (themeFile, command) => {
+      const { out, strictComponentTypes, format, watch } = command.opts()
 
       if (watch) {
         const watchPath = isString(watch) ? watch : path.dirname(themeFile)
@@ -35,6 +36,7 @@ export async function run() {
             themeFile,
             out,
             strictComponentTypes,
+            format,
           })
           console.timeEnd("Duration")
           console.info(new Date().toLocaleString())
@@ -51,6 +53,7 @@ export async function run() {
         themeFile,
         out,
         strictComponentTypes,
+        format,
         onError: () => process.exit(1),
       })
     })

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -103,6 +103,7 @@ async function readTheme(themeFilePath: string) {
 async function run() {
   const themeFile = process.argv[2]
   const strictComponentTypes = process.argv.includes("--strict-component-types")
+  const format = process.argv.includes("--format")
 
   if (!themeFile) {
     throw new Error("No path to theme file provided.")
@@ -117,6 +118,7 @@ async function run() {
   const template = await createThemeTypingsInterface(theme, {
     config: themeKeyConfiguration,
     strictComponentTypes,
+    format,
   })
 
   if (process.send) {

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -222,6 +222,49 @@ describe("Theme typings", () => {
     `)
   })
 
+  it("should create unformatted types", async () => {
+    const themeInterface = await createThemeTypingsInterface(smallTheme, {
+      config: themeKeyConfiguration,
+      format: false,
+    })
+
+    expect(themeInterface).toMatchInlineSnapshot(`
+      "// regenerate by running
+      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+      export interface ThemeTypings {
+        blur: (string & {});
+      borders: \\"sm\\" | \\"md\\" | (string & {});
+      borderStyles: (string & {});
+      borderWidths: (string & {});
+      breakpoints: \\"sm\\" | \\"md\\" | (string & {});
+      colors: \\"niceColor\\" | \\"suchWowColor\\" | \\"onlyColorSchemeColor.50\\" | \\"onlyColorSchemeColor.100\\" | \\"onlyColorSchemeColor.200\\" | \\"onlyColorSchemeColor.300\\" | \\"onlyColorSchemeColor.400\\" | \\"onlyColorSchemeColor.500\\" | \\"onlyColorSchemeColor.600\\" | \\"onlyColorSchemeColor.700\\" | \\"onlyColorSchemeColor.800\\" | \\"onlyColorSchemeColor.900\\" | \\"such.deep.color\\" | (string & {});
+      colorSchemes: \\"onlyColorSchemeColor\\" | (string & {});
+      fonts: \\"sm\\" | \\"md\\" | (string & {});
+      fontSizes: \\"sm\\" | \\"md\\" | (string & {});
+      fontWeights: \\"sm\\" | \\"md\\" | (string & {});
+      layerStyles: \\"red\\" | \\"blue\\" | (string & {});
+      letterSpacings: \\"sm\\" | \\"md\\" | (string & {});
+      lineHeights: \\"sm\\" | \\"md\\" | (string & {});
+      radii: \\"sm\\" | \\"md\\" | (string & {});
+      shadows: \\"sm\\" | \\"md\\" | (string & {});
+      sizes: \\"sm\\" | \\"md\\" | (string & {});
+      space: \\"sm\\" | \\"-sm\\" | \\"md\\" | \\"-md\\" | (string & {});
+      textStyles: \\"small\\" | \\"large\\" | (string & {});
+      transition: \\"sm\\" | \\"md\\" | (string & {});
+      zIndices: \\"sm\\" | \\"md\\" | (string & {});
+        components: {
+        Button: {
+        sizes: \\"sm\\" | (string & {});
+      variants: \\"extraordinary\\" | \\"awesome\\" | \\"unused\\" | (string & {});
+      }  
+      }
+
+      }
+
+      "
+    `)
+  })
+
   it("should include semantic tokens", async () => {
     const themeInterface = await createThemeTypingsInterface(
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9648,6 +9648,11 @@ commander@^8.2.0, commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
+commander@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
+  integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
+
 commitizen@4.2.4, commitizen@^4.0.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/commitizen/-/commitizen-4.2.4.tgz#a3e5b36bd7575f6bf6e7aa19dbbf06b0d8f37165"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`chakra-cli tokens` formats the output file if prettier is available.
However, there are environments like CI that do not require formatting.

I add `--no-format` option to finish type generation faster in such environments.

## ⛳️ Current behavior (updates)

`chakra-cli tokens` always formats the output file if prettier is available

## 🚀 New behavior

`--no-format` disables formatting

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Benchmarks in my local project

| format | no format |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2343568/174332357-989f03d9-34bc-4dae-abbc-adf6cc714ef1.png) | ![image](https://user-images.githubusercontent.com/2343568/174332532-ab7211a0-da25-4a29-b50a-f928d1f5a616.png) |