### PR TITLE
Update thumbRects based on latest thumbs width and height

### DIFF
--- a/.changeset/popular-ants-impress.md
+++ b/.changeset/popular-ants-impress.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/slider": minor
+---
+
+Fix RangerSliderThumb rendering too far to the right when the RangeSlider is
+placed in an Accordion that is not expanded by default

--- a/packages/slider/src/use-range-slider.ts
+++ b/packages/slider/src/use-range-slider.ts
@@ -212,7 +212,7 @@ export function useRangeSlider(props: UseRangeSliderProps) {
   const isVertical = orientation === "vertical"
 
   const [thumbRects, setThumbRects] = useState(
-    Array.from({ length: value.length }).map(() => ({ width: 0, height: 0 })),
+    Array.from({ length: value.length }).map(() => ({ width: -1, height: -1 })),
   )
 
   useEffect(() => {
@@ -226,8 +226,17 @@ export function useRangeSlider(props: UseRangeSliderProps) {
       height: el.offsetHeight,
     }))
 
-    if (rects.length) setThumbRects(rects)
-  }, [])
+    // Keep updating thumbRects until width and height matches the width and height from thumbs
+    for (let i = 0; i < rects.length; i++) {
+      if (
+        rects[i].width !== thumbRects[i].width ||
+        rects[i].height !== thumbRects[i].height
+      ) {
+        setThumbRects(rects)
+        break
+      }
+    }
+  }, [thumbRects])
 
   /**
    * Let's keep a reference to the slider track and thumb


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/5255

## 📝 Description

Uses @primos63's solution to fix the RangerSliderThumb rendering too far to the right when the RangeSlider is placed in an Accordion that is not expanded by default.

## ⛳️ Current behavior (updates)

When the Accordion is not expanded by default, the offsetWidth and offsetHeight of the range slider thumbs are 0 and they are not updated when the AccordionPanel opens. This means that the RangeSliderThumb is shifted to the right as the calculation for positioning the RangeSliderThumb requires the width and height each thumb.

## 🚀 New behavior

Update thumbRects until the width and height matches the width and height of the thumbs.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
I'm not sure if there is a better way subscribe to changes in the DOM when the slider thumbs' offsetWidth and offsetHeight change?