### PR TITLE
fix(InputGroup): make input component z-indexes isolated to the input

### DIFF
--- a/.changeset/green-ligers-knock.md
+++ b/.changeset/green-ligers-knock.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/input": patch
+---
+
+Ensure input z-index overrides are isolated to the input

--- a/packages/components/input/src/input-group.tsx
+++ b/packages/components/input/src/input-group.tsx
@@ -81,6 +81,9 @@ export const InputGroup = forwardRef<InputGroupProps, "div">(
           width: "100%",
           display: "flex",
           position: "relative",
+          // Parts of inputs override z-index to ensure that they stack correctly on each other
+          // Create a new stacking context so that these overrides don't leak out and conflict with other z-indexes
+          isolation: "isolate",
         }}
         {...rest}
       >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/5742

## 📝 Description
z-index on InputElement is set to 2, which leads to issues with overlapping menus/popovers etc

## ⛳️ Current behavior (updates)
Input elements are overlayed on top of overlapping menus/popovers - see https://codesandbox.io/s/nostalgic-newton-pwjm0z?file=/src/index.tsx

## 🚀 New behavior
The input group creates a stacking context, so all the z-indexes being set within it are isolated

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
