### PR TITLE
fix: modal, fixes chakra-ui/chakra-ui#7004

### DIFF
--- a/.changeset/short-parents-stare.md
+++ b/.changeset/short-parents-stare.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+escape key listener now using preventDefault

--- a/packages/components/modal/src/use-modal.ts
+++ b/packages/components/modal/src/use-modal.ts
@@ -97,7 +97,7 @@ export function useModal(props: UseModalProps) {
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key === "Escape") {
-        event.stopPropagation()
+        event.preventDefault()
 
         if (closeOnEsc) {
           onClose?.()


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7004 

## 📝 Description

When nesting Tooltips inside a modal component with the closeOnEsc prop set to false, tabbing to the tooltip will open it, but the event.stopPropagation() on the target modal was blocking users from being able to close the tooltip with the escape key press.  Changing to event.preventDefault fixes this by not blocking bubbling.

## ⛳️ Current behavior (updates)

Behavior should be the same, except now when a modal uses closeOnEsc={false} and tooltip children will be able to close on escape

## 🚀 New behavior

none

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
