### PR TITLE
refactor(checkbox): inject default theme from component

### DIFF
--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -43,6 +43,7 @@
     "@chakra-ui/react-use-merge-refs": "workspace:*",
     "@chakra-ui/react-use-update-effect": "workspace:*",
     "@chakra-ui/react-types": "workspace:*",
+    "@chakra-ui/theme": "workspace:*",
     "@chakra-ui/visually-hidden": "workspace:*",
     "@zag-js/focus-visible": "0.2.1",
     "@chakra-ui/shared-utils": "workspace:*"

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -15,6 +15,7 @@ import { useCheckboxGroupContext } from "./checkbox-context"
 import { CheckboxIcon } from "./checkbox-icon"
 import { CheckboxOptions, UseCheckboxProps } from "./checkbox-types"
 import { useCheckbox } from "./use-checkbox"
+import { Checkbox as checkBoxTheme } from "@chakra-ui/theme/components"
 
 const controlStyles: SystemStyleObject = {
   display: "inline-flex",
@@ -93,7 +94,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
   const group = useCheckboxGroupContext()
 
   const mergedProps = { ...group, ...props } as CheckboxProps
-  const styles = useMultiStyleConfig("Checkbox", mergedProps)
+  const styles = useMultiStyleConfig("Checkbox", mergedProps, checkBoxTheme)
 
   const ownProps = omitThemingProps(props)
 

--- a/packages/components/theme/package.json
+++ b/packages/components/theme/package.json
@@ -13,6 +13,23 @@
   "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
   "license": "MIT",
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./components": "./src/components/index.ts",
+    "./components/*": "./src/components/*.ts",
+    "./foundations/*": "./src/foundations/*.ts",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "components": [
+        "./src/components/index.ts"
+      ],
+      "foundations": [
+        "./src/foundations/index.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/core/system/src/use-style-config.ts
+++ b/packages/core/system/src/use-style-config.ts
@@ -20,6 +20,7 @@ type StylesRef = SystemStyleObject | Record<string, SystemStyleObject>
 function useStyleConfigImpl(
   themeKey: string | null,
   props: ThemingProps & Dict = {},
+  defaultConfig: Record<string, any> = {},
 ) {
   const { styleConfig: styleConfigProp, ...rest } = props
 
@@ -29,7 +30,10 @@ function useStyleConfigImpl(
     ? get(theme, `components.${themeKey}`)
     : undefined
 
-  const styleConfig = styleConfigProp || themeStyleConfig
+  const styleConfig = mergeWith(
+    defaultConfig,
+    styleConfigProp || themeStyleConfig,
+  )
 
   const mergedProps = mergeWith(
     { theme, colorMode },
@@ -59,15 +63,17 @@ function useStyleConfigImpl(
 export function useStyleConfig(
   themeKey: string,
   props: ThemingProps & Dict = {},
+  defaultConfig?: Record<string, any>,
 ) {
-  return useStyleConfigImpl(themeKey, props) as SystemStyleObject
+  return useStyleConfigImpl(themeKey, props, defaultConfig) as SystemStyleObject
 }
 
 export function useMultiStyleConfig(
   themeKey: string,
   props: ThemingProps & Dict = {},
+  defaultConfig?: Record<string, any>,
 ) {
-  return useStyleConfigImpl(themeKey, props) as Record<
+  return useStyleConfigImpl(themeKey, props, defaultConfig) as Record<
     string,
     SystemStyleObject
   >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,7 @@ importers:
       '@chakra-ui/react-use-update-effect': workspace:*
       '@chakra-ui/shared-utils': workspace:*
       '@chakra-ui/system': workspace:*
+      '@chakra-ui/theme': workspace:*
       '@chakra-ui/visually-hidden': workspace:*
       '@zag-js/focus-visible': 0.2.1
       clean-package: 2.1.1
@@ -527,6 +528,7 @@ importers:
       '@chakra-ui/react-use-safe-layout-effect': link:../../hooks/use-safe-layout-effect
       '@chakra-ui/react-use-update-effect': link:../../hooks/use-update-effect
       '@chakra-ui/shared-utils': link:../../utilities/shared-utils
+      '@chakra-ui/theme': link:../theme
       '@chakra-ui/visually-hidden': link:../visually-hidden
       '@zag-js/focus-visible': 0.2.1
     devDependencies:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

Inject default theme from component so that we don't need to declare it in `extendBaseTheme` explicitly anymore.

If this approach seems good, I'll expand it to other components.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

We need to explicitly declare the default component themes to use in `extendBaseTheme`. The style will be broken if we forget the declaration.

https://codesandbox.io/s/create-react-app-ts-forked-2bwzer?file=/src/index.tsx

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

We don't need to declare the component themes.

https://codesandbox.io/s/create-react-app-ts-forked-5g50lg?file=/src/index.tsx

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
