### PR TITLE
refactor(Button): Support next 13 Link

### DIFF
--- a/.changeset/twelve-lemons-look.md
+++ b/.changeset/twelve-lemons-look.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/button": patch
+---
+
+Nest all the children of <Button /> in a React.Fragment to support next 13 Link
+in as prop.

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/system"
 import { cx, dataAttr } from "@chakra-ui/shared-utils"
 
-import { useMemo } from "react"
+import { useMemo, Fragment } from "react"
 import { useButtonGroup } from "./button-context"
 import { ButtonIcon } from "./button-icon"
 import { ButtonSpinner } from "./button-spinner"
@@ -89,37 +89,39 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       className={cx("chakra-button", className)}
       {...rest}
     >
-      {isLoading && spinnerPlacement === "start" && (
-        <ButtonSpinner
-          className="chakra-button__spinner--start"
-          label={loadingText}
-          placement="start"
-          spacing={iconSpacing}
-        >
-          {spinner}
-        </ButtonSpinner>
-      )}
+      <Fragment>
+        {isLoading && spinnerPlacement === "start" && (
+          <ButtonSpinner
+            className="chakra-button__spinner--start"
+            label={loadingText}
+            placement="start"
+            spacing={iconSpacing}
+          >
+            {spinner}
+          </ButtonSpinner>
+        )}
 
-      {isLoading ? (
-        loadingText || (
-          <chakra.span opacity={0}>
-            <ButtonContent {...contentProps} />
-          </chakra.span>
-        )
-      ) : (
-        <ButtonContent {...contentProps} />
-      )}
+        {isLoading ? (
+          loadingText || (
+            <chakra.span opacity={0}>
+              <ButtonContent {...contentProps} />
+            </chakra.span>
+          )
+        ) : (
+          <ButtonContent {...contentProps} />
+        )}
 
-      {isLoading && spinnerPlacement === "end" && (
-        <ButtonSpinner
-          className="chakra-button__spinner--end"
-          label={loadingText}
-          placement="end"
-          spacing={iconSpacing}
-        >
-          {spinner}
-        </ButtonSpinner>
-      )}
+        {isLoading && spinnerPlacement === "end" && (
+          <ButtonSpinner
+            className="chakra-button__spinner--end"
+            label={loadingText}
+            placement="end"
+            spacing={iconSpacing}
+          >
+            {spinner}
+          </ButtonSpinner>
+        )}
+      </Fragment>
     </chakra.button>
   )
 })


### PR DESCRIPTION
## 📝 Description

Next.js 13 just release with a new version of the `next/link` component. In this version it's now possible to render links without the direct `a` as the child of the link component. However this implementation now results in an issue when you try to use the Chakra Button `as` prop with `Link`. 

## ⛳️ Current behavior (updates)

The following setup of the Chakra `<Button />`:
```js
<Button
  as={Link}
  href={linkResolver(link_href)}
  passHref
>
  {link_label}
</Button>
```

Will throw the following error:
```
Error: Multiple children were passed to <Link> with `href` of [`https://google.com`](http://localhost:3000/%60https://google.com%60) but only one child is supported https://nextjs.org/docs/messages/link-multiple-children
```

This makes a lot of sense since the Button renders 3 children:
- Loading with spinnerPlacement=start
- The content or loading text 
- Loading with spinnerPlacement=end

## 🚀 New behavior

Just simply wrapping the children of the `<Button />` component in a `<Fragment>` will resolve the issue and doesn't change the current implementation of the component.

## 💣 Is this a breaking change (**No**):
