### PR TITLE
refactor(input-group): add data-group attribute

### DIFF
--- a/.changeset/two-ligers-join.md
+++ b/.changeset/two-ligers-join.md
@@ -1,0 +1,12 @@
+---
+"@chakra-ui/input": patch
+---
+
+Add `data-group` attribute to `InputGroup` component.
+
+This will allow uniform styling changes for `Input`, `InputElement`, and
+`InputAddon` to occur when detecting state changes such as `:hover` and
+`:focus-within`.
+
+Example gif below with a left and right `InputElement`
+![ezgif com-video-to-gif](https://user-images.githubusercontent.com/65234762/217900818-cbbbd727-2e75-4523-8563-c90eaac1e69b.gif)

--- a/packages/components/input/src/input-group.tsx
+++ b/packages/components/input/src/input-group.tsx
@@ -85,6 +85,7 @@ export const InputGroup = forwardRef<InputGroupProps, "div">(
           // Create a new stacking context so that these overrides don't leak out and conflict with other z-indexes
           isolation: "isolate",
         }}
+        data-group
         {...rest}
       >
         <InputGroupStylesProvider value={styles}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Add `data-group` attribute to `InputGroup` component.

This will allow uniform styling changes for `Input`, `InputElement`, and
`InputAddon` to occur when detecting state changes such as `:hover` and
`:focus-within`.

Example gif below with a left and right `InputElement`

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/65234762/217900818-cbbbd727-2e75-4523-8563-c90eaac1e69b.gif)

