### PR TITLE
fix(editable): fix blur discrepancies

### DIFF
--- a/.changeset/dirty-yaks-relax.md
+++ b/.changeset/dirty-yaks-relax.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/editable": patch
+---
+
+Fix issue where `onSubmit` was called twice when input is blurred with enter
+key.

--- a/packages/components/editable/src/use-editable.ts
+++ b/packages/components/editable/src/use-editable.ts
@@ -6,7 +6,7 @@ import { mergeRefs } from "@chakra-ui/react-use-merge-refs"
 import { useCallbackRef } from "@chakra-ui/react-use-callback-ref"
 import { ariaAttr, callAllHandlers } from "@chakra-ui/shared-utils"
 import { PropGetter } from "@chakra-ui/react-types"
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 export interface UseEditableProps {
   /**
@@ -169,12 +169,16 @@ export function useEditable(props: UseEditableProps = {}) {
     setIsEditing(false)
     setPrevValue(value)
     onSubmitProp?.(value)
+  }, [value, onSubmitProp])
+
+  useEffect(() => {
+    if (isEditing) return
     // https://bugzilla.mozilla.org/show_bug.cgi?id=559561
     const inputEl = inputRef.current
     if (inputEl?.ownerDocument.activeElement === inputEl) {
       inputEl?.blur()
     }
-  }, [value, onSubmitProp])
+  }, [isEditing])
 
   const onChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -228,6 +232,7 @@ export function useEditable(props: UseEditableProps = {}) {
 
   const onBlur = useCallback(
     (event: React.FocusEvent) => {
+      if (!isEditing) return
       const doc = event.currentTarget.ownerDocument
       const relatedTarget = (event.relatedTarget ??
         doc.activeElement) as HTMLElement
@@ -243,7 +248,7 @@ export function useEditable(props: UseEditableProps = {}) {
         }
       }
     },
-    [submitOnBlur, onSubmit, onCancel],
+    [submitOnBlur, onSubmit, onCancel, isEditing],
   )
 
   const getPreviewProps: PropGetter = useCallback(


### PR DESCRIPTION
Fix issue where `onSubmit` was called twice when input is blurred with enter
key.