### PR TITLE
fix(utils): breakpoint calculation

### DIFF
--- a/.changeset/selfish-bees-kneel.md
+++ b/.changeset/selfish-bees-kneel.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/styled-system": patch
+"@chakra-ui/utils": patch
+---
+
+Fix incorrect breakpoint calculation which excluded some viewport widths from
+media query coverage

--- a/packages/styled-system/tests/style-config.test.ts
+++ b/packages/styled-system/tests/style-config.test.ts
@@ -4,7 +4,7 @@ test("should handle single variant", () => {
   expect(recipe({ theme, variant: "solid", size: ["sm", "md"] }))
     .toMatchInlineSnapshot(`
     Object {
-      "@media screen and (min-width: 0px) and (max-width: 39.9365em)": Object {
+      "@media screen and (min-width: 0px) and (max-width: 39.9375em)": Object {
         "fontSize": "sm",
         "h": 8,
         "minW": 8,
@@ -27,7 +27,7 @@ test("should handle single variant", () => {
   expect(recipe({ theme, variant: "solid", size: { base: "sm", sm: "md" } }))
     .toMatchInlineSnapshot(`
     Object {
-      "@media screen and (min-width: 0px) and (max-width: 39.9365em)": Object {
+      "@media screen and (min-width: 0px) and (max-width: 39.9375em)": Object {
         "fontSize": "sm",
         "h": 8,
         "minW": 8,
@@ -50,7 +50,7 @@ test("should handle single variant", () => {
   expect(recipe({ theme, variant: "solid", size: { base: "sm", lg: "md" } }))
     .toMatchInlineSnapshot(`
     Object {
-      "@media screen and (min-width: 0px) and (max-width: 63.9365em)": Object {
+      "@media screen and (min-width: 0px) and (max-width: 63.9375em)": Object {
         "fontSize": "sm",
         "h": 8,
         "minW": 8,
@@ -80,7 +80,7 @@ test("should work with distant breakpoint", () => {
     }),
   ).toMatchInlineSnapshot(`
     Object {
-      "@media screen and (min-width: 0px) and (max-width: 63.9365em)": Object {
+      "@media screen and (min-width: 0px) and (max-width: 63.9375em)": Object {
         "fontSize": "sm",
         "h": 8,
         "minW": 8,
@@ -108,7 +108,7 @@ test("should work with distant breakpoint", () => {
     }),
   ).toMatchInlineSnapshot(`
     Object {
-      "@media screen and (min-width: 0px) and (max-width: 63.9365em)": Object {
+      "@media screen and (min-width: 0px) and (max-width: 63.9375em)": Object {
         "fontSize": "sm",
         "h": 8,
         "minW": 8,

--- a/packages/utils/src/breakpoint.ts
+++ b/packages/utils/src/breakpoint.ts
@@ -37,7 +37,7 @@ function subtract(value: string) {
   const factor = value.endsWith("px")
     ? -1
     : // the equivalent of 1px in em using a 16px base
-      -0.0635
+      -0.0625
   return isNumber(value)
     ? `${value + factor}`
     : value.replace(/(\d+\.?\d*)/u, (m) => `${parseFloat(m) + factor}`)

--- a/packages/utils/tests/responsive.test.ts
+++ b/packages/utils/tests/responsive.test.ts
@@ -142,7 +142,7 @@ test("should work with createBreakpoint output", () => {
   ).toMatchInlineSnapshot(`
     Array [
       Object {
-        "_minW": "-0.0635em",
+        "_minW": "-0.0625em",
         "breakpoint": "base",
         "maxW": "319px",
         "maxWQuery": "@media screen and (max-width: 319px)",


### PR DESCRIPTION
Closes #6269

## 📝 Description

Fixes breakpoint calculation which was causing certain viewport widths to be excluded from media query coverage.

## ⛳️ Current behavior (updates)

Media queries which are generated from theme breakpoints do not cover all possible pixel widths.

## 🚀 New behavior

Media queries cover all possible viewport widths.

## 💣 Is this a breaking change (Yes/No):

No
