### PR TITLE
fix: add correct constraint for useDescendants K generic

### DIFF
--- a/.changeset/loud-ears-happen.md
+++ b/.changeset/loud-ears-happen.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/descendant": patch
+---
+
+Fix issue where generic type contraints throws in TypeScript 4.8+

--- a/packages/components/descendant/src/use-descendant.ts
+++ b/packages/components/descendant/src/use-descendant.ts
@@ -44,9 +44,10 @@ const [DescendantsContextProvider, useDescendantsContext] =
  * - ref callback to register the descendant
  * - Its enabled index compared to other enabled descendants
  */
-function useDescendant<T extends HTMLElement = HTMLElement, K = {}>(
-  options?: DescendantOptions<K>,
-) {
+function useDescendant<
+  T extends HTMLElement = HTMLElement,
+  K extends Record<string, any> = {},
+>(options?: DescendantOptions<K>) {
   const descendants = useDescendantsContext()
   const [index, setIndex] = useState(-1)
   const ref = useRef<T>(null)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/6572

## 📝 Description

> Add correct constraint for useDescendants K generic

## ⛳️ Current behavior (updates)

> Using strict=true on tsconfig with typescript v4.8.2 will fail on build.

## 🚀 New behavior

> Old constraint: `K = {}`
> New constraint `K extends Record<string, any> = {}`

## 💣 Is this a breaking change (Yes/No): No
