### PR TITLE
feat(stack): remove divider around empty space when component is null

### DIFF
--- a/packages/components/layout/src/stack/stack.tsx
+++ b/packages/components/layout/src/stack/stack.tsx
@@ -109,7 +109,12 @@ export const Stack = forwardRef<StackProps, "div">((props, ref) => {
           const wrappedChild = <StackItem key={key}>{child}</StackItem>
           const _child = shouldWrapChildren ? wrappedChild : child
 
-          if (!hasDivider) return _child
+          // Don't show divider if child return null
+          console.log("oooooo")
+          console.log(child)
+          const nullChild =
+            typeof child.type === "function" && child.type() === null
+          if (!hasDivider || nullChild) return _child
 
           const clonedDivider = cloneElement(
             divider as React.ReactElement<any>,

--- a/packages/components/layout/src/stack/stack.tsx
+++ b/packages/components/layout/src/stack/stack.tsx
@@ -110,8 +110,6 @@ export const Stack = forwardRef<StackProps, "div">((props, ref) => {
           const _child = shouldWrapChildren ? wrappedChild : child
 
           // Don't show divider if child return null
-          console.log("oooooo")
-          console.log(child)
           const nullChild =
             typeof child.type === "function" && child.type() === null
           if (!hasDivider || nullChild) return _child

--- a/packages/components/layout/src/stack/stack.tsx
+++ b/packages/components/layout/src/stack/stack.tsx
@@ -109,7 +109,7 @@ export const Stack = forwardRef<StackProps, "div">((props, ref) => {
           const wrappedChild = <StackItem key={key}>{child}</StackItem>
           const _child = shouldWrapChildren ? wrappedChild : child
 
-          // Don't show divider if child return null
+          // Don't show divider if child returns null
           const nullChild =
             typeof child.type === "function" && child.type() === null
           if (!hasDivider || nullChild) return _child

--- a/packages/components/layout/src/stack/stack.tsx
+++ b/packages/components/layout/src/stack/stack.tsx
@@ -111,7 +111,8 @@ export const Stack = forwardRef<StackProps, "div">((props, ref) => {
 
           // Don't show divider if child returns null
           const nullChild =
-            typeof child.type === "function" && child.type() === null
+            typeof child.type === "function" &&
+            (child.type as Function)() === null
           if (!hasDivider || nullChild) return _child
 
           const clonedDivider = cloneElement(

--- a/packages/components/layout/stories/stack.stories.tsx
+++ b/packages/components/layout/stories/stack.stories.tsx
@@ -29,6 +29,17 @@ export const WithCustomDivider = () => (
   </div>
 )
 
+const Empty = () => null
+export const WithCustomDividerAndNullComponent = () => (
+  <div>
+    <Stack spacing="40px" divider={<Divider sx={{ borderColor: "red.200" }} />}>
+      <Box>1</Box>
+      <Empty></Empty>
+      <Box>3</Box>
+    </Stack>
+  </div>
+)
+
 export const Inline = () => (
   <Stack w="100%" bg="blue.500" direction="row">
     <Box boxSize="40px" bg="white" borderRadius="full" />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Sometimes you want to hide the logic for hiding a component inside of the component. When you return null, it adds an extra divider and creates an empty space.

## ⛳️ Current behavior (updates)

Currently, stack with divider will render a divider between a component and an empty component.
![image](https://user-images.githubusercontent.com/2039539/207207930-60ae1a5f-1635-4c41-9fc5-a5c269598ab6.png)

## 🚀 New behavior

With this PR, the divider between an empty component is removed.
![image](https://user-images.githubusercontent.com/2039539/207208036-422f2395-4605-4acc-bc79-cefd924470a2.png)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
no

## 📝 Additional Information
