### PR TITLE
feat(storybook-addon): allow setting the theme via a callback

### DIFF
--- a/.changeset/giant-owls-invent.md
+++ b/.changeset/giant-owls-invent.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/storybook-addon": patch
+---
+
+Allow setting the storybook chakra theme via a callback function, with access to
+the context

--- a/tooling/storybook-addon/src/feature/decorator/ChakraProviderDecorator.tsx
+++ b/tooling/storybook-addon/src/feature/decorator/ChakraProviderDecorator.tsx
@@ -13,7 +13,11 @@ export function ChakraProviderDecorator(
     parameters: { chakra: chakraParams },
     globals: { [DIRECTION_TOOL_ID]: globalDirection },
   } = context
-  const chakraTheme = chakraParams?.theme || theme
+  const chakraTheme = chakraParams?.theme
+    ? typeof chakraParams.theme === "function"
+      ? chakraParams.theme(context)
+      : chakraParams.theme
+    : theme
   const direction = useDirection(globalDirection || chakraTheme?.direction)
   const themeWithDirectionOverride = useMemo(
     () => extendTheme({ direction }, chakraTheme),


### PR DESCRIPTION
## 📝 Description

This will allow setting the theme used in storybook via a callback function, that gives acces to the current context.

The usecase triggering this PR, is to allow selecting a theme via the toolbar.

## ⛳️ Current behavior (updates)

Themes can only be set as objects in storybook

## 🚀 New behavior

Themes can still be set as objects, but can also be set by returning a theme in a callback function

## 💣 Is this a breaking change (Yes/No): No