### PR TITLE
fix: [Radio] adjust value prop type

### DIFF
--- a/.changeset/rich-singers-build.md
+++ b/.changeset/rich-singers-build.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/radio": patch
+---
+
+Update type of `value` and `defaultValue` to `string` instead of `string | number`. This reflects the internal implementation

--- a/packages/components/radio/src/use-radio-group.ts
+++ b/packages/components/radio/src/use-radio-group.ts
@@ -14,12 +14,12 @@ export interface UseRadioGroupProps {
    * The value of the radio to be `checked`
    * (in controlled mode)
    */
-  value?: string | number
+  value?: string
   /**
    * The value of the radio to be `checked`
    * initially (in uncontrolled mode)
    */
-  defaultValue?: string | number
+  defaultValue?: string
   /**
    * Function called once a radio is checked
    * @param nextValue the value of the checked radio

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -24,7 +24,7 @@ export interface UseRadioProps {
    * The value to be used in the radio button.
    * This is the value that will be returned on form submission.
    */
-  value?: string | number
+  value?: string
   /**
    * If `true`, the radio will be checked.
    * You'll need to pass `onChange` to update its value (since it is now controlled)


### PR DESCRIPTION
Closes #6966

## 📝 Description

Radio bugs when accepting number in value prop.

## ⛳️ Current behavior

![image](https://user-images.githubusercontent.com/52859409/203543599-dcbebe1d-9ca7-47b5-9930-fdeaf6ddc629.png)

##🚀 New behavior

![image](https://user-images.githubusercontent.com/52859409/203543733-52aab91c-57ca-4ed2-93aa-ff2d5d12a841.png)

> I change the types of "value" on Radio, and the types of "value" and "defaultValue" on RadioGroup. All to only accepts string instead of "string | number"

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

For more details, please check the discussion on the issue.
