### PR TITLE
fix(pin-input): fix focus management

### DIFF
--- a/.changeset/fuzzy-mails-deny.md
+++ b/.changeset/fuzzy-mails-deny.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/pin-input": minor
+---
+
+- Fixes focus when onComplete triggers onChange- Adds focus management on copy
+  and paste

--- a/packages/components/pin-input/src/use-pin-input.ts
+++ b/packages/components/pin-input/src/use-pin-input.ts
@@ -180,7 +180,10 @@ export function usePinInput(props: UsePinInputProps = {}) {
   const setValue = useCallback(
     (value: string, index: number, handleFocus: boolean = true) => {
       const nextValues = [...values]
-      nextValues[index] = value
+      // Index has to fit into our NextValues
+      const currentIndex =
+        nextValues.length >= index ? index : nextValues.length
+      nextValues[currentIndex] = value
       setValues(nextValues)
 
       const isComplete =
@@ -193,7 +196,7 @@ export function usePinInput(props: UsePinInputProps = {}) {
       if (isComplete) {
         onComplete?.(nextValues.join(""))
       } else {
-        if (handleFocus) focusNext(index)
+        if (handleFocus) focusNext(currentIndex)
       }
     },
     [values, setValues, focusNext, onComplete, descendants],
@@ -237,7 +240,8 @@ export function usePinInput(props: UsePinInputProps = {}) {
         }
 
         // in the case of an autocomplete or copy and paste
-        if (eventValue.length > 2) {
+        // We can copy and pase two and more chars
+        if (eventValue.length >= 2) {
           // see if we can use the string to fill out our values
           if (validate(eventValue, type)) {
             // Ensure the value matches the number of inputs
@@ -246,10 +250,13 @@ export function usePinInput(props: UsePinInputProps = {}) {
               .filter((_, index) => index < descendants.count())
 
             setValues(nextValue)
-
             // if pasting fills the entire input fields, trigger `onComplete`
             if (nextValue.length === descendants.count()) {
               onComplete?.(nextValue.join(""))
+            } else {
+              // If copy and was incomplete - we move focus
+              // -1 is fine as we always have 2 and more chars
+              focusNext(nextValue.length - 1)
             }
           }
         } else {
@@ -306,21 +313,22 @@ export function usePinInput(props: UsePinInputProps = {}) {
       }
     },
     [
-      descendants,
       focusedIndex,
-      getNextValue,
+      type,
+      mask,
       id,
       isDisabled,
-      mask,
       isInvalid,
-      manageFocus,
-      onComplete,
+      values,
       otp,
       placeholder,
+      getNextValue,
       setValue,
       setValues,
-      type,
-      values,
+      descendants,
+      onComplete,
+      focusNext,
+      manageFocus,
     ],
   )
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #6909 <!-- Github issue # here -->

## 📝 Description

- Fixes focus when onComplete triggers onChange
- Adds focus management on copy and paste


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

- If you call onComplete with async/await fetch and clears itself it will lose focus and restrict you from entering new values without changing focus
- If you copy and paste two characters it wont fill itself
- If you copy and paste it wont move your focus

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

- Changes `setValue` to check if index is smaller or the same as nextValue size, move focus to next input
- Checks if two or more characters were copy and pasted
- Moves focus to next input if it was not filled



## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
I don't think so 


## 📝 Additional Information
- 

