### PR TITLE
feat(progress): allow overriding role for Progress

### DIFF
--- a/.changeset/slow-geese-tan.md
+++ b/.changeset/slow-geese-tan.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/progress": minor
+---
+
+Allow overriding `role` for `Progress`

--- a/packages/components/progress/src/progress.tsx
+++ b/packages/components/progress/src/progress.tsx
@@ -39,8 +39,14 @@ export interface ProgressFilledTrackProps
  */
 const ProgressFilledTrack = forwardRef<ProgressFilledTrackProps, "div">(
   (props, ref) => {
-    const { min, max, value, isIndeterminate, ...rest } = props
-    const progress = getProgressProps({ value, min, max, isIndeterminate })
+    const { min, max, value, isIndeterminate, role, ...rest } = props
+    const progress = getProgressProps({
+      value,
+      min,
+      max,
+      isIndeterminate,
+      role,
+    })
 
     const styles = useProgressStyles()
     const trackStyles = {
@@ -122,6 +128,7 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
     title,
+    role,
     ...rest
   } = omitThemingProps(props)
 
@@ -177,6 +184,7 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
           css={css}
           borderRadius={borderRadius}
           title={title}
+          role={role}
         />
         {children}
       </ProgressStylesProvider>

--- a/packages/components/progress/src/progress.utils.tsx
+++ b/packages/components/progress/src/progress.utils.tsx
@@ -47,6 +47,7 @@ export interface GetProgressPropsOptions {
   valueText?: string
   getValueText?(value: number, percent: number): string
   isIndeterminate?: boolean
+  role?: React.AriaRole
 }
 
 /**
@@ -61,6 +62,7 @@ export function getProgressProps(options: GetProgressPropsOptions) {
     valueText,
     getValueText,
     isIndeterminate,
+    role = "progressbar",
   } = options
 
   const percent = valueToPercent(value, min, max)
@@ -79,7 +81,7 @@ export function getProgressProps(options: GetProgressPropsOptions) {
       "aria-valuemin": min,
       "aria-valuenow": isIndeterminate ? undefined : value,
       "aria-valuetext": getAriaValueText(),
-      role: "progressbar",
+      role,
     },
     percent,
     value,

--- a/packages/components/progress/tests/Progress.test.tsx
+++ b/packages/components/progress/tests/Progress.test.tsx
@@ -106,3 +106,20 @@ test("CircularProgress: has the proper aria, data, and role attributes", () => {
 
   expect(progress).toHaveAttribute("aria-valuetext", "20 (20%)")
 })
+
+test("Progress as meter", async () => {
+  const { getByRole, queryByRole, container } = render(
+    <Progress
+      color="green"
+      size="sm"
+      value={20}
+      role="meter"
+      aria-label="Usage"
+    />,
+  )
+
+  expect(getByRole("meter")).toBeVisible()
+  expect(queryByRole("progressbar")).toBeNull()
+
+  await testA11y(container)
+})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/6913

## 📝 Description
Allows overriding the role on `Progress`, for example to use it as a `Meter`

## ⛳️ Current behavior (updates)
Setting `role` prop sets the role for the containing div, rather than overriding the progressbar role

## 🚀 New behavior
Setting `role` prop now overrides `progressbar`

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
