### PR TITLE
chore: update Description type to textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
 
         We're all volunteers here, so help us help you by taking the time to
         accurately fill out this template. ❤️
-  - type: "input"
+  - type: "textarea"
     id: "description"
     attributes:
       label: "Description"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

> Add a brief description
update Description type to textarea in `.github/ISSUE_TEMPLATE/bug_report.yml`

## ⛳️ Current behavior (updates)
> Please describe the current behavior that you are modifying

use `textarea` instead of `input`
When I try to open a bug report issue, the description form just has one line. Some tip wad hidden. In my opinion a textarea would be more appropriate here. Once the PR is accepted, the description will behave the same as Steps to reproduce
<img width="838" alt="image" src="https://user-images.githubusercontent.com/33956589/197968196-97d0eb0f-00cd-4d53-bea2-d3a6cc840aba.png">


## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
