### PR TITLE
Refactor theme to use tokens

### DIFF
--- a/.changeset/poor-news-argue.md
+++ b/.changeset/poor-news-argue.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/css-reset": patch
+"@chakra-ui/provider": patch
+"@chakra-ui/styled-system": patch
+"@chakra-ui/theme": patch
+---
+
+Refactors the theme to use design tokens and css variables as much as possible.
+
+Improve support for `100vh` values by using a polyfill css variable
+`--chakra-vh`.

--- a/packages/css-reset/src/css-reset.tsx
+++ b/packages/css-reset/src/css-reset.tsx
@@ -1,5 +1,29 @@
 import { Global } from "@emotion/react"
 
+const vhPolyfill = `
+  :root {
+    --chakra-vh: 100vh;
+  }
+
+  @supports (height: -webkit-fill-available) {
+    :root {
+      --chakra-vh: -webkit-fill-available;
+    }
+  }
+
+  @supports (height: -moz-fill-available) {
+    :root {
+      --chakra-vh: -moz-fill-available;
+    }
+  }
+
+  @supports (height: 100lvh) {
+    --chakra-vh: 100lvh;
+  }
+`
+
+export const CSSPolyfill = () => <Global styles={vhPolyfill} />
+
 export const CSSReset = () => (
   <Global
     styles={`
@@ -278,6 +302,8 @@ export const CSSReset = () => (
       select::-ms-expand {
         display: none;
       }
+
+      ${vhPolyfill}
     `}
   />
 )

