### PR TITLE
docs(CONTRIBUTING): update tsup link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ that can be consumed in isolation.
 ### Tooling
 
 - [PNPM](https://pnpm.io/) to manage packages and dependecnies
-- [Tsup](https://tsup.egoist.sh/) to bundle packages
+- [Tsup](https://tsup.egoist.dev/) to bundle packages
 - [Storybook](https://storybook.js.org/) for rapid UI component development and
   testing
 - [Testing Library](https://testing-library.com/) for testing components and


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Tsup dependency link is broken because the extension is now `.dev` instead of `.sh`.

## ⛳️ Current behavior (updates)

Clicking on the tsup link in the contributing guide will get you  nowhere.

## 🚀 New behavior

Clicking on the tsup link now gets you to its documentation.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
