### PR TITLE
Add Missing JSDocs and Docsite Links

### DIFF
--- a/.changeset/tricky-squids-kneel.md
+++ b/.changeset/tricky-squids-kneel.md
@@ -34,3 +34,5 @@ Add missing component/function docs and relative docsite links.
 Ensures that all Components, functions, and hooks that have detailed pages on
 the Chakra site have corresponding JSDocs and links back to the docsite via IDE
 intellisense.
+
+Includes adding or fixing links within these docs to related WAI-ARIA patterns.

--- a/.changeset/tricky-squids-kneel.md
+++ b/.changeset/tricky-squids-kneel.md
@@ -31,6 +31,6 @@
 
 Add missing component/function docs and relative docsite links.
 
-This allows for all the components or functions detailed in the Chakra docsite
-to have accessible IDE intellisense with direct access to the related Chakra
-site pages.
+Ensures that all Components, functions, and hooks that have detailed pages on
+the Chakra site have corresponding JSDocs and links back to the docsite via IDE
+intellisense.

--- a/.changeset/tricky-squids-kneel.md
+++ b/.changeset/tricky-squids-kneel.md
@@ -1,0 +1,36 @@
+---
+"@chakra-ui/alert": patch
+"@chakra-ui/button": patch
+"@chakra-ui/checkbox": patch
+"@chakra-ui/close-button": patch
+"@chakra-ui/editable": patch
+"@chakra-ui/form-control": patch
+"@chakra-ui/icon": patch
+"@chakra-ui/input": patch
+"@chakra-ui/layout": patch
+"@chakra-ui/media-query": patch
+"@chakra-ui/menu": patch
+"@chakra-ui/modal": patch
+"@chakra-ui/pin-input": patch
+"@chakra-ui/popover": patch
+"@chakra-ui/radio": patch
+"@chakra-ui/select": patch
+"@chakra-ui/skeleton": patch
+"@chakra-ui/skip-nav": patch
+"@chakra-ui/stat": patch
+"@chakra-ui/switch": patch
+"@chakra-ui/system": patch
+"@chakra-ui/table": patch
+"@chakra-ui/tabs": patch
+"@chakra-ui/toast": patch
+"@chakra-ui/visually-hidden": patch
+"@chakra-ui/react-use-controllable-state": patch
+"@chakra-ui/react-use-disclosure": patch
+"@chakra-ui/hooks": patch
+---
+
+Add missing component/function docs and relative docsite links.
+
+This allows for all the components or functions detailed in the Chakra docsite
+to have accessible IDE intellisense with direct access to the related Chakra
+site pages.

