### PR TITLE
Fix incorrect Select xs sizing

### DIFF
--- a/.changeset/moody-ladybugs-glow.md
+++ b/.changeset/moody-ladybugs-glow.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Fix incorrect Select `xs` sizing

--- a/packages/components/theme/src/components/select.ts
+++ b/packages/components/theme/src/components/select.ts
@@ -68,7 +68,7 @@ const sizes = {
   xs: {
     ...inputTheme.sizes?.xs,
     field: {
-      ...inputTheme.sizes?.sm.field,
+      ...inputTheme.sizes?.xs.field,
       ...iconSpacing,
     },
     icon: {


### PR DESCRIPTION
## 📝 Description

When using `Select` with `xs` size it uses `sm` instead. This fixes the typo.

## 💣 Is this a breaking change (Yes/No):

No


