### PR TITLE
fix(cli): fully support ts config paths

### DIFF
--- a/.changeset/beige-emus-judge.md
+++ b/.changeset/beige-emus-judge.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Support TS Config paths more completely

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2037,7 +2037,6 @@ importers:
     specifiers:
       '@swc/core': ^1.2.177
       '@types/lodash.throttle': ^4.1.7
-      '@types/module-alias': ^2.0.1
       '@types/ora': ^3.2.0
       '@types/update-notifier': 5.0.0
       chokidar: ^3.5.3
@@ -2046,7 +2045,6 @@ importers:
       cli-welcome: ^2.2.2
       commander: ^9.3.0
       lodash.throttle: ^4.1.1
-      module-alias: ^2.2.2
       ora: ^5.3.0
       prettier: ^2.7.1
       regenerator-runtime: ^0.13.7
@@ -2061,7 +2059,6 @@ importers:
       cli-welcome: 2.2.2
       commander: 9.4.0
       lodash.throttle: 4.1.1
-      module-alias: 2.2.2
       ora: 5.4.1
       prettier: 2.7.1
       regenerator-runtime: 0.13.9
@@ -2070,7 +2067,6 @@ importers:
       update-notifier: 5.1.0
     devDependencies:
       '@types/lodash.throttle': 4.1.7
-      '@types/module-alias': 2.0.1
       '@types/ora': 3.2.0
       '@types/update-notifier': 5.0.0
 
@@ -10531,10 +10527,6 @@ packages:
     dependencies:
       '@types/node': 18.0.6
     dev: false
-
-  /@types/module-alias/2.0.1:
-    resolution: {integrity: sha512-DN/CCT1HQG6HquBNJdLkvV+4v5l/oEuwOHUPLxI+Eub0NED+lk0YUfba04WGH90EINiUrNgClkNnwGmbICeWMQ==}
-    dev: true
 
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
@@ -21675,10 +21667,6 @@ packages:
     dependencies:
       pathe: 0.3.2
       pkg-types: 0.3.3
-    dev: false
-
-  /module-alias/2.2.2:
-    resolution: {integrity: sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==}
     dev: false
 
   /moment/2.29.4:

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -47,7 +47,6 @@
     "cli-welcome": "^2.2.2",
     "commander": "^9.3.0",
     "lodash.throttle": "^4.1.1",
-    "module-alias": "^2.2.2",
     "ora": "^5.3.0",
     "prettier": "^2.7.1",
     "regenerator-runtime": "^0.13.7",
@@ -57,7 +56,6 @@
   },
   "devDependencies": {
     "@types/lodash.throttle": "^4.1.7",
-    "@types/module-alias": "^2.0.1",
     "@types/ora": "^3.2.0",
     "@types/update-notifier": "5.0.0"
   }


### PR DESCRIPTION
## 📝 Description

This started out because I was getting errors with the `paths` option in `tsconfig.json`.

We have the following in our config:

```json
"paths": {
  "*": ["first/*", "second/*"]
}
```

The current system doesn't support the solo `*` _at all_. As an aside, it also don't support multiple paths for a single alias. I spent some time trying to make the existing system support the paths, but then found there was already an included package, that does this automatically. A nice added bonus is the removal of a dependency.

## ⛳️ Current behavior (updates)

- There's a crash when trying to use the CLI

```
> chakra-cli tokens --strict-component-types --strict-token-types path/to/theme.ts

 Chakra UI CLI  v2.2.0 by Chakra UI
Generate theme typings for autocomplete


✖ An error occurred
Error: Theme file or package not found
Error: Cannot find module '<path under * alias>'
...
````

## 🚀 New behavior

- Supports multiple paths in the array
- Supports root (`*`) aliases

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
