### PR TITLE
fix: drawer inert siblings' elements when opened

### DIFF
--- a/.changeset/nasty-pots-mix.md
+++ b/.changeset/nasty-pots-mix.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Fix issue where `useInert` doesn't work consistently between the Drawer and Modal

--- a/packages/components/modal/src/drawer-content.tsx
+++ b/packages/components/modal/src/drawer-content.tsx
@@ -71,12 +71,12 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
     const { placement } = useDrawerContext()
 
     return (
-      <chakra.div
-        {...containerProps}
-        className="chakra-modal__content-container"
-        __css={dialogContainerStyles}
-      >
-        <ModalFocusScope>
+      <ModalFocusScope>
+        <chakra.div
+          {...containerProps}
+          className="chakra-modal__content-container"
+          __css={dialogContainerStyles}
+        >
           <MotionDiv
             motionProps={motionProps}
             direction={placement}
@@ -87,8 +87,8 @@ export const DrawerContent = forwardRef<DrawerContentProps, "section">(
           >
             {children}
           </MotionDiv>
-        </ModalFocusScope>
-      </chakra.div>
+        </chakra.div>
+      </ModalFocusScope>
     )
   },
 )

--- a/packages/components/modal/tests/drawer.test.tsx
+++ b/packages/components/modal/tests/drawer.test.tsx
@@ -54,6 +54,13 @@ it("renders on the correct side under 'ltr' direction", () => {
   expect(screen.queryByRole("dialog")).toHaveStyle("left: 0")
 })
 
+it("should make other elements inert when opened", () => {
+  const { container } = render(<SimpleDrawer placement="right" isOpen />)
+
+  expect(container).toHaveAttribute("data-aria-hidden", "true")
+  expect(container).toHaveAttribute("aria-hidden", "true")
+})
+
 // it("swaps sides (left/right) under 'rtl' direction", () => {
 //   render(
 //     <ThemeProvider theme={extendTheme({ direction: "rtl" })}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6604 

## 📝 Description
Add `aria-hidden` to siblings of modal/drawer element, so the screen readers only need to care about the modal.

## ⛳️ Current behavior (updates)

Adding or removing `useInert` does not alter the state of drawer when opened due to its ref not being defined.

## 🚀 New behavior

We use the drawer container ref to trigger the modifications in the DOM attributes.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
