### PR TITLE
refactor(motion-import): lazy load framer-motion 

### DIFF
--- a/.changeset/serious-dodos-sniff.md
+++ b/.changeset/serious-dodos-sniff.md
@@ -1,0 +1,12 @@
+---
+"@chakra-ui/checkbox": minor
+"@chakra-ui/menu": minor
+"@chakra-ui/modal": minor
+"@chakra-ui/popover": minor
+"@chakra-ui/popper": minor
+"@chakra-ui/toast": minor
+"@chakra-ui/tooltip": minor
+"@chakra-ui/transition": minor
+---
+
+Lazy load motion features for components which use framer-motion

--- a/packages/components/button/stories/button.stories.tsx
+++ b/packages/components/button/stories/button.stories.tsx
@@ -10,7 +10,7 @@ import * as React from "react"
 import { FaFacebook, FaTwitter } from "react-icons/fa"
 import { MdBuild, MdCall } from "react-icons/md"
 import { BeatLoader } from "react-spinners"
-import { m } from "framer-motion"
+import { domAnimation, LazyMotion, m } from "framer-motion"
 import { Meta, StoryFn } from "@storybook/react"
 import { ThemingProps } from "@chakra-ui/system"
 import { theme } from "@chakra-ui/theme"
@@ -269,17 +269,19 @@ export const WithMotion = () => {
       <Button onClick={() => setBinary((binary) => !binary)}>
         Toggle binary state: {String(binary)}
       </Button>
-      <MotionButton
-        {...motionConfig}
-        animate={{
-          scale: binary ? 1.2 : 1,
-          backgroundImage: binary
-            ? BG_GRADIENT_SOFT
-            : BG_GRADIENT_SOFT_REVERSED,
-        }}
-      >
-        ({String(binary)}) Doesn't work
-      </MotionButton>
+      <LazyMotion features={domAnimation}>
+        <MotionButton
+          {...motionConfig}
+          animate={{
+            scale: binary ? 1.2 : 1,
+            backgroundImage: binary
+              ? BG_GRADIENT_SOFT
+              : BG_GRADIENT_SOFT_REVERSED,
+          }}
+        >
+          ({String(binary)}) Doesn't work
+        </MotionButton>
+      </LazyMotion>
     </>
   )
 }

--- a/packages/components/button/stories/button.stories.tsx
+++ b/packages/components/button/stories/button.stories.tsx
@@ -10,7 +10,7 @@ import * as React from "react"
 import { FaFacebook, FaTwitter } from "react-icons/fa"
 import { MdBuild, MdCall } from "react-icons/md"
 import { BeatLoader } from "react-spinners"
-import { motion } from "framer-motion"
+import { m } from "framer-motion"
 import { Meta, StoryFn } from "@storybook/react"
 import { ThemingProps } from "@chakra-ui/system"
 import { theme } from "@chakra-ui/theme"
@@ -258,7 +258,7 @@ const motionConfig = {
   },
 }
 
-const MotionButton = motion(Button)
+const MotionButton = m(Button)
 const BG_GRADIENT_SOFT = `linear-gradient(to right, #fa8080, #F40000)`
 const BG_GRADIENT_SOFT_REVERSED = `linear-gradient(to right, #F40000, #fa8080)`
 

--- a/packages/components/checkbox/src/checkbox-icon.tsx
+++ b/packages/components/checkbox/src/checkbox-icon.tsx
@@ -1,5 +1,11 @@
 import { chakra, PropsOf, ChakraComponent } from "@chakra-ui/system"
