### PR TITLE
Change childrenWithinMax check to same as excess

### DIFF
--- a/.changeset/thick-islands-admire.md
+++ b/.changeset/thick-islands-admire.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/avatar": patch
+---
+
+AvatarGroup: Fixed issue where setting `max` to `0` lead to unexpected behavior.

--- a/packages/components/avatar/src/avatar-group.tsx
+++ b/packages/components/avatar/src/avatar-group.tsx
@@ -59,7 +59,7 @@ export const AvatarGroup = forwardRef<AvatarGroupProps, "div">(
     /**
      * get the avatars within the max
      */
-    const childrenWithinMax = max ? validChildren.slice(0, max) : validChildren
+    const childrenWithinMax = max != null ? validChildren.slice(0, max) : validChildren
 
     /**
      * get the remaining avatar count


### PR DESCRIPTION
## 📝 Description

When passing prop max as 0 (zero) excess shows correct value but the all avatars are also rendered that because 0 is a falsey. 

## ⛳️ Current behavior (updates)

Current behavior is that excess and children are rendered if prop `max` is 0 (zero).

## 🚀 New behavior

This will make that only excess will be rendered when passing prop `max` as 0 (zero)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Because slice can work with negative numbers didn't add validation for this case, just because excess don't validate for negative numbers also.
