### PR TITLE
refactor: use default parameters instead of deprecated defaultProps API

### DIFF
--- a/.changeset/fast-starfishes-pretend.md
+++ b/.changeset/fast-starfishes-pretend.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/portal": patch
+---
+
+Use default parameters instead of defaultProps API

--- a/packages/components/portal/src/portal.tsx
+++ b/packages/components/portal/src/portal.tsx
@@ -1,8 +1,8 @@
-import { useSafeLayoutEffect } from "@chakra-ui/react-use-safe-layout-effect"
 import { createContext } from "@chakra-ui/react-context"
+import { useSafeLayoutEffect } from "@chakra-ui/react-use-safe-layout-effect"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { usePortalManager } from "./portal-manager"
-import { useEffect, useMemo, useRef, useState } from "react"
 
 type PortalContext = HTMLDivElement | null
 
@@ -167,16 +167,12 @@ export interface PortalProps {
  */
 
 export function Portal(props: PortalProps) {
-  const { containerRef, ...rest } = props
+  const { containerRef, ...rest } = { appendToParentPortal: true, ...props }
   return containerRef ? (
     <ContainerPortal containerRef={containerRef} {...rest} />
   ) : (
     <DefaultPortal {...rest} />
   )
-}
-
-Portal.defaultProps = {
-  appendToParentPortal: true,
 }
 
 Portal.className = PORTAL_CLASSNAME


### PR DESCRIPTION
Closes #7057

## 📝 Description

React 18.3.0 will remove support for defaultProps to encourage developers to use JavaScript's default parameters syntax. This PR removes `defaultProps` from `<Portal />` and uses default parameters instead.

## ⛳️ Current behavior (updates)

Removing `Portal.defaultProps` in favor of JavaScript syntax.

## 🚀 New behavior

Use default parameters syntax.

## 💣 Is this a breaking change (Yes/No):

No

