### PR TITLE
build(transition): fix ts types for withDelay

### DIFF
--- a/.changeset/smooth-garlics-collect.md
+++ b/.changeset/smooth-garlics-collect.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/transition": patch
+---
+
+Transition: Fix emitted types that were incompatible with latest framer-motion
+release

--- a/packages/transition/src/transition-utils.ts
+++ b/packages/transition/src/transition-utils.ts
@@ -132,11 +132,17 @@ export type WithTransitionConfig<P extends object> = Omit<P, "transition"> & {
 }
 
 export const withDelay = {
-  enter: (transition: Transition, delay?: number | DelayConfig) => ({
+  enter: (
+    transition: Transition,
+    delay?: number | DelayConfig,
+  ): Transition & { delay: number | undefined } => ({
     ...transition,
     delay: isNumber(delay) ? delay : delay?.["enter"],
   }),
-  exit: (transition: Transition, delay?: number | DelayConfig) => ({
+  exit: (
+    transition: Transition,
+    delay?: number | DelayConfig,
+  ): Transition & { delay: number | undefined } => ({
     ...transition,
     delay: isNumber(delay) ? delay : delay?.["exit"],
   }),


### PR DESCRIPTION
## 📝 Description

`withDelay` lacks type annotations for return types. That causes `tsc` to infer return types while emitting type declarations. Sadly, inferred return types have a deep import into `framer-motion`  (`import("framer-motion/types/types")` as you can see [here](https://unpkg.com/@chakra-ui/transition@2.0.2/dist/declarations/src/transition-utils.d.ts)). That deep import is valid for some framer-motion versions (e.g. `6.2.9`) but not for the latest framer-motion version (`6.3.16`). 

By explicitly annotating return types, we fix the problem and also avoid future problems. 

## ⛳️ Current behavior (updates)

1. `@chakra-ui/transition` has type declarations that are prone to failure because inferred types have deep imports into `framer-motion`. Proof: https://unpkg.com/@chakra-ui/transition@2.0.2/dist/declarations/src/transition-utils.d.ts
   ```ts
   ease?: import("framer-motion/types/types").Easing | import("framer-motion/types/types").Easing[] | undefined;
   ```
   
2. `tsc` fails if an app/lib has library typechecks enabled in tsconfig and has a `@chakra-ui/transition@2.0.2` and `framer-motion@6.3.16` dependencies.

## 🚀 New behavior

1. `@chakra-ui/transition` declaration files do not have deep `framer-motion` imports anymore.
2.  `@chakra-ui/transition` does not cause type errors with `framer-motion@6.3.16`.

## 💣 Is this a breaking change (Yes/No):

**No.**
