### PR TITLE
fix(storybook-addon): getThemingArgTypes works without colorScheme

### DIFF
--- a/.changeset/lemon-tools-lick.md
+++ b/.changeset/lemon-tools-lick.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/storybook-addon": patch
+---
+
+Allow getThemingArgTypes to return args when colorScheme is not supported by
+component

--- a/tooling/storybook-addon/src/feature/arg-types.ts
+++ b/tooling/storybook-addon/src/feature/arg-types.ts
@@ -106,7 +106,7 @@ export function getThemingArgTypes<
         defaultValue: component.defaultProps?.colorScheme,
       }
     }
-
-    return argTypes
   }
+
+  return argTypes
 }


### PR DESCRIPTION
## 📝 Description

adjust getThemingArgTypes so it also return arg types when component doesn't support colorSchemes

## ⛳️ Current behavior (updates)

getThemingArgTypes will not return any arg types when component doesn't support colorSchemes

## 🚀 New behavior

getThemingArgTypes now also returns arg types when component only supports variants and/or sizes

## 💣 Is this a breaking change (Yes/No): No
