### PR TITLE
fix: allow SystemStyleFunction to accept a user provided type for props

### DIFF
--- a/.changeset/neat-pets-work.md
+++ b/.changeset/neat-pets-work.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Enhance SystemStyleFunction type to be extensible and allow consumer to pass
+custom types for props

--- a/packages/components/styled-system/src/define-styles.ts
+++ b/packages/components/styled-system/src/define-styles.ts
@@ -12,11 +12,13 @@ export type StyleFunctionProps = {
   [key: string]: any
 }
 
-export type SystemStyleFunction = (
-  props: StyleFunctionProps,
+export type SystemStyleFunction<T extends StyleFunctionProps> = (
+  props: T,
 ) => SystemStyleObject
 
-export type SystemStyleInterpolation = SystemStyleObject | SystemStyleFunction
+export type SystemStyleInterpolation =
+  | SystemStyleObject
+  | SystemStyleFunction<StyleFunctionProps>
 
 // ------------------------------------------------------------------ //
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6796 <!-- Github issue # here -->

## 📝 Description

The type update allows the consumer of the variant functions to add additional type information for the props received from inside the component

## ⛳️ Current behavior (updates)

The current `SystemStyleFunction` signature doesn't let the consumer pass on additional type information about the props it can receive. 

## 🚀 New behavior

The PR allows the user to pass on any additional props type apart from `StyleFunctionProps`. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
