### PR TITLE
Improve FormHelperText contrast

### DIFF
--- a/.changeset/curly-trees-serve.md
+++ b/.changeset/curly-trees-serve.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Improve contrast of FormHelperText to satisfy accessibility check

--- a/packages/theme/src/components/form.ts
+++ b/packages/theme/src/components/form.ts
@@ -15,7 +15,7 @@ const baseStyleRequiredIndicator: SystemStyleFunction = (props) => {
 const baseStyleHelperText: SystemStyleFunction = (props) => {
   return {
     mt: 2,
-    color: mode("gray.500", "whiteAlpha.600")(props),
+    color: mode("gray.600", "whiteAlpha.600")(props),
     lineHeight: "normal",
     fontSize: "sm",
   }


### PR DESCRIPTION
- Changed the font colour for the FormHelperText as the previous colour (gray.500) failed the WebAIM Contrast check (can check here https://webaim.org/resources/contrastchecker/) - check #718096 against #FFFFFF.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description
- Changed the font colour for the FormHelperText as the previous colour (gray.500) failed the WebAIM Contrast check (can check here https://webaim.org/resources/contrastchecker/) - check #718096 against #FFFFFF.
- 
## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying
The colour of the FormHelperText from gray.500 to gray.600, i.e. darker shade of gray to meet accessibility contrast requirements

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No. 

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
