### PR TITLE
test(Modal): make Modal a11y tests cover the modals

### DIFF
--- a/.changeset/slow-pens-rule.md
+++ b/.changeset/slow-pens-rule.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Update modal a11y unit tests to correctly cover the portal

--- a/packages/components/modal/tests/alert-dialog.test.tsx
+++ b/packages/components/modal/tests/alert-dialog.test.tsx
@@ -67,9 +67,27 @@ it("renders an element with role='alertdialog' when opened", () => {
 })
 
 it("passes a11y test closed", async () => {
-  await testA11y(<BasicUsage />)
+  const { baseElement } = render(<BasicUsage />)
+  // Test baseElement because the dialog is in a portal
+  await testA11y(baseElement, {
+    axeOptions: {
+      rules: {
+        // https://github.com/dequelabs/axe-core/issues/3752
+        "aria-dialog-name": { enabled: false },
+      },
+    },
+  })
 })
 
 it("passes a11y test opened", async () => {
-  await testA11y(<BasicUsage isOpen />)
+  const { baseElement } = render(<BasicUsage isOpen />)
+  // Test baseElement because the dialog is in a portal
+  await testA11y(baseElement, {
+    axeOptions: {
+      rules: {
+        // https://github.com/dequelabs/axe-core/issues/3752
+        "aria-dialog-name": { enabled: false },
+      },
+    },
+  })
 })

--- a/packages/components/modal/tests/drawer.test.tsx
+++ b/packages/components/modal/tests/drawer.test.tsx
@@ -45,7 +45,16 @@ it("does renders when isOpen is true", () => {
 })
 
 it("passes a11y test", async () => {
-  await testA11y(<SimpleDrawer placement="left" isOpen />)
+  const { baseElement } = render(<SimpleDrawer placement="left" isOpen />)
+  // Test baseElement because we're in a portal
+  await testA11y(baseElement, {
+    axeOptions: {
+      rules: {
+        // https://github.com/chakra-ui/chakra-ui/issues/7006
+        "aria-dialog-name": { enabled: false },
+      },
+    },
+  })
 })
 
 it("renders on the correct side under 'ltr' direction", () => {

--- a/packages/components/modal/tests/modal.test.tsx
+++ b/packages/components/modal/tests/modal.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "../src"
 
 test("should have no accessibility violations", async () => {
-  const { container } = render(
+  const { baseElement } = render(
     <Modal isOpen onClose={jest.fn()}>
       <ModalOverlay />
       <ModalContent>
@@ -29,7 +29,15 @@ test("should have no accessibility violations", async () => {
     </Modal>,
   )
 
-  await testA11y(container)
+  // Test baseElement because the modal is in a portal
+  await testA11y(baseElement, {
+    axeOptions: {
+      rules: {
+        // https://github.com/dequelabs/axe-core/issues/3752
+        "aria-dialog-name": { enabled: false },
+      },
+    },
+  })
 })
 
 test("should have the proper 'aria' attributes", () => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Related to https://github.com/chakra-ui/chakra-ui/issues/7006 and https://github.com/chakra-ui/chakra-ui/pull/7007

## 📝 Description
The current modal unit tests do not actually cover the modal because it's in a portal, so outside `container`.

## ⛳️ Current behavior (updates)
Unit tests run aXe over `container`, whereas the modal is in a portal so is appended to the `baseElement`

## 🚀 New behavior

Unit tests run aXe over `baseElement`

## 💣 Is this a breaking change (Yes/No):
No - unit tests

## 📝 Additional Information
Had to disable one rule due to https://github.com/chakra-ui/chakra-ui/issues/7006 (for drawer, which doesn't use a `section` element) and https://github.com/dequelabs/axe-core/issues/3752 (for modal/alert dialog)