### PR TITLE
Support motion overrides

### DIFF
--- a/.changeset/lazy-ants-attack.md
+++ b/.changeset/lazy-ants-attack.md
@@ -7,4 +7,4 @@
 "@chakra-ui/tooltip": minor
 ---
 
-Allow control of framer-motion elements
+Allow control of `framer-motion` elements via the `motionProps` prop.

--- a/.changeset/lazy-ants-attack.md
+++ b/.changeset/lazy-ants-attack.md
@@ -1,0 +1,10 @@
+---
+"@chakra-ui/accordion": minor
+"@chakra-ui/checkbox": minor
+"@chakra-ui/menu": minor
+"@chakra-ui/modal": minor
+"@chakra-ui/popover": minor
+"@chakra-ui/tooltip": minor
+---
+
+Allow control of framer-motion elements

--- a/.changeset/ninety-pugs-suffer.md
+++ b/.changeset/ninety-pugs-suffer.md
@@ -2,4 +2,4 @@
 "@chakra-ui/popover": patch
 ---
 
-Refactor popover
+Refactor popover to reduce bundle size

--- a/.changeset/perfect-cycles-argue.md
+++ b/.changeset/perfect-cycles-argue.md
@@ -2,4 +2,6 @@
 "@chakra-ui/tooltip": patch
 ---
 