--- a/packages/provider/src/chakra-provider.tsx
+++ b/packages/provider/src/chakra-provider.tsx
@@ -1,4 +1,4 @@
-import CSSReset from "@chakra-ui/css-reset"
+import { CSSReset, CSSPolyfill } from "@chakra-ui/css-reset"
 import { PortalManager } from "@chakra-ui/portal"
 import {
   ColorModeProvider,
@@ -82,7 +82,7 @@ export const ChakraProvider: React.FC<ChakraProviderProps> = (props) => {
         colorModeManager={colorModeManager}
         options={theme.config}
       >
-        {resetCSS && <CSSReset />}
+        {resetCSS ? <CSSReset /> : <CSSPolyfill />}
         <GlobalStyle />
         {portalZIndex ? (
           <PortalManager zIndex={portalZIndex}>{_children}</PortalManager>

--- a/packages/styled-system/src/utils/index.ts
+++ b/packages/styled-system/src/utils/index.ts
@@ -1,5 +1,6 @@
 import type { ThemeScale } from "../create-theme-vars"
 import { createTransform } from "./create-transform"
+import { pipe } from "./pipe"
 import { logical, PropConfig, toConfig } from "./prop-config"
 import { transformFunctions as transforms } from "./transform-functions"
 
@@ -13,8 +14,8 @@ export const t = {
   colors: toConfig("colors"),
   borders: toConfig("borders"),
   radii: toConfig("radii", transforms.px),
-  space: toConfig("space", transforms.px),
-  spaceT: toConfig("space", transforms.px),
+  space: toConfig("space", pipe(transforms.vh, transforms.px)),
+  spaceT: toConfig("space", pipe(transforms.vh, transforms.px)),
   degreeT(property: PropConfig["property"]) {
     return { property, transform: transforms.degree }
   },
@@ -34,8 +35,8 @@ export const t = {
   propT(property: PropConfig["property"], transform?: PropConfig["transform"]) {
     return { property, transform }
   },
-  sizes: toConfig("sizes", transforms.px),
-  sizesT: toConfig("sizes", transforms.fraction),
+  sizes: toConfig("sizes", pipe(transforms.vh, transforms.px)),
+  sizesT: toConfig("sizes", pipe(transforms.vh, transforms.fraction)),
   shadows: toConfig("shadows"),
   logical,
   blur: toConfig("blur", transforms.blur),

--- a/packages/styled-system/src/utils/pipe.ts
+++ b/packages/styled-system/src/utils/pipe.ts
@@ -1,0 +1,4 @@
+export const pipe =
+  <R>(...fns: Array<(a: R) => R>) =>
+  (v: R) =>
+    fns.reduce((a, b) => b(a), v)

--- a/packages/styled-system/src/utils/transform-functions.ts
+++ b/packages/styled-system/src/utils/transform-functions.ts
@@ -40,6 +40,9 @@ export const transformFunctions = {
     if (value === "auto-gpu") return getTransformGpuTemplate()
     return value
   },
+  vh(value: number | string) {
+    return value === "100vh" ? "var(--chakra-vh)" : value
+  },
   px(value: number | string) {
     if (value == null) return value
     const { unitless } = analyzeCSSValue(value)

--- a/packages/theme/src/components/accordion.ts
+++ b/packages/theme/src/components/accordion.ts
@@ -18,7 +18,7 @@ const baseStyleContainer = defineStyle({
 const baseStyleButton = defineStyle({
   transitionProperty: "common",
   transitionDuration: "normal",
-  fontSize: "1rem",
+  fontSize: "md",
   _focusVisible: {
     boxShadow: "outline",
   },
@@ -29,14 +29,14 @@ const baseStyleButton = defineStyle({
     opacity: 0.4,
     cursor: "not-allowed",
   },
-  px: 4,
-  py: 2,
+  px: "4",
+  py: "2",
 })
 
 const baseStylePanel = defineStyle({
-  pt: 2,
-  px: 4,
-  pb: 5,
+  pt: "2",
+  px: "4",
+  pb: "5",
 })
 
 const baseStyleIcon = defineStyle({
@@ -44,7 +44,6 @@ const baseStyleIcon = defineStyle({
 })
 
 const baseStyle = definePartsStyle({
-  root: {},
   container: baseStyleContainer,
   button: baseStyleButton,
   panel: baseStylePanel,

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -15,30 +15,30 @@ const $bg = cssVar("alert-bg")
 const baseStyle = definePartsStyle({
   container: {
     bg: $bg.reference,
-    px: 4,
-    py: 3,
+    px: "4",
+    py: "3",
   },
   title: {
     fontWeight: "bold",
-    lineHeight: 6,
-    marginEnd: 2,
+    lineHeight: "6",
+    marginEnd: "2",
   },
   description: {
-    lineHeight: 6,
+    lineHeight: "6",
   },
   icon: {
     color: $fg.reference,
     flexShrink: 0,
-    marginEnd: 3,
-    w: 5,
-    h: 6,
+    marginEnd: "3",
+    w: "5",
+    h: "6",
   },
   spinner: {
     color: $fg.reference,
     flexShrink: 0,
-    marginEnd: 3,
-    w: 5,
-    h: 5,
+    marginEnd: "3",
+    w: "5",
+    h: "5",
   },
 })
 

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -152,8 +152,8 @@ const variantUnstyled = defineStyle({
   color: "inherit",
   display: "inline",
   lineHeight: "inherit",
-  m: 0,
-  p: 0,
+  m: "0",
+  p: "0",
 })
 
 const variants = {
@@ -166,28 +166,28 @@ const variants = {
 
 const sizes = {
   lg: defineStyle({
-    h: 12,
-    minW: 12,
+    h: "12",
+    minW: "12",
     fontSize: "lg",
-    px: 6,
+    px: "6",
   }),
   md: defineStyle({
-    h: 10,
-    minW: 10,
+    h: "10",
+    minW: "10",
     fontSize: "md",
-    px: 4,
+    px: "4",
   }),
   sm: defineStyle({
-    h: 8,
-    minW: 8,
+    h: "8",
+    minW: "8",
     fontSize: "sm",
-    px: 3,
+    px: "3",
   }),
   xs: defineStyle({
-    h: 6,
-    minW: 6,
+    h: "6",
+    minW: "6",
     fontSize: "xs",
-    px: 2,
+    px: "2",
   }),
 }
 

--- a/packages/theme/src/components/checkbox.ts
+++ b/packages/theme/src/components/checkbox.ts
@@ -1,6 +1,7 @@
 import { checkboxAnatomy as parts } from "@chakra-ui/anatomy"
 import {
   createMultiStyleConfigHelpers,
+  cssVar,
   defineStyle,
 } from "@chakra-ui/styled-system"
 import { mode } from "@chakra-ui/theme-tools"
@@ -9,11 +10,14 @@ import { runIfFn } from "../utils/run-if-fn"
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
+const $size = cssVar("checkbox-size")
+
 const baseStyleControl = defineStyle((props) => {
   const { colorScheme: c } = props
 
   return {
-    w: "100%",
+    w: $size.reference,
+    h: $size.reference,
     transitionProperty: "box-shadow",
     transitionDuration: "normal",
     border: "2px solid",
@@ -82,19 +86,19 @@ const baseStyle = definePartsStyle((props) => ({
 
 const sizes = {
   sm: definePartsStyle({
-    control: { h: 3, w: 3 },
+    control: { [$size.variable]: "sizes.3" },
     label: { fontSize: "sm" },
-    icon: { fontSize: "0.45rem" },
+    icon: { fontSize: "3xs" },
   }),
   md: definePartsStyle({
-    control: { w: 4, h: 4 },
+    control: { [$size.variable]: "sizes.4" },
     label: { fontSize: "md" },
-    icon: { fontSize: "0.625rem" },
+    icon: { fontSize: "2xs" },
   }),
   lg: definePartsStyle({
-    control: { w: 5, h: 5 },
+    control: { [$size.variable]: "sizes.5" },
     label: { fontSize: "lg" },
-    icon: { fontSize: "0.625rem" },
+    icon: { fontSize: "2xs" },
   }),
 }
 

--- a/packages/theme/src/components/close-button.ts
+++ b/packages/theme/src/components/close-button.ts
@@ -28,16 +28,16 @@ const baseStyle = defineStyle((props) => {
 
 const sizes = {
   lg: defineStyle({
-    [$size.variable]: "40px",
-    fontSize: "16px",
+    [$size.variable]: "sizes.10",
+    fontSize: "md",
   }),
   md: defineStyle({
-    [$size.variable]: "32px",
-    fontSize: "12px",
+    [$size.variable]: "sizes.8",
+    fontSize: "xs",
   }),
   sm: defineStyle({
-    [$size.variable]: "24px",
-    fontSize: "10px",
+    [$size.variable]: "sizes.6",
+    fontSize: "2xs",
   }),
 }
 

--- a/packages/theme/src/components/container.ts
+++ b/packages/theme/src/components/container.ts
@@ -3,8 +3,8 @@ import { defineStyle, defineStyleConfig } from "@chakra-ui/styled-system"
 const baseStyle = defineStyle({
   w: "100%",
   mx: "auto",
-  maxW: "60ch",
-  px: "1rem",
+  maxW: "prose",
+  px: "4",
 })
 
 export const containerTheme = defineStyleConfig({

--- a/packages/theme/src/components/drawer.ts
+++ b/packages/theme/src/components/drawer.ts
@@ -49,28 +49,28 @@ const baseStyleDialog = defineStyle((props) => {
 })
 
 const baseStyleHeader = defineStyle({
-  px: 6,
-  py: 4,
+  px: "6",
+  py: "4",
   fontSize: "xl",
   fontWeight: "semibold",
 })
 
 const baseStyleCloseButton = defineStyle({
   position: "absolute",
-  top: 2,
-  insetEnd: 3,
+  top: "2",
+  insetEnd: "3",
 })
 
 const baseStyleBody = defineStyle({
-  px: 6,
-  py: 2,
-  flex: 1,
+  px: "6",
+  py: "2",
+  flex: "1",
   overflow: "auto",
 })
 
 const baseStyleFooter = defineStyle({
-  px: 6,
-  py: 4,
+  px: "6",
+  py: "4",
 })
 
 const baseStyle = definePartsStyle((props) => ({

--- a/packages/theme/src/components/editable.ts
+++ b/packages/theme/src/components/editable.ts
@@ -9,14 +9,14 @@ const { definePartsStyle, defineMultiStyleConfig } =
 
 const baseStylePreview = defineStyle({
   borderRadius: "md",
-  py: "3px",
+  py: "1",
   transitionProperty: "common",
   transitionDuration: "normal",
 })
 
 const baseStyleInput = defineStyle({
   borderRadius: "md",
-  py: "3px",
+  py: "1",
   transitionProperty: "common",
   transitionDuration: "normal",
   width: "full",
@@ -26,7 +26,7 @@ const baseStyleInput = defineStyle({
 
 const baseStyleTextarea = defineStyle({
   borderRadius: "md",
-  py: "3px",
+  py: "1",
   transitionProperty: "common",
   transitionDuration: "normal",
   width: "full",

--- a/packages/theme/src/components/form-control.ts
+++ b/packages/theme/src/components/form-control.ts
@@ -11,14 +11,14 @@ const { definePartsStyle, defineMultiStyleConfig } =
 
 const baseStyleRequiredIndicator = defineStyle((props) => {
   return {
-    marginStart: 1,
+    marginStart: "1",
     color: mode("red.500", "red.300")(props),
   }
 })
 
 const baseStyleHelperText = defineStyle((props) => {
   return {
-    mt: 2,
+    mt: "2",
     color: mode("gray.600", "whiteAlpha.600")(props),
     lineHeight: "normal",
     fontSize: "sm",
@@ -26,7 +26,10 @@ const baseStyleHelperText = defineStyle((props) => {
 })
 
 const baseStyle = definePartsStyle((props) => ({
-  container: { width: "100%", position: "relative" },
+  container: {
+    width: "100%",
+    position: "relative",
+  },
   requiredIndicator: runIfFn(baseStyleRequiredIndicator, props),
   helperText: runIfFn(baseStyleHelperText, props),
 }))

--- a/packages/theme/src/components/form-error.ts
+++ b/packages/theme/src/components/form-error.ts
@@ -12,7 +12,7 @@ const { definePartsStyle, defineMultiStyleConfig } =
 const baseStyleText = defineStyle((props) => {
   return {
     color: mode("red.500", "red.300")(props),
-    mt: 2,
+    mt: "2",
     fontSize: "sm",
     lineHeight: "normal",
   }

--- a/packages/theme/src/components/form-label.ts
+++ b/packages/theme/src/components/form-label.ts
@@ -2,8 +2,8 @@ import { defineStyle, defineStyleConfig } from "@chakra-ui/styled-system"
 
 const baseStyle = defineStyle({
   fontSize: "md",
-  marginEnd: 3,
-  mb: 2,
+  marginEnd: "3",
+  mb: "2",
   fontWeight: "medium",
   transitionProperty: "common",
   transitionDuration: "normal",

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -17,32 +17,36 @@ const baseStyle = definePartsStyle({
     appearance: "none",
     transitionProperty: "common",
     transitionDuration: "normal",
+    _disabled: {
+      opacity: 0.4,
+      cursor: "not-allowed",
+    },
   },
 })
 
 const size = {
   lg: defineStyle({
     fontSize: "lg",
-    px: 4,
-    h: 12,
+    px: "4",
+    h: "12",
     borderRadius: "md",
   }),
   md: defineStyle({
     fontSize: "md",
-    px: 4,
-    h: 10,
+    px: "4",
+    h: "10",
     borderRadius: "md",
   }),
   sm: defineStyle({
     fontSize: "sm",
-    px: 3,
-    h: 8,
+    px: "3",
+    h: "8",
     borderRadius: "sm",
   }),
   xs: defineStyle({
     fontSize: "xs",
-    px: 2,
-    h: 6,
+    px: "2",
+    h: "6",
     borderRadius: "sm",
   }),
 }
@@ -90,10 +94,6 @@ const variantOutline = definePartsStyle((props) => {
         boxShadow: "none !important",
         userSelect: "all",
       },
-      _disabled: {
-        opacity: 0.4,
-        cursor: "not-allowed",
-      },
       _invalid: {
         borderColor: getColor(theme, ec),
         boxShadow: `0 0 0 1px ${getColor(theme, ec)}`,
@@ -128,10 +128,6 @@ const variantFilled = definePartsStyle((props) => {
         boxShadow: "none !important",
         userSelect: "all",
       },
-      _disabled: {
-        opacity: 0.4,
-        cursor: "not-allowed",
-      },
       _invalid: {
         borderColor: getColor(theme, ec),
       },
@@ -156,8 +152,8 @@ const variantFlushed = definePartsStyle((props) => {
     field: {
       borderBottom: "1px solid",
       borderColor: "inherit",
-      borderRadius: 0,
-      px: 0,
+      borderRadius: "0",
+      px: "0",
       bg: "transparent",
       _readOnly: {
         boxShadow: "none !important",
@@ -171,16 +167,12 @@ const variantFlushed = definePartsStyle((props) => {
         borderColor: getColor(theme, fc),
         boxShadow: `0px 1px 0px 0px ${getColor(theme, fc)}`,
       },
-      _disabled: {
-        opacity: 0.4,
-        cursor: "not-allowed",
-      },
     },
     addon: {
       borderBottom: "2px solid",
       borderColor: "inherit",
-      borderRadius: 0,
-      px: 0,
+      borderRadius: "0",
+      px: "0",
       bg: "transparent",
     },
   }
@@ -189,16 +181,12 @@ const variantFlushed = definePartsStyle((props) => {
 const variantUnstyled = definePartsStyle({
   field: {
     bg: "transparent",
-    px: 0,
+    px: "0",
     height: "auto",
-    _disabled: {
-      opacity: 0.4,
-      cursor: "not-allowed",
-    },
   },
   addon: {
     bg: "transparent",
-    px: 0,
+    px: "0",
     height: "auto",
   },
 })

--- a/packages/theme/src/components/list.ts
+++ b/packages/theme/src/components/list.ts
@@ -8,7 +8,7 @@ const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(parts.keys)
 
 const baseStyleIcon = defineStyle({
-  marginEnd: "0.5rem",
+  marginEnd: "2",
   display: "inline",
   verticalAlign: "text-bottom",
 })

--- a/packages/theme/src/components/list.ts
+++ b/packages/theme/src/components/list.ts
@@ -14,8 +14,6 @@ const baseStyleIcon = defineStyle({
 })
 
 const baseStyle = definePartsStyle({
-  container: {},
-  item: {},
   icon: baseStyleIcon,
 })
 

--- a/packages/theme/src/components/menu.ts
+++ b/packages/theme/src/components/menu.ts
@@ -24,8 +24,8 @@ const baseStyleList = defineStyle((props) => {
 
 const baseStyleItem = defineStyle((props) => {
   return {
-    py: "0.4rem",
-    px: "0.8rem",
+    py: "1.5",
+    px: "3",
     transitionProperty: "background",
     transitionDuration: "ultra-fast",
     transitionTimingFunction: "ease-in",
@@ -60,7 +60,7 @@ const baseStyleDivider = defineStyle({
   border: 0,
   borderBottom: "1px solid",
   borderColor: "inherit",
-  my: "0.5rem",
+  my: "2",
   opacity: 0.6,
 })
 

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -33,7 +33,7 @@ const baseStyleDialog = defineStyle((props) => {
     borderRadius: "md",
     bg: mode("white", "gray.700")(props),
     color: "inherit",
-    my: "3.75rem",
+    my: "16",
     zIndex: "modal",
     maxH: scrollBehavior === "inside" ? "calc(100% - 7.5rem)" : undefined,
     boxShadow: mode("lg", "dark-lg")(props),
@@ -41,31 +41,31 @@ const baseStyleDialog = defineStyle((props) => {
 })
 
 const baseStyleHeader = defineStyle({
-  px: 6,
-  py: 4,
+  px: "6",
+  py: "4",
   fontSize: "xl",
   fontWeight: "semibold",
 })
 
 const baseStyleCloseButton = defineStyle({
   position: "absolute",
-  top: 2,
-  insetEnd: 3,
+  top: "2",
+  insetEnd: "3",
 })
 
 const baseStyleBody = defineStyle((props) => {
   const { scrollBehavior } = props
   return {
-    px: 6,
-    py: 2,
-    flex: 1,
+    px: "6",
+    py: "2",
+    flex: "1",
     overflow: scrollBehavior === "inside" ? "auto" : undefined,
   }
 })
 
 const baseStyleFooter = defineStyle({
-  px: 6,
-  py: 4,
+  px: "6",
+  py: "4",
 })
 
 const baseStyle = definePartsStyle((props) => ({
@@ -91,8 +91,8 @@ function getSize(value: string) {
         "@supports(min-height: -webkit-fill-available)": {
           minH: "-webkit-fill-available",
         },
-        my: 0,
-        borderRadius: 0,
+        my: "0",
+        borderRadius: "0",
       },
     })
   }

--- a/packages/theme/src/components/modal.ts
+++ b/packages/theme/src/components/modal.ts
@@ -88,9 +88,6 @@ function getSize(value: string) {
       dialog: {
         maxW: "100vw",
         minH: "100vh",
-        "@supports(min-height: -webkit-fill-available)": {
-          minH: "-webkit-fill-available",
-        },
         my: "0",
         borderRadius: "0",
       },

--- a/packages/theme/src/components/number-input.ts
+++ b/packages/theme/src/components/number-input.ts
@@ -16,7 +16,7 @@ const $inputPadding = cssVar("number-input-input-padding")
 const inputPaddingValue = calc($stepperWidth).add("0.5rem").toString()
 
 const baseStyleRoot = defineStyle({
-  [$stepperWidth.variable]: "24px",
+  [$stepperWidth.variable]: "sizes.6",
   [$inputPadding.variable]: inputPaddingValue,
 })
 

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -67,7 +67,6 @@ const baseStyle = definePartsStyle((props) => ({
   header: baseStyleHeader,
   body: baseStyleBody,
   footer: baseStyleFooter,
-  arrow: {},
   closeButton: baseStyleCloseButton,
 }))
 

--- a/packages/theme/src/components/progress.ts
+++ b/packages/theme/src/components/progress.ts
@@ -62,16 +62,16 @@ const baseStyle = definePartsStyle((props) => ({
 
 const sizes = {
   xs: definePartsStyle({
-    track: { h: "0.25rem" },
+    track: { h: "1" },
   }),
   sm: definePartsStyle({
-    track: { h: "0.5rem" },
+    track: { h: "2" },
   }),
   md: definePartsStyle({
-    track: { h: "0.75rem" },
+    track: { h: "3" },
   }),
   lg: definePartsStyle({
-    track: { h: "1rem" },
+    track: { h: "4" },
   }),
 }
 

--- a/packages/theme/src/components/radio.ts
+++ b/packages/theme/src/components/radio.ts
@@ -38,15 +38,15 @@ const baseStyle = definePartsStyle((props) => ({
 
 const sizes = {
   md: definePartsStyle({
-    control: { w: 4, h: 4 },
+    control: { w: "4", h: "4" },
     label: { fontSize: "md" },
   }),
   lg: definePartsStyle({
-    control: { w: 5, h: 5 },
+    control: { w: "5", h: "5" },
     label: { fontSize: "lg" },
   }),
   sm: definePartsStyle({
-    control: { width: 3, height: 3 },
+    control: { width: "3", height: "3" },
     label: { fontSize: "sm" },
   }),
 }

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -23,9 +23,9 @@ const baseStyleField = defineStyle((props) => {
 })
 
 const baseStyleIcon = defineStyle({
-  width: "1.5rem",
+  width: "6",
   height: "100%",
-  insetEnd: "0.5rem",
+  insetEnd: "2",
   position: "relative",
   color: "currentColor",
   fontSize: "xl",

--- a/packages/theme/src/components/select.ts
+++ b/packages/theme/src/components/select.ts
@@ -28,7 +28,7 @@ const baseStyleIcon = defineStyle({
   insetEnd: "0.5rem",
   position: "relative",
   color: "currentColor",
-  fontSize: "1.25rem",
+  fontSize: "xl",
   _disabled: {
     opacity: 0.5,
   },
@@ -40,7 +40,7 @@ const baseStyle = definePartsStyle((props) => ({
 }))
 
 const iconSpacing = defineStyle({
-  paddingInlineEnd: "2rem",
+  paddingInlineEnd: "8",
 })
 
 const sizes = {
@@ -72,7 +72,7 @@ const sizes = {
       ...iconSpacing,
     },
     icon: {
-      insetEnd: "0.25rem",
+      insetEnd: "1",
     },
   },
 }

--- a/packages/theme/src/components/skip-link.ts
+++ b/packages/theme/src/components/skip-link.ts
@@ -6,7 +6,7 @@ const baseStyle = defineStyle((props) => ({
   fontWeight: "semibold",
   _focusVisible: {
     boxShadow: "outline",
-    padding: "1rem",
+    padding: "4",
     position: "fixed",
     top: "6",
     insetStart: "6",

--- a/packages/theme/src/components/skip-link.ts
+++ b/packages/theme/src/components/skip-link.ts
@@ -8,8 +8,8 @@ const baseStyle = defineStyle((props) => ({
     boxShadow: "outline",
     padding: "1rem",
     position: "fixed",
-    top: "1.5rem",
-    insetStart: "1.5rem",
+    top: "6",
+    insetStart: "6",
     bg: mode("white", "gray.700")(props),
   },
 }))

--- a/packages/theme/src/components/slider.ts
+++ b/packages/theme/src/components/slider.ts
@@ -1,12 +1,16 @@
 import { sliderAnatomy as parts } from "@chakra-ui/anatomy"
 import {
   createMultiStyleConfigHelpers,
+  cssVar,
   defineStyle,
 } from "@chakra-ui/styled-system"
 import { mode, orient } from "@chakra-ui/theme-tools"
 
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(parts.keys)
+
+const $thumbSize = cssVar("slider-thumb-size")
+const $trackSize = cssVar("slider-track-size")
 
 const baseStyleContainer = defineStyle((props) => {
   const { orientation } = props
@@ -29,7 +33,14 @@ const baseStyleContainer = defineStyle((props) => {
 })
 
 const baseStyleTrack = defineStyle((props) => {
+  const orientationStyles = orient({
+    orientation: props.orientation,
+    horizontal: { h: $trackSize.reference },
+    vertical: { w: $trackSize.reference },
+  })
+
   return {
+    ...orientationStyles,
     overflow: "hidden",
     borderRadius: "sm",
     bg: mode("gray.200", "whiteAlpha.200")(props),
@@ -60,6 +71,9 @@ const baseStyleThumb = defineStyle((props) => {
   })
 
   return {
+    ...orientationStyle,
+    w: $thumbSize.reference,
+    h: $thumbSize.reference,
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
@@ -73,9 +87,12 @@ const baseStyleThumb = defineStyle((props) => {
     borderColor: "transparent",
     transitionProperty: "transform",
     transitionDuration: "normal",
-    _focusVisible: { boxShadow: "outline" },
-    _disabled: { bg: "gray.300" },
-    ...orientationStyle,
+    _focusVisible: {
+      boxShadow: "outline",
+    },
+    _disabled: {
+      bg: "gray.300",
+    },
   }
 })
 
@@ -96,37 +113,25 @@ const baseStyle = definePartsStyle((props) => ({
   filledTrack: baseStyleFilledTrack(props),
 }))
 
-const sizeLg = definePartsStyle((props) => {
-  return {
-    thumb: { w: "16px", h: "16px" },
-    track: orient({
-      orientation: props.orientation,
-      horizontal: { h: "4px" },
-      vertical: { w: "4px" },
-    }),
-  }
+const sizeLg = definePartsStyle({
+  container: {
+    [$thumbSize.variable]: `sizes.4`,
+    [$trackSize.variable]: `sizes.1`,
+  },
 })
 
-const sizeMd = definePartsStyle((props) => {
-  return {
-    thumb: { w: "14px", h: "14px" },
-    track: orient({
-      orientation: props.orientation,
-      horizontal: { h: "4px" },
-      vertical: { w: "4px" },
-    }),
-  }
+const sizeMd = definePartsStyle({
+  container: {
+    [$thumbSize.variable]: `sizes.3.5`,
+    [$trackSize.variable]: `sizes.1`,
+  },
 })
 
-const sizeSm = definePartsStyle((props) => {
-  return {
-    thumb: { w: "10px", h: "10px" },
-    track: orient({
-      orientation: props.orientation,
-      horizontal: { h: "2px" },
-      vertical: { w: "2px" },
-    }),
-  }
+const sizeSm = definePartsStyle({
+  container: {
+    [$thumbSize.variable]: `sizes.2.5`,
+    [$trackSize.variable]: `sizes.0.5`,
+  },
 })
 
 const sizes = {

--- a/packages/theme/src/components/spinner.ts
+++ b/packages/theme/src/components/spinner.ts
@@ -10,19 +10,19 @@ const baseStyle = defineStyle({
 
 const sizes = {
   xs: defineStyle({
-    [$size.variable]: "0.75rem",
+    [$size.variable]: "sizes.3",
   }),
   sm: defineStyle({
-    [$size.variable]: "1rem",
+    [$size.variable]: "sizes.4",
   }),
   md: defineStyle({
-    [$size.variable]: "1.5rem",
+    [$size.variable]: "sizes.6",
   }),
   lg: defineStyle({
-    [$size.variable]: "2rem",
+    [$size.variable]: "sizes.8",
   }),
   xl: defineStyle({
-    [$size.variable]: "3rem",
+    [$size.variable]: "sizes.12",
   }),
 }
 

--- a/packages/theme/src/components/stat.ts
+++ b/packages/theme/src/components/stat.ts
@@ -13,7 +13,7 @@ const baseStyleLabel = defineStyle({
 
 const baseStyleHelpText = defineStyle({
   opacity: 0.8,
-  marginBottom: 2,
+  marginBottom: "2",
 })
 
 const baseStyleNumber = defineStyle({
@@ -23,8 +23,8 @@ const baseStyleNumber = defineStyle({
 
 const baseStyleIcon = defineStyle({
   marginEnd: 1,
-  w: "14px",
-  h: "14px",
+  w: "3.5",
+  h: "3.5",
   verticalAlign: "middle",
 })
 

--- a/packages/theme/src/components/switch.ts
+++ b/packages/theme/src/components/switch.ts
@@ -19,7 +19,7 @@ const baseStyleTrack = defineStyle((props) => {
 
   return {
     borderRadius: "full",
-    p: "2px",
+    p: "0.5",
     width: [$width.reference],
     height: [$height.reference],
     transitionProperty: "common",
@@ -66,19 +66,19 @@ const sizes = {
   sm: definePartsStyle({
     container: {
       [$width.variable]: "1.375rem",
-      [$height.variable]: "0.75rem",
+      [$height.variable]: "sizes.3",
     },
   }),
   md: definePartsStyle({
     container: {
       [$width.variable]: "1.875rem",
-      [$height.variable]: "1rem",
+      [$height.variable]: "sizes.4",
     },
   }),
   lg: definePartsStyle({
     container: {
       [$width.variable]: "2.875rem",
-      [$height.variable]: "1.5rem",
+      [$height.variable]: "sizes.6",
     },
   }),
 }

--- a/packages/theme/src/components/tag.ts
+++ b/packages/theme/src/components/tag.ts
@@ -24,13 +24,13 @@ const baseStyleLabel = defineStyle({
 })
 
 const baseStyleCloseButton = defineStyle({
-  fontSize: "18px",
-  w: "1.25rem",
-  h: "1.25rem",
+  fontSize: "lg",
+  w: "5",
+  h: "5",
   transitionProperty: "common",
   transitionDuration: "normal",
   borderRadius: "full",
-  marginStart: "0.375rem",
+  marginStart: "1.5",
   marginEnd: "-1",
   opacity: 0.5,
   _disabled: {
@@ -40,8 +40,12 @@ const baseStyleCloseButton = defineStyle({
     boxShadow: "outline",
     bg: "rgba(0, 0, 0, 0.14)",
   },
-  _hover: { opacity: 0.8 },
-  _active: { opacity: 1 },
+  _hover: {
+    opacity: 0.8,
+  },
+  _active: {
+    opacity: 1,
+  },
 })
 
 const baseStyle = definePartsStyle({
@@ -53,10 +57,10 @@ const baseStyle = definePartsStyle({
 const sizes = {
   sm: definePartsStyle({
     container: {
-      minH: "1.25rem",
-      minW: "1.25rem",
+      minH: "5",
+      minW: "5",
       fontSize: "xs",
-      px: 2,
+      px: "2",
     },
     closeButton: {
       marginEnd: "-2px",
@@ -65,18 +69,18 @@ const sizes = {
   }),
   md: definePartsStyle({
     container: {
-      minH: "1.5rem",
-      minW: "1.5rem",
+      minH: "6",
+      minW: "6",
       fontSize: "sm",
-      px: 2,
+      px: "2",
     },
   }),
   lg: definePartsStyle({
     container: {
-      minH: 8,
-      minW: 8,
+      minH: "8",
+      minW: "8",
       fontSize: "md",
-      px: 3,
+      px: "3",
     },
   }),
 }

--- a/packages/theme/src/components/textarea.ts
+++ b/packages/theme/src/components/textarea.ts
@@ -3,8 +3,8 @@ import { inputTheme } from "./input"
 
 const baseStyle = defineStyle({
   ...inputTheme.baseStyle?.field,
-  paddingY: "8px",
-  minHeight: "80px",
+  paddingY: "2",
+  minHeight: "20",
   lineHeight: "short",
   verticalAlign: "top",
 })

--- a/packages/theme/src/components/tooltip.ts
+++ b/packages/theme/src/components/tooltip.ts
@@ -2,22 +2,25 @@ import { defineStyle, defineStyleConfig } from "@chakra-ui/styled-system"
 import { cssVar, mode } from "@chakra-ui/theme-tools"
 
 const $bg = cssVar("tooltip-bg")
+const $fg = cssVar("tooltip-fg")
 const $arrowBg = cssVar("popper-arrow-bg")
 
 const baseStyle = defineStyle((props) => {
   const bg = mode("gray.700", "gray.300")(props)
+  const fg = mode("whiteAlpha.900", "gray.900")(props)
   return {
+    bg: $bg.reference,
+    color: $fg.reference,
     [$bg.variable]: `colors.${bg}`,
-    px: "8px",
-    py: "2px",
-    bg: [$bg.reference],
-    [$arrowBg.variable]: [$bg.reference],
-    color: mode("whiteAlpha.900", "gray.900")(props),
+    [$fg.reference]: `colors.${fg}`,
+    [$arrowBg.variable]: $bg.reference,
+    px: "2",
+    py: "0.5",
     borderRadius: "sm",
     fontWeight: "medium",
     fontSize: "sm",
     boxShadow: "md",
-    maxW: "320px",
+    maxW: "xs",
     zIndex: "tooltip",
   }
 })

--- a/packages/theme/src/foundations/sizes.ts
+++ b/packages/theme/src/foundations/sizes.ts
@@ -18,6 +18,7 @@ const largeSizes = {
   "6xl": "72rem",
   "7xl": "80rem",
   "8xl": "90rem",
+  prose: "60ch",
 }
 
 const container = {

--- a/packages/theme/src/foundations/typography.ts
+++ b/packages/theme/src/foundations/typography.ts
@@ -45,6 +45,8 @@ const typography = {
   },
 
   fontSizes: {
+    "3xs": "0.45rem",
+    "2xs": "0.625rem",
     xs: "0.75rem",
     sm: "0.875rem",
     md: "1rem",


### PR DESCRIPTION
## 📝 Description

This PR refactors our default theme to use design tokens and css variables as much as possible.

It also improves support for `100vh` values by using a polyfill css variable.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
