### PR TITLE
Fix color mode behavior

### DIFF
--- a/packages/components/color-mode/src/color-mode-provider.tsx
+++ b/packages/components/color-mode/src/color-mode-provider.tsx
@@ -102,11 +102,10 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   useEffect(() => {
     if (!useSystemColorMode) return
 
-    if (initialColorMode === "system") {
-      const system = getSystemTheme(defaultColorMode)
-      if (system !== colorModeManager.get()) {
-        setColorMode(system)
-      }
+    const system = getSystemTheme(defaultColorMode)
+    const stored = colorModeManager.get()
+    if (stored !== undefined && system !== stored) {
+      setColorMode(system)
     }
 
     return addListener(setColorMode)

--- a/packages/components/color-mode/src/color-mode-provider.tsx
+++ b/packages/components/color-mode/src/color-mode-provider.tsx
@@ -101,8 +101,24 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
 
   useEffect(() => {
     if (!useSystemColorMode) return
+
+    if (initialColorMode === "system") {
+      const system = getSystemTheme(defaultColorMode)
+      if (system !== colorModeManager.get()) {
+        setColorMode(system)
+      }
+    }
+
     return addListener(setColorMode)
-  }, [useSystemColorMode, addListener, setColorMode])
+  }, [
+    useSystemColorMode,
+    addListener,
+    setColorMode,
+    getSystemTheme,
+    defaultColorMode,
+    colorModeManager,
+    initialColorMode,
+  ])
 
   // presence of `value` indicates a controlled context
   const context = useMemo(

--- a/packages/components/color-mode/test/color-mode-provider.test.tsx
+++ b/packages/components/color-mode/test/color-mode-provider.test.tsx
@@ -51,13 +51,13 @@ describe("<ColorModeProvider /> localStorage browser", () => {
     expect(getColorModeButton()).toHaveTextContent(result.expect)
   })
 
-  test("useSystemColorMode is true, initialColorMode is system and stored value is different from system value", () => {
+  test("useSystemColorMode is true and stored value is different from system value", () => {
     mockMatchMedia("dark")
     mockLocalStorage("light")
 
     const options = {
       useSystemColorMode: true,
-      initialColorMode: "system",
+      initialColorMode: "light",
     } as const
     render(
       <ColorModeProvider options={options}>

--- a/packages/components/color-mode/test/color-mode-provider.test.tsx
+++ b/packages/components/color-mode/test/color-mode-provider.test.tsx
@@ -50,6 +50,22 @@ describe("<ColorModeProvider /> localStorage browser", () => {
     )
     expect(getColorModeButton()).toHaveTextContent(result.expect)
   })
+
+  test("useSystemColorMode is true, initialColorMode is system and stored value is different from system value", () => {
+    mockMatchMedia("dark")
+    mockLocalStorage("light")
+
+    const options = {
+      useSystemColorMode: true,
+      initialColorMode: "system",
+    } as const
+    render(
+      <ColorModeProvider options={options}>
+        <DummyComponent />
+      </ColorModeProvider>,
+    )
+    expect(getColorModeButton()).toHaveTextContent("dark")
+  })
 })
 
 describe("Config options", () => {


### PR DESCRIPTION
## 📝 Description

Follow system color mode on page load, if `useSystemColorMode` is `true`.

## ⛳️ Current behavior (updates)

1. set system as "dark mode" (app follows)
2. leave page
3. set system as "light mode"
4. come back to page
5. app is still "dark mode"

## 🚀 New behavior

1. set system as "dark mode" (app follows)
2. leave page
3. set system as "light mode"
4. come back to page
5. app changes to "light mode"

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
