### PR TITLE
ci(codesandbox): use pnpm v7 in CodeSandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,6 @@
 {
   "node": "16",
+  "installCommand": "csb:install",
   "sandboxes": ["/examples/create-react-app"],
   "packages": [
     "packages/components/accordion",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "twitter:gen": "tsx scripts/twitter-generate.ts",
     "twitter:write": "tsx scripts/twitter-write.ts",
     "csb": "tsx scripts/csb.ts",
+    "csb:install": "pnpm add -g @pnpm/exe@7 && pnpm install",
     "create:pkg": "plop component",
     "version": "changeset version",
     "release": "changeset publish",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The pnpm version in CodeSandbox CI is v6 and we can't change it in config. This causes an error on the build.

As a workaround, install pnpm v7 at the beginning of the build.

## ⛳️ Current behavior (updates)

CodeSandbox builds fail.

## 🚀 New behavior

CodeSandbox builds succeed.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
