### PR TITLE
feat: allow wrapping tab panel

### DIFF
--- a/.changeset/small-bugs-prove.md
+++ b/.changeset/small-bugs-prove.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tabs": minor
+---
+
+Allow wrapping tab panels

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -7,13 +7,13 @@ import { getValidChildren } from "@chakra-ui/react-children-utils"
 import { mergeRefs } from "@chakra-ui/react-use-merge-refs"
 import { lazyDisclosure, LazyMode } from "@chakra-ui/lazy-utils"
 import { callAllHandlers } from "@chakra-ui/shared-utils"
-import React, {
-  cloneElement,
+import {
   useCallback,
   useEffect,
   useRef,
   useState,
   useId,
+  createElement,
 } from "react"
 
 /* -------------------------------------------------------------------------------------------------
@@ -177,8 +177,6 @@ export const [TabsProvider, useTabsContext] = createContext<UseTabsReturn>({
     "useTabsContext: `context` is undefined. Seems you forgot to wrap all tabs components within <Tabs />",
 })
 
-type Child = React.ReactElement<any>
-
 export interface UseTabListProps {
   children?: React.ReactNode
   onKeyDown?: React.KeyboardEventHandler
@@ -323,6 +321,8 @@ export interface UseTabPanelsProps {
   children?: React.ReactNode
 }
 
+const [TabPanelsProvider, useTabPanelsContext] = createContext<any>({})
+
 /**
  * Tabs hook for managing the visibility of multiple tab panels.
  *
@@ -340,12 +340,18 @@ export function useTabPanels<P extends UseTabPanelsProps>(props: P) {
   const validChildren = getValidChildren(props.children)
 
   const children = validChildren.map((child, index) =>
-    cloneElement(child as Child, {
-      isSelected: index === selectedIndex,
-      id: makeTabPanelId(id, index),
-      // Refers to the associated tab element, and also provides an accessible name to the tab panel.
-      "aria-labelledby": makeTabId(id, index),
-    }),
+    createElement(
+      TabPanelsProvider,
+      {
+        value: {
+          isSelected: index === selectedIndex,
+          id: makeTabPanelId(id, index),
+          tabId: makeTabId(id, index),
+          selectedIndex,
+        },
+      },
+      child,
+    ),
   )
 
   return { ...props, children }
@@ -358,8 +364,9 @@ export function useTabPanels<P extends UseTabPanelsProps>(props: P) {
  * @param props props object for the tab panel
  */
 export function useTabPanel(props: Record<string, any>) {
-  const { isSelected, id, children, ...htmlProps } = props
+  const { children, ...htmlProps } = props
   const { isLazy, lazyBehavior } = useTabsContext()
+  const { isSelected, id, tabId } = useTabPanelsContext()
 
   const hasBeenSelected = useRef(false)
   if (isSelected) {
@@ -379,6 +386,7 @@ export function useTabPanel(props: Record<string, any>) {
     ...htmlProps,
     children: shouldRenderChildren ? children : null,
     role: "tabpanel",
+    "aria-labelledby": tabId,
     hidden: !isSelected,
     id,
   }

--- a/packages/tabs/src/use-tabs.ts
+++ b/packages/tabs/src/use-tabs.ts
@@ -321,7 +321,12 @@ export interface UseTabPanelsProps {
   children?: React.ReactNode
 }
 
-const [TabPanelsProvider, useTabPanelsContext] = createContext<any>({})
+const [TabPanelProvider, useTabPanelContext] = createContext<{
+  isSelected: boolean
+  id: string
+  tabId: string
+  selectedIndex: number
+}>({})
 
 /**
  * Tabs hook for managing the visibility of multiple tab panels.
@@ -341,7 +346,7 @@ export function useTabPanels<P extends UseTabPanelsProps>(props: P) {
 
   const children = validChildren.map((child, index) =>
     createElement(
-      TabPanelsProvider,
+      TabPanelProvider,
       {
         value: {
           isSelected: index === selectedIndex,
@@ -366,7 +371,7 @@ export function useTabPanels<P extends UseTabPanelsProps>(props: P) {
 export function useTabPanel(props: Record<string, any>) {
   const { children, ...htmlProps } = props
   const { isLazy, lazyBehavior } = useTabsContext()
-  const { isSelected, id, tabId } = useTabPanelsContext()
+  const { isSelected, id, tabId } = useTabPanelContext()
 
   const hasBeenSelected = useRef(false)
   if (isSelected) {

--- a/packages/tabs/stories/tabs.stories.tsx
+++ b/packages/tabs/stories/tabs.stories.tsx
@@ -280,3 +280,24 @@ export const withinDrawer = () => (
     </DrawerOverlay>
   </Drawer>
 )
+
+export const WithTabPanelWrapper = () => (
+  <Tabs>
+    <TabList>
+      <Tab>FIrst Tab</Tab>
+      <Tab>Second Tab</Tab>
+      <Tab>Third Tab</Tab>
+    </TabList>
+    <TabPanels>
+      <div>
+        <TabPanel>Tab panel 1</TabPanel>
+      </div>
+      <div>
+        <TabPanel>Tab panel 2</TabPanel>
+      </div>
+      <div>
+        <TabPanel>Tab panel 3</TabPanel>
+      </div>
+    </TabPanels>
+  </Tabs>
+)


### PR DESCRIPTION
Closes #6443

## 📝 Description

This PR allows wrapping tab panels with arbitrary elements. To ensure backward compatibility, we're using react context to propagate the details we currently pass via props.

## ⛳️ Current behavior (updates)

Can't wrap tab panel

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
