### PR TITLE
feat: add props to editable

### DIFF
--- a/.changeset/strong-pianos-report.md
+++ b/.changeset/strong-pianos-report.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/editable": major
+---
+
+Adds finalFocusRef and onBlur to Editable component

--- a/packages/components/editable/stories/editable.stories.tsx
+++ b/packages/components/editable/stories/editable.stories.tsx
@@ -167,3 +167,22 @@ export const Disabled = () => (
     <EditableControls />
   </Editable>
 )
+
+export const FinalFocusRef = () => {
+  const finalFocusRef = React.useRef(null)
+
+  return (
+    <>
+      <input ref={finalFocusRef} />
+      <Editable
+        finalFocusRef={finalFocusRef}
+        defaultValue="Final fantasy"
+        fontSize="xl"
+      >
+        <EditablePreview />
+        <EditableInput />
+        <EditableControls />
+      </Editable>
+    </>
+  )
+}


### PR DESCRIPTION
## 📝 Description

> Adds two new props to editable component -- finalFocusRef and onBlur.

## ⛳️ Current behavior (updates)

> Editable always focuses edit buttons on blur. 
> Editable requires you to add onSubmit and onCancel hooks if you want to always make a change onBlur. 

## 🚀 New behavior

> Focusing on the edit button is sometimes not desirable, and the workaround is very hacky (involving setTimeouts). This change also makes Editable more inline with other chakra ui components.
> We can now add a simple onBlur callback to always take an action onSubmit or onCancel

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
