### PR TITLE
Add explicit type declaration to `ChakraProvider.defaultProps`

### DIFF
--- a/.changeset/three-jokes-swim.md
+++ b/.changeset/three-jokes-swim.md
@@ -2,4 +2,4 @@
 "@chakra-ui/react": minor
 ---
 
-Add explicit type declaration for `ChakraProvider.defaultProps`.
+Remove `ChakraProvider.defaultProps` and move logic inside the component.

--- a/.changeset/three-jokes-swim.md
+++ b/.changeset/three-jokes-swim.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+Add explicit type declaration for `ChakraProvider.defaultProps`.

--- a/packages/react/src/chakra-provider.tsx
+++ b/packages/react/src/chakra-provider.tsx
@@ -2,7 +2,7 @@ import {
   ChakraProvider as BaseChakraProvider,
   ChakraProviderProps as BaseChakraProviderProps,
 } from "@chakra-ui/provider"
-import { theme } from "@chakra-ui/theme"
+import { theme, Theme } from "@chakra-ui/theme"
 import { ToastProvider, ToastProviderProps } from "@chakra-ui/toast"
 
 export interface ChakraProviderProps extends BaseChakraProviderProps {
@@ -23,6 +23,10 @@ export function ChakraProvider({
       <ToastProvider {...toastOptions} />
     </BaseChakraProvider>
   )
+}
+
+export declare namespace ChakraProvider {
+  export let defaultProps: { theme: Theme }
 }
 
 ChakraProvider.defaultProps = {

--- a/packages/react/src/chakra-provider.tsx
+++ b/packages/react/src/chakra-provider.tsx
@@ -2,7 +2,7 @@ import {
   ChakraProvider as BaseChakraProvider,
   ChakraProviderProps as BaseChakraProviderProps,
 } from "@chakra-ui/provider"
-import { theme, Theme } from "@chakra-ui/theme"
+import { theme as defaultTheme } from "@chakra-ui/theme"
 import { ToastProvider, ToastProviderProps } from "@chakra-ui/toast"
 
 export interface ChakraProviderProps extends BaseChakraProviderProps {
@@ -17,18 +17,11 @@ export function ChakraProvider({
   toastOptions,
   ...restProps
 }: ChakraProviderProps) {
+  const theme = restProps.theme ?? defaultTheme
   return (
-    <BaseChakraProvider {...restProps}>
+    <BaseChakraProvider {...restProps} theme={theme}>
       {children}
       <ToastProvider {...toastOptions} />
     </BaseChakraProvider>
   )
-}
-
-export declare namespace ChakraProvider {
-  export let defaultProps: { theme: Theme }
-}
-
-ChakraProvider.defaultProps = {
-  theme,
 }

--- a/packages/react/src/chakra-provider.tsx
+++ b/packages/react/src/chakra-provider.tsx
@@ -14,12 +14,12 @@ export interface ChakraProviderProps extends BaseChakraProviderProps {
 
 export function ChakraProvider({
   children,
+  theme = defaultTheme,
   toastOptions,
   ...restProps
 }: ChakraProviderProps) {
-  const theme = restProps.theme ?? defaultTheme
   return (
-    <BaseChakraProvider {...restProps} theme={theme}>
+    <BaseChakraProvider theme={theme} {...restProps}>
       {children}
       <ToastProvider {...toastOptions} />
     </BaseChakraProvider>


### PR DESCRIPTION
Closes #6463

## 📝 Description

This PR adds an explicit declaration to `chakra-provider.tsx` that will forcefully change the declaration output from this:

```
declare function ChakraProvider({ children, toastOptions, ...restProps }: ChakraProviderProps): JSX.Element;
declare namespace ChakraProvider {
    var defaultProps;
}
```

to this:

```
declare function ChakraProvider({ children, toastOptions, ...restProps }: ChakraProviderProps): JSX.Element;
declare namespace ChakraProvider {
    let defaultProps: {
        theme: Theme;
    };
}
```

I was

## ⛳️ Current behavior (updates)

The current implementation leaves TypeScript to infer the type that must be emitted for `ChakraProvider.defaultProps`, which it fails to do. This causes TypeScript builds to fail in strict mode for consumers of `@chakra-ui/react`.

## 🚀 New behavior

The new implementation explicitly declares the type that needs to be emitted.

## 💣 Is this a breaking change (Yes/**No**):

I don't believe this is a real breaking change, though I guess it could _potentially_ break builds in some edge cases.

## 📝 Additional Information

I did find alternative ways to do this without the `declare namespace`, but they require depending on the `@chakra-ui/theme-tools` package and inline the gigantic theme type into the emitted declaration file.