### PR TITLE
fix: checkbox style overrides

### DIFF
--- a/.changeset/strange-bugs-chew.md
+++ b/.changeset/strange-bugs-chew.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+Allow checkbox control and root's style to be overriden from theme

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -15,26 +15,22 @@ import { CheckboxIcon } from "./checkbox-icon"
 import { CheckboxOptions, UseCheckboxProps } from "./checkbox-types"
 import { useCheckbox } from "./use-checkbox"
 
-const CheckboxControl = chakra("span", {
-  baseStyle: {
-    display: "inline-flex",
-    alignItems: "center",
-    justifyContent: "center",
-    verticalAlign: "top",
-    userSelect: "none",
-    flexShrink: 0,
-  },
-})
+const controlStyles: SystemStyleObject = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  verticalAlign: "top",
+  userSelect: "none",
+  flexShrink: 0,
+}
 
-const CheckboxRoot = chakra("label", {
-  baseStyle: {
-    cursor: "pointer",
-    display: "inline-flex",
-    alignItems: "center",
-    verticalAlign: "top",
-    position: "relative",
-  },
-})
+const rootStyles: SystemStyleObject = {
+  cursor: "pointer",
+  display: "inline-flex",
+  alignItems: "center",
+  verticalAlign: "top",
+  position: "relative",
+}
 
 type CheckboxControlProps = Omit<HTMLChakraProps<"div">, keyof UseCheckboxProps>
 
@@ -126,8 +122,8 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
   })
 
   return (
-    <CheckboxRoot
-      __css={styles.container}
+    <chakra.label
+      __css={{ ...rootStyles, ...styles.container }}
       className={cx("chakra-checkbox", className)}
       {...getRootProps()}
     >
@@ -135,13 +131,13 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
         className="chakra-checkbox__input"
         {...getInputProps(inputProps, ref)}
       />
-      <CheckboxControl
-        __css={styles.control}
+      <chakra.span
+        __css={{ ...controlStyles, ...styles.control }}
         className="chakra-checkbox__control"
         {...getCheckboxProps()}
       >
         {clonedIcon}
-      </CheckboxControl>
+      </chakra.span>
       {children && (
         <chakra.span
           className="chakra-checkbox__label"
@@ -154,7 +150,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
           {children}
         </chakra.span>
       )}
-    </CheckboxRoot>
+    </chakra.label>
   )
 })
 


### PR DESCRIPTION
Closes #6749

## 📝 Description

This PR refactors the checkbox component to be slightly less strict in its default styles. Using the chakra factory with `baseStyles` has more specificity over the `__css` prop, making it hard to override from the theme.

## ⛳️ Current behavior (updates)

Can't override certain properties in the checkbox theme

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
