### PR TITLE
feat(useStyles): export useStyles with component namespace

### DIFF
--- a/.changeset/breezy-bobcats-grow.md
+++ b/.changeset/breezy-bobcats-grow.md
@@ -1,0 +1,19 @@
+---
+"@chakra-ui/accordion": patch
+"@chakra-ui/alert": patch
+"@chakra-ui/avatar": patch
+"@chakra-ui/breadcrumb": patch
+"@chakra-ui/editable": patch
+"@chakra-ui/form-control": patch
+"@chakra-ui/menu": patch
+"@chakra-ui/number-input": patch
+"@chakra-ui/popover": patch
+"@chakra-ui/progress": patch
+"@chakra-ui/slider": patch
+"@chakra-ui/stat": patch
+"@chakra-ui/table": patch
+"@chakra-ui/tabs": patch
+"@chakra-ui/tag": patch
+---
+
+export useStyles with component namespace

--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -25,6 +25,7 @@ import {
 } from "./use-accordion"
 
 const [StylesProvider, useStyles] = createStylesContext("Accordion")
+export const useAccordionStyles = useStyles
 
 /* -------------------------------------------------------------------------------------------------
  * Accordion - The wrapper that provides context for all accordion items

--- a/packages/alert/src/alert.tsx
+++ b/packages/alert/src/alert.tsx
@@ -15,6 +15,7 @@ import { Spinner } from "@chakra-ui/spinner"
 import { CheckIcon, InfoIcon, WarningIcon } from "./icons"
 
 const [StylesProvider, useStyles] = createStylesContext("Alert")
+export const useAlertStyles = useStyles
 
 const STATUSES = {
   info: { icon: InfoIcon, colorScheme: "blue" },

--- a/packages/avatar/src/avatar.tsx
+++ b/packages/avatar/src/avatar.tsx
@@ -16,6 +16,7 @@ import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
 const [StylesProvider, useStyles] = createStylesContext("Avatar")
+export const useAvatarStyles = useStyles
 
 interface AvatarOptions {
   /**

--- a/packages/breadcrumb/src/breadcrumb.tsx
+++ b/packages/breadcrumb/src/breadcrumb.tsx
@@ -14,6 +14,7 @@ import { getValidChildren } from "@chakra-ui/react-utils"
 import * as React from "react"
 
 const [StylesProvider, useStyles] = createStylesContext("Breadcrumb")
+export const useBreadcrumbStyles = useStyles
 
 export interface BreadcrumbSeparatorProps extends HTMLChakraProps<"div"> {
   /**

--- a/packages/editable/src/editable.tsx
+++ b/packages/editable/src/editable.tsx
@@ -18,6 +18,7 @@ import {
 } from "./use-editable"
 
 const [StylesProvider, useStyles] = createStylesContext("Editable")
+export const useEditableStyles = useStyles
 
 type EditableContext = Omit<UseEditableReturn, "htmlProps">
 

--- a/packages/form-control/src/form-error.tsx
+++ b/packages/form-control/src/form-error.tsx
@@ -13,6 +13,7 @@ import * as React from "react"
 import { useFormControlContext } from "./form-control"
 
 const [StylesProvider, useStyles] = createStylesContext("FormError")
+export const useFormErrorStyles = useStyles
 
 export interface FormErrorMessageProps
   extends HTMLChakraProps<"div">,

--- a/packages/layout/src/list.tsx
+++ b/packages/layout/src/list.tsx
@@ -14,6 +14,7 @@ import { __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
 const [StylesProvider, useStyles] = createStylesContext("List")
+export const useListStyles = useStyles
 
 interface ListOptions {
   /**

--- a/packages/menu/src/menu.tsx
+++ b/packages/menu/src/menu.tsx
@@ -34,6 +34,7 @@ import {
 } from "./use-menu"
 
 const [StylesProvider, useStyles] = createStylesContext("Menu")
+export const useMenuStyles = useStyles
 
 export interface MenuProps extends UseMenuProps, ThemingProps<"Menu"> {
   children: MaybeRenderProp<{

--- a/packages/number-input/src/number-input.tsx
+++ b/packages/number-input/src/number-input.tsx
@@ -19,6 +19,7 @@ import {
 } from "./use-number-input"
 
 const [StylesProvider, useStyles] = createStylesContext("NumberInput")
+export const useNumberInputStyles = useStyles
 
 interface NumberInputContext extends Omit<UseNumberInputReturn, "htmlProps"> {}
 

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -20,6 +20,7 @@ import { usePopover, UsePopoverProps } from "./use-popover"
 export { usePopoverContext }
 
 const [StylesProvider, useStyles] = createStylesContext("Popover")
+export const usePopoverStyles = useStyles
 
 export interface PopoverProps extends UsePopoverProps, ThemingProps<"Popover"> {
   /**

--- a/packages/progress/src/progress.tsx
+++ b/packages/progress/src/progress.tsx
@@ -18,6 +18,7 @@ import {
 } from "./progress.utils"
 
 const [StylesProvider, useStyles] = createStylesContext("Progress")
+export const useProgressStyles = useStyles
 
 export interface ProgressLabelProps extends HTMLChakraProps<"div"> {}
 

--- a/packages/slider/src/range-slider.tsx
+++ b/packages/slider/src/range-slider.tsx
@@ -30,6 +30,7 @@ const [RangeSliderProvider, useRangeSliderContext] =
   })
 
 const [StylesProvider, useStyles] = createStylesContext("RangeSlider")
+export const useRangeSliderStyles = useStyles
 
 export { RangeSliderProvider, useRangeSliderContext }
 

--- a/packages/slider/src/slider.tsx
+++ b/packages/slider/src/slider.tsx
@@ -23,6 +23,7 @@ const [SliderProvider, useSliderContext] = createContext<SliderContext>({
 })
 
 const [StylesProvider, useStyles] = createStylesContext("Slider")
+export const useSliderStyles = useStyles
 
 export { SliderProvider, useSliderContext }
 

--- a/packages/stat/src/stat.tsx
+++ b/packages/stat/src/stat.tsx
@@ -14,6 +14,7 @@ import { VisuallyHidden } from "@chakra-ui/visually-hidden"
 import * as React from "react"
 
 const [StylesProvider, useStyles] = createStylesContext("Stat")
+export const useStatStyles = useStyles
 
 export interface StatLabelProps extends HTMLChakraProps<"dt"> {}
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -11,6 +11,7 @@ import { cx, __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
 const [StylesProvider, useStyles] = createStylesContext("Table")
+export const useTableStyles = useStyles
 
 export interface TableContainerProps extends HTMLChakraProps<"div"> {}
 

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -25,6 +25,7 @@ import {
 } from "./use-tabs"
 
 const [StylesProvider, useStyles] = createStylesContext("Tabs")
+export const useTabsStyles = useStyles
 
 interface TabsOptions {
   /**

--- a/packages/tag/src/tag.tsx
+++ b/packages/tag/src/tag.tsx
@@ -13,6 +13,7 @@ import { __DEV__ } from "@chakra-ui/utils"
 import * as React from "react"
 
 const [StylesProvider, useStyles] = createStylesContext("Tag")
+export const useTagStyles = useStyles
 
 export interface TagProps
   extends HTMLChakraProps<"span">,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> export useStyles with component namespace. Sometimes I need to customize some components, because useStyle is not exported, so I can't use the theming system.

## ⛳️ Current behavior (updates)

> Unable to get styles in theme using useStyles

## 🚀 New behavior

> I am able to use the styles in the context/theme in some custom components

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
