### PR TITLE
fix(Checkbox): empty item in useMemo dependencies

### DIFF
--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -143,7 +143,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
       color: iconColor,
       ...styles.icon,
     }),
-    [iconColor, iconSize, , state.isIndeterminate, styles.icon],
+    [iconColor, iconSize, state.isIndeterminate, styles.icon],
   )
 
   const clonedIcon = cloneElement(icon, {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

> `iconStyles`  variable, after refactoring commit, started to have an empty item in the `useMemo` dependency.

 As far as I can understand, it's not an expected behavior, so I deleted this empty item from the dependency list.
