### PR TITLE
fix(focus): fixed accidental focus thefts from overly eager transitionend handler

### DIFF
--- a/.changeset/small-colts-fry.md
+++ b/.changeset/small-colts-fry.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react-use-focus-effect": patch
+"@chakra-ui/hooks": patch
+---
+
+Fixed an issue with focus sometimes being moved back to the open element when it
+was intentionally moved away from it.

--- a/packages/hooks/use-focus-effect/package.json
+++ b/packages/hooks/use-focus-effect/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@chakra-ui/react-use-event-listener": "workspace:*",
     "@chakra-ui/react-use-update-effect": "workspace:*",
+    "@chakra-ui/react-use-safe-layout-effect": "workspace:*",
     "@chakra-ui/dom-utils": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1748,12 +1748,14 @@ importers:
     specifiers:
       '@chakra-ui/dom-utils': workspace:*
       '@chakra-ui/react-use-event-listener': workspace:*
+      '@chakra-ui/react-use-safe-layout-effect': workspace:*
       '@chakra-ui/react-use-update-effect': workspace:*
       clean-package: 2.1.1
       react: ^18.2.0
     dependencies:
       '@chakra-ui/dom-utils': link:../../utilities/dom-utils
       '@chakra-ui/react-use-event-listener': link:../use-event-listener
+      '@chakra-ui/react-use-safe-layout-effect': link:../use-safe-layout-effect
       '@chakra-ui/react-use-update-effect': link:../use-update-effect
     devDependencies:
       clean-package: 2.1.1
@@ -4494,6 +4496,7 @@ packages:
       invariant: 2.2.4
       prop-types: 15.8.1
       react-lifecycles-compat: 3.0.4
+    dev: true
 
   /@gatsbyjs/reach-router/1.3.7_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-KQ5FvMb4BZUlSo+yQgd4t4WB8vkVPWfKjTpSl+Bx/FZhU6OL4lpwgfX7fXAY/18DogqyJCFiNAjV5eo3rQ5Alw==}
@@ -4506,7 +4509,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-lifecycles-compat: 3.0.4
-    dev: false
 
   /@gatsbyjs/webpack-hot-middleware/2.25.3:
     resolution: {integrity: sha512-ul17OZ8Dlw+ATRbnuU+kwxuAlq9lKbYz/2uBS1FLCdgoPTF1H2heP7HbUbgfMZbfRQNcCG2rMscMnr32ritCDw==}
@@ -12134,7 +12136,7 @@ packages:
       '@babel/core': 7.18.9
       '@babel/runtime': 7.18.9
       '@babel/types': 7.18.9
-      gatsby: 4.19.2
+      gatsby: 4.19.2_biqbaboplfbrettd7655fr4n2y
       gatsby-core-utils: 3.19.0
 
   /babel-plugin-syntax-object-rest-spread/6.13.0:
@@ -16935,7 +16937,6 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-    dev: false
 
   /gatsby-link/4.19.1_xqk4ktfct2mldtt7zqnjb4ueue:
     resolution: {integrity: sha512-LCazIxhPOGHJKJVrr5s3jJHYtmaCnaaHQtW9WS0CWvPkW/zC4rKDXyEn8xDWVYaUnRnXUVDhv4Psp6J+Xqifxg==}
@@ -16949,6 +16950,7 @@ packages:
       '@types/reach__router': 1.3.10
       gatsby-page-utils: 2.19.0
       prop-types: 15.8.1
+    dev: true
 
   /gatsby-page-utils/2.19.0:
     resolution: {integrity: sha512-eYStV4jQbuEBKhatH3yzWA+lmoydJBCZVg6w2GG38eSsgcj9pdep8oQqyQdGFU3dy/HizWmWCv+wW9FIUoVQsQ==}
@@ -17036,7 +17038,7 @@ packages:
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
       fs-extra: 10.1.0
-      gatsby: 4.19.2
+      gatsby: 4.19.2_biqbaboplfbrettd7655fr4n2y
       gatsby-core-utils: 3.19.0
       gatsby-page-utils: 2.19.0
       gatsby-plugin-utils: 3.13.0_upd2dfgy6javngtb6zz74pjfdq
@@ -17104,7 +17106,7 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.9
       '@babel/runtime': 7.18.9
       babel-plugin-remove-graphql-queries: 4.19.0_dxeruin6mssvjcve62e33yojya
