### PR TITLE
Feat/vertical button group

### DIFF
--- a/.changeset/many-items-shake.md
+++ b/.changeset/many-items-shake.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/button": patch
+"@chakra-ui/theme": patch
+---
+
+Added support for vertical button groups. Specifically when `isAttached` is
+applied, the buttons are now flush in a vertical direction.

--- a/packages/components/button/src/button-group.tsx
+++ b/packages/components/button/src/button-group.tsx
@@ -13,7 +13,9 @@ import { ButtonGroupOptions } from "./button-types"
 export interface ButtonGroupProps
   extends HTMLChakraProps<"div">,
     ThemingProps<"Button">,
-    ButtonGroupOptions {}
+    ButtonGroupOptions {
+  isVertical?: boolean
+}
 
 export const ButtonGroup = forwardRef<ButtonGroupProps, "div">(
   function ButtonGroup(props, ref) {
@@ -25,6 +27,7 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">(
       spacing = "0.5rem",
       isAttached,
       isDisabled,
+      isVertical,
       ...rest
     } = props
 
@@ -40,11 +43,26 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">(
     }
 
     if (isAttached) {
-      groupStyles = {
-        ...groupStyles,
-        "> *:first-of-type:not(:last-of-type)": { borderEndRadius: 0 },
-        "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
-        "> *:not(:first-of-type):last-of-type": { borderStartRadius: 0 },
+      if (isVertical) {
+        groupStyles = {
+          ...groupStyles,
+          "> *:first-of-type:not(:last-of-type)": {
+            borderEndStartRadius: 0,
+            borderEndEndRadius: 0,
+          },
+          "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
+          "> *:not(:first-of-type):last-of-type": {
+            borderStartEndRadius: 0,
+            borderStartStartRadius: 0,
+          },
+        }
+      } else {
+        groupStyles = {
+          ...groupStyles,
+          "> *:first-of-type:not(:last-of-type)": { borderEndRadius: 0 },
+          "> *:not(:first-of-type):not(:last-of-type)": { borderRadius: 0 },
+          "> *:not(:first-of-type):last-of-type": { borderStartRadius: 0 },
+        }
       }
     } else {
       groupStyles = {
@@ -61,6 +79,8 @@ export const ButtonGroup = forwardRef<ButtonGroupProps, "div">(
           __css={groupStyles}
           className={_className}
           data-attached={isAttached ? "" : undefined}
+          data-vertical={isVertical ? "" : undefined}
+          flexDir={isVertical ? "column" : undefined}
           {...rest}
         />
       </ButtonGroupProvider>

--- a/packages/components/button/stories/button.stories.tsx
+++ b/packages/components/button/stories/button.stories.tsx
@@ -238,6 +238,22 @@ export const WithAttachedButtons = () => (
   </ButtonGroup>
 )
 
+export const WithAttachedButtonsVertical = () => (
+  <ButtonGroup size="lg" isVertical isAttached variant="outline">
+    <IconButton fontSize="2xl" aria-label="Email Santa" icon={<EmailIcon />} />
+    <IconButton
+      fontSize="2xl"
+      aria-label="Call the Grinch"
+      icon={<PhoneIcon />}
+    />
+    <IconButton
+      fontSize="2xl"
+      aria-label="Add to friends"
+      icon={<ChevronDownIcon />}
+    />
+  </ButtonGroup>
+)
+
 export const WithSocialButton = () => (
   <Stack direction="row">
     <Button colorScheme="facebook" leftIcon={<FaFacebook />}>

--- a/packages/components/button/tests/button-group.test.tsx
+++ b/packages/components/button/tests/button-group.test.tsx
@@ -69,3 +69,55 @@ test("Should flush outline button", () => {
     marginInlineEnd: "",
   })
 })
+
+test("Should flush vertical button", () => {
+  const { getByText } = render(
+    <ButtonGroup isAttached isVertical>
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+      <Button>Button 4</Button>
+    </ButtonGroup>,
+  )
+  expect(getByText(/Button 1/i)).toHaveStyle({
+    borderBottomLeftRadius: "0",
+    borderBottomRightRadius: "0",
+  })
+  expect(getByText(/Button 2/i)).toHaveStyle({
+    borderRadius: "0px",
+  })
+  expect(getByText(/Button 3/i)).toHaveStyle({
+    borderRadius: "0px",
+  })
+  expect(getByText(/Button 4/i)).toHaveStyle({
+    borderTopLeftRadius: "0",
+    borderTopRightRadius: "0",
+  })
+})
+
+test("Should flush vertical outline button", () => {
+  const { getByText } = render(
+    <ButtonGroup isAttached isVertical variant="outline">
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+      <Button>Button 4</Button>
+    </ButtonGroup>,
+  )
+  expect(getByText(/Button 1/i)).toHaveStyle({
+    marginInlineEnd: "",
+    // marginBottom: "-1px",
+  })
+  expect(getByText(/Button 2/i)).toHaveStyle({
+    marginInlineEnd: "",
+    // marginBottom: "-1px",
+  })
+  expect(getByText(/Button 3/i)).toHaveStyle({
+    marginInlineEnd: "",
+    // marginBottom: "-1px",
+  })
+  expect(getByText(/Button 4/i)).toHaveStyle({
+    marginInlineEnd: "",
+    marginBottom: "",
+  })
+})

--- a/packages/components/theme/src/components/button.ts
+++ b/packages/components/theme/src/components/button.ts
@@ -60,6 +60,11 @@ const variantOutline = defineStyle((props) => {
     ".chakra-button__group[data-attached] > &:not(:last-of-type)": {
       marginEnd: "-1px",
     },
+    ".chakra-button__group[data-attached][data-vertical] > &:not(:last-of-type)":
+      {
+        marginEnd: "",
+        marginBottom: "-1px",
+      },
     ...runIfFn(variantGhost, props),
   }
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6885

## 📝 Description

Adds the `isVertical` prop to `ButtonGroup` component that allows for vertically orientated button groups.

## ⛳️ Current behavior (updates)

In order to vertically orientate button groups a user would need to specify `flexDir="column"` currently, however even doing so will still present challenges of incorrect border radius' for the first and last buttons. See the codesandbox below for an example: 
https://codesandbox.io/s/vertical-attached-button-group-hwzk95?file=/src/index.tsx:232-233

## 🚀 New behavior

With this feature PR, the `isVertical` prop has been added to `ButtonGroup`. This will update the border radius' correctly for vertical button groups and change the flex direction. This also updates the button theme as there was a prior request to collapse border's when buttons are flush together with `isAttached` prop.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
