### PR TITLE
refactor(menu): replace framer-motion with css animation

### DIFF
--- a/.changeset/rich-plums-listen.md
+++ b/.changeset/rich-plums-listen.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": minor
+---
+
+replace framer-motion with CSS animation

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -57,13 +57,11 @@
     "@chakra-ui/button": "workspace:*",
     "@chakra-ui/shared-utils": "workspace:*",
     "react-icons": "^4.2.0",
-    "framer-motion": "^6.2.9",
     "react": "^18.0.0",
     "clean-package": "2.1.1"
   },
   "peerDependencies": {
     "@chakra-ui/system": ">=2.0.0",
-    "framer-motion": ">=4.0.0",
     "react": ">=18"
   },
   "scripts": {

--- a/packages/components/menu/src/menu-list.tsx
+++ b/packages/components/menu/src/menu-list.tsx
@@ -1,7 +1,12 @@
 import { callAll, cx } from "@chakra-ui/shared-utils"
-import { chakra, forwardRef, HTMLChakraProps } from "@chakra-ui/system"
+import {
+  chakra,
+  forwardRef,
+  HTMLChakraProps,
+  keyframes,
+} from "@chakra-ui/system"
 
-import { HTMLMotionProps, motion, Variants } from "framer-motion"
+import { useMemo } from "react"
 import { useMenuStyles } from "./menu"
 import { useMenuContext, useMenuList, useMenuPositioner } from "./use-menu"
 
@@ -10,71 +15,76 @@ export interface MenuListProps extends HTMLChakraProps<"div"> {
    * Props for the root element that positions the menu.
    */
   rootProps?: HTMLChakraProps<"div">
-  /**
-   * The framer-motion props to animate the menu list
-   */
-  motionProps?: HTMLMotionProps<"div">
 }
 
-const motionVariants: Variants = {
-  enter: {
-    visibility: "visible",
-    opacity: 1,
-    scale: 1,
-    transition: {
-      duration: 0.2,
-      ease: [0.4, 0, 0.2, 1],
-    },
-  },
-  exit: {
-    transitionEnd: {
-      visibility: "hidden",
-    },
+const enterAnim = keyframes({
+  from: {
     opacity: 0,
-    scale: 0.8,
-    transition: {
-      duration: 0.1,
-      easings: "easeOut",
-    },
+    transform: "scale(0.8)",
+    visibility: "hidden",
   },
-}
+  to: {
+    opacity: 1,
+    transform: "scale(1)",
+    visibility: "visible",
+  },
+})
 
-const MenuTransition = chakra(motion.div)
+const exitAnim = keyframes({
+  from: {
+    opacity: 1,
+    transform: "scale(1)",
+    visibility: "visible",
+  },
+  to: {
+    opacity: 0,
+    transform: "scale(0.8)",
+    visibility: "hidden",
+  },
+})
 
 export const MenuList = forwardRef<MenuListProps, "div">(function MenuList(
   props,
   ref,
 ) {
-  const { rootProps, motionProps, ...rest } = props
-  const {
-    isOpen,
-    onTransitionEnd,
-    unstable__animationState: animated,
-  } = useMenuContext()
+  const { rootProps, ...rest } = props
+  const { isOpen, hasBeenOpened, onTransitionEnd } = useMenuContext()
 
   const listProps = useMenuList(rest, ref) as any
   const positionerProps = useMenuPositioner(rootProps)
 
   const styles = useMenuStyles()
 
+  const animation = useMemo(() => {
+    if (!hasBeenOpened.current) {
+      return undefined
+    }
+
+    return isOpen
+      ? `${enterAnim} 200ms cubic-bezier(0.4, 0, 0.2, 1.0)`
+      : `${exitAnim} 100ms ease-out`
+  }, [isOpen, hasBeenOpened])
+
   return (
     <chakra.div
       {...positionerProps}
-      __css={{ zIndex: props.zIndex ?? styles.list?.zIndex }}
+      __css={{
+        zIndex: props.zIndex ?? styles.list?.zIndex,
+      }}
     >
-      <MenuTransition
-        variants={motionVariants}
-        initial={false}
-        animate={isOpen ? "enter" : "exit"}
-        __css={{ outline: 0, ...styles.list }}
-        {...motionProps}
+      <chakra.div
+        __css={{
+          outline: 0,
+          visibility: isOpen ? "visible" : "hidden",
+          animation: animation,
+          ...styles.list,
+        }}
+        style={{
+          ...listProps.style,
+        }}
         className={cx("chakra-menu__menu-list", listProps.className)}
         {...listProps}
-        onUpdate={onTransitionEnd}
-        onAnimationComplete={callAll(
-          animated.onComplete,
-          listProps.onAnimationComplete,
-        )}
+        onAnimationEnd={callAll(onTransitionEnd, listProps.onAnimationComplete)}
       />
     </chakra.div>
   )

--- a/packages/components/menu/src/use-menu.ts
+++ b/packages/components/menu/src/use-menu.ts
@@ -244,6 +244,11 @@ export function useMenu(props: UseMenuProps = {}) {
    */
   const [buttonId, menuId] = useIds(id, `menu-button`, `menu-list`)
 
+  const hasBeenOpened = useRef(false)
+  if (isOpen) {
+    hasBeenOpened.current = true
+  }
+
   const openAndFocusMenu = useCallback(() => {
     onOpen()
     focusMenu()
@@ -290,6 +295,7 @@ export function useMenu(props: UseMenuProps = {}) {
     forceUpdate: popper.forceUpdate,
     orientation: "vertical",
     isOpen,
+    hasBeenOpened,
     onToggle,
     onOpen,
     onClose,
@@ -399,7 +405,7 @@ export function useMenuList(
     focusedIndex,
     setFocusedIndex,
     menuRef,
-    isOpen,
+    hasBeenOpened,
     onClose,
     menuId,
     isLazy,
@@ -472,11 +478,6 @@ export function useMenuList(
       setFocusedIndex,
     ],
   )
-
-  const hasBeenOpened = useRef(false)
-  if (isOpen) {
-    hasBeenOpened.current = true
-  }
 
   const shouldRenderChildren = lazyDisclosure({
     wasSelected: hasBeenOpened.current,

--- a/packages/hooks/use-animation-state/src/index.ts
+++ b/packages/hooks/use-animation-state/src/index.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { useEventListener } from "@chakra-ui/react-use-event-listener"
+import { getOwnerWindow } from "@chakra-ui/dom-utils"
 export type UseAnimationStateProps = {
   isOpen: boolean
   ref: React.RefObject<HTMLElement>
@@ -30,5 +31,10 @@ export function useAnimationState(props: UseAnimationStateProps) {
 
   return {
     present: !hidden,
+    onComplete() {
+      const win = getOwnerWindow(ref.current)
+      const evt = new win.CustomEvent("animationend", { bubbles: true })
+      ref.current?.dispatchEvent(evt)
+    },
   }
 }

--- a/packages/hooks/use-animation-state/src/index.ts
+++ b/packages/hooks/use-animation-state/src/index.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react"
 import { useEventListener } from "@chakra-ui/react-use-event-listener"
-import { getOwnerWindow } from "@chakra-ui/dom-utils"
 export type UseAnimationStateProps = {
   isOpen: boolean
   ref: React.RefObject<HTMLElement>
@@ -31,10 +30,5 @@ export function useAnimationState(props: UseAnimationStateProps) {
 
   return {
     present: !hidden,
-    onComplete() {
-      const win = getOwnerWindow(ref.current)
-      const evt = new win.CustomEvent("animationend", { bubbles: true })
-      ref.current?.dispatchEvent(evt)
-    },
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -866,7 +866,6 @@ importers:
       '@chakra-ui/theme': workspace:*
       '@chakra-ui/transition': workspace:*
       clean-package: 2.1.1
-      framer-motion: ^6.2.9
       react: ^18.2.0
       react-icons: ^4.2.0
     dependencies:
@@ -894,7 +893,6 @@ importers:
       '@chakra-ui/system': link:../../core/system
       '@chakra-ui/theme': link:../theme
       clean-package: 2.1.1
-      framer-motion: 6.5.1_react@18.2.0
       react: 18.2.0
       react-icons: 4.4.0_react@18.2.0
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Related to https://github.com/chakra-ui/chakra-ui/issues/4975

## 📝 Description

Removing framer-motion from MenuList component and Replacing it with CSS animation.

## ⛳️ Current behavior (updates)

The animation of MenuList is implemented with framer-motion.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

The animation of MenuList is implemented with CSS animation.

## 💣 Is this a breaking change (Yes/No):

`motionProps` is removed because framer-motion is no longer used.

It's better to provide something to customize CSS animation, but i have no idea about how to do it. Props or theme?

## 📝 Additional Information
