### PR TITLE
fix(media-query): change logic of judging if break point values has s…

### DIFF
--- a/.changeset/moody-planets-float.md
+++ b/.changeset/moody-planets-float.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/media-query": minor
+---
+
+fix getClosestValue to return nullable closest break point value

--- a/packages/media-query/src/media-query.utils.ts
+++ b/packages/media-query/src/media-query.utils.ts
@@ -16,7 +16,7 @@ export function getClosestValue<T = any>(
   while (stopIndex >= 0) {
     const key = breakpoints[stopIndex]
 
-    if (values[key] != null) {
+    if (values.hasOwnProperty(key)) {
       index = stopIndex
       break
     }

--- a/packages/media-query/tests/utils.test.ts
+++ b/packages/media-query/tests/utils.test.ts
@@ -8,6 +8,12 @@ test("should get the closest responsive value", () => {
   expect(getClosestValue({ sm: "40px", md: "500px" }, "base")).toBe(undefined)
   expect(getClosestValue({}, "")).toBe(undefined)
 })
+test("should get the closest responsive value even if values contains nullable value", () => {
+  expect(getClosestValue({ base: "40px", md: undefined }, "xl")).toBe(undefined)
+  expect(getClosestValue({ base: "40px", md: null }, "xl")).toBe(null)
+  expect(getClosestValue({ sm: "40px", md: undefined }, "xl")).toBe(undefined)
+  expect(getClosestValue({ sm: "40px", md: null }, "xl")).toBe(null)
+})
 test("should get the closest responsive value with custom breakpoints", () => {
   const customBreakPoints = ["base", "sm", "md", "custom", "xl"]
   expect(


### PR DESCRIPTION
…pecific break point key

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes [#6307](https://github.com/chakra-ui/chakra-ui/issues/6307)

## 📝 Description

useBreakPointValue(getClosestValue) doesn't return nullable value even if it is the closest break point value. It returns a value of the closest break point among non nullable values instead of actual closest break point value.
This is caused by a logic that judges break point values has specific break point key by checking break point value is null or not with non strict equality operator, even there is a possibility that user intensionally set nullable value.

## ⛳️ Current behavior (updates)

useBreakPointValue(getClosestValue) returns a value of the closest break point among non nullable values instead of actual closest break point value.

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
