### PR TITLE
fix(popper): Resolving issue where PopoverArrow would have different border than contents

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2125,7 +2125,13 @@
       "login": "vadimdemedes",
       "name": "Vadim Demedes",
       "avatar_url": "https://avatars.githubusercontent.com/u/697676?v=4",
-      "profile": "https://vadimdemedes.com",
+      "profile": "https://vadimdemedes.com"
+    },
+    {
+      "login": "tenkir",
+      "name": "Jonathan Blair",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3649828?v=4",
+      "profile": "https://github.com/tenkir",
       "contributions": [
         "code"
       ]

--- a/.changeset/friendly-mugs-build.md
+++ b/.changeset/friendly-mugs-build.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/popper": minor
+---
+
+Removing box shadow from popper arrows. Add borders on popover arrow. This
+resolves an issue where the border of the arrow on a popover would not match the
+border of the popover contents itself.

--- a/packages/components/popper/src/modifiers.ts
+++ b/packages/components/popper/src/modifiers.ts
@@ -1,5 +1,5 @@
 import { Placement, Modifier, State } from "@popperjs/core"
-import { getBoxShadow, toTransformOrigin, cssVars } from "./utils"
+import { getBorder, toTransformOrigin, cssVars } from "./utils"
 
 /* -------------------------------------------------------------------------------------------------
  The match width modifier sets the popper width to match the reference.
@@ -25,7 +25,7 @@ export const matchWidth: Modifier<"matchWidth", any> = {
 /* -------------------------------------------------------------------------------------------------
   The transform origin modifier sets the css `transformOrigin` value of the popper
   based on the dynamic placement state of the popper.
-  
+
   Useful when we need to animate/transition the popper.
 * -----------------------------------------------------------------------------------------------*/
 
@@ -136,6 +136,8 @@ const setInnerArrowStyles = (state: State) => {
     inner.style.setProperty("--popper-arrow-default-shadow", boxShadow)
   }
 
+  const border = getBorder(state.placement)
+
   Object.assign(inner.style, {
     transform: "rotate(45deg)",
     background: cssVars.arrowBg.varRef,
@@ -145,6 +147,6 @@ const setInnerArrowStyles = (state: State) => {
     height: "100%",
     position: "absolute",
     zIndex: "inherit",
-    boxShadow: `var(--popper-arrow-shadow, var(--popper-arrow-default-shadow))`,
+    ...border,
   })
 }

--- a/packages/components/popper/src/utils.ts
+++ b/packages/components/popper/src/utils.ts
@@ -14,15 +14,39 @@ export const cssVars = {
   arrowOffset: toVar("--popper-arrow-offset"),
 } as const
 
-export function getBoxShadow(placement: Placement) {
-  if (placement.includes("top"))
-    return `1px 1px 0px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("bottom"))
-    return `-1px -1px 0px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("right"))
-    return `-1px 1px 0px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("left"))
-    return `1px -1px 0px 0 var(--popper-arrow-shadow-color)`
+export function getBorder(placement: Placement) {
+  const borderDefinition = `1px solid var(--popper-arrow-shadow-color)`
+  const transparentBorderDefinition = `1px solid transparent`
+
+  if (placement.includes("top")) {
+    return {
+      borderBottom: borderDefinition,
+      borderRight: borderDefinition,
+      borderLeft: transparentBorderDefinition,
+      borderTop: transparentBorderDefinition,
+    }
+  } else if (placement.includes("bottom")) {
+    return {
+      borderTop: borderDefinition,
+      borderLeft: borderDefinition,
+      borderRight: transparentBorderDefinition,
+      borderBottom: transparentBorderDefinition,
+    }
+  } else if (placement.includes("right")) {
+    return {
+      borderBottom: borderDefinition,
+      borderLeft: borderDefinition,
+      borderTop: transparentBorderDefinition,
+      borderRight: transparentBorderDefinition,
+    }
+  } else if (placement.includes("left")) {
+    return {
+      borderTop: borderDefinition,
+      borderRight: borderDefinition,
+      borderBottom: transparentBorderDefinition,
+      borderLeft: transparentBorderDefinition,
+    }
+  }
 }
 
 const transforms: Record<string, string> = {


### PR DESCRIPTION
Closes [#5934](https://github.com/chakra-ui/chakra-ui/issues/5934).

## 📝 Description

PopoverArrow used a box-shadow with blur to generate the borders on it's edges. This resulted in a blurry border, when the border of the rest of the popover was solid. This was particularly noticeable on dark backgrounds.


## ⛳️ Current behavior (updates)
![Old borders over dark background](https://user-images.githubusercontent.com/3649828/182470980-445b9028-86e3-4dcc-80c9-77a109722ad7.png)

PopoverArrow always had blurred border, which was detatched from the Popover content.

## 🚀 New behavior
![New borders over dark background](https://user-images.githubusercontent.com/3649828/182493633-504d70d3-3361-4737-b1e7-4f28bcf06573.png)


PopoverArrow will have the same border as the rest of the PopOver or Tooltip.

This PR uses variations of border to generate the borders, rather than a box-shadow implementation. 

By using transparent borders on the interior edges of the arrow, we can eliminate the overlap typically seen with border implementations. This results in accurate borders which match the rest of the container.

![Border Explaination](https://user-images.githubusercontent.com/3649828/182493936-21f21929-8f1d-4157-ab27-ae546d8717d0.jpg)

Here is a minimum CSS implementation of adding a transparent border on right side, compared to no transparent border on left:

![Transparent border example](https://user-images.githubusercontent.com/3649828/182498877-da0985ed-cd0a-46ee-becd-6ebeb202b5c3.png)



This PR also removes the now unused `getBoxShadow` function from `packages/popper/src/utils.ts`

## 💣 Is this a breaking change (Yes/No):

No

## Additional Information

Not sure if this small visual change requires a test, but I can add one if necessary.


