### PR TITLE
fix(types): disallow `checked` prop where it shouldn't be accepted

### DIFF
--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -38,11 +38,7 @@ const CheckboxRoot = chakra("label", {
 
 type CheckboxControlProps = Omit<HTMLChakraProps<"div">, keyof UseCheckboxProps>
 
-type BaseInputProps = Pick<
-  PropsOf<"input">,
-  "onBlur" | "checked" | "defaultChecked"
->
-
+type BaseInputProps = Pick<PropsOf<"input">, "onBlur">
 export interface CheckboxProps
   extends CheckboxControlProps,
     BaseInputProps,
@@ -58,103 +54,108 @@ export interface CheckboxProps
  *
  * @see Docs https://chakra-ui.com/checkbox
  */
-export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
-  props,
-  ref,
-) {
-  const group = useCheckboxGroupContext()
+export const Checkbox = forwardRef<CheckboxProps, "input", "checked">(
+  function Checkbox(props, ref) {
+    const group = useCheckboxGroupContext()
 
-  const mergedProps = { ...group, ...props } as CheckboxProps
-  const styles = useMultiStyleConfig("Checkbox", mergedProps)
+    const mergedProps = { ...group, ...props } as CheckboxProps
+    const styles = useMultiStyleConfig("Checkbox", mergedProps)
 
-  const ownProps = omitThemingProps(props)
+    const ownProps = omitThemingProps(props)
 
-  const {
-    spacing = "0.5rem",
-    className,
-    children,
-    iconColor,
-    iconSize,
-    icon = <CheckboxIcon />,
-    isChecked: isCheckedProp,
-    isDisabled = group?.isDisabled,
-    onChange: onChangeProp,
-    inputProps,
-    ...rest
-  } = ownProps
+    const {
+      spacing = "0.5rem",
+      className,
+      children,
+      iconColor,
+      iconSize,
+      icon = <CheckboxIcon />,
+      isChecked: isCheckedProp,
+      isDisabled = group?.isDisabled,
+      onChange: onChangeProp,
+      inputProps,
+      ...rest
+    } = ownProps
 
-  let isChecked = isCheckedProp
-  if (group?.value && ownProps.value) {
-    isChecked = group.value.includes(ownProps.value)
-  }
+    let isChecked = isCheckedProp
+    if (group?.value && ownProps.value) {
+      isChecked = group.value.includes(ownProps.value)
+    }
 
-  let onChange = onChangeProp
-  if (group?.onChange && ownProps.value) {
-    onChange = callAll(group.onChange, onChangeProp)
-  }
+    let onChange = onChangeProp
+    if (group?.onChange && ownProps.value) {
+      onChange = callAll(group.onChange, onChangeProp)
+    }
 
-  const {
-    state,
-    getInputProps,
-    getCheckboxProps,
-    getLabelProps,
-    getRootProps,
-  } = useCheckbox({
-    ...rest,
-    isDisabled,
-    isChecked,
-    onChange,
-  })
+    const {
+      state,
+      getInputProps,
+      getCheckboxProps,
+      getLabelProps,
+      getRootProps,
+    } = useCheckbox({
+      ...rest,
+      isDisabled,
+      isChecked,
+      onChange,
+    })
 
-  const iconStyles: SystemStyleObject = useMemo(
-    () => ({
-      opacity: state.isChecked || state.isIndeterminate ? 1 : 0,
-      transform:
-        state.isChecked || state.isIndeterminate ? "scale(1)" : "scale(0.95)",
-      fontSize: iconSize,
-      color: iconColor,
-      ...styles.icon,
-    }),
-    [iconColor, iconSize, state.isChecked, state.isIndeterminate, styles.icon],
-  )
+    const iconStyles: SystemStyleObject = useMemo(
+      () => ({
+        opacity: state.isChecked || state.isIndeterminate ? 1 : 0,
+        transform:
+          state.isChecked || state.isIndeterminate ? "scale(1)" : "scale(0.95)",
+        fontSize: iconSize,
+        color: iconColor,
+        ...styles.icon,
+      }),
+      [
+        iconColor,
+        iconSize,
+        state.isChecked,
+        state.isIndeterminate,
+        styles.icon,
+      ],
+    )
 
-  const clonedIcon = cloneElement(icon, {
-    __css: iconStyles,
-    isIndeterminate: state.isIndeterminate,
-    isChecked: state.isChecked,
-  })
+    const clonedIcon = cloneElement(icon, {
+      __css: iconStyles,
+      isIndeterminate: state.isIndeterminate,
+      isChecked: state.isChecked,
+    })
 
-  return (
-    <CheckboxRoot
-      __css={styles.container}
-      className={cx("chakra-checkbox", className)}
-      {...getRootProps()}
-    >
-      <input
-        className="chakra-checkbox__input"
-        {...getInputProps(inputProps, ref)}
-      />
-      <CheckboxControl
-        __css={styles.control}
-        className="chakra-checkbox__control"
-        {...getCheckboxProps()}
+    return (
+      <CheckboxRoot
+        __css={styles.container}
+        className={cx("chakra-checkbox", className)}
+        {...getRootProps()}
       >
-        {clonedIcon}
-      </CheckboxControl>
-      {children && (
-        <chakra.span
-          className="chakra-checkbox__label"
-          {...getLabelProps()}
-          __css={{
-            marginStart: spacing,
-            ...styles.label,
-          }}
+        <input
+          className="chakra-checkbox__input"
+          {...getInputProps(inputProps, ref)}
+        />
+        <CheckboxControl
+          __css={styles.control}
+          className="chakra-checkbox__control"
+          {...getCheckboxProps()}
         >
-          {children}
-        </chakra.span>
-      )}
-    </CheckboxRoot>
-  )
-})
+          {clonedIcon}
+        </CheckboxControl>
+        {children && (
+          <chakra.span
+            className="chakra-checkbox__label"
+            {...getLabelProps()}
+            __css={{
+              marginStart: spacing,
+              ...styles.label,
+            }}
+          >
+            {children}
+          </chakra.span>
+        )}
+      </CheckboxRoot>
+    )
+  },
+)
 
 Checkbox.displayName = "Checkbox"

