### PR TITLE
fix(badge): ellipsis show up when using noOfLines and maxW

### DIFF
--- a/.changeset/green-donkeys-do.md
+++ b/.changeset/green-donkeys-do.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/layout": patch
+---
+
+The ellipsis can show up on the Badge component using noOfLines and maxW.

--- a/packages/components/layout/src/badge.tsx
+++ b/packages/components/layout/src/badge.tsx
@@ -5,8 +5,10 @@ import {
   ThemingProps,
   useStyleConfig,
   HTMLChakraProps,
+  ChakraProps,
 } from "@chakra-ui/system"
 import { cx } from "@chakra-ui/shared-utils"
+import { useMemo } from "react"
 
 export interface BadgeProps
   extends HTMLChakraProps<"span">,
@@ -21,18 +23,34 @@ export interface BadgeProps
 export const Badge = forwardRef<BadgeProps, "span">(function Badge(props, ref) {
   const styles = useStyleConfig("Badge", props)
   const { className, ...rest } = omitThemingProps(props)
+  const badgeStyle = useMemo((): ChakraProps => {
+    if (props.noOfLines) {
+      return {
+        __css: {
+          verticalAlign: "middle",
+          ...styles,
+        },
+        sx: {
+          display: props.display || "-webkit-inline-box",
+        },
+      }
+    }
+    return {
+      __css: {
+        display: "inline-block",
+        whiteSpace: "nowrap",
+        verticalAlign: "middle",
+        ...styles,
+      },
+    }
+  }, [props.display, props.noOfLines, styles])
 
   return (
     <chakra.span
       ref={ref}
       className={cx("chakra-badge", props.className)}
       {...rest}
-      __css={{
-        display: "inline-block",
-        whiteSpace: "nowrap",
-        verticalAlign: "middle",
-        ...styles,
-      }}
+      {...badgeStyle}
     />
   )
 })

--- a/packages/components/layout/src/badge.tsx
+++ b/packages/components/layout/src/badge.tsx
@@ -32,6 +32,7 @@ export const Badge = forwardRef<BadgeProps, "span">(function Badge(props, ref) {
         },
         sx: {
           display: props.display || "-webkit-inline-box",
+          ...rest.sx,
         },
       }
     }
@@ -43,7 +44,7 @@ export const Badge = forwardRef<BadgeProps, "span">(function Badge(props, ref) {
         ...styles,
       },
     }
-  }, [props.display, props.noOfLines, styles])
+  }, [props.display, props.noOfLines, styles, rest.sx])
 
   return (
     <chakra.span

--- a/packages/components/layout/tests/layout.test.tsx
+++ b/packages/components/layout/tests/layout.test.tsx
@@ -37,6 +37,31 @@ describe("<Badge />", () => {
   test("passes a11y test", async () => {
     await testA11y(<Badge>this is a badge</Badge>)
   })
+
+  test("default style property", () => {
+    render(<Badge>My Badge</Badge>)
+
+    expect(screen.getByText("My Badge")).toHaveStyle({
+      display: "inline-block",
+      whiteSpace: "nowrap",
+      verticalAlign: "middle",
+    })
+  })
+
+  test("ellipsis with noOfLines and maxW props", () => {
+    render(
+      <Badge noOfLines={1} maxW={10}>
+        My Badge
+      </Badge>,
+    )
+
+    expect(screen.getByText("My Badge")).toHaveStyle({
+      display: "-webkit-inline-box",
+      verticalAlign: "middle",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    })
+  })
 })
 
 describe("<Container />", () => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # https://github.com/chakra-ui/chakra-ui/issues/7027

## 📝 Description
`Badge` is able to truncate the inner text after a specific number of lines, passing the `noOfLines` and `maxW` props.

## ⛳️ Current behavior (updates)
The ellipsis does not appear on the Badge component using `noOfLines` and `maxW`. It used to work on `@chakra-ui/react": "^1.7.3`.

## 🚀 New behavior
The ellipsis can show up on the Badge component using `noOfLines` and `maxW`.


https://user-images.githubusercontent.com/11571318/204123706-c7d69dbe-5eaf-4f6c-b3f3-e6617464c6fe.mov



## 💣 Is this a breaking change (Yes/No):

No API change, no change in visual appearance.

## 📝 Additional Information
