### PR TITLE
Remove duplicate command in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,6 @@ end with `.stories.tsx`.
 
 **`pnpm release`**: publish changed packages.
 
-**`pnpm storybook`**: run storybook to explore components.
-
 ## Think you found a bug?
 
 Please conform to the issue template and provide a clear path to reproduction


### PR DESCRIPTION
## 📝 Description

There are currently duplicate command descriptions for running storybook in https://github.com/chakra-ui/chakra-ui/blob/main/CONTRIBUTING.md#commands.

## ⛳️ Current behavior (updates)

There are two descriptions for the command `pnpm storybook`.

## 🚀 New behavior

Removed the duplicate entry, leaving one description for the command `pnpm storybook`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The duplicate description was added in https://github.com/chakra-ui/chakra-ui/pull/6650.