### PR TITLE
docs: fix default values for min and max prop of NumberInput

### DIFF
--- a/.changeset/pink-elephants-divide.md
+++ b/.changeset/pink-elephants-divide.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/counter": patch
+---
+
+Fix default values for min and max prop in docs

--- a/packages/counter/src/use-counter.ts
+++ b/packages/counter/src/use-counter.ts
@@ -33,12 +33,12 @@ export interface UseCounterProps {
   step?: number
   /**
    * The minimum value of the counter
-   * @default -Infinity
+   * @default Number.MIN_SAFE_INTEGER
    */
   min?: number
   /**
    * The maximum value of the counter
-   * @default Infinity
+   * @default Number.MAX_SAFE_INTEGER
    */
   max?: number
   /**


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui-docs/issues/914

## 📝 Description

Corrects defaults for min and max prop of `NumberInput` Component in docs.

## ⛳️ Current behavior (updates)

Default value is `Infinity` in docs but in the implementation it differs.

## 🚀 New behavior

Default value is corrected to `Number.MIN_SAFE_INTEGER` / `Number.MAX_SAFE_INTEGER`, see https://github.com/chakra-ui/chakra-ui/blob/main/packages/counter/src/use-counter.ts#L64-L65

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Interface `UseCounterProps` with the wrong default values is only used for `UseNumberInputProps` of `NumberInput`.