### PR TITLE
fix(utils): avoid TypeError in getCSSVar when theme is an empty object

### DIFF
--- a/.changeset/proud-planes-poke.md
+++ b/.changeset/proud-planes-poke.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/utils": patch
+---
+
+fix(utils): avoid TypeError in getCSSVar when theme is an empty object

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -152,4 +152,4 @@ export const fromEntries = <T extends unknown>(entries: [string, any][]) =>
  * Get the CSS variable ref stored in the theme
  */
 export const getCSSVar = (theme: Dict, scale: string, value: any) =>
-  theme.__cssMap[`${scale}.${value}`]?.varRef ?? value
+  theme.__cssMap?.[`${scale}.${value}`]?.varRef ?? value


### PR DESCRIPTION
Closes #6270 for version 2.x

## 📝 Description

See PR #6274

This is exactly the same change, but as a PR onto the main branch as a convenience for you folks so you don't have to cherry-pick it.