### PR TITLE
fix/styled-system

### DIFF
--- a/.changeset/tricky-kangaroos-lie.md
+++ b/.changeset/tricky-kangaroos-lie.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Chage isCSSVariableTokenValue to handle RGB colors.

--- a/packages/components/styled-system/src/css.ts
+++ b/packages/components/styled-system/src/css.ts
@@ -10,6 +10,10 @@ function isCssVar(value: string): boolean {
   return /^var\(--.+\)$/.test(value)
 }
 
+function isRgbColor(val: string) {
+  return /rgb/i.test(val)
+}
+
 const isCSSVariableTokenValue = (key: string, value: any): value is string =>
   key.startsWith("--") && typeof value === "string" && !isCssVar(value)
 
@@ -19,8 +23,13 @@ const resolveTokenValue = (theme: Record<string, any>, value: string) => {
   const getVar = (val: string) => theme.__cssMap?.[val]?.varRef
   const getValue = (val: string) => getVar(val) ?? val
 
+  if (isRgbColor(value)) {
+    return getValue(value)
+  }
+
   const valueSplit = value.split(",").map((v) => v.trim())
   const [tokenValue, fallbackValue] = valueSplit
+
   value = getVar(tokenValue) ?? getValue(fallbackValue) ?? getValue(value)
 
   return value
@@ -180,5 +189,6 @@ export const css = (styles: StyleObjectOrFn) => (theme: CssTheme) => {
     pseudos: pseudoSelectors,
     configs: systemPropConfigs,
   })
+
   return cssFn(styles)
 }

--- a/packages/components/styled-system/tests/css.test.ts
+++ b/packages/components/styled-system/tests/css.test.ts
@@ -644,3 +644,17 @@ test("should resolve !important syntax", () => {
     }
   `)
 })
+
+test("assign RGBA color to a cssVar", () => {
+  const styles = {
+    bg: "var(--alert-bg)",
+    "--alert-bg": "rgba(254, 178, 178, 0.16)",
+  }
+
+  expect(css(styles)(theme)).toMatchInlineSnapshot(`
+    Object {
+      "--alert-bg": "rgba(254, 178, 178, 0.16)",
+      "background": "var(--alert-bg)",
+    }
+`)
+})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6637 <!-- Github issue # here -->

## 📝 Description

This PR changes `isCSSVariableTokenValue` to return a valid color string when an RGB value are received as an argument. 


## ⛳️ Current behavior (updates)
RGB color values are being parsed by accident to an invalid value inside `isCSSVariableTokenValue`.

https://github.com/chakra-ui/chakra-ui/blob/8d0ca11b3ad7027e12e208f1fe70a04ba4bfc69b/packages/components/styled-system/src/css.ts#L22 

## 🚀 New behavior
If the received value is an RGB color string, we return early with a valid color string. 

## 💣 Is this a breaking change (Yes/No): No. 

## 📝 Additional Information