-import { AnimatePresence, CustomDomComponent, m } from "framer-motion"
+import {
+  AnimatePresence,
+  CustomDomComponent,
+  domAnimation,
+  LazyMotion,
+  m,
+} from "framer-motion"
 
 function __motion<T extends ChakraComponent<any, any>>(
   el: T,
@@ -16,30 +22,32 @@ const MotionSvg = __motion(chakra.svg)
 
 function CheckIcon(props: PropsOf<typeof MotionSvg>) {
   return (
-    <MotionSvg
-      width="1.2em"
-      viewBox="0 0 12 10"
-      variants={{
-        unchecked: {
-          opacity: 0,
-          strokeDashoffset: 16,
-        },
-        checked: {
-          opacity: 1,
-          strokeDashoffset: 0,
-          transition: { duration: 0.2 },
-        },
-      }}
-      style={{
-        fill: "none",
-        strokeWidth: 2,
-        stroke: "currentColor",
-        strokeDasharray: 16,
-      }}
-      {...props}
-    >
-      <polyline points="1.5 6 4.5 9 10.5 1" />
-    </MotionSvg>
+    <LazyMotion features={domAnimation}>
+      <MotionSvg
+        width="1.2em"
+        viewBox="0 0 12 10"
+        variants={{
+          unchecked: {
+            opacity: 0,
+            strokeDashoffset: 16,
+          },
+          checked: {
+            opacity: 1,
+            strokeDashoffset: 0,
+            transition: { duration: 0.2 },
+          },
+        }}
+        style={{
+          fill: "none",
+          strokeWidth: 2,
+          stroke: "currentColor",
+          strokeDasharray: 16,
+        }}
+        {...props}
+      >
+        <polyline points="1.5 6 4.5 9 10.5 1" />
+      </MotionSvg>
+    </LazyMotion>
   )
 }
 

--- a/packages/components/checkbox/src/checkbox-icon.tsx
+++ b/packages/components/checkbox/src/checkbox-icon.tsx
@@ -1,14 +1,14 @@
 import { chakra, PropsOf, ChakraComponent } from "@chakra-ui/system"
-import { AnimatePresence, CustomDomComponent, motion } from "framer-motion"
+import { AnimatePresence, CustomDomComponent, m } from "framer-motion"
 
 function __motion<T extends ChakraComponent<any, any>>(
   el: T,
 ): CustomDomComponent<PropsOf<T>> {
-  const m = motion as any
-  if ("custom" in m && typeof m.custom === "function") {
-    return m.custom(el)
+  const mF = m as any
+  if ("custom" in mF && typeof mF.custom === "function") {
+    return mF.custom(el)
   }
-  return m(el)
+  return mF(el)
 }
 
 // @future: only call `motion(chakra.svg)` when we drop framer-motion v3 support
@@ -74,7 +74,7 @@ function CheckboxTransition({ open, children }: any) {
   return (
     <AnimatePresence initial={false}>
       {open && (
-        <motion.div
+        <m.div
           variants={{
             unchecked: { scale: 0.5 },
             checked: { scale: 1 },
@@ -90,7 +90,7 @@ function CheckboxTransition({ open, children }: any) {
           }}
         >
           {children}
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   )

--- a/packages/components/menu/src/menu-list.tsx
+++ b/packages/components/menu/src/menu-list.tsx
@@ -7,7 +7,7 @@ import {
 } from "@chakra-ui/system"
 import { cx, callAll } from "@chakra-ui/shared-utils"
 
-import { CustomDomComponent, motion, Variants } from "framer-motion"
+import { CustomDomComponent, m, Variants } from "framer-motion"
 import { useMenuStyles } from "./menu"
 import { useMenuContext, useMenuList, useMenuPositioner } from "./use-menu"
 
@@ -44,11 +44,11 @@ const motionVariants: Variants = {
 function __motion<T extends ChakraComponent<any, any>>(
   el: T,
 ): CustomDomComponent<PropsOf<T>> {
-  const m = motion as any
-  if ("custom" in m && typeof m.custom === "function") {
-    return m.custom(el)
+  const mF = m as any
+  if ("custom" in mF && typeof mF.custom === "function") {
+    return mF.custom(el)
   }
-  return m(el)
+  return mF(el)
 }
 
 // @future: only call `motion(chakra.div)` when we drop framer-motion v3 support

--- a/packages/components/menu/src/menu-list.tsx
+++ b/packages/components/menu/src/menu-list.tsx
@@ -7,7 +7,13 @@ import {
 } from "@chakra-ui/system"
 import { cx, callAll } from "@chakra-ui/shared-utils"
 
-import { CustomDomComponent, m, Variants } from "framer-motion"
+import {
+  CustomDomComponent,
+  domAnimation,
+  LazyMotion,
+  m,
+  Variants,
+} from "framer-motion"
 import { useMenuStyles } from "./menu"
 import { useMenuContext, useMenuList, useMenuPositioner } from "./use-menu"
 
@@ -72,26 +78,28 @@ export const MenuList = forwardRef<MenuListProps, "div">((props, ref) => {
       {...positionerProps}
       __css={{ zIndex: props.zIndex ?? styles.list?.zIndex }}
     >
-      <MenuTransition
-        {...ownProps}
-        /**
-         * We could call this on either `onAnimationComplete` or `onUpdate`.
-         * It seems the re-focusing works better with the `onUpdate`
-         */
-        onUpdate={onTransitionEnd}
-        onAnimationComplete={callAll(
-          animated.onComplete,
-          ownProps.onAnimationComplete,
-        )}
-        className={cx("chakra-menu__menu-list", ownProps.className)}
-        variants={motionVariants}
-        initial={false}
-        animate={isOpen ? "enter" : "exit"}
-        __css={{
-          outline: 0,
-          ...styles.list,
-        }}
-      />
+      <LazyMotion features={domAnimation}>
+        <MenuTransition
+          {...ownProps}
+          /**
+           * We could call this on either `onAnimationComplete` or `onUpdate`.
+           * It seems the re-focusing works better with the `onUpdate`
+           */
+          onUpdate={onTransitionEnd}
+          onAnimationComplete={callAll(
+            animated.onComplete,
+            ownProps.onAnimationComplete,
+          )}
+          className={cx("chakra-menu__menu-list", ownProps.className)}
+          variants={motionVariants}
+          initial={false}
+          animate={isOpen ? "enter" : "exit"}
+          __css={{
+            outline: 0,
+            ...styles.list,
+          }}
+        />
+      </LazyMotion>
     </chakra.div>
   )
 })

--- a/packages/components/modal/src/modal-overlay.tsx
+++ b/packages/components/modal/src/modal-overlay.tsx
@@ -6,11 +6,11 @@ import {
   forwardRef,
 } from "@chakra-ui/system"
 import { fadeConfig } from "@chakra-ui/transition"
-import { motion, HTMLMotionProps } from "framer-motion"
+import { m, HTMLMotionProps } from "framer-motion"
 
 import { useModalStyles, useModalContext } from "./modal"
 
-const MotionDiv = chakra(motion.div)
+const MotionDiv = chakra(m.div)
 
 export interface ModalOverlayProps
   extends Omit<HTMLMotionProps<"div">, "color" | "transition">,

--- a/packages/components/modal/src/modal-overlay.tsx
+++ b/packages/components/modal/src/modal-overlay.tsx
@@ -6,7 +6,7 @@ import {
   forwardRef,
 } from "@chakra-ui/system"
 import { fadeConfig } from "@chakra-ui/transition"
-import { m, HTMLMotionProps } from "framer-motion"
+import { domAnimation, LazyMotion, m, HTMLMotionProps } from "framer-motion"
 
 import { useModalStyles, useModalContext } from "./modal"
 
@@ -43,13 +43,15 @@ export const ModalOverlay = forwardRef<ModalOverlayProps, "div">(
     const motionProps: any = motionPreset === "none" ? {} : fadeConfig
 
     return (
-      <MotionDiv
-        {...motionProps}
-        __css={overlayStyle}
-        ref={ref}
-        className={_className}
-        {...rest}
-      />
+      <LazyMotion features={domAnimation}>
+        <MotionDiv
+          {...motionProps}
+          __css={overlayStyle}
+          ref={ref}
+          className={_className}
+          {...rest}
+        />
+      </LazyMotion>
     )
   },
 )

--- a/packages/components/modal/src/modal-transition.tsx
+++ b/packages/components/modal/src/modal-transition.tsx
@@ -1,6 +1,6 @@
 import { chakra, ChakraProps } from "@chakra-ui/system"
 import { scaleFadeConfig, slideFadeConfig } from "@chakra-ui/transition"
-import { HTMLMotionProps, m } from "framer-motion"
+import { domAnimation, HTMLMotionProps, LazyMotion, m } from "framer-motion"
 import { forwardRef } from "react"
 
 export interface ModalTransitionProps
@@ -31,7 +31,11 @@ export const ModalTransition = forwardRef(
   (props: ModalTransitionProps, ref: React.Ref<any>) => {
     const { preset, ...rest } = props
     const motionProps = transitions[preset]
-    return <Motion ref={ref} {...(motionProps as ChakraProps)} {...rest} />
+    return (
+      <LazyMotion features={domAnimation}>
+        <Motion ref={ref} {...(motionProps as ChakraProps)} {...rest} />
+      </LazyMotion>
+    )
   },
 )
 

--- a/packages/components/modal/src/modal-transition.tsx
+++ b/packages/components/modal/src/modal-transition.tsx
@@ -1,6 +1,6 @@
 import { chakra, ChakraProps } from "@chakra-ui/system"
 import { scaleFadeConfig, slideFadeConfig } from "@chakra-ui/transition"
-import { HTMLMotionProps, motion } from "framer-motion"
+import { HTMLMotionProps, m } from "framer-motion"
 import { forwardRef } from "react"
 
 export interface ModalTransitionProps
@@ -25,7 +25,7 @@ const transitions = {
   none: {},
 }
 
-const Motion = chakra(motion.section)
+const Motion = chakra(m.section)
 
 export const ModalTransition = forwardRef(
   (props: ModalTransitionProps, ref: React.Ref<any>) => {

--- a/packages/components/popover/src/popover-transition.tsx
+++ b/packages/components/popover/src/popover-transition.tsx
@@ -1,5 +1,5 @@
 import { chakra, HTMLChakraProps, forwardRef } from "@chakra-ui/system"
-import { HTMLMotionProps, motion, Variant } from "framer-motion"
+import { HTMLMotionProps, m, Variant } from "framer-motion"
 import React from "react"
 import { usePopoverContext } from "./popover-context"
 
@@ -57,7 +57,7 @@ const scaleFade: MotionVariants = {
   },
 }
 
-const Section = motion(chakra.section)
+const Section = m(chakra.section)
 
 export interface PopoverTransitionProps
   extends HTMLMotionChakraProps<"section"> {}

--- a/packages/components/popover/src/popover-transition.tsx
+++ b/packages/components/popover/src/popover-transition.tsx
@@ -1,5 +1,11 @@
 import { chakra, HTMLChakraProps, forwardRef } from "@chakra-ui/system"
-import { HTMLMotionProps, m, Variant } from "framer-motion"
+import {
+  domAnimation,
+  HTMLMotionProps,
+  LazyMotion,
+  m,
+  Variant,
+} from "framer-motion"
 import React from "react"
 import { usePopoverContext } from "./popover-context"
 
@@ -68,13 +74,15 @@ export const PopoverTransition = forwardRef(function PopoverTransition(
 ) {
   const { isOpen } = usePopoverContext()
   return (
-    <Section
-      ref={ref}
-      variants={mergeVariants(props.variants)}
-      {...props}
-      initial={false}
-      animate={isOpen ? "enter" : "exit"}
-    />
+    <LazyMotion features={domAnimation}>
+      <Section
+        ref={ref}
+        variants={mergeVariants(props.variants)}
+        {...props}
+        initial={false}
+        animate={isOpen ? "enter" : "exit"}
+      />
+    </LazyMotion>
   )
 }) as React.ComponentType<HTMLMotionChakraProps<"section">>
 

--- a/packages/components/popper/README.md
+++ b/packages/components/popper/README.md
@@ -105,7 +105,13 @@ popper and transition to different elements.
 // 1. Import components
 import { useDisclosure } from "@chakra-ui/hooks"
 import { usePopper } from "@chakra-ui/popper"
-import { m, AnimatePresence, Variants } from "framer-motion"
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m,
+  Variants,
+} from "framer-motion"
 
 export function Example() {
   // 2. Create toggle state
@@ -135,31 +141,33 @@ export function Example() {
       <div {...getPopperProps()}>
         <AnimatePresence>
           {isOpen && (
-            <m.div
-              transition={{
-                type: "spring",
-                duration: 0.2,
-              }}
-              variants={slide}
-              initial="exit"
-              animate="enter"
-              exit="exit"
-              style={{
-                background: "red",
-                width: 200,
-                transformOrigin,
-                borderRadius: 4,
-              }}
-            >
-              Testing
-              <div
-                {...getArrowProps({
-                  style: {
-                    background: "red",
-                  },
-                })}
-              />
-            </m.div>
+            <LazyMotion features={domAnimation}>
+              <m.div
+                transition={{
+                  type: "spring",
+                  duration: 0.2,
+                }}
+                variants={slide}
+                initial="exit"
+                animate="enter"
+                exit="exit"
+                style={{
+                  background: "red",
+                  width: 200,
+                  transformOrigin,
+                  borderRadius: 4,
+                }}
+              >
+                Testing
+                <div
+                  {...getArrowProps({
+                    style: {
+                      background: "red",
+                    },
+                  })}
+                />
+              </m.div>
+            </LazyMotion>
           )}
         </AnimatePresence>
       </div>

--- a/packages/components/popper/README.md
+++ b/packages/components/popper/README.md
@@ -105,7 +105,7 @@ popper and transition to different elements.
 // 1. Import components
 import { useDisclosure } from "@chakra-ui/hooks"
 import { usePopper } from "@chakra-ui/popper"
-import { motion, AnimatePresence, Variants } from "framer-motion"
+import { m, AnimatePresence, Variants } from "framer-motion"
 
 export function Example() {
   // 2. Create toggle state
@@ -135,7 +135,7 @@ export function Example() {
       <div {...getPopperProps()}>
         <AnimatePresence>
           {isOpen && (
-            <motion.div
+            <m.div
               transition={{
                 type: "spring",
                 duration: 0.2,
@@ -159,7 +159,7 @@ export function Example() {
                   },
                 })}
               />
-            </motion.div>
+            </m.div>
           )}
         </AnimatePresence>
       </div>

--- a/packages/components/popper/stories/popper-v2.stories.tsx
+++ b/packages/components/popper/stories/popper-v2.stories.tsx
@@ -1,4 +1,4 @@
-import { m } from "framer-motion"
+import { domAnimation, LazyMotion, m } from "framer-motion"
 import * as React from "react"
 import { usePopper } from "../src"
 
@@ -116,29 +116,31 @@ export const WithAnimation = () => {
         Trigger
       </button>
       <div {...getPopperProps()}>
-        <m.div
-          style={{
-            transformOrigin,
-            background: "red",
-            padding: 8,
-          }}
-          transition={{ duration: 0.15 }}
-          initial={false}
-          animate={
-            isOpen ? { scale: 1, opacity: 1 } : { scale: 0.85, opacity: 0.01 }
-          }
-        >
-          <div
-            {...getArrowProps({
-              shadowColor: "rgba(0,0,0,0.3)",
-              size: "8px",
-              bg: "red",
-            })}
+        <LazyMotion features={domAnimation}>
+          <m.div
+            style={{
+              transformOrigin,
+              background: "red",
+              padding: 8,
+            }}
+            transition={{ duration: 0.15 }}
+            initial={false}
+            animate={
+              isOpen ? { scale: 1, opacity: 1 } : { scale: 0.85, opacity: 0.01 }
+            }
           >
-            <div {...getArrowInnerProps()} />
-          </div>
-          Popper
-        </m.div>
+            <div
+              {...getArrowProps({
+                shadowColor: "rgba(0,0,0,0.3)",
+                size: "8px",
+                bg: "red",
+              })}
+            >
+              <div {...getArrowInnerProps()} />
+            </div>
+            Popper
+          </m.div>
+        </LazyMotion>
       </div>
     </div>
   )

--- a/packages/components/popper/stories/popper-v2.stories.tsx
+++ b/packages/components/popper/stories/popper-v2.stories.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion"
+import { m } from "framer-motion"
 import * as React from "react"
 import { usePopper } from "../src"
 
@@ -116,7 +116,7 @@ export const WithAnimation = () => {
         Trigger
       </button>
       <div {...getPopperProps()}>
-        <motion.div
+        <m.div
           style={{
             transformOrigin,
             background: "red",
@@ -138,7 +138,7 @@ export const WithAnimation = () => {
             <div {...getArrowInnerProps()} />
           </div>
           Popper
-        </motion.div>
+        </m.div>
       </div>
     </div>
   )

--- a/packages/components/popper/stories/popper.stories.tsx
+++ b/packages/components/popper/stories/popper.stories.tsx
@@ -1,5 +1,5 @@
 import { useDisclosure } from "@chakra-ui/hooks"
-import { motion, Variants } from "framer-motion"
+import { m, Variants } from "framer-motion"
 import * as React from "react"
 import { usePopper } from "../src"
 
@@ -62,7 +62,7 @@ export const WithTransition = () => {
         Toggle
       </button>
       <div ref={popperRef} style={{ ["--popper-arrow-bg" as string]: "red" }}>
-        <motion.div
+        <m.div
           transition={{
             duration: 0.15,
             easings: "easeInOut",
@@ -81,7 +81,7 @@ export const WithTransition = () => {
           <div data-popper-arrow="">
             <div data-popper-arrow-inner="" />
           </div>
-        </motion.div>
+        </m.div>
       </div>
     </>
   )

--- a/packages/components/popper/stories/popper.stories.tsx
+++ b/packages/components/popper/stories/popper.stories.tsx
@@ -1,5 +1,5 @@
 import { useDisclosure } from "@chakra-ui/hooks"
-import { m, Variants } from "framer-motion"
+import { domAnimation, LazyMotion, m, Variants } from "framer-motion"
 import * as React from "react"
 import { usePopper } from "../src"
 
@@ -62,26 +62,28 @@ export const WithTransition = () => {
         Toggle
       </button>
       <div ref={popperRef} style={{ ["--popper-arrow-bg" as string]: "red" }}>
-        <m.div
-          transition={{
-            duration: 0.15,
-            easings: "easeInOut",
-          }}
-          variants={slide}
-          initial={false}
-          animate={isOpen ? "enter" : "exit"}
-          style={{
-            background: bg,
-            width: 200,
-            transformOrigin: "var(--popper-transform-origin)",
-            borderRadius: 4,
-          }}
-        >
-          Testing
-          <div data-popper-arrow="">
-            <div data-popper-arrow-inner="" />
-          </div>
-        </m.div>
+        <LazyMotion features={domAnimation}>
+          <m.div
+            transition={{
+              duration: 0.15,
+              easings: "easeInOut",
+            }}
+            variants={slide}
+            initial={false}
+            animate={isOpen ? "enter" : "exit"}
+            style={{
+              background: bg,
+              width: 200,
+              transformOrigin: "var(--popper-transform-origin)",
+              borderRadius: 4,
+            }}
+          >
+            Testing
+            <div data-popper-arrow="">
+              <div data-popper-arrow-inner="" />
+            </div>
+          </m.div>
+        </LazyMotion>
       </div>
     </>
   )

--- a/packages/components/system/stories/system.stories.tsx
+++ b/packages/components/system/stories/system.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { motion } from "framer-motion"
+import { m } from "framer-motion"
 import {
   chakra,
   ThemeProvider,
@@ -12,7 +12,7 @@ export default {
   title: "System / Core",
 }
 
-const MotionBox = motion(chakra.div)
+const MotionBox = m(chakra.div)
 
 export const WithFramerMotion = () => (
   <MotionBox

--- a/packages/components/system/stories/system.stories.tsx
+++ b/packages/components/system/stories/system.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { m } from "framer-motion"
+import { domAnimation, LazyMotion, m } from "framer-motion"
 import {
   chakra,
   ThemeProvider,
@@ -15,18 +15,20 @@ export default {
 const MotionBox = m(chakra.div)
 
 export const WithFramerMotion = () => (
-  <MotionBox
-    mt="40px"
-    w="40px"
-    h="40px"
-    bg="red.200"
-    ml="60px"
-    animate={{
-      scale: [1, 2, 2, 1, 1],
-      rotate: [0, 0, 270, 270, 0],
-      borderRadius: ["20%", "20%", "50%", "50%", "20%"],
-    }}
-  />
+  <LazyMotion features={domAnimation}>
+    <MotionBox
+      mt="40px"
+      w="40px"
+      h="40px"
+      bg="red.200"
+      ml="60px"
+      animate={{
+        scale: [1, 2, 2, 1, 1],
+        rotate: [0, 0, 270, 270, 0],
+        borderRadius: ["20%", "20%", "50%", "50%", "20%"],
+      }}
+    />
+  </LazyMotion>
 )
 
 export const ApplyProp = () => (

--- a/packages/components/toast/src/toast.component.tsx
+++ b/packages/components/toast/src/toast.component.tsx
@@ -1,7 +1,13 @@
 import { useTimeout } from "@chakra-ui/react-use-timeout"
 import { useUpdateEffect } from "@chakra-ui/react-use-update-effect"
 import { runIfFn } from "@chakra-ui/shared-utils"
-import { m, useIsPresent, Variants } from "framer-motion"
+import {
+  LazyMotion,
+  domAnimation,
+  m,
+  useIsPresent,
+  Variants,
+} from "framer-motion"
 import { chakra } from "@chakra-ui/system"
 import type { ToastOptions } from "./toast.types"
 import { getToastStyle } from "./toast.utils"
@@ -102,27 +108,29 @@ export const ToastComponent = memo((props: ToastComponentProps) => {
   const toastStyle = useMemo(() => getToastStyle(position), [position])
 
   return (
-    <m.li
-      layout
-      className="chakra-toast"
-      variants={motionVariants}
-      initial="initial"
-      animate="animate"
-      exit="exit"
-      onHoverStart={onMouseEnter}
-      onHoverEnd={onMouseLeave}
-      custom={{ position }}
-      style={toastStyle}
-    >
-      <chakra.div
-        role="status"
-        aria-atomic="true"
-        className="chakra-toast__inner"
-        __css={containerStyles}
+    <LazyMotion features={domAnimation}>
+      <m.li
+        layout
+        className="chakra-toast"
+        variants={motionVariants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        onHoverStart={onMouseEnter}
+        onHoverEnd={onMouseLeave}
+        custom={{ position }}
+        style={toastStyle}
       >
-        {runIfFn(message, { id, onClose: close })}
-      </chakra.div>
-    </m.li>
+        <chakra.div
+          role="status"
+          aria-atomic="true"
+          className="chakra-toast__inner"
+          __css={containerStyles}
+        >
+          {runIfFn(message, { id, onClose: close })}
+        </chakra.div>
+      </m.li>
+    </LazyMotion>
   )
 })
 

--- a/packages/components/toast/src/toast.component.tsx
+++ b/packages/components/toast/src/toast.component.tsx
@@ -1,7 +1,7 @@
 import { useTimeout } from "@chakra-ui/react-use-timeout"
 import { useUpdateEffect } from "@chakra-ui/react-use-update-effect"
 import { runIfFn } from "@chakra-ui/shared-utils"
-import { motion, useIsPresent, Variants } from "framer-motion"
+import { m, useIsPresent, Variants } from "framer-motion"
 import { chakra } from "@chakra-ui/system"
 import type { ToastOptions } from "./toast.types"
 import { getToastStyle } from "./toast.utils"
@@ -102,7 +102,7 @@ export const ToastComponent = memo((props: ToastComponentProps) => {
   const toastStyle = useMemo(() => getToastStyle(position), [position])
 
   return (
-    <motion.li
+    <m.li
       layout
       className="chakra-toast"
       variants={motionVariants}
@@ -122,7 +122,7 @@ export const ToastComponent = memo((props: ToastComponentProps) => {
       >
         {runIfFn(message, { id, onClose: close })}
       </chakra.div>
-    </motion.li>
+    </m.li>
   )
 })
 

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -11,7 +11,7 @@ import {
   getCSSVar,
 } from "@chakra-ui/system"
 import { omit, pick } from "@chakra-ui/object-utils"
-import { AnimatePresence, m } from "framer-motion"
+import { AnimatePresence, domAnimation, LazyMotion, m } from "framer-motion"
 import { Children, cloneElement } from "react"
 import { scale } from "./tooltip.transition"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
@@ -146,33 +146,35 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
                 pointerEvents: "none",
               }}
             >
-              <StyledTooltip
-                variants={scale}
-                {...(tooltipProps as any)}
-                initial="exit"
-                animate="enter"
-                exit="exit"
-                __css={styles}
-              >
-                {label}
-                {hasAriaLabel && (
-                  <chakra.span srOnly {...hiddenProps}>
-                    {ariaLabel}
-                  </chakra.span>
-                )}
-                {hasArrow && (
-                  <chakra.div
-                    data-popper-arrow
-                    className="chakra-tooltip__arrow-wrapper"
-                  >
+              <LazyMotion features={domAnimation}>
+                <StyledTooltip
+                  variants={scale}
+                  {...(tooltipProps as any)}
+                  initial="exit"
+                  animate="enter"
+                  exit="exit"
+                  __css={styles}
+                >
+                  {label}
+                  {hasAriaLabel && (
+                    <chakra.span srOnly {...hiddenProps}>
+                      {ariaLabel}
+                    </chakra.span>
+                  )}
+                  {hasArrow && (
                     <chakra.div
-                      data-popper-arrow-inner
-                      className="chakra-tooltip__arrow"
-                      __css={{ bg: styles.bg }}
-                    />
-                  </chakra.div>
-                )}
-              </StyledTooltip>
+                      data-popper-arrow
+                      className="chakra-tooltip__arrow-wrapper"
+                    >
+                      <chakra.div
+                        data-popper-arrow-inner
+                        className="chakra-tooltip__arrow"
+                        __css={{ bg: styles.bg }}
+                      />
+                    </chakra.div>
+                  )}
+                </StyledTooltip>
+              </LazyMotion>
             </chakra.div>
           </Portal>
         )}

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -11,7 +11,7 @@ import {
   getCSSVar,
 } from "@chakra-ui/system"
 import { omit, pick } from "@chakra-ui/object-utils"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, m } from "framer-motion"
 import { Children, cloneElement } from "react"
 import { scale } from "./tooltip.transition"
 import { useTooltip, UseTooltipProps } from "./use-tooltip"
@@ -52,7 +52,7 @@ export interface TooltipProps
   portalProps?: Pick<PortalProps, "appendToParentPortal" | "containerRef">
 }
 
-const StyledTooltip = chakra(motion.div)
+const StyledTooltip = chakra(m.div)
 
 /**
  * Tooltips display informative text when users hover, focus on, or tap an element.

--- a/packages/components/tooltip/stories/tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/tooltip.stories.tsx
@@ -2,7 +2,7 @@ import { Modal, ModalContent, ModalOverlay } from "@chakra-ui/modal"
 import { Portal } from "@chakra-ui/portal"
 import { Button } from "@chakra-ui/button"
 import { chakra } from "@chakra-ui/system"
-import { AnimatePresence, m } from "framer-motion"
+import { AnimatePresence, domAnimation, LazyMotion, m } from "framer-motion"
 import * as React from "react"
 import { Tooltip, useTooltip } from "../src"
 
@@ -81,37 +81,39 @@ export const WithTransition = () => {
         {isOpen && (
           <Portal>
             <div {...getTooltipPositionerProps()}>
-              <m.div
-                initial="exit"
-                animate="enter"
-                exit="exit"
-                {...(getTooltipProps() as any)}
-              >
+              <LazyMotion features={domAnimation}>
                 <m.div
-                  transition={{
-                    duration: 0.12,
-                    ease: [0.4, 0, 0.2, 1],
-                    bounce: 0.5,
-                  }}
-                  variants={{
-                    exit: { scale: 0.9, opacity: 0 },
-                    enter: { scale: 1, opacity: 1 },
-                  }}
-                  style={{
-                    transformOrigin: "var(--popper-transform-origin)",
-                    background: "tomato",
-                    ["--popper-arrow-bg" as string]: "tomato",
-                    color: "white",
-                    borderRadius: "4px",
-                    padding: "0.5em 1em",
-                  }}
+                  initial="exit"
+                  animate="enter"
+                  exit="exit"
+                  {...(getTooltipProps() as any)}
                 >
-                  Fade! This is tooltip
-                  <div data-popper-arrow>
-                    <div data-popper-arrow-inner />
-                  </div>
+                  <m.div
+                    transition={{
+                      duration: 0.12,
+                      ease: [0.4, 0, 0.2, 1],
+                      bounce: 0.5,
+                    }}
+                    variants={{
+                      exit: { scale: 0.9, opacity: 0 },
+                      enter: { scale: 1, opacity: 1 },
+                    }}
+                    style={{
+                      transformOrigin: "var(--popper-transform-origin)",
+                      background: "tomato",
+                      ["--popper-arrow-bg" as string]: "tomato",
+                      color: "white",
+                      borderRadius: "4px",
+                      padding: "0.5em 1em",
+                    }}
+                  >
+                    Fade! This is tooltip
+                    <div data-popper-arrow>
+                      <div data-popper-arrow-inner />
+                    </div>
+                  </m.div>
                 </m.div>
-              </m.div>
+              </LazyMotion>
             </div>
           </Portal>
         )}

--- a/packages/components/tooltip/stories/tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/tooltip.stories.tsx
@@ -2,7 +2,7 @@ import { Modal, ModalContent, ModalOverlay } from "@chakra-ui/modal"
 import { Portal } from "@chakra-ui/portal"
 import { Button } from "@chakra-ui/button"
 import { chakra } from "@chakra-ui/system"
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, m } from "framer-motion"
 import * as React from "react"
 import { Tooltip, useTooltip } from "../src"
 
@@ -81,13 +81,13 @@ export const WithTransition = () => {
         {isOpen && (
           <Portal>
             <div {...getTooltipPositionerProps()}>
-              <motion.div
+              <m.div
                 initial="exit"
                 animate="enter"
                 exit="exit"
                 {...(getTooltipProps() as any)}
               >
-                <motion.div
+                <m.div
                   transition={{
                     duration: 0.12,
                     ease: [0.4, 0, 0.2, 1],
@@ -110,8 +110,8 @@ export const WithTransition = () => {
                   <div data-popper-arrow>
                     <div data-popper-arrow-inner />
                   </div>
-                </motion.div>
-              </motion.div>
+                </m.div>
+              </m.div>
             </div>
           </Portal>
         )}

--- a/packages/components/transition/src/collapse.tsx
+++ b/packages/components/transition/src/collapse.tsx
@@ -1,7 +1,9 @@
 import { cx, warn } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
+  LazyMotion,
   m,
   Variants as _Variants,
 } from "framer-motion"
@@ -138,21 +140,23 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
     return (
       <AnimatePresence initial={false} custom={custom}>
         {show && (
-          <m.div
-            ref={ref}
-            {...rest}
-            className={cx("chakra-collapse", className)}
-            style={{
-              overflow: "hidden",
-              display: "block",
-              ...style,
-            }}
-            custom={custom}
-            variants={variants as _Variants}
-            initial={unmountOnExit ? "exit" : false}
-            animate={animate}
-            exit="exit"
-          />
+          <LazyMotion features={domAnimation}>
+            <m.div
+              ref={ref}
+              {...rest}
+              className={cx("chakra-collapse", className)}
+              style={{
+                overflow: "hidden",
+                display: "block",
+                ...style,
+              }}
+              custom={custom}
+              variants={variants as _Variants}
+              initial={unmountOnExit ? "exit" : false}
+              animate={animate}
+              exit="exit"
+            />
+          </LazyMotion>
         )}
       </AnimatePresence>
     )

--- a/packages/components/transition/src/collapse.tsx
+++ b/packages/components/transition/src/collapse.tsx
@@ -2,7 +2,7 @@ import { cx, warn } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import { forwardRef, useEffect, useState } from "react"
@@ -138,7 +138,7 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
     return (
       <AnimatePresence initial={false} custom={custom}>
         {show && (
-          <motion.div
+          <m.div
             ref={ref}
             {...rest}
             className={cx("chakra-collapse", className)}

--- a/packages/components/transition/src/fade.tsx
+++ b/packages/components/transition/src/fade.tsx
@@ -1,7 +1,9 @@
 import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
+  LazyMotion,
   m,
   Variants as _Variants,
 } from "framer-motion"
@@ -60,14 +62,16 @@ export const Fade = forwardRef<HTMLDivElement, FadeProps>(function Fade(
   return (
     <AnimatePresence custom={custom}>
       {show && (
-        <m.div
-          ref={ref}
-          className={cx("chakra-fade", className)}
-          custom={custom}
-          {...fadeConfig}
-          animate={animate}
-          {...rest}
-        />
+        <LazyMotion features={domAnimation}>
+          <m.div
+            ref={ref}
+            className={cx("chakra-fade", className)}
+            custom={custom}
+            {...fadeConfig}
+            animate={animate}
+            {...rest}
+          />
+        </LazyMotion>
       )}
     </AnimatePresence>
   )

--- a/packages/components/transition/src/fade.tsx
+++ b/packages/components/transition/src/fade.tsx
@@ -2,7 +2,7 @@ import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import { forwardRef } from "react"
@@ -60,7 +60,7 @@ export const Fade = forwardRef<HTMLDivElement, FadeProps>(function Fade(
   return (
     <AnimatePresence custom={custom}>
       {show && (
-        <motion.div
+        <m.div
           ref={ref}
           className={cx("chakra-fade", className)}
           custom={custom}

--- a/packages/components/transition/src/scale-fade.tsx
+++ b/packages/components/transition/src/scale-fade.tsx
@@ -2,7 +2,7 @@ import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import { forwardRef } from "react"
@@ -77,7 +77,7 @@ export const ScaleFade = forwardRef<HTMLDivElement, ScaleFadeProps>(
     return (
       <AnimatePresence custom={custom}>
         {show && (
-          <motion.div
+          <m.div
             ref={ref}
             className={cx("chakra-offset-slide", className)}
             {...scaleFadeConfig}

--- a/packages/components/transition/src/scale-fade.tsx
+++ b/packages/components/transition/src/scale-fade.tsx
@@ -1,7 +1,9 @@
 import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
+  LazyMotion,
   m,
   Variants as _Variants,
 } from "framer-motion"
@@ -77,14 +79,16 @@ export const ScaleFade = forwardRef<HTMLDivElement, ScaleFadeProps>(
     return (
       <AnimatePresence custom={custom}>
         {show && (
-          <m.div
-            ref={ref}
-            className={cx("chakra-offset-slide", className)}
-            {...scaleFadeConfig}
-            animate={animate}
-            custom={custom}
-            {...rest}
-          />
+          <LazyMotion features={domAnimation}>
+            <m.div
+              ref={ref}
+              className={cx("chakra-offset-slide", className)}
+              {...scaleFadeConfig}
+              animate={animate}
+              custom={custom}
+              {...rest}
+            />
+          </LazyMotion>
         )}
       </AnimatePresence>
     )

--- a/packages/components/transition/src/slide-fade.tsx
+++ b/packages/components/transition/src/slide-fade.tsx
@@ -1,7 +1,9 @@
 import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
+  LazyMotion,
   m,
   Variants as _Variants,
 } from "framer-motion"
@@ -103,14 +105,16 @@ export const SlideFade = forwardRef<HTMLDivElement, SlideFadeProps>(
     return (
       <AnimatePresence custom={custom}>
         {show && (
-          <m.div
-            ref={ref}
-            className={cx("chakra-offset-slide", className)}
-            custom={custom}
-            {...slideFadeConfig}
-            animate={animate}
-            {...rest}
-          />
+          <LazyMotion features={domAnimation}>
+            <m.div
+              ref={ref}
+              className={cx("chakra-offset-slide", className)}
+              custom={custom}
+              {...slideFadeConfig}
+              animate={animate}
+              {...rest}
+            />
+          </LazyMotion>
         )}
       </AnimatePresence>
     )

--- a/packages/components/transition/src/slide-fade.tsx
+++ b/packages/components/transition/src/slide-fade.tsx
@@ -2,7 +2,7 @@ import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
+  m,
   Variants as _Variants,
 } from "framer-motion"
 import { forwardRef } from "react"
@@ -103,7 +103,7 @@ export const SlideFade = forwardRef<HTMLDivElement, SlideFadeProps>(
     return (
       <AnimatePresence custom={custom}>
         {show && (
-          <motion.div
+          <m.div
             ref={ref}
             className={cx("chakra-offset-slide", className)}
             custom={custom}

--- a/packages/components/transition/src/slide.tsx
+++ b/packages/components/transition/src/slide.tsx
@@ -1,7 +1,9 @@
 import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
+  domAnimation,
   HTMLMotionProps,
+  LazyMotion,
   m,
   MotionStyle,
   Variants as TVariants,
@@ -94,17 +96,19 @@ export const Slide = forwardRef<HTMLDivElement, SlideProps>(function Slide(
   return (
     <AnimatePresence custom={custom}>
       {show && (
-        <m.div
-          {...rest}
-          ref={ref}
-          initial="exit"
-          className={cx("chakra-slide", className)}
-          animate={animate}
-          exit="exit"
-          custom={custom}
-          variants={variants as TVariants}
-          style={computedStyle}
-        />
+        <LazyMotion features={domAnimation}>
+          <m.div
+            {...rest}
+            ref={ref}
+            initial="exit"
+            className={cx("chakra-slide", className)}
+            animate={animate}
+            exit="exit"
+            custom={custom}
+            variants={variants as TVariants}
+            style={computedStyle}
+          />
+        </LazyMotion>
       )}
     </AnimatePresence>
   )

--- a/packages/components/transition/src/slide.tsx
+++ b/packages/components/transition/src/slide.tsx
@@ -2,7 +2,7 @@ import { cx } from "@chakra-ui/shared-utils"
 import {
   AnimatePresence,
   HTMLMotionProps,
-  motion,
+  m,
   MotionStyle,
   Variants as TVariants,
 } from "framer-motion"
@@ -94,7 +94,7 @@ export const Slide = forwardRef<HTMLDivElement, SlideProps>(function Slide(
   return (
     <AnimatePresence custom={custom}>
       {show && (
-        <motion.div
+        <m.div
           {...rest}
           ref={ref}
           initial="exit"


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/6697

## 📝 Description
Lazy load a subset of `framer-motion` feature in order to reduce overall bundle size of Chakra UI. See: https://www.framer.com/docs/lazy-motion/ and https://www.framer.com/docs/guide-reduce-bundle-size/

## ⛳️ Current behavior (updates)
Currently we are using `import { motion } from "framer-motion"` which is supposedly a larger component than `m`. This PR replaces this with `import { m }`, and wraps all usage of `m` with a `<LazyMotion>` component, as per recommendations in https://www.framer.com/docs/lazy-motion/

## 🚀 New behavior
Use `import { m } from "framer-motion"` instead, and wrap all usage with `<LazyMotion features={domAnimation} />`

## 💣 Is this a breaking change (Yes/No):
No