### PR TITLE
fix(slider): default value cannot be set after update

### DIFF
--- a/.changeset/strange-buses-exercise.md
+++ b/.changeset/strange-buses-exercise.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react-use-controllable-state": patch
+---
+
+Fix slider default value issue

--- a/packages/hooks/use-controllable-state/src/index.ts
+++ b/packages/hooks/use-controllable-state/src/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { useCallbackRef } from "@chakra-ui/react-use-callback-ref"
 
 /**
@@ -36,11 +36,10 @@ export function useControllableState<T>(props: UseControllableStateProps<T>) {
   const shouldUpdateProp = useCallbackRef(shouldUpdate)
 
   const [uncontrolledState, setUncontrolledState] = useState(defaultValue as T)
-
   const controlled = valueProp !== undefined
   const value = controlled ? valueProp : uncontrolledState
 
-  const setValue = useCallback(
+  const setValue = useCallbackRef(
     (next: React.SetStateAction<T>) => {
       const setter = next as (prevState?: T) => T
       const nextValue = typeof next === "function" ? setter(value) : next


### PR DESCRIPTION
fix(slider): default value cannot be set after update

Fixes #6619