### PR TITLE
Spreads rest of the props at bottom on LinkOverlay

### DIFF
--- a/.changeset/shaggy-lizards-provide.md
+++ b/.changeset/shaggy-lizards-provide.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+- Allows rel, target, and some others props to be defined on LinkOverlay without being overriden 

--- a/packages/components/layout/src/link-box.tsx
+++ b/packages/components/layout/src/link-box.tsx
@@ -13,7 +13,6 @@ export const LinkOverlay = forwardRef<LinkOverlayProps, "a">(
     const { isExternal, target, rel, className, ...rest } = props
     return (
       <chakra.a
-        {...rest}
         ref={ref}
         className={cx("chakra-linkbox__overlay", className)}
         rel={isExternal ? "noopener noreferrer" : rel}
@@ -31,6 +30,7 @@ export const LinkOverlay = forwardRef<LinkOverlayProps, "a">(
             width: "100%",
             height: "100%",
           },
+          {...rest}
         }}
       />
     )


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/6841

## 📝 Description

Moves spreading of rest of the props on LinkOverlay to bottom after other props to ensure properties to be overridden if required

## ⛳️ Current behavior (updates)
- Properties like rel, target are not able to be overriden by user with LinkOverlay
## 🚀 New behavior
- With this fix, users can be able to override properties of LinkOverlay element which are already defined 

## 💣 Is this a breaking change (Yes/No): 
No