-      gatsby: 4.19.2
+      gatsby: 4.19.2_biqbaboplfbrettd7655fr4n2y
     transitivePeerDependencies:
       - supports-color
 
@@ -17141,7 +17143,7 @@ packages:
       '@gatsbyjs/potrace': 2.2.0
       fastq: 1.13.0
       fs-extra: 10.1.0
-      gatsby: 4.19.2
+      gatsby: 4.19.2_biqbaboplfbrettd7655fr4n2y
       gatsby-core-utils: 3.19.0
       gatsby-sharp: 0.13.0
       graphql: 15.8.0
@@ -17165,7 +17167,6 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-    dev: false
 
   /gatsby-react-router-scroll/5.19.0_xqk4ktfct2mldtt7zqnjb4ueue:
     resolution: {integrity: sha512-tl1E2/ger3Aw5Vb5n53i9wCBePYqb2dBilO05pd6FfgKYJveFidQwGzzOn1F9smdWq+5c3KJSTlKJaNYPwn72w==}
@@ -17178,6 +17179,7 @@ packages:
       '@babel/runtime': 7.18.9
       '@gatsbyjs/reach-router': 1.3.7
       prop-types: 15.8.1
+    dev: true
 
   /gatsby-script/1.4.0:
     resolution: {integrity: sha512-+GmHTAfFq/sQWPvl1E8QvApRfxqqamhdqjFo4YloOQRAlDc+e3nMzTzvgj8z3IWqDqlvEfHMnlvQg60E5ThO/A==}
@@ -17185,6 +17187,7 @@ packages:
     peerDependencies:
       react: ^16.9.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0
+    dev: true
 
   /gatsby-script/1.4.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-+GmHTAfFq/sQWPvl1E8QvApRfxqqamhdqjFo4YloOQRAlDc+e3nMzTzvgj8z3IWqDqlvEfHMnlvQg60E5ThO/A==}
@@ -17195,7 +17198,6 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-    dev: false
 
   /gatsby-sharp/0.13.0:
     resolution: {integrity: sha512-dGuIuWP3rC7hXl/CgkHEY4WQEW+B9Rsg8uo6u+OumuLnLBxD4vTusEIGctVKzlyIxpENEQylQ7w1JKHX9fOy9g==}
@@ -17474,6 +17476,7 @@ packages:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
+    dev: true
 
   /gatsby/4.19.2_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-e39NL+nEi0GPlE62mz66lwllbR4Baof4l/b187df4tLWZhoUU9mY/flohxPHFH4gxXqD2AqGnJsm/jOXsIKO0g==}
@@ -17673,7 +17676,6 @@ packages:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
-    dev: false
 
   /gauge/3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}


### PR DESCRIPTION
## 📝 Description

This is an attempt to fix focus theft when the focus is intentionally moved away from the open element and even when it is moved outside of the current window.

## ⛳️ Current behavior (updates)

<img width="1728" alt="VS Code open with two panels side-by-side. Source code on the left, XState extension on the right" src="https://user-images.githubusercontent.com/9800850/196977313-68378892-85b1-4641-8a9a-7e35eed7785f.png">

Notice that I have a focus on the popover on the right. We manage the open state of that popover ourselves and we don't use focus trapping in it.

I've noticed that sometimes when I move the focus to the source code on the left then I quickly lose my cursor in the code. I've investigated the issue and it turned out that the popover element was being programmatically focused by Chakra after I manually moved it outside of that window.

After further investigation, I've managed to narrow it down to this `focus` call:
https://github.com/Andarist/chakra-ui/blob/5af9b7dddd0e1c7788ee9459246909758da3adc1/packages/legacy/hooks/src/use-focus-on-show.ts#L53
that was called by a `transitionend` handler here:
https://github.com/Andarist/chakra-ui/blob/5af9b7dddd0e1c7788ee9459246909758da3adc1/packages/legacy/hooks/src/use-focus-on-show.ts#L62

## 🚀 New behavior

I've introduced a ref dance to ensure that the `autoFocus` logic only gets applied after we change from `visible: false` to `visible: true`. If the component stays visible I don't think that `focus` should ever be called from here - the hook is called `useFocusOnShow`, so it should only ever be called on show.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
