### PR TITLE
fix: remove default props from all components in support of 18.3.0

### DIFF
--- a/examples/gatsby/src/components/header.js
+++ b/examples/gatsby/src/components/header.js
@@ -2,7 +2,7 @@ import { Link } from "gatsby"
 import PropTypes from "prop-types"
 import React from "react"
 
-const Header = ({ siteTitle }) => (
+const Header = ({ siteTitle = "" }) => (
   <header
     style={{
       background: `rebeccapurple`,
@@ -33,10 +33,6 @@ const Header = ({ siteTitle }) => (
 
 Header.propTypes = {
   siteTitle: PropTypes.string,
-}
-
-Header.defaultProps = {
-  siteTitle: ``,
 }
 
 export default Header

--- a/packages/components/modal/src/modal.tsx
+++ b/packages/components/modal/src/modal.tsx
@@ -136,6 +136,18 @@ const [ModalContextProvider, useModalContext] = createContext<ModalContext>({
  * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
  */
 export const Modal: React.FC<ModalProps> = (props) => {
+  const defaultProps: ModalProps = {
+    scrollBehavior: "outside",
+    autoFocus: true,
+    trapFocus: true,
+    returnFocusOnClose: true,
+    blockScrollOnMount: true,
+    allowPinchZoom: false,
+    motionPreset: "scale",
+    lockFocusAcrossFrames: true,
+    ...props,
+  }
+
   const {
     portalProps,
     children,
@@ -150,10 +162,10 @@ export const Modal: React.FC<ModalProps> = (props) => {
     motionPreset,
     lockFocusAcrossFrames,
     onCloseComplete,
-  } = props
+  } = defaultProps
 
-  const styles = useMultiStyleConfig("Modal", props)
-  const modal = useModal(props)
+  const styles = useMultiStyleConfig("Modal", defaultProps)
+  const modal = useModal(defaultProps)
 
   const context = {
     ...modal,
@@ -178,17 +190,6 @@ export const Modal: React.FC<ModalProps> = (props) => {
       </ModalStylesProvider>
     </ModalContextProvider>
   )
-}
-
-Modal.defaultProps = {
-  lockFocusAcrossFrames: true,
-  returnFocusOnClose: true,
-  scrollBehavior: "outside",
-  trapFocus: true,
-  autoFocus: true,
-  blockScrollOnMount: true,
-  allowPinchZoom: false,
-  motionPreset: "scale",
 }
 
 Modal.displayName = "Modal"

--- a/packages/components/portal/src/portal.tsx
+++ b/packages/components/portal/src/portal.tsx
@@ -167,16 +167,17 @@ export interface PortalProps {
  */
 
 export function Portal(props: PortalProps) {
-  const { containerRef, ...rest } = props
+  const defaultProps: PortalProps = {
+    appendToParentPortal: true,
+    ...props,
+  }
+
+  const { containerRef, ...rest } = defaultProps
   return containerRef ? (
     <ContainerPortal containerRef={containerRef} {...rest} />
   ) : (
     <DefaultPortal {...rest} />
   )
-}
-
-Portal.defaultProps = {
-  appendToParentPortal: true,
 }
 
 Portal.className = PORTAL_CLASSNAME

--- a/packages/components/skeleton/src/skeleton.tsx
+++ b/packages/components/skeleton/src/skeleton.tsx
@@ -87,7 +87,12 @@ const bgFade = keyframes({
  * @see Docs https://chakra-ui.com/docs/components/skeleton
  */
 export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
-  const styles = useStyleConfig("Skeleton", props)
+  const defaultProps: SkeletonProps = {
+    fadeDuration: 0.4,
+    speed: 0.8,
+    ...props,
+  }
+  const styles = useStyleConfig("Skeleton", defaultProps)
   const isFirstRender = useIsFirstRender()
 
   const {
@@ -98,7 +103,7 @@ export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
     speed,
     className,
     ...rest
-  } = omitThemingProps(props)
+  } = omitThemingProps(defaultProps)
 
   const [startColorVar, endColorVar] = useToken("colors", [
     startColor,
@@ -142,10 +147,5 @@ export const Skeleton = forwardRef<SkeletonProps, "div">((props, ref) => {
     />
   )
 })
-
-Skeleton.defaultProps = {
-  fadeDuration: 0.4,
-  speed: 0.8,
-}
 
 Skeleton.displayName = "Skeleton"

--- a/packages/components/slider/src/range-slider.tsx
+++ b/packages/components/slider/src/range-slider.tsx
@@ -54,15 +54,19 @@ export interface RangeSliderProps
  */
 export const RangeSlider = forwardRef<RangeSliderProps, "div">(
   function RangeSlider(props, ref) {
-    const styles = useMultiStyleConfig("Slider", props)
-    const ownProps = omitThemingProps(props)
+    const defaultProps: RangeSliderProps = {
+      orientation: "horizontal",
+      ...props,
+    }
+    const styles = useMultiStyleConfig("Slider", defaultProps)
+    const ownProps = omitThemingProps(defaultProps)
     const { direction } = useTheme()
     ownProps.direction = direction
 
     const { getRootProps, ...context } = useRangeSlider(ownProps)
     const ctx = useMemo(
-      () => ({ ...context, name: props.name }),
-      [context, props.name],
+      () => ({ ...context, name: defaultProps.name }),
+      [context, defaultProps.name],
     )
 
     return (
@@ -73,17 +77,13 @@ export const RangeSlider = forwardRef<RangeSliderProps, "div">(
             className="chakra-slider"
             __css={styles.container}
           >
-            {props.children}
+            {defaultProps.children}
           </chakra.div>
         </RangeSliderStylesProvider>
       </RangeSliderProvider>
     )
   },
 )
-
-RangeSlider.defaultProps = {
-  orientation: "horizontal",
-}
 
 RangeSlider.displayName = "RangeSlider"
 

--- a/packages/components/slider/src/slider.tsx
+++ b/packages/components/slider/src/slider.tsx
@@ -45,8 +45,12 @@ export interface SliderProps
  * @see WAI-ARIA https://www.w3.org/WAI/ARIA/apg/patterns/slider/
  */
 export const Slider = forwardRef<SliderProps, "div">((props, ref) => {
-  const styles = useMultiStyleConfig("Slider", props)
-  const ownProps = omitThemingProps(props)
+  const defaultProps: SliderProps = {
+    orientation: "horizontal",
+    ...props,
+  }
+  const styles = useMultiStyleConfig("Slider", defaultProps)
+  const ownProps = omitThemingProps(defaultProps)
   const { direction } = useTheme()
   ownProps.direction = direction
 
@@ -60,20 +64,16 @@ export const Slider = forwardRef<SliderProps, "div">((props, ref) => {
       <SliderStylesProvider value={styles}>
         <chakra.div
           {...rootProps}
-          className={cx("chakra-slider", props.className)}
+          className={cx("chakra-slider", defaultProps.className)}
           __css={styles.container}
         >
-          {props.children}
+          {defaultProps.children}
           <input {...inputProps} />
         </chakra.div>
       </SliderStylesProvider>
     </SliderProvider>
   )
 })
-
-Slider.defaultProps = {
-  orientation: "horizontal",
-}
 
 Slider.displayName = "Slider"
 


### PR DESCRIPTION
Closes #7057

## 📝 Description

React 18.3.0 will deprecate the use of `defaultProps` as a means of passing props into function components. This PR alleviates this problem in every instance of the codebase, which is also causing me quite a bit of problems when upgrading to Next 13.

## ⛳️ Current behavior (updates)

Currently the codebase uses `defaultProps` on 4 or 5 components, which is an outdated way of passing props into a function component.

## 🚀 New behavior

Instead, we can destructure props inside the component itself and assign default values.

## 💣 Is this a breaking change (Yes/No):

Nope

## 📝 Additional Information

All tests and building passes. I also tested all relevant components in Storybook to ensure consistency and a lack of feature regression.