### PR TITLE
fix: bring in TS4.8 fix from #6573

### DIFF
--- a/.changeset/light-meals-grab.md
+++ b/.changeset/light-meals-grab.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/descendant": minor
+---
+
+Allow compilation with TypeScript 4.8

--- a/.changeset/light-meals-grab.md
+++ b/.changeset/light-meals-grab.md
@@ -1,5 +1,5 @@
 ---
-"@chakra-ui/descendant": minor
+"@chakra-ui/descendant": patch
 ---
 
 Allow compilation with TypeScript 4.8

--- a/packages/descendant/src/use-descendant.ts
+++ b/packages/descendant/src/use-descendant.ts
@@ -40,9 +40,10 @@ const [DescendantsContextProvider, useDescendantsContext] =
  * - ref callback to register the descendant
  * - Its enabled index compared to other enabled descendants
  */
-function useDescendant<T extends HTMLElement = HTMLElement, K = {}>(
-  options?: DescendantOptions<K>,
-) {
+function useDescendant<
+  T extends HTMLElement = HTMLElement,
+  K extends Record<string, any> = {},
+>(options?: DescendantOptions<K>) {
   const descendants = useDescendantsContext()
   const [index, setIndex] = useState(-1)
   const ref = useRef<T>(null)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description


> Fixes typescript 4.8 compatibility in useDescendents. This was brought in from #6573 to the v1 branch.

I realize that the v1 branch has ceased development but my project hasn't been able to update to React 18 yet, and this issue is preventing me from upgrading to Typescript 4.8.

## ⛳️ Current behavior (updates)

> V1 won't compile with TypeScript 4.8

## 🚀 New behavior

> V1 now compiles with TypesScript 4.8

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
