### PR TITLE
fix: translate errors

### DIFF
--- a/.changeset/kind-penguins-play.md
+++ b/.changeset/kind-penguins-play.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/system": minor
+---
+
+Fixed issue where TS throws an error when using the `translate` style prop due
+to clash with the native DOM translate attribute.
+
+This was fixed by omitting the native `translate` attribute and introducing a
+new `htmlTranslate` attribute for user who need this.

--- a/packages/core/system/src/should-forward-prop.ts
+++ b/packages/core/system/src/should-forward-prop.ts
@@ -24,7 +24,12 @@ const allPropNames = new Set([
  *
  * https://github.com/chakra-ui/chakra-ui/issues/149
  */
-const validHTMLProps = new Set(["htmlWidth", "htmlHeight", "htmlSize"])
+const validHTMLProps = new Set([
+  "htmlWidth",
+  "htmlHeight",
+  "htmlSize",
+  "htmlTranslate",
+])
 
 export function shouldForwardProp(prop: string): boolean {
   return validHTMLProps.has(prop) || !allPropNames.has(prop)

--- a/packages/core/system/src/system.types.tsx
+++ b/packages/core/system/src/system.types.tsx
@@ -38,7 +38,12 @@ export type PropsOf<T extends As> = React.ComponentPropsWithoutRef<T> & {
 export type OmitCommonProps<
   Target,
   OmitAdditionalProps extends keyof any = never,
-> = Omit<Target, "transition" | "as" | "color" | OmitAdditionalProps>
+> = Omit<
+  Target,
+  "transition" | "as" | "color" | "translate" | OmitAdditionalProps
+> & {
+  htmlTranslate?: "yes" | "no" | undefined
+}
 
 export type RightJoinProps<
   SourceProps extends object = {},


### PR DESCRIPTION
Closes #7221

## 📝 Description

Fix TS issue with the native `translate` props.

## ⛳️ Current behavior (updates)

Throws a TS error when spreading the style props unto an element

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
