### PR TITLE
fix(progress): Adding aria-valuetext property to the Progress component

### DIFF
--- a/.changeset/wet-ears-warn.md
+++ b/.changeset/wet-ears-warn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/progress": patch
+---
+
+Ensure `aria-valuetext` property is set on the correct element

--- a/packages/components/progress/src/progress.tsx
+++ b/packages/components/progress/src/progress.tsx
@@ -127,6 +127,7 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
     isIndeterminate,
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
+    "aria-valuetext": ariaValueText,
     title,
     role,
     ...rest
@@ -177,6 +178,7 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
         <ProgressFilledTrack
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
+          aria-valuetext={ariaValueText}
           min={min}
           max={max}
           value={value}

--- a/packages/components/progress/tests/Progress.test.tsx
+++ b/packages/components/progress/tests/Progress.test.tsx
@@ -26,6 +26,13 @@ test("Progress renders correctly", async () => {
         isAnimated
         value={80}
       />
+      <Progress
+        aria-label="Account Usage"
+        aria-valuetext="Value text"
+        colorScheme="green"
+        size="sm"
+        value={20}
+      />
     </div>,
   )
   await testA11y(container)
@@ -49,7 +56,7 @@ test("CircularProgress renders correctly", async () => {
 
 test("Progress: has the proper aria, data, and role attributes", () => {
   const { getByRole, rerender } = render(
-    <Progress color="green" size="sm" value={20} />,
+    <Progress color="green" size="sm" aria-valuetext="text" value={20} />,
   )
 
   let progress = getByRole("progressbar")
@@ -58,7 +65,7 @@ test("Progress: has the proper aria, data, and role attributes", () => {
   expect(progress).toHaveAttribute("aria-valuemax", "100")
   expect(progress).toHaveAttribute("aria-valuemin", "0")
   expect(progress).toHaveAttribute("aria-valuenow", "20")
-  expect(progress).not.toHaveAttribute("aria-valuetext")
+  expect(progress).toHaveAttribute("aria-valuetext", "text")
 
   // rerender as indeterminate
   rerender(<Progress color="green" size="sm" isIndeterminate />)


### PR DESCRIPTION
## 📝 Description
Updating properties for the `Progress` component, so that we can accommodate all the cases for addressing a11 issues. This PR is for adding `aria-valuetext` on the proper level (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext)
> Add a brief description

## ⛳️ Current behavior (updates)
Currently, if we pass the `aria-valuetext` prop to the Progress component it gets applied to the wrapper div
 
![Screenshot 2022-12-01 at 7 58 55 PM](https://user-images.githubusercontent.com/3450224/205137204-871d75b0-b58c-4773-8ee1-05ac9ae6783b.png)

this is invalid behavior and the screen readers cannot read it properly
> Please describe the current behavior that you are modifying
## 🚀 New behavior
With the change that I've included, the `aria-valuetext` prop is passed properly to the desired div, and the screen reader is reading the value correctly (tested with VoiceOver on iOS device, as well with VoiceOver in web browser/s).

![Screenshot 2022-12-01 at 8 03 17 PM](https://user-images.githubusercontent.com/3450224/205137989-5979469c-4da1-49ca-b5bb-b54ab85e8da5.png)
> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
- this is useful when we want to have a progress bar that declares steps, for example, then we can use `aria-valuetext="Step 1 of 2"` to be read by the screen reader and so on, this is just one simple example.