### PR TITLE
fix(css-reset): Use dvh unit if supported

### DIFF
--- a/.changeset/wet-yaks-guess.md
+++ b/.changeset/wet-yaks-guess.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/css-reset": patch
+---
+
+fix(css-reset): Use dvh unit if supported
+
+This allows the user agent to dynamically adapt the height of a Modal, depending on what parts of the UI (e.g. address bar) are visible.

--- a/packages/components/css-reset/src/css-reset.tsx
+++ b/packages/components/css-reset/src/css-reset.tsx
@@ -17,9 +17,9 @@ const vhPolyfill = `
     }
   }
 
-  @supports (height: 100lvh) {
+  @supports (height: 100dvh) {
     :root {
-      --chakra-vh: 100lvh;
+      --chakra-vh: 100dvh;
     }
   }
 `


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6798

## 📝 Description

- There is an issue with the visibility of important elements of Modals

## ⛳️ Current behavior (updates)

- Currently parts of the modal can be hidden because of visible UI of the operating system (e.g. address bar in iOS)
- This provides a bad UX as e.g. the close icon or the footer of a modal isn't visible / accessible to the user

## 🚀 New behavior

- By using the `dvh` unit the browser correctly adapts the actual visible height automatically
- Like the previously used `lvh` unit this is only supported in certain browsers, see https://developer.mozilla.org/en-US/docs/Web/CSS/length#browser_compatibility
- By using `@supports` we ensure progressive enhancement (like before)

## 💣 Is this a breaking change (~Yes~/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

- This is **not** a breaking change as the browser support for `lvh` and `dvh` units is equal

## 📝 Additional Information

- Good reference blog post discussing the difference in units and recommendation for the `dvh` unit: https://www.bram.us/2021/07/08/the-large-small-and-dynamic-viewports/