### PR TITLE
fix(use-media-query): return correct value on initial mount if srr is…

### DIFF
--- a/.changeset/clean-zoos-teach.md
+++ b/.changeset/clean-zoos-teach.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+Fix value returned on initial mount if ssr option is enabled

--- a/packages/components/media-query/src/use-media-query.ts
+++ b/packages/components/media-query/src/use-media-query.ts
@@ -28,20 +28,29 @@ export function useMediaQuery(
   fallbackValues = fallbackValues.filter((v) => v != null) as boolean[]
 
   const [value, setValue] = useState(() => {
-    return queries.map((query, index) => ({
-      media: query,
-      matches: ssr
-        ? !!fallbackValues[index]
-        : env.window.matchMedia(query).matches,
-    }))
+    return queries.map((query, index) => {
+      const queryMatch = (env.window.matchMedia &&
+        env.window.matchMedia(query)) || { matches: false }
+
+      return {
+        media: query,
+        matches:
+          ssr && typeof env.window.matchMedia !== "function"
+            ? !!fallbackValues[index]
+            : queryMatch.matches,
+      }
+    })
   })
 
   useEffect(() => {
     setValue(
-      queries.map((query) => ({
-        media: query,
-        matches: env.window.matchMedia(query).matches,
-      })),
+      queries.map((query) => {
+        const matches = env.window.matchMedia(query).matches
+        return {
+          media: query,
+          matches,
+        }
+      }),
     )
 
     const mql = queries.map((query) => env.window.matchMedia(query))

--- a/packages/components/media-query/tests/use-media-query.test.ts
+++ b/packages/components/media-query/tests/use-media-query.test.ts
@@ -43,4 +43,20 @@ describe("with useMediaQuery", () => {
     act(() => window.resizeTo(360, 640))
     expect(result.current).toEqual([true, false, false, false])
   })
+
+  test("should return correct value after first render", () => {
+    act(() => window.resizeTo(540, 800))
+
+    const { result } = renderHook(() =>
+      useMediaQuery([
+        "(max-width: 410px)",
+        "(min-width: 411px) and (max-width: 615px)",
+        "(min-width: 616px) and (max-width: 1023px)",
+        "(min-width: 1024px)",
+      ]),
+    )
+
+    expect(result.all[0]).toEqual([false, true, false, false])
+    expect(result.current).toEqual([false, true, false, false])
+  })
 })


### PR DESCRIPTION
… enabled

Closes # 6930

## 📝 Description

Fixes problem when responsive components were flashing on mount because base value was used initially before rerendering with wanted value

## ⛳️ Current behavior (updates)

If component using useBreakpointValue() hook renders at the first time, it uses base value and rerenders to use correct value

## 🚀 New behavior

If component using useBreakpointValue() hook renders at the first time, it uses correct value and does not rerender unnecessarily

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