--- a/packages/components/accordion/src/accordion.tsx
+++ b/packages/components/accordion/src/accordion.tsx
@@ -34,6 +34,7 @@ export interface AccordionProps
  *
  * It wraps all accordion items in a `div` for better grouping.
  * @see Docs https://chakra-ui.com/accordion
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/accordion/
  */
 export const Accordion = forwardRef<AccordionProps, "div">(function Accordion(
   { children, reduceMotion, ...props },

--- a/packages/components/accordion/src/use-accordion.ts
+++ b/packages/components/accordion/src/use-accordion.ts
@@ -41,6 +41,8 @@ export interface UseAccordionProps {
 /**
  * useAccordion hook provides all the state and focus management logic
  * for accordion items.
+ *
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/accordion/
  */
 export function useAccordion(props: UseAccordionProps) {
   const {

--- a/packages/components/alert/src/alert.tsx
+++ b/packages/components/alert/src/alert.tsx
@@ -35,6 +35,7 @@ export interface AlertProps
  * page, feature or action
  *
  * @see Docs https://chakra-ui.com/docs/components/alert
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/alert/
  */
 export const Alert = forwardRef<AlertProps, "div">(function Alert(props, ref) {
   const { status = "info", addRole = true, ...rest } = omitThemingProps(props)

--- a/packages/components/alert/src/alert.tsx
+++ b/packages/components/alert/src/alert.tsx
@@ -33,6 +33,8 @@ export interface AlertProps
 /**
  * Alert is used to communicate the state or status of a
  * page, feature or action
+ *
+ * @see Docs https://chakra-ui.com/docs/components/alert
  */
 export const Alert = forwardRef<AlertProps, "div">(function Alert(props, ref) {
   const { status = "info", addRole = true, ...rest } = omitThemingProps(props)

--- a/packages/components/breadcrumb/src/breadcrumb.tsx
+++ b/packages/components/breadcrumb/src/breadcrumb.tsx
@@ -22,6 +22,7 @@ export interface BreadcrumbProps
  * It renders a `nav` element with `aria-label` set to `Breadcrumb`
  *
  * @see Docs https://chakra-ui.com/breadcrumb
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/
  */
 export const Breadcrumb = forwardRef<BreadcrumbProps, "nav">(
   function Breadcrumb(props, ref) {

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -26,6 +26,7 @@ export interface ButtonProps
  * Button component is used to trigger an action or event, such as submitting a form, opening a Dialog, canceling an action, or performing a delete operation.
  *
  * @see Docs https://chakra-ui.com/docs/components/button
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/button/
  */
 export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
   const group = useButtonGroup()

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -22,6 +22,11 @@ export interface ButtonProps
     ButtonOptions,
     ThemingProps<"Button"> {}
 
+/**
+ * Button component is used to trigger an action or event, such as submitting a form, opening a Dialog, canceling an action, or performing a delete operation.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/button
+ */
 export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
   const group = useButtonGroup()
   const styles = useStyleConfig("Button", { ...group, ...props })

--- a/packages/components/button/src/icon-button.tsx
+++ b/packages/components/button/src/icon-button.tsx
@@ -28,7 +28,7 @@ export interface IconButtonProps extends BaseButtonProps {
 }
 
 /**
- * Icon button renders an icon within in a button.
+ * Icon button renders an icon within a button.
  *
  * @see Docs https://chakra-ui.com/docs/components/icon-button
  */

--- a/packages/components/button/src/icon-button.tsx
+++ b/packages/components/button/src/icon-button.tsx
@@ -27,6 +27,11 @@ export interface IconButtonProps extends BaseButtonProps {
   "aria-label": string
 }
 
+/**
+ * Icon button renders an icon within in a button.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/icon-button
+ */
 export const IconButton = forwardRef<IconButtonProps, "button">(
   (props, ref) => {
     const { icon, children, isRound, "aria-label": ariaLabel, ...rest } = props

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -57,6 +57,7 @@ export interface CheckboxProps
  * multiple values from several options.
  *
  * @see Docs https://chakra-ui.com/checkbox
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
  */
 export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
   props,

--- a/packages/components/checkbox/src/use-checkbox-group.ts
+++ b/packages/components/checkbox/src/use-checkbox-group.ts
@@ -15,6 +15,7 @@ function isInputEvent(value: any): value is { target: HTMLInputElement } {
  * It is consumed by the `CheckboxGroup` component
  *
  * @see Docs https://chakra-ui.com/docs/hooks/use-checkbox-group
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
  */
 export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
   const {

--- a/packages/components/checkbox/src/use-checkbox-group.ts
+++ b/packages/components/checkbox/src/use-checkbox-group.ts
@@ -13,6 +13,8 @@ function isInputEvent(value: any): value is { target: HTMLInputElement } {
  * for a group of checkboxes.
  *
  * It is consumed by the `CheckboxGroup` component
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-checkbox-group
  */
 export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
   const {

--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -16,6 +16,7 @@ import { CheckboxState, UseCheckboxProps } from "./checkbox-types"
  * for a checkbox. It is consumed by the `Checkbox` component
  *
  * @see Docs https://chakra-ui.com/checkbox#hooks
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
  */
 export function useCheckbox(props: UseCheckboxProps = {}) {
   const formControlProps = useFormControlProps(props)

--- a/packages/components/close-button/src/close-button.tsx
+++ b/packages/components/close-button/src/close-button.tsx
@@ -34,6 +34,8 @@ export interface CloseButtonProps
  *
  * It is used to handle the close functionality in feedback and overlay components
  * like Alerts, Toasts, Drawers and Modals.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/close-button
  */
 export const CloseButton = forwardRef<CloseButtonProps, "button">(
   function CloseButton(props, ref) {

--- a/packages/components/editable/src/editable.tsx
+++ b/packages/components/editable/src/editable.tsx
@@ -39,6 +39,8 @@ export interface EditableProps
  *
  * The wrapper that provides context and logic for all editable
  * components. It renders a `div`
+ *
+ * @see Docs https://chakra-ui.com/docs/components/editable
  */
 export const Editable = forwardRef<EditableProps, "div">(function Editable(
   props,

--- a/packages/components/form-control/src/form-control.tsx
+++ b/packages/components/form-control/src/form-control.tsx
@@ -211,6 +211,8 @@ export interface FormControlProps
  *
  * This is commonly used in form elements such as `input`,
  * `select`, `textarea`, etc.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/form-control
  */
 export const FormControl = forwardRef<FormControlProps, "div">(
   function FormControl(props, ref) {

--- a/packages/components/icon/src/icon.tsx
+++ b/packages/components/icon/src/icon.tsx
@@ -29,6 +29,11 @@ export interface IconProps
   extends Omit<React.SVGAttributes<SVGElement>, keyof ChakraProps>,
     ChakraProps {}
 
+/**
+ * The Icon component renders as an svg element to help define your own custom components.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/icon#using-the-icon-component
+ */
 export const Icon = forwardRef<IconProps, "svg">((props, ref) => {
   const {
     as: element,

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -40,6 +40,8 @@ export interface InputProps
  * Input
  *
  * Element that allows users enter single valued data.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/input
  */
 export const Input = forwardRef<InputProps, "input">(function Input(
   props,

--- a/packages/components/layout/src/container.tsx
+++ b/packages/components/layout/src/container.tsx
@@ -25,6 +25,8 @@ export interface ContainerProps
  * to keep its content centered.
  *
  * It also sets a default max-width of `60ch` (60 characters).
+ *
+ * @see Docs https://chakra-ui.com/docs/components/container
  */
 export const Container = forwardRef<ContainerProps, "div">(function Container(
   props,

--- a/packages/components/layout/src/heading.tsx
+++ b/packages/components/layout/src/heading.tsx
@@ -12,6 +12,13 @@ export interface HeadingProps
   extends HTMLChakraProps<"h2">,
     ThemingProps<"Heading"> {}
 
+/**
+ * `Heading` is used to render semantic HTML heading elements.
+ *
+ * By default, renders as `h2` with themantic size `xl`
+ *
+ * @see Docs https://chakra-ui.com/docs/components/heading
+ */
 export const Heading = forwardRef<HeadingProps, "h2">(function Heading(
   props,
   ref,

--- a/packages/components/layout/src/highlight.tsx
+++ b/packages/components/layout/src/highlight.tsx
@@ -68,6 +68,11 @@ export const Mark = forwardRef<MarkProps, "mark">(function Mark(props, ref) {
   )
 })
 
+/**
+ * `Highlight` allows you to highlight substrings of a text.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/highlight
+ */
 export function Highlight(props: HighlightProps): JSX.Element {
   const { children, query, styles } = props
 

--- a/packages/components/layout/src/stack/h-stack.tsx
+++ b/packages/components/layout/src/stack/h-stack.tsx
@@ -4,6 +4,8 @@ import { Stack, StackProps } from "./stack"
 
 /**
  * A view that arranges its children in a horizontal line.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/stack
  */
 export const HStack = forwardRef<StackProps, "div">((props, ref) => (
   <Stack align="center" {...props} direction="row" ref={ref} />

--- a/packages/components/layout/src/stack/v-stack.tsx
+++ b/packages/components/layout/src/stack/v-stack.tsx
@@ -4,6 +4,8 @@ import { Stack, StackProps } from "./stack"
 
 /**
  * A view that arranges its children in a vertical line.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/stack
  */
 export const VStack = forwardRef<StackProps, "div">((props, ref) => (
   <Stack align="center" {...props} direction="column" ref={ref} />

--- a/packages/components/media-query/src/hide.tsx
+++ b/packages/components/media-query/src/hide.tsx
@@ -4,6 +4,11 @@ import { ShowProps } from "./show"
 
 export type HideProps = ShowProps
 
+/**
+ * `Hide` wraps a component to not render if the provided media query matches.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/show-hide
+ */
 export function Hide(props: HideProps) {
   const { children, ssr } = props
   const query = useQuery(props)

--- a/packages/components/media-query/src/media-query.hook.ts
+++ b/packages/components/media-query/src/media-query.hook.ts
@@ -2,6 +2,8 @@ import { useMediaQuery, UseMediaQueryOptions } from "./use-media-query"
 
 /**
  * React hook used to get the user's animation preference.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-prefers-reduced-motion
  */
 export function usePrefersReducedMotion(
   options?: UseMediaQueryOptions,

--- a/packages/components/media-query/src/show.tsx
+++ b/packages/components/media-query/src/show.tsx
@@ -21,6 +21,11 @@ export interface ShowProps {
   children?: React.ReactNode
 }
 
+/**
+ * `Show` wraps a component to render if the provided media query matches.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/show-hide
+ */
 export function Show(props: ShowProps) {
   const { children, ssr } = props
   const query = useQuery(props)

--- a/packages/components/media-query/src/use-breakpoint-value.ts
+++ b/packages/components/media-query/src/use-breakpoint-value.ts
@@ -13,6 +13,8 @@ import { useBreakpoint, UseBreakpointOptions } from "./use-breakpoint"
  *
  * @example
  * const width = useBreakpointValue({ base: '150px', md: '250px' })
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-breakpoint-value
  */
 export function useBreakpointValue<T = any>(
   values: Partial<Record<string, T>> | T[],

--- a/packages/components/media-query/src/use-media-query.ts
+++ b/packages/components/media-query/src/use-media-query.ts
@@ -11,6 +11,8 @@ export type UseMediaQueryOptions = {
  *
  * @param query the media query to match
  * @param options the media query options { fallback, ssr }
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-media-query
  */
 export function useMediaQuery(
   query: string | string[],

--- a/packages/components/menu/src/menu-button.tsx
+++ b/packages/components/menu/src/menu-button.tsx
@@ -25,6 +25,8 @@ const StyledMenuButton = forwardRef<MenuButtonProps, "button">((props, ref) => {
 
 /**
  * The trigger for the menu list. Must be a direct child of `Menu`.
+ *
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
  */
 export const MenuButton = forwardRef<MenuButtonProps, "button">(
   (props, ref) => {

--- a/packages/components/menu/src/menu.tsx
+++ b/packages/components/menu/src/menu.tsx
@@ -37,6 +37,8 @@ export interface MenuProps extends UseMenuProps, ThemingProps<"Menu"> {
 /**
  * Menu provides context, state, and focus management
  * to its sub-components. It doesn't render any DOM node.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/menu
  */
 export const Menu: React.FC<MenuProps> = (props) => {
   const { children } = props

--- a/packages/components/modal/src/alert-dialog.tsx
+++ b/packages/components/modal/src/alert-dialog.tsx
@@ -6,6 +6,11 @@ export interface AlertDialogProps extends Omit<ModalProps, "initialFocusRef"> {
   leastDestructiveRef: NonNullable<ModalProps["initialFocusRef"]>
 }
 
+/**
+ * `AlertDialog` component is used interrupt the user with a mandatory confirmation or action.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/alert-dialog
+ */
 export function AlertDialog(props: AlertDialogProps) {
   const { leastDestructiveRef, ...rest } = props
   return <Modal {...rest} initialFocusRef={leastDestructiveRef} />

--- a/packages/components/modal/src/alert-dialog.tsx
+++ b/packages/components/modal/src/alert-dialog.tsx
@@ -10,6 +10,7 @@ export interface AlertDialogProps extends Omit<ModalProps, "initialFocusRef"> {
  * `AlertDialog` component is used interrupt the user with a mandatory confirmation or action.
  *
  * @see Docs https://chakra-ui.com/docs/components/alert-dialog
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
  */
 export function AlertDialog(props: AlertDialogProps) {
   const { leastDestructiveRef, ...rest } = props

--- a/packages/components/modal/src/drawer.tsx
+++ b/packages/components/modal/src/drawer.tsx
@@ -47,6 +47,12 @@ export interface DrawerProps
       "scrollBehavior" | "motionPreset" | "isCentered" | keyof ThemingProps
     > {}
 
+/**
+ * The Drawer component is a panel that slides out from the edge of the screen.
+ * It can be useful when you need users to complete a task or view some details without leaving the current page.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/drawer
+ */
 export function Drawer(props: DrawerProps) {
   const {
     isOpen,

--- a/packages/components/modal/src/modal.tsx
+++ b/packages/components/modal/src/modal.tsx
@@ -133,6 +133,7 @@ const [ModalContextProvider, useModalContext] = createContext<ModalContext>({
  * It doesn't render any DOM node.
  *
  * @see Docs https://chakra-ui.com/docs/components/modal
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
  */
 export const Modal: React.FC<ModalProps> = (props) => {
   const {

--- a/packages/components/modal/src/modal.tsx
+++ b/packages/components/modal/src/modal.tsx
@@ -131,6 +131,8 @@ const [ModalContextProvider, useModalContext] = createContext<ModalContext>({
  * to all other modal components.
  *
  * It doesn't render any DOM node.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/modal
  */
 export const Modal: React.FC<ModalProps> = (props) => {
   const {

--- a/packages/components/number-input/src/use-number-input.ts
+++ b/packages/components/number-input/src/use-number-input.ts
@@ -132,7 +132,7 @@ type InputSelection = { start: number | null; end: number | null }
  * It returns prop getters you can use to build your own
  * custom number inputs.
  *
- * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices-1.1/#spinbutton
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/
  * @see Docs     https://www.chakra-ui.com/useNumberInput
  * @see WHATWG   https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)
  */

--- a/packages/components/pin-input/src/pin-input.tsx
+++ b/packages/components/pin-input/src/pin-input.tsx
@@ -42,6 +42,11 @@ export interface PinInputProps
   children: React.ReactNode
 }
 
+/**
+ * The `PinInput` component is similar to the Input component, but is optimized for entering sequences of digits quickly.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/pin-input
+ */
 export function PinInput(props: PinInputProps) {
   const styles = useStyleConfig("PinInput", props)
 

--- a/packages/components/popover/src/popover.tsx
+++ b/packages/components/popover/src/popover.tsx
@@ -24,6 +24,8 @@ export interface PopoverProps extends UsePopoverProps, ThemingProps<"Popover"> {
 /**
  * Popover is used to bring attention to specific user interface elements,
  * typically to suggest an action or to guide users through a new experience.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/popover
  */
 export function Popover(props: PopoverProps) {
   const styles = useMultiStyleConfig("Popover", props)

--- a/packages/components/radio/src/use-radio-group.ts
+++ b/packages/components/radio/src/use-radio-group.ts
@@ -49,7 +49,9 @@ export interface UseRadioGroupProps {
 }
 
 /**
- * React hook to manage a group of radio inputs
+ * `useRadioGroup` is a custom hook that provides all the state management logic for a group of radios.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-radio-group
  */
 export function useRadioGroup(props: UseRadioGroupProps = {}) {
   const {

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -80,6 +80,11 @@ export interface RadioState {
   isRequired: boolean | undefined
 }
 
+/**
+ * `useRadio` is a custom hook used to provide radio functionality, as well as state and focus management to custom radio components when using it.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-radio
+ */
 export function useRadio(props: UseRadioProps = {}) {
   const {
     defaultChecked,

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -67,6 +67,8 @@ export interface SelectProps
 
 /**
  * React component used to select one item from a list of options.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/select
  */
 export const Select = forwardRef<SelectProps, "select">((props, ref) => {
   const styles = useMultiStyleConfig("Select", props)

--- a/packages/components/skeleton/src/skeleton.tsx
+++ b/packages/components/skeleton/src/skeleton.tsx
@@ -84,6 +84,11 @@ const bgFade = keyframes({
   to: { borderColor: endColor, background: endColor },
 })
 
+/**
+ * `Skeleton` is used to display the loading state of some component.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/skeleton
+ */
 export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
   const styles = useStyleConfig("Skeleton", props)
   const isFirstRender = useIsFirstRender()
@@ -152,6 +157,11 @@ export interface SkeletonTextProps extends SkeletonProps {
 
 const defaultNoOfLines = 3
 
+/**
+ * `SkeletonText` is used to display the loading state in the form of text.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/skeleton
+ */
 export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
   const {
     noOfLines = defaultNoOfLines,
@@ -221,6 +231,11 @@ export const SkeletonText: React.FC<SkeletonTextProps> = (props) => {
 
 SkeletonText.displayName = "SkeletonText"
 
+/**
+ * `SkeletonCircle` is used to display the loading state in the form of a circular avatar.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/skeleton
+ */
 export const SkeletonCircle: React.FC<SkeletonProps> = ({
   size = "2rem",
   ...rest

--- a/packages/components/skip-nav/src/skip-nav.tsx
+++ b/packages/components/skip-nav/src/skip-nav.tsx
@@ -38,6 +38,8 @@ function getStyles(styles: any): SystemStyleObject {
 
 /**
  * Renders a link that remains hidden until focused to skip to the main content.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/skip-nav
  */
 export const SkipNavLink = forwardRef<SkipNavLinkProps, "a">(
   function SkipNavLink(props, ref) {
@@ -54,7 +56,9 @@ SkipNavLink.displayName = "SkipNavLink"
 export interface SkipNavContentProps extends HTMLChakraProps<"div"> {}
 
 /**
- * Renders a div as the target for the link.
+ * Renders a div as the target for the `SkipNavLink`.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/skip-nav
  */
 export const SkipNavContent = forwardRef<SkipNavContentProps, "div">(
   function SkipNavContent(props, ref) {

--- a/packages/components/slider/src/range-slider.tsx
+++ b/packages/components/slider/src/range-slider.tsx
@@ -50,7 +50,7 @@ export interface RangeSliderProps
  * It provides context and functionality for all slider components
  *
  * @see Docs     https://chakra-ui.com/docs/form/slider
- * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#slider
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/
  */
 export const RangeSlider = forwardRef<RangeSliderProps, "div">(
   function RangeSlider(props, ref) {

--- a/packages/components/slider/src/slider.tsx
+++ b/packages/components/slider/src/slider.tsx
@@ -42,7 +42,7 @@ export interface SliderProps
  * It provides context and functionality for all slider components
  *
  * @see Docs     https://chakra-ui.com/docs/form/slider
- * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#slider
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/slider/
  */
 export const Slider = forwardRef<SliderProps, "div">((props, ref) => {
   const styles = useMultiStyleConfig("Slider", props)

--- a/packages/components/slider/src/use-range-slider.ts
+++ b/packages/components/slider/src/use-range-slider.ts
@@ -128,7 +128,7 @@ export interface UseRangeSliderProps {
  * prop getters for the component parts
  *
  * @see Docs     https://chakra-ui.com/docs/form/slider
- * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices-1.1/#slider
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/
  */
 export function useRangeSlider(props: UseRangeSliderProps) {
   const {

--- a/packages/components/slider/src/use-slider.ts
+++ b/packages/components/slider/src/use-slider.ts
@@ -116,7 +116,7 @@ export interface UseSliderProps {
  * prop getters for the component parts
  *
  * @see Docs     https://chakra-ui.com/docs/form/slider
- * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices-1.1/#slider
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/slider/
  */
 export function useSlider(props: UseSliderProps) {
   const {

--- a/packages/components/stat/src/stat.tsx
+++ b/packages/components/stat/src/stat.tsx
@@ -23,6 +23,11 @@ export interface StatProps
   extends HTMLChakraProps<"div">,
     ThemingProps<"Stat"> {}
 
+/**
+ * The `Stat` component is used to display some statistics.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/stat
+ */
 export const Stat = forwardRef<StatProps, "div">(function Stat(props, ref) {
   const styles = useMultiStyleConfig("Stat", props)
   const statStyles: SystemStyleObject = {

--- a/packages/components/switch/src/switch.tsx
+++ b/packages/components/switch/src/switch.tsx
@@ -24,6 +24,11 @@ export interface SwitchProps
   spacing?: SystemProps["marginLeft"]
 }
 
+/**
+ * The `Switch` component is used as an alternative for the checkbox component for switching between "enabled" and "disabled" states.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/switch
+ */
 export const Switch = forwardRef<SwitchProps, "input">(function Switch(
   props,
   ref,

--- a/packages/components/switch/src/switch.tsx
+++ b/packages/components/switch/src/switch.tsx
@@ -28,6 +28,7 @@ export interface SwitchProps
  * The `Switch` component is used as an alternative for the checkbox component for switching between "enabled" and "disabled" states.
  *
  * @see Docs https://chakra-ui.com/docs/components/switch
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/switch/
  */
 export const Switch = forwardRef<SwitchProps, "input">(function Switch(
   props,

--- a/packages/components/system/src/factory.ts
+++ b/packages/components/system/src/factory.ts
@@ -33,5 +33,10 @@ function factory() {
     },
   }) as ChakraFactory & HTMLChakraComponents
 }
-
+/**
+ * The Chakra factory serves as an object of chakra enabled JSX elements,
+ * and also a function that can be used to enable custom component receive chakra's style props.
+ *
+ * @see Docs https://chakra-ui.com/docs/styled-system/chakra-factory
+ */
 export const chakra = factory()

--- a/packages/components/system/src/hooks.ts
+++ b/packages/components/system/src/hooks.ts
@@ -28,6 +28,11 @@ function getTokenValue<T extends StringOrNumber>(
   return getValue(value) ?? getValue(fallback) ?? fallback
 }
 
+/**
+ * `useToken` is a custom hook used to resolve design tokens from the theme.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-token
+ */
 export function useToken<T extends StringOrNumber | StringOrNumber[]>(
   scale: string,
   token: T,

--- a/packages/components/system/src/use-theme.ts
+++ b/packages/components/system/src/use-theme.ts
@@ -3,6 +3,11 @@ import { Dict } from "@chakra-ui/utils"
 import { ThemeContext } from "@emotion/react"
 import { useContext } from "react"
 
+/**
+ * `useTheme` is a custom hook used to get the theme object from context.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-theme
+ */
 export function useTheme<T extends object = Dict>() {
   const theme = useContext(
     ThemeContext as unknown as React.Context<T | undefined>,

--- a/packages/components/table/src/table.tsx
+++ b/packages/components/table/src/table.tsx
@@ -26,6 +26,11 @@ export interface TableProps
     TableOptions,
     ThemingProps<"Table"> {}
 
+/**
+ * The `Table` component is used to organize and display data efficiently. It renders a `<table>` element by default.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/table
+ */
 export const Table = forwardRef<TableProps, "table">((props, ref) => {
   const styles = useMultiStyleConfig("Table", props)
   const { className, ...tableProps } = omitThemingProps(props)

--- a/packages/components/table/src/table.tsx
+++ b/packages/components/table/src/table.tsx
@@ -30,6 +30,7 @@ export interface TableProps
  * The `Table` component is used to organize and display data efficiently. It renders a `<table>` element by default.
  *
  * @see Docs https://chakra-ui.com/docs/components/table
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/table/
  */
 export const Table = forwardRef<TableProps, "table">((props, ref) => {
   const styles = useMultiStyleConfig("Table", props)

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -51,6 +51,7 @@ export interface TabsProps
  * Provides context and logic for all tabs components.
  *
  * @see Docs https://chakra-ui.com/docs/components/tabs
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
  */
 export const Tabs = forwardRef<TabsProps, "div">(function Tabs(props, ref) {
   const styles = useMultiStyleConfig("Tabs", props)

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -49,6 +49,8 @@ export interface TabsProps
  * Tabs
  *
  * Provides context and logic for all tabs components.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/tabs
  */
 export const Tabs = forwardRef<TabsProps, "div">(function Tabs(props, ref) {
   const styles = useMultiStyleConfig("Tabs", props)

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -95,6 +95,7 @@ export interface UseTabsProps {
  * so all child components can read from it.
  * There is no document link yet
  * @see Docs https://chakra-ui.com/docs/components/useTabs
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
  */
 export function useTabs(props: UseTabsProps) {
   const {

--- a/packages/components/toast/src/toast.tsx
+++ b/packages/components/toast/src/toast.tsx
@@ -19,6 +19,11 @@ export interface ToastProps
   onClose?: () => void
 }
 
+/**
+ * The `Toast` component is used to give feedback to users after an action has taken place.
+ *
+ * @see Docs https://chakra-ui.com/docs/components/toast
+ */
 export const Toast: React.FC<ToastProps> = (props) => {
   const {
     status,

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -58,7 +58,7 @@ const StyledTooltip = chakra(motion.div)
  * Tooltips display informative text when users hover, focus on, or tap an element.
  *
  * @see Docs     https://chakra-ui.com/docs/overlay/tooltip
- * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#tooltip
+ * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
  */
 export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
   const styles = useStyleConfig("Tooltip", props)

--- a/packages/components/visually-hidden/src/visually-hidden.tsx
+++ b/packages/components/visually-hidden/src/visually-hidden.tsx
@@ -4,6 +4,8 @@ import { visuallyHiddenStyle } from "./visually-hidden.style"
 /**
  * Visually hidden component used to hide
  * elements on screen
+ *
+ * @see Docs https://chakra-ui.com/docs/components/visually-hidden
  */
 export const VisuallyHidden = chakra("span", {
   baseStyle: visuallyHiddenStyle,
@@ -15,6 +17,8 @@ VisuallyHidden.displayName = "VisuallyHidden"
  * Visually hidden input component for designing
  * custom input components using the html `input`
  * as a proxy
+ *
+ * @see Docs https://chakra-ui.com/docs/components/visually-hidden#visually-hidden-input
  */
 export const VisuallyHiddenInput = chakra("input", {
   baseStyle: visuallyHiddenStyle,

--- a/packages/hooks/use-controllable-state/src/index.ts
+++ b/packages/hooks/use-controllable-state/src/index.ts
@@ -1,6 +1,11 @@
 import { useCallback, useMemo, useState } from "react"
 import { useCallbackRef } from "@chakra-ui/react-use-callback-ref"
 
+/**
+ * Given a prop value and state value, the useControllableProp hook is used to determine whether a component is controlled or uncontrolled, and also returns the computed value.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-controllable#usecontrollableprop
+ */
 export function useControllableProp<T>(prop: T | undefined, state: T) {
   const controlled = typeof prop !== "undefined"
   const value = controlled ? prop : state
@@ -14,6 +19,11 @@ export interface UseControllableStateProps<T> {
   shouldUpdate?: (prev: T, next: T) => boolean
 }
 
+/**
+ * The `useControllableState` hook returns the state and function that updates the state, just like React.useState does.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-controllable#usecontrollablestate
+ */
 export function useControllableState<T>(props: UseControllableStateProps<T>) {
   const {
     value: valueProp,

--- a/packages/hooks/use-disclosure/src/index.ts
+++ b/packages/hooks/use-disclosure/src/index.ts
@@ -11,6 +11,12 @@ export interface UseDisclosureProps {
 
 type HTMLProps = React.HTMLAttributes<HTMLElement>
 
+/**
+ * `useDisclosure` is a custom hook used to help handle common open, close, or toggle scenarios.
+ * It can be used to control feedback component such as `Modal`, `AlertDialog`, `Drawer`, etc.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-disclosure
+ */
 export function useDisclosure(props: UseDisclosureProps = {}) {
   const {
     onClose: onCloseProp,

--- a/packages/legacy/hooks/src/use-boolean.ts
+++ b/packages/legacy/hooks/src/use-boolean.ts
@@ -6,6 +6,8 @@ type InitialState = boolean | (() => boolean)
  * React hook to manage boolean (on - off) states
  *
  * @param initialState the initial boolean state value
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-boolean
  */
 export function useBoolean(initialState: InitialState = false) {
   const [value, setValue] = useState(initialState)

--- a/packages/legacy/hooks/src/use-clipboard.ts
+++ b/packages/legacy/hooks/src/use-clipboard.ts
@@ -20,6 +20,8 @@ export interface UseClipboardOptions {
  * @param {Object} optionsOrTimeout
  * @param {string} optionsOrTimeout.format - set the desired MIME type
  * @param {number} optionsOrTimeout.timeout - delay (in ms) to switch back to initial state once copied.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-clipboard
  */
 export function useClipboard(
   text: string,

--- a/packages/legacy/hooks/src/use-merge-refs.ts
+++ b/packages/legacy/hooks/src/use-merge-refs.ts
@@ -31,6 +31,8 @@ export function assignRef<T = any>(ref: ReactRef<T> | undefined, value: T) {
  *   const internalRef = React.useRef();
  *   return <div {...props} ref={useMergeRefs(internalRef, ref)} />;
  * });
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-merge-refs
  */
 export function useMergeRefs<T>(...refs: (ReactRef<T> | undefined)[]) {
   return useMemo(() => {

--- a/packages/legacy/hooks/src/use-outside-click.ts
+++ b/packages/legacy/hooks/src/use-outside-click.ts
@@ -20,6 +20,8 @@ export interface UseOutsideClickProps {
 /**
  * Example, used in components like Dialogs and Popovers, so they can close
  * when a user clicks outside them.
+ *
+ * @see Docs https://chakra-ui.com/docs/hooks/use-outside-click
  */
 export function useOutsideClick(props: UseOutsideClickProps) {
   const { ref, handler, enabled = true } = props


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Ensures that all Components, functions, and hooks that have detailed pages on the Chakra site have corresponding JSDocs and links back to the docsite via IDE intellisense.

Includes add/fixing links to related WAI-ARIA patterns.

## ⛳️ Current behavior (updates)

Some components, hooks, and functions did not have JSDocs and/or links back to their corresponding pages of the Chakra docsite.

## 🚀 New behavior
All components, hooks, and functions with corresponding docsite pages will now have JSDocs and site links for IDE intellisense viewing.

## 💣 Is this a breaking change (Yes/No):

No, as this does not change any functionality of the package.

## 📝 Additional Information

This is to help provide more accessibility of the package within the user's IDE. Only some of the components had JSDocs with site links.
