### PR TITLE
Update `_disabled` to use state selector

### DIFF
--- a/.changeset/new-dolls-trade.md
+++ b/.changeset/new-dolls-trade.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/styled-system": patch
+"@chakra-ui/utils": patch
+"@chakra-ui/dom-utils": patch
+---
+
+Update disabled selector to use state selector `:disabled`, instead of `[disabled]` attribute selector.
+This is useful when an editable element is wrapped within `<fieldset disabled>`

--- a/packages/components/styled-system/src/pseudos.ts
+++ b/packages/components/styled-system/src/pseudos.ts
@@ -68,7 +68,7 @@ export const pseudoSelectors = {
    * - `&:disabled`
    * - `&[data-disabled]`
    */
-  _disabled: "&[disabled], &[aria-disabled=true], &[data-disabled]",
+  _disabled: "&:disabled, &[aria-disabled=true], &[data-disabled]",
   /**
    * Styles for CSS Selector `&:readonly`
    */

--- a/packages/legacy/utils/src/dom-query.ts
+++ b/packages/legacy/utils/src/dom-query.ts
@@ -2,15 +2,15 @@ import { isHTMLElement } from "./dom"
 import { isFocusable, isTabbable } from "./tabbable"
 
 const focusableElList = [
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
+  "input:not(:disabled)",
+  "select:not(:disabled)",
+  "textarea:not(:disabled)",
   "embed",
   "iframe",
   "object",
   "a[href]",
   "area[href]",
-  "button:not([disabled])",
+  "button:not(:disabled)",
   "[tabindex]",
   "audio[controls]",
   "video[controls]",

--- a/packages/utilities/dom-utils/src/index.ts
+++ b/packages/utilities/dom-utils/src/index.ts
@@ -1,15 +1,15 @@
 import { isFocusable, isTabbable } from "./tabbable"
 
 const focusableElList = [
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
+  "input:not(:disabled)",
+  "select:not(:disabled)",
+  "textarea:not(:disabled)",
   "embed",
   "iframe",
   "object",
   "a[href]",
   "area[href]",
-  "button:not([disabled])",
+  "button:not(:disabled)",
   "[tabindex]",
   "audio[controls]",
   "video[controls]",


### PR DESCRIPTION
## 📝 Description
The following HTML did not apply the `_disabled` style. because the selector used in `_disabled` was `[disabled]` instead of `:disabled`.

```
<fieldset disabled>
  <chakra.button _disabled={{color="#999"}}>click!!</button>
</fieldset>
```

So replaced `[disabled]` with `:disabled` to reflect the disabled state correctly.

## ⛳️ Current behavior (updates)
`_disabled` in `<fieldset disabled>` doesn't work 

## 🚀 New behavior
`_disabled` in `<fieldset disabled>` will work 


## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
