### PR TITLE
feat(cli): allow generating theme typings to use via module augmentation

### DIFF
--- a/.changeset/serious-numbers-know.md
+++ b/.changeset/serious-numbers-know.md
@@ -5,5 +5,5 @@
 Allow generating theme typings to use via module augmentation
 
 ```bash
-chakra-cli tokens --template augmentation
+chakra-cli tokens --template augmentation --out ./types/chakra-ui__styled-system.d.ts
 ```

--- a/.changeset/serious-numbers-know.md
+++ b/.changeset/serious-numbers-know.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/cli": minor
+---
+
+Allow generating theme typings to use via module augmentation
+
+```bash
+chakra-cli tokens --template augmentation
+```

--- a/tooling/cli/README.md
+++ b/tooling/cli/README.md
@@ -25,6 +25,7 @@ Options:
   --strict-token-types      Generate strict types for theme tokens (e.g. color, spacing)
   --no-format               Disable auto formatting
   --watch [path]            Watch directory for changes and rebuild
+  --template <template>     Choose the template to use for the generation (choices: "default", "augmentation", default: "default"
   -h, --help                display help for command
 
 Example call:

--- a/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
+++ b/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
@@ -54,7 +54,7 @@ function applyThemeTypingTemplate(
   switch (template) {
     case "augmentation":
       return `// regenerate by running
-// npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+// npx @chakra-ui/cli tokens path/to/your/theme.(js|ts) --template augmentation --out path/to/this/file 
 import { BaseThemeTypings } from "@chakra-ui/styled-system";
 declare module "@chakra-ui/styled-system" {
   export interface CustomThemeTypings extends BaseThemeTypings {

--- a/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
+++ b/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
@@ -37,11 +37,41 @@ export interface ThemeKeyOptions {
   flatMap?: (value: string) => string | string[]
 }
 
+export type TypingsTemplate = "default" | "augmentation"
+
 export interface CreateThemeTypingsInterfaceOptions {
   config: ThemeKeyOptions[]
   strictComponentTypes?: boolean
   format?: boolean
   strictTokenTypes?: boolean
+  template?: TypingsTemplate
+}
+
+function applyThemeTypingTemplate(
+  typingContent: string,
+  template: TypingsTemplate,
+) {
+  switch (template) {
+    case "augmentation":
+      return `// regenerate by running
+// npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+import { BaseThemeTypings } from "@chakra-ui/styled-system";
+declare module "@chakra-ui/styled-system" {
+  export interface CustomThemeTypings extends BaseThemeTypings {
+    ${typingContent}
+  }
+}
+`
+    case "default":
+    default:
+      return `// regenerate by running
+// npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+import { BaseThemeTypings } from "./shared.types.js"
+export interface ThemeTypings extends BaseThemeTypings {
+  ${typingContent}
+}
+`
+  }
 }
 
 export async function createThemeTypingsInterface(
@@ -51,6 +81,7 @@ export async function createThemeTypingsInterface(
     strictComponentTypes = false,
     format = true,
     strictTokenTypes = false,
+    template = "default",
   }: CreateThemeTypingsInterfaceOptions,
 ) {
   const unions = config.reduce(
@@ -87,20 +118,12 @@ export async function createThemeTypingsInterface(
   const colorSchemes = extractColorSchemeTypes(theme)
   const componentTypes = extractComponentTypes(theme)
 
-  const template =
-    // language=ts
-    `// regenerate by running
-// npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
-import { BaseThemeTypings } from "./shared.types.js"
-export interface ThemeTypings extends BaseThemeTypings {
-  ${printUnionMap(
+  const typingContent = `${printUnionMap(
     { ...unions, textStyles, layerStyles, colorSchemes },
     strictTokenTypes,
   )}
-  ${printComponentTypes(componentTypes, strictComponentTypes)}
-}
+  ${printComponentTypes(componentTypes, strictComponentTypes)}`
+  const themeTypings = applyThemeTypingTemplate(typingContent, template)
 
-`
-
-  return format ? formatWithPrettierIfAvailable(template) : template
+  return format ? formatWithPrettierIfAvailable(themeTypings) : themeTypings
 }

--- a/tooling/cli/src/index.ts
+++ b/tooling/cli/src/index.ts
@@ -1,6 +1,6 @@
 import "regenerator-runtime/runtime"
 import * as path from "path"
-import { program } from "commander"
+import { Option, program } from "commander"
 import chokidar from "chokidar"
 import throttle from "lodash.throttle"
 import { initCLI } from "./utils/init-cli"
@@ -15,6 +15,7 @@ type OptionsType = {
   format: boolean
   watch?: string
   strictTokenTypes?: boolean
+  template?: "default" | "augmentation"
 }
 
 export async function run() {
@@ -36,8 +37,23 @@ export async function run() {
       "--strict-token-types",
       "Generate strict types for theme tokens (e.g. color, spacing)",
     )
+    .addOption(
+      new Option(
+        "--template <template>",
+        "Choose the template to use for the generation",
+      )
+        .default("default")
+        .choices(["default", "augmentation"]),
+    )
     .action(async (themeFile: string, options: OptionsType) => {
-      const { out, strictComponentTypes, format, strictTokenTypes, watch } = options
+      const {
+        out,
+        strictComponentTypes,
+        format,
+        strictTokenTypes,
+        watch,
+        template,
+      } = options
 
       if (watch) {
         const watchPath =
@@ -49,6 +65,8 @@ export async function run() {
             out,
             strictComponentTypes,
             format,
+            strictTokenTypes,
+            template,
           })
           console.timeEnd("Duration")
           console.info(new Date().toLocaleString())
@@ -67,6 +85,7 @@ export async function run() {
         strictComponentTypes,
         format,
         strictTokenTypes,
+        template,
         onError: () => process.exit(1),
       })
     })

--- a/tooling/cli/src/scripts/read-theme-file.worker.ts
+++ b/tooling/cli/src/scripts/read-theme-file.worker.ts
@@ -3,7 +3,10 @@ import path from "path"
 import fs from "fs"
 import * as tsNode from "ts-node"
 import * as tsConfigPaths from "tsconfig-paths"
-import { createThemeTypingsInterface } from "../command/tokens/create-theme-typings-interface"
+import {
+  createThemeTypingsInterface,
+  TypingsTemplate,
+} from "../command/tokens/create-theme-typings-interface"
 import { themeKeyConfiguration } from "../command/tokens/config"
 import { isObject } from "../utils/is-object"
 
@@ -83,6 +86,8 @@ async function run() {
   const strictComponentTypes = process.argv.includes("--strict-component-types")
   const format = process.argv.includes("--format")
   const strictTokenTypes = process.argv.includes("--strict-token-types")
+  const templateArg = process.argv.find((arg) => arg.includes("--template="))
+  const template = templateArg ? templateArg.split("=")[1] : undefined
 
   if (!themeFile) {
     throw new Error("No path to theme file provided.")
@@ -95,17 +100,18 @@ async function run() {
     throw new Error("Theme not found in default or named `theme` export")
   }
 
-  const template = await createThemeTypingsInterface(theme, {
+  const themeTypings = await createThemeTypingsInterface(theme, {
     config: themeKeyConfiguration,
     strictComponentTypes,
     format,
     strictTokenTypes,
+    template: template as TypingsTemplate,
   })
 
   if (process.send) {
-    process.send(template)
+    process.send(themeTypings)
   } else {
-    process.stdout.write(template)
+    process.stdout.write(themeTypings)
   }
 }
 

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -456,7 +456,7 @@ describe("Theme typings", () => {
 
     expect(themeInterface).toMatchInlineSnapshot(`
       "// regenerate by running
-      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts) --template augmentation --out path/to/this/file
       import { BaseThemeTypings } from \\"@chakra-ui/styled-system\\"
       declare module \\"@chakra-ui/styled-system\\" {
         export interface CustomThemeTypings extends BaseThemeTypings {

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -264,7 +264,6 @@ describe("Theme typings", () => {
       }
 
       }
-
       "
     `)
   })
@@ -442,6 +441,64 @@ describe("Theme typings", () => {
           Button: {
             sizes: \\"sm\\"
             variants: \\"extraordinary\\" | \\"awesome\\" | \\"unused\\"
+          }
+        }
+      }
+      "
+    `)
+  })
+
+  it("should create typings for a theme for interface augmentation", async () => {
+    const themeInterface = await createThemeTypingsInterface(smallTheme, {
+      config: themeKeyConfiguration,
+      template: "augmentation",
+    })
+
+    expect(themeInterface).toMatchInlineSnapshot(`
+      "// regenerate by running
+      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+      import { BaseThemeTypings } from \\"@chakra-ui/styled-system\\"
+      declare module \\"@chakra-ui/styled-system\\" {
+        export interface CustomThemeTypings extends BaseThemeTypings {
+          blur: string & {}
+          borders: \\"sm\\" | \\"md\\" | (string & {})
+          borderStyles: string & {}
+          borderWidths: string & {}
+          breakpoints: \\"sm\\" | \\"md\\" | (string & {})
+          colors:
+            | \\"niceColor\\"
+            | \\"suchWowColor\\"
+            | \\"onlyColorSchemeColor.50\\"
+            | \\"onlyColorSchemeColor.100\\"
+            | \\"onlyColorSchemeColor.200\\"
+            | \\"onlyColorSchemeColor.300\\"
+            | \\"onlyColorSchemeColor.400\\"
+            | \\"onlyColorSchemeColor.500\\"
+            | \\"onlyColorSchemeColor.600\\"
+            | \\"onlyColorSchemeColor.700\\"
+            | \\"onlyColorSchemeColor.800\\"
+            | \\"onlyColorSchemeColor.900\\"
+            | \\"such.deep.color\\"
+            | (string & {})
+          colorSchemes: \\"onlyColorSchemeColor\\" | (string & {})
+          fonts: \\"sm\\" | \\"md\\" | (string & {})
+          fontSizes: \\"sm\\" | \\"md\\" | (string & {})
+          fontWeights: \\"sm\\" | \\"md\\" | (string & {})
+          layerStyles: \\"red\\" | \\"blue\\" | (string & {})
+          letterSpacings: \\"sm\\" | \\"md\\" | (string & {})
+          lineHeights: \\"sm\\" | \\"md\\" | (string & {})
+          radii: \\"sm\\" | \\"md\\" | (string & {})
+          shadows: \\"sm\\" | \\"md\\" | (string & {})
+          sizes: \\"sm\\" | \\"md\\" | (string & {})
+          space: \\"sm\\" | \\"-sm\\" | \\"md\\" | \\"-md\\" | (string & {})
+          textStyles: \\"small\\" | \\"large\\" | (string & {})
+          transition: \\"sm\\" | \\"md\\" | (string & {})
+          zIndices: \\"sm\\" | \\"md\\" | (string & {})
+          components: {
+            Button: {
+              sizes: \\"sm\\" | (string & {})
+              variants: \\"extraordinary\\" | \\"awesome\\" | \\"unused\\" | (string & {})
+            }
           }
         }
       }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/6901

## 📝 Description
https://github.com/chakra-ui/chakra-ui/pull/5579 added the ability to override the theme typings by module augmentation rather than by writing to node_modules (which would better support e.g. Yarn PnP, for example).

This allows generating theme typings in a structure which can be used in this way.

## ⛳️ Current behavior (updates)
The CLI generates theme typings in a structure which is designed for use in overwriting node_modules.

## 🚀 New behavior
When the CLI is run with `--template augmentation`, theme typings are generated which are appropriate for use with module augmentation.

## 💣 Is this a breaking change (Yes/No):
No - default behaviour is still to generate theme typings in the old format.

## 📝 Additional Information
