### PR TITLE
fix: invalid regexp group on firefox 69

### DIFF
--- a/.changeset/invalid-regexp-group.md
+++ b/.changeset/invalid-regexp-group.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": patch
+---
+
+Update the regex of parseGradient to make it works on legacy Firefox browser.

--- a/packages/core/styled-system/src/utils/parse-gradient.ts
+++ b/packages/core/styled-system/src/utils/parse-gradient.ts
@@ -29,8 +29,10 @@ export function parseGradient(
   theme: Record<string, any>,
 ) {
   if (value == null || globalSet.has(value)) return value
-  const regex = /(?<type>^[a-z-A-Z]+)\((?<values>(.*))\)/g
-  const { type, values } = regex.exec(value)?.groups ?? {}
+  const regex = /(^[a-z-A-Z]+)\(((.*))\)/g
+  const results = regex.exec(value)
+  const type = results?.[1]
+  const values = results?.[2]
 
   if (!type || !values) return value
 

--- a/packages/core/styled-system/src/utils/parse-gradient.ts
+++ b/packages/core/styled-system/src/utils/parse-gradient.ts
@@ -29,7 +29,7 @@ export function parseGradient(
   theme: Record<string, any>,
 ) {
   if (value == null || globalSet.has(value)) return value
-  const regex = /(^[a-z-A-Z]+)\(((.*))\)/g
+  const regex = /(^[a-z-A-Z]+)\((.*)\)/g
   const results = regex.exec(value)
   const type = results?.[1]
   const values = results?.[2]


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7317

## 📝 Description

Update the regex of parseGradient in @chakra-ui/styled-system to make it works on legacy Firefox browser.

## ⛳️ Current behavior (updates)

The regex of parseGradient in styled-system doesn't work on Firefox 69.

<img width="1684" alt="图片" src="https://user-images.githubusercontent.com/35302658/216754242-5be5cd73-f955-401b-adf8-847ed5f277ed.png">

## 🚀 New behavior

New regex works well on firefox 69 and other modern browsers.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Seems firefox 69 doesn't support named capture groups in regex.

<img width="575" alt="图片" src="https://user-images.githubusercontent.com/35302658/216754474-22c12a05-8b56-48be-b017-7d19681d2a73.png">

![图片](https://user-images.githubusercontent.com/35302658/216754377-53521f04-29ff-4878-8e9d-71767a96f892.png)

more details: https://stackoverflow.com/questions/55774080/firefox-gives-syntaxerror-invalid-regexp-group
