### PR TITLE
fix(border.ts): create new tag br for borderRadius

### DIFF
--- a/packages/styled-system/src/config/border.ts
+++ b/packages/styled-system/src/config/border.ts
@@ -144,6 +144,10 @@ export interface BorderProps {
   /**
    * The CSS `border` property
    */
+  br?: Token<CSS.Property.BorderRadius | number, "radii">
+  /**
+   * The CSS `border` property
+   */
   border?: Token<CSS.Property.Border | number, "borders">
   /**
    * The CSS `border-width` property


### PR DESCRIPTION
I use chakra a lot and I realized that with the br tag for borderRadius, it would be much simpler.

Just updated so it can be passed just br instead of borderRadius.

