### PR TITLE
refactor/add range slider interfaces

### DIFF
--- a/.changeset/clean-garlics-wink.md
+++ b/.changeset/clean-garlics-wink.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/slider": patch
+---
+
+Expose `RangeSliderState` and `RangeSliderActions` types to improve
+documentation

--- a/packages/components/slider/src/use-range-slider.ts
+++ b/packages/components/slider/src/use-range-slider.ts
@@ -121,6 +121,23 @@ export interface UseRangeSliderProps {
   minStepsBetweenThumbs?: number
 }
 
+export interface RangeSliderState {
+  value: number[]
+  isFocused: boolean
+  isDragging: boolean
+  getThumbPercent: (index: number) => number
+  getThumbMinValue: (index: number) => number
+  getThumbMaxValue: (index: number) => number
+}
+
+export interface RangeSliderActions {
+  setValueAtIndex(index: number, val: number): void
+  setActiveIndex: React.Dispatch<React.SetStateAction<number>>
+  stepUp(index: number, step?: number): void
+  stepDown(index: number, step?: number): void
+  reset(): void
+}
+
 /**
  * React hook that implements an accessible range slider.
  *
@@ -246,7 +263,7 @@ export function useRangeSlider(props: UseRangeSliderProps) {
   const tenSteps = (max - min) / 10
   const oneStep = step || (max - min) / 100
 
-  const actions = useMemo(
+  const actions: RangeSliderActions = useMemo(
     () => ({
       setValueAtIndex(index: number, val: number) {
         if (!isInteractive) return
@@ -571,15 +588,17 @@ export function useRangeSlider(props: UseRangeSliderProps) {
     [name, value, ids],
   )
 
+  const state: RangeSliderState = {
+    value,
+    isFocused,
+    isDragging,
+    getThumbPercent: (index: number) => thumbPercents[index],
+    getThumbMinValue: (index: number) => valueBounds[index].min,
+    getThumbMaxValue: (index: number) => valueBounds[index].max,
+  }
+
   return {
-    state: {
-      value,
-      isFocused,
-      isDragging,
-      getThumbPercent: (index: number) => thumbPercents[index],
-      getThumbMinValue: (index: number) => valueBounds[index].min,
-      getThumbMaxValue: (index: number) => valueBounds[index].max,
-    },
+    state,
     actions,
     getRootProps,
     getTrackProps,


### PR DESCRIPTION
Closes [#7094](https://github.com/chakra-ui/chakra-ui/issues/7094)

## 📝 Description

Added interfaces for casting and to write a conciser documentation in the useRangeSlider hook in [#1288](https://github.com/chakra-ui/chakra-ui-docs/issues/1288)

## ⛳️ Current behavior (updates)

No behavior was modified

## 🚀 New behavior

No behavior was modified

## 💣 Is this a breaking change (Yes/No):

No
## 📝 Additional Information