--- a/packages/components/editable/src/editable-input.tsx
+++ b/packages/components/editable/src/editable-input.tsx
@@ -10,7 +10,7 @@ export interface EditableInputProps extends HTMLChakraProps<"input"> {}
  * The input used in the `edit` mode
  */
 
-export const EditableInput = forwardRef<EditableInputProps, "input">(
+export const EditableInput = forwardRef<EditableInputProps, "input", "checked">(
   function EditableInput(props, ref) {
     const { getInputProps } = useEditableContext()
     const styles = useEditableStyles()

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -41,7 +41,7 @@ export interface InputProps
  *
  * Element that allows users enter single valued data.
  */
-export const Input = forwardRef<InputProps, "input">(function Input(
+export const Input = forwardRef<InputProps, "input", "checked">(function Input(
   props,
   ref,
 ) {

--- a/packages/components/number-input/src/number-input.tsx
+++ b/packages/components/number-input/src/number-input.tsx
@@ -152,25 +152,27 @@ export interface NumberInputFieldProps extends HTMLChakraProps<"input"> {}
  *
  * @see Docs http://chakra-ui.com/numberinput
  */
-export const NumberInputField = forwardRef<NumberInputFieldProps, "input">(
-  function NumberInputField(props, ref) {
-    const { getInputProps } = useNumberInputContext()
+export const NumberInputField = forwardRef<
+  NumberInputFieldProps,
+  "input",
+  "checked"
+>(function NumberInputField(props, ref) {
+  const { getInputProps } = useNumberInputContext()
 
-    const input = getInputProps(props, ref)
-    const styles = useNumberInputStyles()
+  const input = getInputProps(props, ref)
+  const styles = useNumberInputStyles()
 
-    return (
-      <chakra.input
-        {...input}
-        className={cx("chakra-numberinput__field", props.className)}
-        __css={{
-          width: "100%",
-          ...styles.field,
-        }}
-      />
-    )
-  },
-)
+  return (
+    <chakra.input
+      {...input}
+      className={cx("chakra-numberinput__field", props.className)}
+      __css={{
+        width: "100%",
+        ...styles.field,
+      }}
+    />
+  )
+})
 
 NumberInputField.displayName = "NumberInputField"
 

--- a/packages/components/pin-input/src/pin-input.tsx
+++ b/packages/components/pin-input/src/pin-input.tsx
@@ -63,7 +63,7 @@ PinInput.displayName = "PinInput"
 
 export interface PinInputFieldProps extends HTMLChakraProps<"input"> {}
 
-export const PinInputField = forwardRef<PinInputFieldProps, "input">(
+export const PinInputField = forwardRef<PinInputFieldProps, "input", "checked">(
   function PinInputField(props, ref) {
     const inputProps = usePinInputField(props, ref)
     return (

--- a/packages/components/radio/src/radio.tsx
+++ b/packages/components/radio/src/radio.tsx
@@ -39,7 +39,7 @@ export interface RadioProps
  *
  * @see Docs https://chakra-ui.com/radio
  */
-export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
+export const Radio = forwardRef<RadioProps, "input", Omitted>((props, ref) => {
   const group = useRadioGroupContext()
   const { onChange: onChangeProp, value: valueProp } = props
 

--- a/packages/components/switch/src/switch.tsx
+++ b/packages/components/switch/src/switch.tsx
@@ -24,84 +24,87 @@ export interface SwitchProps
   spacing?: SystemProps["marginLeft"]
 }
 
-export const Switch = forwardRef<SwitchProps, "input">(function Switch(
-  props,
-  ref,
-) {
-  const styles = useMultiStyleConfig("Switch", props)
+export const Switch = forwardRef<SwitchProps, "input", "checked">(
+  function Switch(props, ref) {
+    const styles = useMultiStyleConfig("Switch", props)
 
-  const { spacing = "0.5rem", children, ...ownProps } = omitThemingProps(props)
+    const {
+      spacing = "0.5rem",
+      children,
+      ...ownProps
+    } = omitThemingProps(props)
 
-  const {
-    state,
-    getInputProps,
-    getCheckboxProps,
-    getRootProps,
-    getLabelProps,
-  } = useCheckbox(ownProps)
+    const {
+      state,
+      getInputProps,
+      getCheckboxProps,
+      getRootProps,
+      getLabelProps,
+    } = useCheckbox(ownProps)
 
-  const containerStyles: SystemStyleObject = useMemo(
-    () => ({
-      display: "inline-block",
-      position: "relative",
-      verticalAlign: "middle",
-      lineHeight: 0,
-      ...styles.container,
-    }),
-    [styles.container],
-  )
+    const containerStyles: SystemStyleObject = useMemo(
+      () => ({
+        display: "inline-block",
+        position: "relative",
+        verticalAlign: "middle",
+        lineHeight: 0,
+        ...styles.container,
+      }),
+      [styles.container],
+    )
 
-  const trackStyles: SystemStyleObject = useMemo(
-    () => ({
-      display: "inline-flex",
-      flexShrink: 0,
-      justifyContent: "flex-start",
-      boxSizing: "content-box",
-      cursor: "pointer",
-      ...styles.track,
-    }),
-    [styles.track],
-  )
+    const trackStyles: SystemStyleObject = useMemo(
+      () => ({
+        display: "inline-flex",
+        flexShrink: 0,
+        justifyContent: "flex-start",
+        boxSizing: "content-box",
+        cursor: "pointer",
+        ...styles.track,
+      }),
+      [styles.track],
+    )
 
-  const labelStyles: SystemStyleObject = useMemo(
-    () => ({
-      userSelect: "none",
-      marginStart: spacing,
-      ...styles.label,
-    }),
-    [spacing, styles.label],
-  )
+    const labelStyles: SystemStyleObject = useMemo(
+      () => ({
+        userSelect: "none",
+        marginStart: spacing,
+        ...styles.label,
+      }),
+      [spacing, styles.label],
+    )
 
-  return (
-    <chakra.label
-      {...getRootProps()}
-      className={cx("chakra-switch", props.className)}
-      __css={containerStyles}
-    >
-      <input className="chakra-switch__input" {...getInputProps({}, ref)} />
-      <chakra.span
-        {...getCheckboxProps()}
-        className="chakra-switch__track"
-        __css={trackStyles}
+    return (
+      <chakra.label
+        {...getRootProps()}
+        className={cx("chakra-switch", props.className)}
+        __css={containerStyles}
       >
+        <input className="chakra-switch__input" {...getInputProps({}, ref)} />
         <chakra.span
-          __css={styles.thumb}
-          className="chakra-switch__thumb"
-          data-checked={dataAttr(state.isChecked)}
-          data-hover={dataAttr(state.isHovered)}
-        />
-      </chakra.span>
-      {children && (
-        <chakra.span
-          className="chakra-switch__label"
-          {...getLabelProps()}
-          __css={labelStyles}
+          {...getCheckboxProps()}
+          className="chakra-switch__track"
+          __css={trackStyles}
         >
-          {children}
+          <chakra.span
+            __css={styles.thumb}
+            className="chakra-switch__thumb"
+            data-checked={dataAttr(state.isChecked)}
+            data-hover={dataAttr(state.isHovered)}
+          />
         </chakra.span>
-      )}
-    </chakra.label>
-  )
-})
+        {children && (
+          <chakra.span
+            className="chakra-switch__label"
+            {...getLabelProps()}
+            __css={labelStyles}
+          >
+            {children}
+          </chakra.span>
+        )}
+      </chakra.label>
+    )
+  },
+)
 
 Switch.displayName = "Switch"

--- a/packages/components/system/src/forward-ref.tsx
+++ b/packages/components/system/src/forward-ref.tsx
@@ -5,7 +5,11 @@
 import { forwardRef as forwardReactRef } from "react"
 import { As, ComponentWithAs, PropsOf, RightJoinProps } from "./system.types"
 
-export function forwardRef<Props extends object, Component extends As>(
+export function forwardRef<
+  Props extends object,
+  Component extends As,
+  Omitted extends string = never,
+>(
   component: React.ForwardRefRenderFunction<
     any,
     RightJoinProps<PropsOf<Component>, Props> & {
@@ -15,6 +19,7 @@ export function forwardRef<Props extends object, Component extends As>(
 ) {
   return forwardReactRef(component) as unknown as ComponentWithAs<
     Component,
-    Props
+    Props,
+    Omitted
   >
 }

--- a/packages/components/system/src/system.types.tsx
+++ b/packages/components/system/src/system.types.tsx
@@ -55,11 +55,15 @@ export type MergeWithAs<
     as?: AsComponent
   }
 
-export type ComponentWithAs<Component extends As, Props extends object = {}> = {
+export type ComponentWithAs<
+  Component extends As,
+  Props extends object = {},
+  Omitted extends string = never,
+> = {
   <AsComponent extends As = Component>(
     props: MergeWithAs<
-      React.ComponentProps<Component>,
-      React.ComponentProps<AsComponent>,
+      Omit<React.ComponentProps<Component>, Omitted>,
+      Omit<React.ComponentProps<AsComponent>, Omitted>,
       Props,
       AsComponent
     >,


### PR DESCRIPTION
## 📝 Description

## ⛳️ Current behavior (updates)

`checked` prop is allowed on `Switch`, `Checkbox`, `Radio`, and text-like inputs. It's especially confusing when it comes to the first mentioned group because in reality only `isChecked` prop is accepted and handled correctly.

## 🚀 New behavior

`checked` prop is no longer accepted where it shouldn't be

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

:warning: this is mostly PoC and groundwork for the work that has to be done. I probably won't be able to finish this PR and a core Chakra member should take over this. I've merely located the places where this prop shouldn't be accepted.

Similar PR: https://github.com/chakra-ui/chakra-ui/pull/5296/files
