### PR TITLE
Fix: Popover pointerdown regression

### DIFF
--- a/.changeset/neat-flies-smile.md
+++ b/.changeset/neat-flies-smile.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react-use-focus-on-pointer-down": patch
+---
+
+Fix issue where focus on pointerdown doesn't work on safari

--- a/packages/hooks/use-focus-on-pointer-down/src/index.ts
+++ b/packages/hooks/use-focus-on-pointer-down/src/index.ts
@@ -44,7 +44,7 @@ export function useFocusOnPointerDown(props: UseFocusOnMouseDownProps) {
       return el?.contains(target) || el === target
     })
 
-    if (doc().activeElement === target && isValidTarget) {
+    if (doc().activeElement !== target && isValidTarget) {
       event.preventDefault()
       target.focus()
     }


### PR DESCRIPTION
Closes #6658

## 📝 Description

Fix regression where the popover doesn't close for Safari. A recent refactoring caused this

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
