### PR TITLE
fix(modal): Add wrapper to make centered modal scrollable

### DIFF
--- a/.changeset/two-suits-learn.md
+++ b/.changeset/two-suits-learn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": minor
+---
+
+Add wrapper to make centered modal scrollable

--- a/packages/modal/src/modal.tsx
+++ b/packages/modal/src/modal.tsx
@@ -242,16 +242,19 @@ export const ModalContent = forwardRef<ModalContentProps, "section">(
     }
 
     const dialogContainerStyles: SystemStyleObject = {
-      display: "flex",
       width: "100vw",
       height: "100vh",
-      "@supports(height: -webkit-fill-available)": {
-        height: "-webkit-fill-available",
-      },
       position: "fixed",
       left: 0,
       top: 0,
       ...styles.dialogContainer,
+    }
+
+    const scrollWrapperStyles: SystemStyleObject = {
+      display: "flex",
+      width: "100vw",
+      minHeight: "100vh",
+      ...styles.scrollWrapper,
     }
 
     const { motionPreset } = useModalContext()
@@ -265,14 +268,16 @@ export const ModalContent = forwardRef<ModalContentProps, "section">(
           tabIndex={-1}
           __css={dialogContainerStyles}
         >
-          <ModalTransition
-            preset={motionPreset}
-            className={_className}
-            {...dialogProps}
-            __css={dialogStyles}
-          >
-            {children}
-          </ModalTransition>
+          <chakra.div __css={scrollWrapperStyles}>
+            <ModalTransition
+              preset={motionPreset}
+              className={_className}
+              {...dialogProps}
+              __css={dialogStyles}
+            >
+              {children}
+            </ModalTransition>
+          </chakra.div>
         </chakra.div>
       </ModalFocusScope>
     )

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -13,14 +13,22 @@ const baseStyleOverlay: SystemStyleObject = {
 }
 
 const baseStyleDialogContainer: SystemStyleFunction = (props) => {
+  const { scrollBehavior } = props
+
+  return {
+    zIndex: "modal",
+    overflow: scrollBehavior === "inside" ? "hidden" : "auto",
+  }
+}
+
+const baseStyleScrollWrapper: SystemStyleFunction = (props) => {
   const { isCentered, scrollBehavior } = props
 
   return {
     display: "flex",
-    zIndex: "modal",
     justifyContent: "center",
+    height: scrollBehavior === "inside" ? "100vh" : "auto",
     alignItems: isCentered ? "center" : "flex-start",
-    overflow: scrollBehavior === "inside" ? "hidden" : "auto",
   }
 }
 
@@ -69,6 +77,7 @@ const baseStyleFooter: SystemStyleObject = {
 const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
   overlay: baseStyleOverlay,
   dialogContainer: baseStyleDialogContainer(props),
+  scrollWrapper: baseStyleScrollWrapper(props),
   dialog: baseStyleDialog(props),
   header: baseStyleHeader,
   closeButton: baseStyleCloseButton,


### PR DESCRIPTION
## 📝 Description
[According to docs](https://chakra-ui.com/docs/components/modal/usage#make-modal-vertically-centered), if the content within the modal overflows beyond the viewport, using this prop will make it unscrollable.

But actually can add a wrapper using `min-height: 100vh` under fixed div. This will make the content centered, but also scrollable when viewport smaller than content.


## ⛳️ Current behavior (updates)
Unscrollable when having `isCentered` prop.

![Jul-23-2022 16-49-33](https://user-images.githubusercontent.com/4176802/180597914-d41feeea-3bc7-4dfe-b84e-520cefbbb9d7.gif)


## 🚀 New behavior
Scrollable when having `isCentered` prop.

![Jul-23-2022 16-44-58](https://user-images.githubusercontent.com/4176802/180597768-afcc9168-1087-4caa-9d73-c95820e92d3f.gif)


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
