### PR TITLE
fix(editable):  input retaining focus when programmaticaly leaving input mode

### DIFF
--- a/.changeset/seven-kiwis-argue.md
+++ b/.changeset/seven-kiwis-argue.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/editable": patch
+---
+
+Fixed issue where input retained focus after exiting input programmaticaly.

--- a/packages/components/editable/src/use-editable.ts
+++ b/packages/components/editable/src/use-editable.ts
@@ -169,6 +169,11 @@ export function useEditable(props: UseEditableProps = {}) {
     setIsEditing(false)
     setPrevValue(value)
     onSubmitProp?.(value)
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=559561
+    const inputEl = inputRef.current
+    if (inputEl?.ownerDocument.activeElement === inputEl) {
+      inputEl?.blur()
+    }
   }, [value, onSubmitProp])
 
   const onChange = useCallback(

--- a/packages/components/editable/stories/editable.stories.tsx
+++ b/packages/components/editable/stories/editable.stories.tsx
@@ -84,16 +84,15 @@ const EditableControls = () => {
 
 export const Basic = () => (
   <Editable
-    defaultValue="Rasengan ⚡️"
-    fontSize="xl"
     textAlign="center"
-    isPreviewFocusable={false}
-    submitOnBlur={false}
-    onChange={console.log}
+    value="Rasengan ⚡️"
+    fontSize="2xl"
+    onSubmit={() => console.log("onSubmit", Math.random())}
+    isPreviewFocusable
   >
     <EditablePreview />
     <EditableInput />
-    <EditableControls />
+    {/* <EditableControls /> */}
   </Editable>
 )
 


### PR DESCRIPTION
Closes #6819 
Fixed input retaining focus when programmaticaly leaving input mode