### PR TITLE
feat: allow responsive values in orientation divider component

### DIFF
--- a/.changeset/mean-foxes-cheer.md
+++ b/.changeset/mean-foxes-cheer.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/layout": minor
+---
+
+Change the `orientation` prop name for `axis` and apply the `ResponsiveValue`
+type to it in order to be responsive depending on breakpoints in the `Divider`
+component

--- a/packages/components/layout/src/divider.tsx
+++ b/packages/components/layout/src/divider.tsx
@@ -5,8 +5,10 @@ import {
   ThemingProps,
   useStyleConfig,
   HTMLChakraProps,
+  ResponsiveValue,
 } from "@chakra-ui/system"
 import { cx } from "@chakra-ui/shared-utils"
+import { useBreakpointValue } from "../../../components/media-query/src/use-breakpoint-value"
 
 /**
  * Layout component used to visually separate content in a list or group.
@@ -28,12 +30,12 @@ export const Divider = forwardRef<DividerProps, "hr">(function Divider(
     borderColor,
     ...styles
   } = useStyleConfig("Divider", props)
-  const {
-    className,
-    orientation = "horizontal",
-    __css,
-    ...rest
-  } = omitThemingProps(props)
+  const { className, axis, __css, ...rest } = omitThemingProps(props)
+
+  const axisValue = axis
+    ? useBreakpointValue(typeof axis === "string" ? [axis] : axis) ??
+      "horizontal"
+    : "horizontal"
 
   const dividerStyles = {
     vertical: {
@@ -51,15 +53,14 @@ export const Divider = forwardRef<DividerProps, "hr">(function Divider(
   return (
     <chakra.hr
       ref={ref}
-      aria-orientation={orientation}
+      aria-orientation={axisValue}
       {...rest}
       __css={{
         ...styles,
         border: "0",
-
         borderColor,
         borderStyle,
-        ...dividerStyles[orientation],
+        ...dividerStyles[axisValue],
         ...__css,
       }}
       className={cx("chakra-divider", className)}
@@ -70,7 +71,7 @@ export const Divider = forwardRef<DividerProps, "hr">(function Divider(
 export interface DividerProps
   extends HTMLChakraProps<"div">,
     ThemingProps<"Divider"> {
-  orientation?: "horizontal" | "vertical"
+  axis?: ResponsiveValue<"horizontal" | "vertical">
 }
 
 Divider.displayName = "Divider"

--- a/packages/components/layout/stories/divider.stories.tsx
+++ b/packages/components/layout/stories/divider.stories.tsx
@@ -19,10 +19,8 @@ export default {
  */
 export const Basic = () => <Divider />
 
-export const Vertical = () => <Divider orientation="vertical" />
+export const Vertical = () => <Divider axis="vertical" />
 
-export const Horizontal = () => <Divider orientation="horizontal" />
+export const Horizontal = () => <Divider axis="horizontal" />
 
-export const DashedVariant = () => (
-  <Divider orientation="horizontal" variant="dashed" />
-)
+export const DashedVariant = () => <Divider variant="dashed" />


### PR DESCRIPTION
Closes [#7125](https://github.com/chakra-ui/chakra-ui/issues/7125)

## 📝 Description

Allow the Divider to have an orientation set by an object, such as:

`<Divider orientation={{ base: "horizontal", md: "vertical" }} />`

## ⛳️ Current behavior (updates)

The `Divider` component doesn't allow responsive value in the `orientation` prop.

## 🚀 New behavior

Now the component accepts a responsive value in the `axis` prop (name changed due to conflicts with the default `orientation` type stated in the `ThemingProps`).

The default orientation is still `horizontal` if the `axis` prop is not passed.

## 💣 Is this a breaking change (Yes/No):

Yes.
It changes the `orientation` prop name for `axis` so it will impact in the chakra-ui docs if it gets merged in that the `Divider` docs needs to be updated with that new prop name.
