### PR TITLE
fix(Menu): prevent infinite rerendering

### DIFF
--- a/.changeset/slimy-paws-add.md
+++ b/.changeset/slimy-paws-add.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Ensure only one focus animation runs at a time, to prevent infinite rerenders.

--- a/packages/components/menu/stories/menu.stories.tsx
+++ b/packages/components/menu/stories/menu.stories.tsx
@@ -323,6 +323,25 @@ export const WithLetterNavigation = () => (
   </Menu>
 )
 
+export const WithScrolling = () => {
+  const items = React.useMemo(
+    () => Array.from({ length: 30 }).map((_, i) => `Option ${i}`),
+    [],
+  )
+  return (
+    <Menu>
+      <MenuButton>Choose an option</MenuButton>
+      <MenuList maxHeight="15rem" overflowY="scroll">
+        {items.map((value, i) => (
+          <MenuItem key={i} value={value}>
+            {value}
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Menu>
+  )
+}
+
 export const JustAnotherExample = () => (
   <Menu>
     <MenuButton as={Button}>Your Cats</MenuButton>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7139 <!-- Github issue # here -->
Closes #7100 

## 📝 Description

Mousing over multiple menu items quickly causes infinite rerenders. This breaks the focusing behaviour for the default `Menu` as per #7100, as the focus no longer changes when hovering over a `MenuItem`. The problem is even worse for a `Menu` with scrollable `MenuItem`s as it causes the jittering issue from #7139. This behaviour was introduced via #7032 in [@chakra-ui/react@2.4.2](https://github.com/chakra-ui/chakra-ui/releases/tag/%40chakra-ui%2Freact%402.4.2).

## ⛳️ Current behavior (updates)

Infinite rerenders are caused when an animation frame is requested to focus a `MenuItem`, and before this animation frame can execute, another animation frame is requested to focus a different `MenuItem`. This can be replicated by mousing over multiple menu items quickly.

Consider a `Menu` with 2 options, "Option 0" at index 0 and "Option 1" at index 1. The infinite sequence is as follows:
1. Mouse enters "Option 0", resulting in a [`setFocusedIndex`](https://github.com/chakra-ui/chakra-ui/blob/80971001d7b77d02d5f037487a37237ded315480/packages/components/menu/src/use-menu.ts#L602) for index 0
2. `useUpdateEffect` [requests an animation frame](https://github.com/chakra-ui/chakra-ui/blob/80971001d7b77d02d5f037487a37237ded315480/packages/components/menu/src/use-menu.ts#L656) to focus Option 0
3. Before the animation from step 2 can execute, steps 1 and 2 repeat for Option 1, resulting in a `setFocusedIndex` for index 1 and a 2nd queued animation frame
4. Animation frame from step 2 executes, resulting in Option 0 being focused
5. `onFocus` (introduced in #7032) fires for option 0, which calls a `setFocusedIndex` for Option 0
6. Animation frame from step 3 executes, resulting in Option 1 being focused
7. `onFocus` fires for option 1, which calls a `setFocusedIndex` for Option 1
8. New `focusedIndex` is 0 due to step 5, which causes `useUpdateEffect` to request a new animation frame to focus Option 0
9. Before the animation from step 8 can execute, step 8 repeats for Option 1, resulting in a `setFocusedIndex` for index 1 and a 2nd queued animation

...and so on.

## 🚀 New behavior

The idea is to ensure that whenever an animation frame is requested, the previous one is cancelled. Since each `MenuItem` is only aware of its own animations, the animation frame ID has to be tracked at the `Menu` level. `MenuItem` retrieves `focusAnimationId` and `setFocusAnimationId` from `MenuContext`, and cancels any pending animations before requesting a new one.

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
Also added a new story with a scrolling `Menu` component.