### PR TITLE
fix(menu): export menu provider

### DIFF
--- a/.changeset/blue-fireants-perform.md
+++ b/.changeset/blue-fireants-perform.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Export menu provider

--- a/packages/components/menu/src/index.ts
+++ b/packages/components/menu/src/index.ts
@@ -19,6 +19,7 @@ export { MenuOptionGroup } from "./menu-option-group"
 export type { MenuOptionGroupProps } from "./menu-option-group"
 export {
   MenuDescendantsProvider,
+  MenuProvider,
   useMenu,
   useMenuButton,
   useMenuContext,


### PR DESCRIPTION
Closes #7368


## ⛳️ Current behavior (updates)

`MenuProvider` not exported

## 🚀 New behavior

Exports `MenuProvider`

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

