### PR TITLE
chore: speed up storybook builds

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,11 +1,19 @@
 const path = require("path")
+const fs = require("fs")
+
+// [Workaround] This logic means `"../packages/*/stories/*.stories.tsx"` but it's much faster.
+const stories = fs
+  .readdirSync("packages")
+  .map((package) => `packages/${package}/stories`)
+  .filter((storyDir) => fs.existsSync(storyDir))
+  .map((storyDir) => `../${storyDir}/*.stories.tsx`)
 
 module.exports = {
   core: {
     builder: "@storybook/builder-webpack5",
     disableTelemetry: true,
   },
-  stories: ["../packages/**/stories/*.stories.tsx"],
+  stories,
   addons: [
     "@storybook/addon-a11y",
     "@storybook/addon-essentials",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR is a workaround.

Storybook build is very slow after build system migration in #6356.
I think this is a storybook's issue but I haven't been able to find the root cause.

I fixed this issue by not using glob patterns for directories in the `stories` setting.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I tested with the following settings

- original => slow
  - `stories: ["../packages/**/stories/*.stories.tsx"]`
- single directory => slow
  - `stories: ["../packages/*/stories/*.stories.tsx"]`
- without `packages` => slow
  - `stories: ["../**/stories/*.stories.tsx"]`
- single package => fast 
  - `stories: ["../packages/button/stories/*.stories.tsx"]`
- two packages => slow
  - `stories: ["../packages/{button,alert}/stories/*.stories.tsx"]`
