### PR TITLE
Potentially hacky fix for `thumbRects[i] is undefined`

### DIFF
--- a/packages/slider/src/slider-utils.ts
+++ b/packages/slider/src/slider-utils.ts
@@ -45,10 +45,14 @@ export function getStyles(options: {
     ...orient({
       orientation,
       vertical: {
-        bottom: `calc(${thumbPercents[i]}% - ${thumbRects[i].height / 2}px)`,
+        bottom: `calc(${thumbPercents[i]}% - ${
+          (thumbRects[i] || thumbRects[0]).height / 2
+        }px)`,
       },
       horizontal: {
-        left: `calc(${thumbPercents[i]}% - ${thumbRects[i].width / 2}px)`,
+        left: `calc(${thumbPercents[i]}% - ${
+          (thumbRects[i] || thumbRects[0]).width / 2
+        }px)`,
       },
     }),
   })

--- a/packages/slider/src/use-range-slider.ts
+++ b/packages/slider/src/use-range-slider.ts
@@ -227,7 +227,7 @@ export function useRangeSlider(props: UseRangeSliderProps) {
     }))
 
     if (rects.length) setThumbRects(rects)
-  }, [])
+  }, [value.length])
 
   /**
    * Let's keep a reference to the slider track and thumb


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6375.

## 📝 Description

This fixes the linked issue by falling back to using the size of the
first "thumb" when calculating the thumbs styles in the case where the
desired index is not present.

This is probably not a fully "correct" fix, in the case where thumbs are
different sizes, but this does fix my issue even if it is hacky. If
there is a more _correct_ solution then that would be even better.

## ⛳️ Current behavior (updates)

When trying to dynamically add new "thumbs" to a `RangeSlider` after
intial instantiation, the error `thumbRects[i] is undefined` is thrown.

## 🚀 New behavior

Error is no longer thrown.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information