### PR TITLE
fix(Modal): make header an h2 so it is named by its content

### DIFF
--- a/.changeset/fast-owls-bake.md
+++ b/.changeset/fast-owls-bake.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Change `ModalHeader` to render an `h2` so that it is named by its content

--- a/packages/components/modal/src/modal-header.tsx
+++ b/packages/components/modal/src/modal-header.tsx
@@ -9,7 +9,7 @@ import { useEffect } from "react"
 
 import { useModalContext, useModalStyles } from "./modal"
 
-export interface ModalHeaderProps extends HTMLChakraProps<"header"> {}
+export interface ModalHeaderProps extends HTMLChakraProps<"h2"> {}
 
 /**
  * ModalHeader
@@ -18,39 +18,37 @@ export interface ModalHeaderProps extends HTMLChakraProps<"header"> {}
  *
  * @see Docs https://chakra-ui.com/modal
  */
-export const ModalHeader = forwardRef<ModalHeaderProps, "header">(
-  (props, ref) => {
-    const { className, ...rest } = props
+export const ModalHeader = forwardRef<ModalHeaderProps, "h2">((props, ref) => {
+  const { className, ...rest } = props
 
-    const { headerId, setHeaderMounted } = useModalContext()
+  const { headerId, setHeaderMounted } = useModalContext()
 
-    /**
-     * Notify us if this component was rendered or used,
-     * so we can append `aria-labelledby` automatically
-     */
-    useEffect(() => {
-      setHeaderMounted(true)
-      return () => setHeaderMounted(false)
-    }, [setHeaderMounted])
+  /**
+   * Notify us if this component was rendered or used,
+   * so we can append `aria-labelledby` automatically
+   */
+  useEffect(() => {
+    setHeaderMounted(true)
+    return () => setHeaderMounted(false)
+  }, [setHeaderMounted])
 
-    const _className = cx("chakra-modal__header", className)
+  const _className = cx("chakra-modal__header", className)
 
-    const styles = useModalStyles()
-    const headerStyles: SystemStyleObject = {
-      flex: 0,
-      ...styles.header,
-    }
+  const styles = useModalStyles()
+  const headerStyles: SystemStyleObject = {
+    flex: 0,
+    ...styles.header,
+  }
 
-    return (
-      <chakra.header
-        ref={ref}
-        className={_className}
-        id={headerId}
-        {...rest}
-        __css={headerStyles}
-      />
-    )
-  },
-)
+  return (
+    <chakra.h2
+      ref={ref}
+      className={_className}
+      id={headerId}
+      {...rest}
+      __css={headerStyles}
+    />
+  )
+})
 
 ModalHeader.displayName = "ModalHeader"

--- a/packages/components/modal/tests/alert-dialog.test.tsx
+++ b/packages/components/modal/tests/alert-dialog.test.tsx
@@ -67,9 +67,11 @@ it("renders an element with role='alertdialog' when opened", () => {
 })
 
 it("passes a11y test closed", async () => {
-  await testA11y(<BasicUsage />)
+  const { baseElement } = render(<BasicUsage />)
+  await testA11y(baseElement)
 })
 
 it("passes a11y test opened", async () => {
-  await testA11y(<BasicUsage isOpen />)
+  const { baseElement } = render(<BasicUsage isOpen />)
+  await testA11y(baseElement)
 })

--- a/packages/components/modal/tests/drawer.test.tsx
+++ b/packages/components/modal/tests/drawer.test.tsx
@@ -45,7 +45,9 @@ it("does renders when isOpen is true", () => {
 })
 
 it("passes a11y test", async () => {
-  await testA11y(<SimpleDrawer placement="left" isOpen />)
+  const { baseElement } = render(<SimpleDrawer placement="left" isOpen />)
+  // Test baseElement because we're in a portal
+  await testA11y(baseElement)
 })
 
 it("renders on the correct side under 'ltr' direction", () => {

--- a/packages/components/modal/tests/modal.test.tsx
+++ b/packages/components/modal/tests/modal.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "../src"
 
 test("should have no accessibility violations", async () => {
-  const { container } = render(
+  const { baseElement } = render(
     <Modal isOpen onClose={jest.fn()}>
       <ModalOverlay />
       <ModalContent>
@@ -29,7 +29,7 @@ test("should have no accessibility violations", async () => {
     </Modal>,
   )
 
-  await testA11y(container)
+  await testA11y(baseElement)
 })
 
 test("should have the proper 'aria' attributes", () => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/7006

## 📝 Description

`header` renders a `banner` when scoped to the body, so it isn't named by its contents, so the `Drawer` `role="dialog"` element has no accessible name

## ⛳️ Current behavior (updates)

`ModalHeader`, `DrawerHeader` and `AlertDialogHeader` render `header` DOM elements

## 🚀 New behavior

`ModalHeader`, `DrawerHeader` and `AlertDialogHeader` render `h2` DOM elements

## 💣 Is this a breaking change (Yes/No):
No API change, no change in visual appearance. If users have snapshotted the DOM they might see it.

## 📝 Additional Information
