### PR TITLE
feat: transform multiple token vals in shorthand space props

### DIFF
--- a/.changeset/big-feet-tan.md
+++ b/.changeset/big-feet-tan.md
@@ -1,0 +1,26 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Allow multiple token values to be converted in shortand spacing props
+
+For the props `margin`, `m`, `padding`, and `p` you can supply multiple tokens
+as you would for the standard CSS conventions with `top right bottom left`, and
+the tokens will be converted accordingly.
+
+For example: `margin="3 4"`
+
+converts to `margin: "var(--chakra-space-3) var(--chakra-space-4)"`
+
+Or (mixing with unit values)...
+
+`p="1 10px 5"`
+
+converts to
+
+`padding: "var(--chakra-space-1) 10px var(--chakra-space-5)"`
+
+and so on!
+
+> 🚨 Note: This does not work for spacing shorthands like `paddingX` or
+> `marginY`, where they should only except one value.

--- a/packages/core/styled-system/tests/css.test.ts
+++ b/packages/core/styled-system/tests/css.test.ts
@@ -645,3 +645,43 @@ test("should resolve !important syntax", () => {
     }
   `)
 })
+
+test("transforms multiple token values in a shorthand spacing prop", () => {
+  // normal css prop naming
+  expect(
+    css({
+      margin: "1 4 3",
+      padding: "1 4 3",
+    })(theme),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "margin": "var(--space-1) var(--space-4) var(--space-3)",
+      "padding": "var(--space-1) var(--space-4) var(--space-3)",
+    }
+  `)
+  // shorthand css prop naming
+  expect(
+    css({
+      m: "1 4 3",
+      p: "1 4 3",
+    })(theme),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "margin": "var(--space-1) var(--space-4) var(--space-3)",
+      "padding": "var(--space-1) var(--space-4) var(--space-3)",
+    }
+  `)
+
+  // Mixed values (tokens and units)
+  expect(
+    css({
+      margin: "4 2rem",
+      padding: "4px 4",
+    })(theme),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "margin": "var(--space-4) 2rem",
+      "padding": "4px var(--space-4)",
+    }
+  `)
+})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR provides the ability to pass in multiple token values to the shorthand space props `margin`, `m`, `padding`, and `p`, per standard CSS convention.

## ⛳️ Current behavior (updates)

Only one value can be supplied to the above-mentioned props. So `margin="4"` converts to `margin: "16rem"` for all sides of an element.

## 🚀 New behavior

i.e.
`margin="1 3"` (Note that it's a string!)

converts to
`margin: "0.25rem 0.75rem"` (or the equivalent CSS vars)

Or...

`p="1 10px 4"` (Mixed with unit vals and 3 for top, left/right, bottom)

converts to
`padding: "0.25rem 10px 16rem"`

## 💣 Is this a breaking change (Yes/No):

This should have no effect on existing projects, as no altering of existing implementation is needed for the new transformation to work.

## 📝 Additional Information
This would not be applied to shorthand directional spacing props like `paddingX`, `my`, and similar, as for their purposes should only accept one value to address `top-bottom` or `left-right`, else different spacing values should be addressed in some other way.