### PR TITLE
fix: Avoid TypeError in getCSSVar when theme is an empty object

### DIFF
--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -152,4 +152,4 @@ export const fromEntries = <T extends unknown>(entries: [string, any][]) =>
  * Get the CSS variable ref stored in the theme
  */
 export const getCSSVar = (theme: Dict, scale: string, value: any) =>
-  theme.__cssMap[`${scale}.${value}`]?.varRef ?? value
+  theme.__cssMap?.[`${scale}.${value}`]?.varRef ?? value


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6270

## 📝 Description

This amends `getCSSVars` to include `__cssMap` in the optional operator chaining.

It fixes the root cause for #6270.

## ⛳️ Current behavior (updates)

Tooltip component throws: 

```
Error name:    "TypeError"
Error message: "Cannot read properties of undefined (reading 'colors.red.600')"

at Object.getCSSVar (node_modules/@chakra-ui/utils/dist/chakra-ui-utils.cjs.dev.js:367:69)
          at node_modules/@chakra-ui/tooltip/dist/chakra-ui-tooltip.cjs.dev.js:306:57
```

when it is called in a test environment.

## 🚀 New behavior

It does not throw anymore when `theme` is an empty object :partying_face: 

## 💣 Is this a breaking change (Yes/No):

No
