### PR TITLE
feat(gatsby-plugin): add option to use `ChakraBaseProvider

### DIFF
--- a/.changeset/wet-pumas-prove.md
+++ b/.changeset/wet-pumas-prove.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/gatsby-plugin": minor
+---
+
+Add option to use `ChakraBaseProvider` instead of `ChakraProvider`. This will
+only apply theme tokens initially and not default theming for components.

--- a/tooling/gatsby-plugin/README.md
+++ b/tooling/gatsby-plugin/README.md
@@ -79,6 +79,12 @@ module.exports = {
          * if your app uses a lot z-index to position elements.
          */
         portalZIndex: 40,
+        /**
+         * @property {boolean} [isBaseProvider=false]
+         * Setting this to true will render the `ChakraBaseProvider`
+         * with only the inclusion of theme tokens and not components
+         */
+        isBaseProvider: false,
       },
     },
   ],

--- a/tooling/gatsby-plugin/README.md
+++ b/tooling/gatsby-plugin/README.md
@@ -82,7 +82,7 @@ module.exports = {
         /**
          * @property {boolean} [isBaseProvider=false]
          * Setting this to true will render the `ChakraBaseProvider`
-         * with only the inclusion of theme tokens and not components
+         * which only uses theme tokens initially and not default component themes
          */
         isBaseProvider: false,
       },

--- a/tooling/gatsby-plugin/gatsby-ssr.js
+++ b/tooling/gatsby-plugin/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { ColorModeScript } from "@chakra-ui/react"
 import { WrapRootElement } from "./src/provider"
-import theme from "./src/theme"
+import { theme } from "./src/theme"
 
 export const onRenderBody = ({ setPreBodyComponents }) => {
   setPreBodyComponents([

--- a/tooling/gatsby-plugin/src/provider.js
+++ b/tooling/gatsby-plugin/src/provider.js
@@ -1,15 +1,19 @@
 import * as React from "react"
-import { ChakraProvider } from "@chakra-ui/react"
-import theme from "./theme"
+import { ChakraProvider, ChakraBaseProvider } from "@chakra-ui/react"
+import { theme as defaultTheme, baseTheme } from "./theme"
 
-export const WrapRootElement = ({ element, resetCSS = true, portalZIndex }) => {
+export const WrapRootElement = ({
+  element,
+  isBaseProvider = false,
+  resetCSS = true,
+  portalZIndex,
+}) => {
+  const Provider = isBaseProvider ? ChakraBaseProvider : ChakraProvider
+
+  const theme = isBaseProvider ? baseTheme : defaultTheme
   return (
-    <ChakraProvider
-      theme={theme}
-      resetCSS={resetCSS}
-      portalZIndex={portalZIndex}
-    >
+    <Provider theme={theme} resetCSS={resetCSS} portalZIndex={portalZIndex}>
       {element}
-    </ChakraProvider>
+    </Provider>
   )
 }

--- a/tooling/gatsby-plugin/src/theme.js
+++ b/tooling/gatsby-plugin/src/theme.js
@@ -1,3 +1,3 @@
-import { theme } from "@chakra-ui/react"
+import { theme, baseTheme } from "@chakra-ui/react"
 
-export default theme
+export { theme, baseTheme }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This adds an option to the Gatsby plugin for the user to be able to use `ChakraBaseProvider` instead of `ChakraProvider`, which only applies theme tokens initially and not default component themes.

## ⛳️ Current behavior (updates)

Only the `ChakraProvider` is rendered.

## 🚀 New behavior

Adds the option `isBaseProvider` to render the `ChakraBaseProvider` instead. 

> Default value is `false`

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No because the new option is set to `false` so the original behavior is default.

## 📝 Additional Information

This is to keep the plugin up-to-date with the addition of `ChakraBaseProvider` in `v2.4.2`.

> Side note: as of this PR, the docsite should be updated to include `ChakraBaseProvider` for all frameworks.
