### PR TITLE
fix: add `[disabled]` on top of `:disabled` selector to fix regression

### DIFF
--- a/.changeset/seven-ducks-rest.md
+++ b/.changeset/seven-ducks-rest.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/styled-system": patch
+"@chakra-ui/utils": patch
+"@chakra-ui/dom-utils": patch
+---
+
+Added `[disabled]` selector on top of `:disabled`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 </p>
 
 <h1 align="center">Build Accessible React Apps with Speed ⚡️</h1>
-
 <br>
 
 <p align="center">
@@ -18,6 +17,7 @@
     <img alt="Discord" src="https://img.shields.io/discord/660863154703695893.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2" />
   </a>
 </p>
+
 <br />
 
 Chakra UI provides a set of accessible, reusable, and composable React

--- a/packages/components/button/stories/button.stories.tsx
+++ b/packages/components/button/stories/button.stories.tsx
@@ -176,7 +176,7 @@ export const WithLoadingSpinnerPlacement = () => (
 
 export const WithDisabled = () => (
   <HStack spacing="24px">
-    <Button isDisabled colorScheme="teal" variant="solid">
+    <Button as="div" isDisabled colorScheme="teal" variant="solid">
       Button
     </Button>
     <Button isDisabled colorScheme="teal" variant="outline">

--- a/packages/components/button/tests/button.test.tsx
+++ b/packages/components/button/tests/button.test.tsx
@@ -127,11 +127,21 @@ test("Has the proper type attribute", () => {
 })
 
 test("Should be disabled", () => {
-  const { getByRole } = render(
+  const { getByTestId, getByRole, rerender } = render(
     <Button isDisabled data-testid="btn">
       I'm a invalid button
     </Button>,
   )
   const button = getByRole("button")
   expect(button).toBeDisabled()
+
+  // This case was introduced to check against regression of #6700
+  rerender(
+    <Button as="div" isDisabled data-testid="btn">
+      I'm a invalid button
+    </Button>,
+  )
+
+  const buttonAsDiv = getByTestId("btn")
+  expect(buttonAsDiv).toHaveAttribute("disabled")
 })

--- a/packages/components/styled-system/src/pseudos.ts
+++ b/packages/components/styled-system/src/pseudos.ts
@@ -67,8 +67,9 @@ export const pseudoSelectors = {
    * - `&[aria-disabled=true]`
    * - `&:disabled`
    * - `&[data-disabled]`
+   * - `&[disabled]`
    */
-  _disabled: "&:disabled, &[aria-disabled=true], &[data-disabled]",
+  _disabled: "&:disabled, &[disabled], &[aria-disabled=true], &[data-disabled]",
   /**
    * Styles for CSS Selector `&:readonly`
    */

--- a/packages/legacy/utils/src/dom-query.ts
+++ b/packages/legacy/utils/src/dom-query.ts
@@ -2,15 +2,15 @@ import { isHTMLElement } from "./dom"
 import { isFocusable, isTabbable } from "./tabbable"
 
 const focusableElList = [
-  "input:not(:disabled)",
-  "select:not(:disabled)",
-  "textarea:not(:disabled)",
+  "input:not(:disabled):not([disabled])",
+  "select:not(:disabled):not([disabled])",
+  "textarea:not(:disabled):not([disabled])",
   "embed",
   "iframe",
   "object",
   "a[href]",
   "area[href]",
-  "button:not(:disabled)",
+  "button:not(:disabled):not([disabled])",
   "[tabindex]",
   "audio[controls]",
   "video[controls]",

--- a/packages/utilities/dom-utils/src/index.ts
+++ b/packages/utilities/dom-utils/src/index.ts
@@ -1,15 +1,15 @@
 import { isFocusable, isTabbable } from "./tabbable"
 
 const focusableElList = [
-  "input:not(:disabled)",
-  "select:not(:disabled)",
-  "textarea:not(:disabled)",
+  "input:not(:disabled):not([disabled])",
+  "select:not(:disabled):not([disabled])",
+  "textarea:not(:disabled):not([disabled])",
   "embed",
   "iframe",
   "object",
   "a[href]",
   "area[href]",
-  "button:not(:disabled)",
+  "button:not(:disabled):not([disabled])",
   "[tabindex]",
   "audio[controls]",
   "video[controls]",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6736 

## 📝 Description

> Add a brief description

Changes in #6700 caused components not to be disabled when `isDisabled` prop was used together with the `as` prop. This PR reverts the removed `[disabled]` CSS selector but keeps the `:disabled` selector on top.

## ⛳️ Current behavior (updates)

`<Button as="div" isDisabled />` is not disabled properly 

## 🚀 New behavior

`<Button as="div" isDisabled />` now is disabled properly

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