-Fixed the wrapping children display + changed mouse events with pointer events
+Fixed issue where disabled tooltip triggers require an extra wrapper (via
+`shouldWrapChildren). This was fixed by switching from mouse events to pointer
+events

--- a/.changeset/strange-guests-deliver.md
+++ b/.changeset/strange-guests-deliver.md
@@ -1,5 +1,0 @@
----
-"@chakra-ui/modal": minor
----
-
-Add support for `motionProps` in components that use `framer-motion`

--- a/.changeset/strange-guests-deliver.md
+++ b/.changeset/strange-guests-deliver.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": minor
+---
+
+Add support for `motionProps` in components that use `framer-motion`

--- a/packages/components/accordion/src/accordion-panel.tsx
+++ b/packages/components/accordion/src/accordion-panel.tsx
@@ -1,5 +1,5 @@
 import { chakra, forwardRef, HTMLChakraProps } from "@chakra-ui/system"
-import { Collapse } from "@chakra-ui/transition"
+import { Collapse, CollapseProps } from "@chakra-ui/transition"
 import { cx } from "@chakra-ui/shared-utils"
 import {
   useAccordionItemContext,
@@ -7,7 +7,12 @@ import {
 } from "./accordion-context"
 import { useAccordionContext } from "./use-accordion"
 
-export interface AccordionPanelProps extends HTMLChakraProps<"div"> {}
+export interface AccordionPanelProps extends HTMLChakraProps<"div"> {
+  /**
+   * The properties passed to the underlying `Collapse` component.
+   */
+  motionProps?: CollapseProps
+}
 
 /**
  * Accordion panel that holds the content for each accordion.
@@ -17,13 +22,15 @@ export interface AccordionPanelProps extends HTMLChakraProps<"div"> {}
  */
 export const AccordionPanel = forwardRef<AccordionPanelProps, "div">(
   function AccordionPanel(props, ref) {
+    const { className, motionProps, ...rest } = props
+
     const { reduceMotion } = useAccordionContext()
     const { getPanelProps, isOpen } = useAccordionItemContext()
 
     // remove `hidden` prop, 'coz we're using height animation
-    const panelProps = getPanelProps(props, ref)
+    const panelProps = getPanelProps(rest, ref)
 
-    const _className = cx("chakra-accordion__panel", props.className)
+    const _className = cx("chakra-accordion__panel", className)
     const styles = useAccordionStyles()
 
     if (!reduceMotion) {
@@ -35,7 +42,11 @@ export const AccordionPanel = forwardRef<AccordionPanelProps, "div">(
     )
 
     if (!reduceMotion) {
-      return <Collapse in={isOpen}>{child}</Collapse>
+      return (
+        <Collapse in={isOpen} {...motionProps}>
+          {child}
+        </Collapse>
+      )
     }
 
     return child

--- a/packages/components/checkbox/src/checkbox-icon.tsx
+++ b/packages/components/checkbox/src/checkbox-icon.tsx
@@ -1,18 +1,7 @@
-import { chakra, PropsOf, ChakraComponent } from "@chakra-ui/system"
-import { AnimatePresence, CustomDomComponent, motion } from "framer-motion"
+import { chakra, PropsOf } from "@chakra-ui/system"
+import { AnimatePresence, motion } from "framer-motion"
 
-function __motion<T extends ChakraComponent<any, any>>(
-  el: T,
-): CustomDomComponent<PropsOf<T>> {
-  const m = motion as any
-  if ("custom" in m && typeof m.custom === "function") {
-    return m.custom(el)
-  }
-  return m(el)
-}
-
-// @future: only call `motion(chakra.svg)` when we drop framer-motion v3 support
-const MotionSvg = __motion(chakra.svg)
+const MotionSvg = chakra(motion.svg)
 
 function CheckIcon(props: PropsOf<typeof MotionSvg>) {
   return (

--- a/packages/components/modal/src/drawer-content.tsx
+++ b/packages/components/modal/src/drawer-content.tsx
@@ -45,7 +45,7 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
     const dialogContainerStyles: SystemStyleObject = {
       display: "flex",
       width: "100vw",
-      height: "100vh",
+      height: "$100vh",
       position: "fixed",
       left: 0,
       top: 0,

--- a/packages/components/modal/src/drawer-content.tsx
+++ b/packages/components/modal/src/drawer-content.tsx
@@ -1,11 +1,12 @@
 import { cx } from "@chakra-ui/shared-utils"
 import {
   chakra,
+  forwardRef,
   HTMLChakraProps,
   SystemStyleObject,
-  forwardRef,
 } from "@chakra-ui/system"
 import { Slide } from "@chakra-ui/transition"
+import type { HTMLMotionProps } from "framer-motion"
 
 import { useDrawerContext } from "./drawer"
 import { useModalContext, useModalStyles } from "./modal"
@@ -13,7 +14,9 @@ import { ModalFocusScope } from "./modal-focus"
 
 const MotionDiv = chakra(Slide)
 
-export interface DrawerContentProps extends HTMLChakraProps<"section"> {}
+export interface DrawerContentProps extends HTMLChakraProps<"section"> {
+  motionProps?: HTMLMotionProps<"section">
+}
 
 /**
  * ModalContent is used to group modal's content. It has all the
@@ -21,7 +24,7 @@ export interface DrawerContentProps extends HTMLChakraProps<"section"> {}
  */
 export const DrawerContent = forwardRef<DrawerContentProps, "section">(
   (props, ref) => {
-    const { className, children, ...rest } = props
+    const { className, children, motionProps, ...rest } = props
 
     const { getDialogProps, getDialogContainerProps, isOpen } =
       useModalContext()
@@ -62,6 +65,7 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
       >
         <ModalFocusScope>
           <MotionDiv
+            motionProps={motionProps}
             direction={placement}
             in={isOpen}
             className={_className}

--- a/packages/components/modal/src/drawer-content.tsx
+++ b/packages/components/modal/src/drawer-content.tsx
@@ -11,7 +11,7 @@ import { useDrawerContext } from "./drawer"
 import { useModalContext, useModalStyles } from "./modal"
 import { ModalFocusScope } from "./modal-focus"
 
-const StyledSlide = chakra(Slide)
+const MotionDiv = chakra(Slide)
 
 export interface DrawerContentProps extends HTMLChakraProps<"section"> {}
 
@@ -61,7 +61,7 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
         __css={dialogContainerStyles}
       >
         <ModalFocusScope>
-          <StyledSlide
+          <MotionDiv
             direction={placement}
             in={isOpen}
             className={_className}
@@ -69,7 +69,7 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
             __css={dialogStyles}
           >
             {children}
-          </StyledSlide>
+          </MotionDiv>
         </ModalFocusScope>
       </chakra.div>
     )

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -5,6 +5,7 @@ import {
   SystemStyleObject,
   forwardRef,
 } from "@chakra-ui/system"
+import { HTMLMotionProps } from "framer-motion"
 
 import { useModalContext, useModalStyles } from "./modal"
 import { ModalFocusScope } from "./modal-focus"
@@ -15,6 +16,10 @@ export interface ModalContentProps extends HTMLChakraProps<"section"> {
    * The props to forward to the modal's content wrapper
    */
   containerProps?: HTMLChakraProps<"div">
+  /**
+   * The custom framer-motion transition to use for the modal
+   */
+  motionProps?: HTMLMotionProps<"section">
 }
 
 /**
@@ -23,7 +28,13 @@ export interface ModalContentProps extends HTMLChakraProps<"section"> {
  */
 export const ModalContent = forwardRef<ModalContentProps, "section">(
   (props, ref) => {
-    const { className, children, containerProps: rootProps, ...rest } = props
+    const {
+      className,
+      children,
+      containerProps: rootProps,
+      motionProps,
+      ...rest
+    } = props
 
     const { getDialogProps, getDialogContainerProps } = useModalContext()
 
@@ -46,10 +57,7 @@ export const ModalContent = forwardRef<ModalContentProps, "section">(
     const dialogContainerStyles: SystemStyleObject = {
       display: "flex",
       width: "100vw",
-      height: "100vh",
-      "@supports(height: -webkit-fill-available)": {
-        height: "-webkit-fill-available",
-      },
+      height: "$100vh",
       position: "fixed",
       left: 0,
       top: 0,
@@ -63,12 +71,12 @@ export const ModalContent = forwardRef<ModalContentProps, "section">(
         <chakra.div
           {...containerProps}
           className="chakra-modal__content-container"
-          // tabindex="-1" means that the element is not reachable via sequential keyboard navigation, @see #4686
           tabIndex={-1}
           __css={dialogContainerStyles}
         >
           <ModalTransition
             preset={motionPreset}
+            motionProps={motionProps}
             className={_className}
             {...dialogProps}
             __css={dialogStyles}

--- a/packages/components/modal/src/modal-overlay.tsx
+++ b/packages/components/modal/src/modal-overlay.tsx
@@ -16,6 +16,7 @@ export interface ModalOverlayProps
   extends Omit<HTMLMotionProps<"div">, "color" | "transition">,
     ChakraProps {
   children?: React.ReactNode
+  motionProps?: HTMLMotionProps<"div">
 }
 
 /**
@@ -26,7 +27,7 @@ export interface ModalOverlayProps
  */
 export const ModalOverlay = forwardRef<ModalOverlayProps, "div">(
   (props, ref) => {
-    const { className, transition, ...rest } = props
+    const { className, transition, motionProps: _motionProps, ...rest } = props
     const _className = cx("chakra-modal__overlay", className)
 
     const styles = useModalStyles()
@@ -40,7 +41,10 @@ export const ModalOverlay = forwardRef<ModalOverlayProps, "div">(
     }
 
     const { motionPreset } = useModalContext()
-    const motionProps: any = motionPreset === "none" ? {} : fadeConfig
+    const defaultMotionProps: HTMLMotionProps<"div"> =
+      motionPreset === "none" ? {} : fadeConfig
+
+    const motionProps: any = _motionProps || defaultMotionProps
 
     return (
       <MotionDiv

--- a/packages/components/modal/src/modal-transition.tsx
+++ b/packages/components/modal/src/modal-transition.tsx
@@ -6,7 +6,8 @@ import { forwardRef } from "react"
 export interface ModalTransitionProps
   extends Omit<HTMLMotionProps<"section">, "color" | "transition">,
     ChakraProps {
-  preset: "slideInBottom" | "slideInRight" | "scale" | "none"
+  preset?: "slideInBottom" | "slideInRight" | "scale" | "none"
+  motionProps?: HTMLMotionProps<"section">
 }
 
 const transitions = {
@@ -25,13 +26,18 @@ const transitions = {
   none: {},
 }
 
-const Motion = chakra(motion.section)
+const MotionSection = chakra(motion.section)
+
+const getMotionProps = (preset: ModalTransitionProps["preset"]) => {
+  return transitions[preset || "none"]
+}
 
 export const ModalTransition = forwardRef(
   (props: ModalTransitionProps, ref: React.Ref<any>) => {
-    const { preset, ...rest } = props
-    const motionProps = transitions[preset]
-    return <Motion ref={ref} {...(motionProps as ChakraProps)} {...rest} />
+    const { preset, motionProps = getMotionProps(preset), ...rest } = props
+    return (
+      <MotionSection ref={ref} {...(motionProps as ChakraProps)} {...rest} />
+    )
   },
 )
 

--- a/packages/components/modal/stories/drawer.stories.tsx
+++ b/packages/components/modal/stories/drawer.stories.tsx
@@ -4,7 +4,7 @@ import { Drawer, DrawerBody, DrawerOverlay, DrawerHeader } from "../src/drawer"
 import { DrawerContent } from "../src/drawer-content"
 
 export default {
-  title: "Components / Overlay / Modal / Drawer",
+  title: "Components / Overlay / Drawer",
 }
 
 export const DrawerExample = () => {
@@ -15,6 +15,35 @@ export const DrawerExample = () => {
       <Drawer isOpen={open} onClose={() => setOpen(false)}>
         <DrawerOverlay />
         <DrawerContent>
+          <div>This is the drawer content</div>
+          <button>This is a button</button>
+        </DrawerContent>
+      </Drawer>
+    </>
+  )
+}
+
+export const WithCustomMotion = () => {
+  const [open, setOpen] = React.useState(false)
+  return (
+    <>
+      <button onClick={() => setOpen(!open)}>Open</button>
+      <Drawer isOpen={open} onClose={() => setOpen(false)}>
+        <DrawerOverlay />
+        <DrawerContent
+          motionProps={{
+            variants: {
+              enter: {
+                x: "0%",
+                transition: { duration: 0.2 },
+              },
+              exit: {
+                x: "100%",
+                transition: { duration: 0.1 },
+              },
+            },
+          }}
+        >
           <div>This is the drawer content</div>
           <button>This is a button</button>
         </DrawerContent>

--- a/packages/components/modal/stories/modal.stories.tsx
+++ b/packages/components/modal/stories/modal.stories.tsx
@@ -196,3 +196,38 @@ export const FullWithLongContent = () => {
     </>
   )
 }
+
+export function WithCustomMotionProps() {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  return (
+    <>
+      <Button onClick={onOpen}>Open</Button>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent
+          motionProps={{
+            initial: "exit",
+            animate: "enter",
+            exit: "exit",
+            variants: {
+              enter: { opacity: 1, y: 10 },
+              exit: { opacity: 0, y: 0, transition: { duration: 0.1 } },
+            },
+          }}
+        >
+          <ModalCloseButton />
+          <ModalHeader>Welcome Home</ModalHeader>
+          <ModalBody>
+            Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
+            ullamco deserunt aute id consequat veniam incididunt duis in sint
+            irure nisi.
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={onClose}>Cancel</Button>
+            <Button>Save</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -1,20 +1,22 @@
+import { callAll, cx } from "@chakra-ui/shared-utils"
 import {
   chakra,
   forwardRef,
   HTMLChakraProps,
   SystemStyleObject,
 } from "@chakra-ui/system"
-import { callAll, cx } from "@chakra-ui/shared-utils"
+import { HTMLMotionProps } from "framer-motion"
 import { usePopoverContext, usePopoverStyles } from "./popover-context"
 import { PopoverTransition, PopoverTransitionProps } from "./popover-transition"
 
 export interface PopoverContentProps extends PopoverTransitionProps {
   rootProps?: HTMLChakraProps<"div">
+  motionProps?: HTMLMotionProps<"section">
 }
 
 export const PopoverContent = forwardRef<PopoverContentProps, "section">(
   function PopoverContent(props, ref) {
-    const { rootProps, ...contentProps } = props
+    const { rootProps, motionProps, ...contentProps } = props
 
     const { getPopoverProps, getPopoverPositionerProps, onAnimationComplete } =
       usePopoverContext()
@@ -34,6 +36,7 @@ export const PopoverContent = forwardRef<PopoverContentProps, "section">(
         className="chakra-popover__popper"
       >
         <PopoverTransition
+          {...motionProps}
           {...getPopoverProps(contentProps, ref)}
           onAnimationComplete={callAll(
             onAnimationComplete,

--- a/packages/components/popover/src/popover-transition.tsx
+++ b/packages/components/popover/src/popover-transition.tsx
@@ -16,13 +16,14 @@ type HTMLMotionChakraProps<T extends keyof React.ReactHTML> = Omit<
     | "onDragStart"
     | "onAnimationStart"
     | "variants"
+    | "transition"
   > & {
     variants?: MotionVariants
   }
 
 type MotionVariants = Partial<Record<"enter" | "exit", Variant>>
 
-function mergeVariants(variants?: MotionVariants) {
+function mergeVariants(variants?: MotionVariants): any {
   if (!variants) return
   return {
     enter: {
@@ -57,29 +58,26 @@ const scaleFade: MotionVariants = {
   },
 }
 
-const Section = motion(chakra.section)
+const MotionSection = chakra(motion.section)
 
 export interface PopoverTransitionProps
   extends HTMLMotionChakraProps<"section"> {}
 
 export const PopoverTransition = forwardRef(function PopoverTransition(
-  props: HTMLMotionChakraProps<"section">,
+  props: PopoverTransitionProps,
   ref: React.Ref<any>,
 ) {
+  const { variants = scaleFade, ...rest } = props
   const { isOpen } = usePopoverContext()
   return (
-    <Section
+    <MotionSection
       ref={ref}
-      variants={mergeVariants(props.variants)}
-      {...props}
+      variants={mergeVariants(variants)}
       initial={false}
       animate={isOpen ? "enter" : "exit"}
+      {...rest}
     />
   )
-}) as React.ComponentType<HTMLMotionChakraProps<"section">>
-
-PopoverTransition.defaultProps = {
-  variants: scaleFade,
-}
+})
 
 PopoverTransition.displayName = "PopoverTransition"

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -11,7 +11,7 @@ import {
   getCSSVar,
 } from "@chakra-ui/system"
 import { omit, pick } from "@chakra-ui/object-utils"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, HTMLMotionProps, motion } from "framer-motion"
 import { Children, cloneElement } from "react"
 import { scale } from "./tooltip.transition"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
@@ -50,9 +50,10 @@ export interface TooltipProps
    * Props to be forwarded to the portal component
    */
   portalProps?: Pick<PortalProps, "appendToParentPortal" | "containerRef">
+  motionProps?: HTMLMotionProps<"div">
 }
 
-const StyledTooltip = chakra(motion.div)
+const MotionDiv = chakra(motion.div)
 
 /**
  * Tooltips display informative text when users hover, focus on, or tap an element.
@@ -76,6 +77,7 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
     background,
     backgroundColor,
     bgColor,
+    motionProps,
     ...rest
   } = ownProps
 
@@ -123,7 +125,7 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
     ? omit(_tooltipProps, ["role", "id"])
     : _tooltipProps
 
-  const hiddenProps = pick(_tooltipProps, ["role", "id"])
+  const srOnlyProps = pick(_tooltipProps, ["role", "id"])
 
   /**
    * If the `label` is empty, there's no point showing the tooltip.
@@ -146,17 +148,18 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
                 pointerEvents: "none",
               }}
             >
-              <StyledTooltip
+              <MotionDiv
                 variants={scale}
-                {...(tooltipProps as any)}
                 initial="exit"
                 animate="enter"
                 exit="exit"
+                {...motionProps}
+                {...(tooltipProps as any)}
                 __css={styles}
               >
                 {label}
                 {hasAriaLabel && (
-                  <chakra.span srOnly {...hiddenProps}>
+                  <chakra.span srOnly {...srOnlyProps}>
                     {ariaLabel}
                   </chakra.span>
                 )}
@@ -172,7 +175,7 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
                     />
                   </chakra.div>
                 )}
-              </StyledTooltip>
+              </MotionDiv>
             </chakra.div>
           </Portal>
         )}

--- a/packages/components/transition/src/collapse.tsx
+++ b/packages/components/transition/src/collapse.tsx
@@ -7,7 +7,7 @@ import {
 } from "framer-motion"
 import { forwardRef, useEffect, useState } from "react"
 import {
-  TransitionEasings,
+  TRANSITION_EASINGS,
   Variants,
   withDelay,
   WithTransitionConfig,
@@ -36,12 +36,12 @@ export interface CollapseOptions {
 
 const defaultTransitions = {
   exit: {
-    height: { duration: 0.2, ease: TransitionEasings.ease },
-    opacity: { duration: 0.3, ease: TransitionEasings.ease },
+    height: { duration: 0.2, ease: TRANSITION_EASINGS.ease },
+    opacity: { duration: 0.3, ease: TRANSITION_EASINGS.ease },
   },
   enter: {
-    height: { duration: 0.3, ease: TransitionEasings.ease },
-    opacity: { duration: 0.4, ease: TransitionEasings.ease },
+    height: { duration: 0.3, ease: TRANSITION_EASINGS.ease },
+    opacity: { duration: 0.4, ease: TRANSITION_EASINGS.ease },
   },
 }
 

--- a/packages/components/transition/src/fade.tsx
+++ b/packages/components/transition/src/fade.tsx
@@ -7,7 +7,7 @@ import {
 } from "framer-motion"
 import { forwardRef } from "react"
 import {
-  TransitionDefaults,
+  TRANSITION_DEFAULTS,
   Variants,
   withDelay,
   WithTransitionConfig,
@@ -20,13 +20,13 @@ const variants: Variants = {
   enter: ({ transition, transitionEnd, delay } = {}) => ({
     opacity: 1,
     transition:
-      transition?.enter ?? withDelay.enter(TransitionDefaults.enter, delay),
+      transition?.enter ?? withDelay.enter(TRANSITION_DEFAULTS.enter, delay),
     transitionEnd: transitionEnd?.enter,
   }),
   exit: ({ transition, transitionEnd, delay } = {}) => ({
     opacity: 0,
     transition:
-      transition?.exit ?? withDelay.exit(TransitionDefaults.exit, delay),
+      transition?.exit ?? withDelay.exit(TRANSITION_DEFAULTS.exit, delay),
     transitionEnd: transitionEnd?.exit,
   }),
 }

--- a/packages/components/transition/src/index.ts
+++ b/packages/components/transition/src/index.ts
@@ -13,4 +13,9 @@ export type { SlideDirection, SlideProps, SlideOptions } from "./slide"
 export { SlideFade, slideFadeConfig } from "./slide-fade"
 export type { SlideFadeProps } from "./slide-fade"
 
-export { TransitionEasings as EASINGS } from "./transition-utils"
+export {
+  TRANSITION_EASINGS as EASINGS,
+  getSlideTransition,
+  withDelay,
+} from "./transition-utils"
+export type { TransitionProperties } from "./transition-utils"

--- a/packages/components/transition/src/scale-fade.tsx
+++ b/packages/components/transition/src/scale-fade.tsx
@@ -7,7 +7,7 @@ import {
 } from "framer-motion"
 import { forwardRef } from "react"
 import {
-  TransitionDefaults,
+  TRANSITION_DEFAULTS,
   Variants,
   withDelay,
   WithTransitionConfig,
@@ -33,13 +33,13 @@ const variants: Variants<ScaleFadeOptions> = {
       ? { scale: initialScale, transitionEnd: transitionEnd?.exit }
       : { transitionEnd: { scale: initialScale, ...transitionEnd?.exit } }),
     transition:
-      transition?.exit ?? withDelay.exit(TransitionDefaults.exit, delay),
+      transition?.exit ?? withDelay.exit(TRANSITION_DEFAULTS.exit, delay),
   }),
   enter: ({ transitionEnd, transition, delay }) => ({
     opacity: 1,
     scale: 1,
     transition:
-      transition?.enter ?? withDelay.enter(TransitionDefaults.enter, delay),
+      transition?.enter ?? withDelay.enter(TRANSITION_DEFAULTS.enter, delay),
     transitionEnd: transitionEnd?.enter,
   }),
 }

--- a/packages/components/transition/src/slide-fade.tsx
+++ b/packages/components/transition/src/slide-fade.tsx
@@ -7,7 +7,7 @@ import {
 } from "framer-motion"
 import { forwardRef } from "react"
 import {
-  TransitionDefaults,
+  TRANSITION_DEFAULTS,
   Variants,
   withDelay,
   WithTransitionConfig,
@@ -38,7 +38,7 @@ const variants: Variants<SlideFadeOptions> = {
     x: offsetX,
     y: offsetY,
     transition:
-      transition?.exit ?? withDelay.exit(TransitionDefaults.exit, delay),
+      transition?.exit ?? withDelay.exit(TRANSITION_DEFAULTS.exit, delay),
     transitionEnd: transitionEnd?.exit,
   }),
   enter: ({ transition, transitionEnd, delay }) => ({
@@ -46,7 +46,7 @@ const variants: Variants<SlideFadeOptions> = {
     x: 0,
     y: 0,
     transition:
-      transition?.enter ?? withDelay.enter(TransitionDefaults.enter, delay),
+      transition?.enter ?? withDelay.enter(TRANSITION_DEFAULTS.enter, delay),
     transitionEnd: transitionEnd?.enter,
   }),
   exit: ({ offsetY, offsetX, transition, transitionEnd, reverse, delay }) => {
@@ -54,7 +54,7 @@ const variants: Variants<SlideFadeOptions> = {
     return {
       opacity: 0,
       transition:
-        transition?.exit ?? withDelay.exit(TransitionDefaults.exit, delay),
+        transition?.exit ?? withDelay.exit(TRANSITION_DEFAULTS.exit, delay),
       ...(reverse
         ? { ...offset, transitionEnd: transitionEnd?.exit }
         : { transitionEnd: { ...offset, ...transitionEnd?.exit } }),

--- a/packages/components/transition/src/slide.tsx
+++ b/packages/components/transition/src/slide.tsx
@@ -61,7 +61,9 @@ export interface SlideOptions {
 
 export interface SlideProps
   extends WithTransitionConfig<HTMLMotionProps<"div">>,
-    SlideOptions {}
+    SlideOptions {
+  motionProps?: HTMLMotionProps<"div">
+}
 
 export const Slide = forwardRef<HTMLDivElement, SlideProps>(function Slide(
   props,
@@ -76,6 +78,7 @@ export const Slide = forwardRef<HTMLDivElement, SlideProps>(function Slide(
     transition,
     transitionEnd,
     delay,
+    motionProps,
     ...rest
   } = props
 
@@ -104,6 +107,7 @@ export const Slide = forwardRef<HTMLDivElement, SlideProps>(function Slide(
           custom={custom}
           variants={variants as TVariants}
           style={computedStyle}
+          {...motionProps}
         />
       )}
     </AnimatePresence>

--- a/packages/components/transition/src/slide.tsx
+++ b/packages/components/transition/src/slide.tsx
@@ -9,8 +9,8 @@ import {
 import { forwardRef } from "react"
 import {
   SlideDirection,
-  slideTransition,
-  TransitionEasings,
+  getSlideTransition,
+  TRANSITION_EASINGS,
   Variants,
   withDelay,
   WithTransitionConfig,
@@ -21,7 +21,7 @@ export type { SlideDirection }
 const defaultTransition = {
   exit: {
     duration: 0.15,
-    ease: TransitionEasings.easeInOut,
+    ease: TRANSITION_EASINGS.easeInOut,
   },
   enter: {
     type: "spring",
@@ -32,7 +32,7 @@ const defaultTransition = {
 
 const variants: Variants<SlideOptions> = {
   exit: ({ direction, transition, transitionEnd, delay }) => {
-    const { exit: exitStyles } = slideTransition({ direction })
+    const { exit: exitStyles } = getSlideTransition({ direction })
     return {
       ...exitStyles,
       transition:
@@ -41,7 +41,7 @@ const variants: Variants<SlideOptions> = {
     }
   },
   enter: ({ direction, transitionEnd, transition, delay }) => {
-    const { enter: enterStyles } = slideTransition({ direction })
+    const { enter: enterStyles } = getSlideTransition({ direction })
     return {
       ...enterStyles,
       transition:
@@ -79,7 +79,7 @@ export const Slide = forwardRef<HTMLDivElement, SlideProps>(function Slide(
     ...rest
   } = props
 
-  const transitionStyles = slideTransition({ direction })
+  const transitionStyles = getSlideTransition({ direction })
   const computedStyle: MotionStyle = Object.assign(
     { position: "fixed" },
     transitionStyles.position,

--- a/packages/components/transition/src/transition-utils.ts
+++ b/packages/components/transition/src/transition-utils.ts
@@ -1,11 +1,22 @@
 import type { Target, TargetAndTransition, Transition } from "framer-motion"
 
+export type TransitionProperties = {
+  /**
+   * Custom `transition` definition for `enter` and `exit`
+   */
+  transition?: TransitionConfig
+  /**
+   * Custom `transitionEnd` definition for `enter` and `exit`
+   */
+  transitionEnd?: TransitionEndConfig
+  /**
+   * Custom `delay` definition for `enter` and `exit`
+   */
+  delay?: number | DelayConfig
+}
+
 type TargetResolver<P = {}> = (
-  props: P & {
-    transition?: TransitionConfig
-    transitionEnd?: TransitionEndConfig
-    delay?: number | DelayConfig
-  },
+  props: P & TransitionProperties,
 ) => TargetAndTransition
 
 type Variant<P = {}> = TargetAndTransition | TargetResolver<P>
@@ -24,14 +35,14 @@ export type TransitionEndConfig = WithMotionState<Target>
 
 export type DelayConfig = WithMotionState<number>
 
-export const TransitionEasings = {
+export const TRANSITION_EASINGS = {
   ease: [0.25, 0.1, 0.25, 1],
   easeIn: [0.4, 0, 1, 1],
   easeOut: [0, 0, 0.2, 1],
   easeInOut: [0.4, 0, 0.2, 1],
 } as const
 
-export const TransitionVariants = {
+export const TRANSITION_VARIANTS = {
   scale: {
     enter: { scale: 1 },
     exit: { scale: 0.95 },
@@ -80,55 +91,44 @@ export const TransitionVariants = {
 
 export type SlideDirection = "top" | "left" | "bottom" | "right"
 
-export function slideTransition(options?: { direction?: SlideDirection }) {
+export function getSlideTransition(options?: { direction?: SlideDirection }) {
   const side = options?.direction ?? "right"
   switch (side) {
     case "right":
-      return TransitionVariants.slideRight
+      return TRANSITION_VARIANTS.slideRight
     case "left":
-      return TransitionVariants.slideLeft
+      return TRANSITION_VARIANTS.slideLeft
     case "bottom":
-      return TransitionVariants.slideDown
+      return TRANSITION_VARIANTS.slideDown
     case "top":
-      return TransitionVariants.slideUp
+      return TRANSITION_VARIANTS.slideUp
     default:
-      return TransitionVariants.slideRight
+      return TRANSITION_VARIANTS.slideRight
   }
 }
 
-export const TransitionDefaults = {
+export const TRANSITION_DEFAULTS = {
   enter: {
     duration: 0.2,
-    ease: TransitionEasings.easeOut,
+    ease: TRANSITION_EASINGS.easeOut,
   },
   exit: {
     duration: 0.1,
-    ease: TransitionEasings.easeIn,
+    ease: TRANSITION_EASINGS.easeIn,
   },
 } as const
 
-export type WithTransitionConfig<P extends object> = Omit<P, "transition"> & {
-  /**
-   * If `true`, the element will unmount when `in={false}` and animation is done
-   */
-  unmountOnExit?: boolean
-  /**
-   * Show the component; triggers when enter or exit states
-   */
-  in?: boolean
-  /**
-   * Custom `transition` definition for `enter` and `exit`
-   */
-  transition?: TransitionConfig
-  /**
-   * Custom `transitionEnd` definition for `enter` and `exit`
-   */
-  transitionEnd?: TransitionEndConfig
-  /**
-   * Custom `delay` definition for `enter` and `exit`
-   */
-  delay?: number | DelayConfig
-}
+export type WithTransitionConfig<P extends object> = Omit<P, "transition"> &
+  TransitionProperties & {
+    /**
+     * If `true`, the element will unmount when `in={false}` and animation is done
+     */
+    unmountOnExit?: boolean
+    /**
+     * Show the component; triggers when enter or exit states
+     */
+    in?: boolean
+  }
 
 export const withDelay = {
   enter: (


### PR DESCRIPTION
Closes #6449
Closes #5843
Closes #6189
Closes #5883

## 📝 Description

This PR adds support for overriding framer motion props across components.

## ⛳️ Current behavior (updates)

It's almost impossible to override the framer motion config for menu, popover, tooltip, etc.

## 🚀 New behavior

Motion-related elements now have `motionProps` prop that allows users to have full control over the styling.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
