### PR TITLE
fix: Resolving issue where PopoverArrow would have different border than contents

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2100,6 +2100,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "tenkir",
+      "name": "Jonathan Blair",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3649828?v=4",
+      "profile": "https://github.com/tenkir",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.changeset/friendly-mugs-build.md
+++ b/.changeset/friendly-mugs-build.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/popper": minor
+---
+
+Removing box shadow from popper arrows. Add borders on popover arrow. This
+resolves an issue where the border of the arrow on a popover would not match the
+border of the popover contents itself.

--- a/packages/popper/src/modifiers.ts
+++ b/packages/popper/src/modifiers.ts
@@ -1,5 +1,5 @@
 import { Placement, Modifier, State } from "@popperjs/core"
-import { getBoxShadow, toTransformOrigin, cssVars } from "./utils"
+import { getBorder, getOffset, toTransformOrigin, cssVars } from "./utils"
 
 /* -------------------------------------------------------------------------------------------------
  The match width modifier sets the popper width to match the reference.
@@ -25,7 +25,7 @@ export const matchWidth: Modifier<"matchWidth", any> = {
 /* -------------------------------------------------------------------------------------------------
   The transform origin modifier sets the css `transformOrigin` value of the popper
   based on the dynamic placement state of the popper.
-  
+
   Useful when we need to animate/transition the popper.
 * -----------------------------------------------------------------------------------------------*/
 
@@ -131,6 +131,9 @@ const setInnerArrowStyles = (state: State) => {
 
   if (!inner) return
 
+  const border = getBorder(state.placement)
+  const offset = getOffset(state.placement)
+
   Object.assign(inner.style, {
     transform: "rotate(45deg)",
     background: cssVars.arrowBg.varRef,
@@ -140,6 +143,7 @@ const setInnerArrowStyles = (state: State) => {
     height: "100%",
     position: "absolute",
     zIndex: "inherit",
-    boxShadow: getBoxShadow(state.placement),
+    ...border,
+    ...offset,
   })
 }

--- a/packages/popper/src/utils.ts
+++ b/packages/popper/src/utils.ts
@@ -14,15 +14,52 @@ export const cssVars = {
   arrowOffset: toVar("--popper-arrow-offset"),
 } as const
 
-export function getBoxShadow(placement: Placement) {
-  if (placement.includes("top"))
-    return `1px 1px 1px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("bottom"))
-    return `-1px -1px 1px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("right"))
-    return `-1px 1px 1px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("left"))
-    return `1px -1px 1px 0 var(--popper-arrow-shadow-color)`
+export function getOffset(placement: Placement) {
+  const distance = "-.5px"
+
+  if (placement.includes("top")) {
+    return {
+      bottom: distance,
+    }
+  } else if (placement.includes("bottom")) {
+    return {
+      top: distance,
+    }
+  } else if (placement.includes("right")) {
+    return {
+      left: distance,
+    }
+  } else if (placement.includes("left")) {
+    return {
+      right: distance,
+    }
+  }
+}
+
+export function getBorder(placement: Placement) {
+  const borderDefinition = `1px solid var(--popper-arrow-shadow-color)`
+
+  if (placement.includes("top")) {
+    return {
+      borderBottom: borderDefinition,
+      borderRight: borderDefinition,
+    }
+  } else if (placement.includes("bottom")) {
+    return {
+      borderTop: borderDefinition,
+      borderLeft: borderDefinition,
+    }
+  } else if (placement.includes("right")) {
+    return {
+      borderBottom: borderDefinition,
+      borderLeft: borderDefinition,
+    }
+  } else if (placement.includes("left")) {
+    return {
+      borderTop: borderDefinition,
+      borderRight: borderDefinition,
+    }
+  }
 }
 
 const transforms: Record<string, string> = {


### PR DESCRIPTION
Closes [#5934](https://github.com/chakra-ui/chakra-ui/issues/5934)

## 📝 Description

PopoverArrow used a box-shadow with blur to generate the borders on it's edges. This resulted in a blurry border, when the border of the rest of the popover was solid. This was particularly noticeable on dark backgrounds.


## ⛳️ Current behavior (updates)
![Old borders over dark background](https://user-images.githubusercontent.com/3649828/182470980-445b9028-86e3-4dcc-80c9-77a109722ad7.png)

PopoverArrow always had blurred border.

## 🚀 New behavior
![New borders over dark background](https://user-images.githubusercontent.com/3649828/182470547-c58c48aa-62cd-408b-ba55-345ba96b781e.png)

PopoverArrow will have the same border as the rest of the PopOver or Tooltip.

This PR uses variations of border to generate the borders, rather than a box-shadow implementation. 
This results in accurate borders which match the rest of the container.

This PR also removes the now unused `getBoxShadow` function from `packages/popper/src/utils.ts`

## 💣 Is this a breaking change (Yes/No):

No

## Additional Information

Not sure if this small visual change requires a test, but I can add one if necessary.


