### PR TITLE
fix: Omit keys by default if keys are not set

### DIFF
--- a/packages/utilities/object-utils/src/index.ts
+++ b/packages/utilities/object-utils/src/index.ts
@@ -38,7 +38,7 @@ export function split<T extends Record<string, any>, K extends keyof T>(
   const omitted: Record<string, any> = {}
 
   for (const [key, value] of Object.entries(object)) {
-    if (keys.includes(key as T[K])) picked[key] = value
+    if (keys && keys.includes(key as T[K])) picked[key] = value
     else omitted[key] = value
   }
 


### PR DESCRIPTION
This fixes a case where split utility function is called without keys, resulting in "keys is undefined" error message.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Stumbled upon a problem while just simply trying to use a `<Menu />` component.

## ⛳️ Current behavior (updates)

Crashes with a long stack ending up to this object-utils class with an error message stating that keys is undefined.

## 🚀 New behavior

Using a `<Menu />` in my case works.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

I have no desire to find out why split is getting called with undefined "keys" attribute. It somehow is and this change prepares for the case in a manner I assume is safe for all possible use cases.
