### PR TITLE
fix: improve toast accessibility

### DIFF
--- a/packages/components/toast/src/toast.provider.tsx
+++ b/packages/components/toast/src/toast.provider.tsx
@@ -112,23 +112,25 @@ export const ToastProvider = (props: ToastProviderProps) => {
     const toasts = state[position]
 
     return (
-      <ul
-        role="region"
+      <div
+        role="alert"
         aria-live="polite"
         key={position}
         id={`chakra-toast-manager-${position}`}
         style={getToastListStyle(position)}
       >
-        <AnimatePresence initial={false}>
-          {toasts.map((toast) => (
-            <Component
-              key={toast.id}
-              motionVariants={motionVariants}
-              {...toast}
-            />
-          ))}
-        </AnimatePresence>
-      </ul>
+        <ul>
+          <AnimatePresence initial={false}>
+            {toasts.map((toast) => (
+              <Component
+                key={toast.id}
+                motionVariants={motionVariants}
+                {...toast}
+              />
+            ))}
+          </AnimatePresence>
+        </ul>
+      </div>
     )
   })
 


### PR DESCRIPTION
Closes #6164 

## 📝 Description

Fixes the following accessibility issues related to toast component:
 - [aria-allowed-role](https://dequeuniversity.com/rules/axe/4.4/aria-allowed-role?application=RuleDescription)
 - [landmark-unique](https://dequeuniversity.com/rules/axe/4.4/landmark-unique?application=RuleDescription)


## ⛳️ Current behavior (updates)

Currently the Chakra-UI's Toast component violates two accessibility rules (aria-allowed-role, landmark-unique). This can be noticed by running the [axe devtools](https://www.deque.com/axe/devtools/) or other axe tools.

## 🚀 New behavior

Markup is updated to better suit an accessible toast component.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Read more about patterns for accessible toasts here:
 - https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 - https://adrianroselli.com/2020/01/defining-toast-messages.html#Accessibility