### PR TITLE
ci(codesandbox): remove workaround that install pnpm v7 on csb CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,5 @@
 {
   "node": "16",
-  "installCommand": "csb:install",
   "sandboxes": ["/examples/create-react-app"],
   "packages": [
     "packages/components/accordion",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "twitter:gen": "tsx scripts/twitter-generate.ts",
     "twitter:write": "tsx scripts/twitter-write.ts",
     "csb": "tsx scripts/csb.ts",
-    "csb:install": "pnpm add -g @pnpm/exe@7 && pnpm install",
     "create:pkg": "plop component",
     "version": "changeset version",
     "release": "changeset publish",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

It seems that now codesandbox CI pre-installs pnpm v7.18.2 and current workaround causes an error.

https://ci.codesandbox.io/status/chakra-ui/chakra-ui/pr/7128/builds/328172

So this PR reverts #7015.

