### PR TITLE
fix: restore zindex of input element

### DIFF
--- a/.changeset/clever-planets-fetch.md
+++ b/.changeset/clever-planets-fetch.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/input": minor
+---
+
+Restore zIndex of InputElement to 1

--- a/packages/input/src/input-element.tsx
+++ b/packages/input/src/input-element.tsx
@@ -18,7 +18,7 @@ const StyledInputElement = chakra("div", {
     justifyContent: "center",
     position: "absolute",
     top: "0",
-    zIndex: 2,
+    zIndex: 1,
   },
 })
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #5742 

## 📝 Description

Restore of `InputElement`s zIndex from 2 to 1 which leads to problems in overlapping with e.g. `MenuList` and `Popover`. This is basically a revert of https://github.com/chakra-ui/chakra-ui/pull/1906

## ⛳️ Current behavior (updates)

Overlapping `InputElements` on e.g. open `MenuList`, see first example in: 
https://codesandbox.io/s/objective-almeida-i2rcvl?file=/src/index.tsx

## 🚀 New behavior

Restore to 'old' zIndex 1 since the bug from back then seems not to exist anymore with the current Chakra UI version (copy&pasted example):
https://codesandbox.io/s/serene-platform-3wuu74?file=/src/index.tsx

## 💣 Is this a breaking change (Yes/No):

Possibly not
