### PR TITLE
perf: improve responsiveness of modal dialogs

### DIFF
--- a/.changeset/test-malant.md
+++ b/.changeset/test-malant.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/utils": patch
+---
+
+Fix issue where get-focusables causes excessive repaint due to computed style
+calls

--- a/packages/utils/src/dom-query.ts
+++ b/packages/utils/src/dom-query.ts
@@ -20,14 +20,14 @@ const focusableElList = [
 
 const focusableElSelector = focusableElList.join()
 
+const isVisible = (el: HTMLElement) => el.offsetWidth > 0 && el.offsetHeight > 0
+
 export function getAllFocusable<T extends HTMLElement>(container: T) {
   const focusableEls = Array.from(
     container.querySelectorAll<T>(focusableElSelector),
   )
   focusableEls.unshift(container)
-  return focusableEls
-    .filter(isFocusable)
-    .filter((el) => window.getComputedStyle(el).display !== "none")
+  return focusableEls.filter((el) => isFocusable(el) && isVisible(el))
 }
 
 export function getFirstFocusable<T extends HTMLElement>(container: T) {


### PR DESCRIPTION
Closes #6249

## 📝 Description

Fix issue where `getAllFocusables` causes excessive repaint due to `getComputedStyle` calls. This affects the drawer, alert dialog, and dialog components