### PR TITLE
fix: add focusvisible styles to MenuButton component without passing as prop

### DIFF
--- a/packages/components/menu/src/menu-button.tsx
+++ b/packages/components/menu/src/menu-button.tsx
@@ -1,4 +1,9 @@
-import { forwardRef, HTMLChakraProps, chakra } from "@chakra-ui/system"
+import {
+  forwardRef,
+  HTMLChakraProps,
+  chakra,
+  useStyleConfig,
+} from "@chakra-ui/system"
 import { cx } from "@chakra-ui/shared-utils"
 
 import { useMenuStyles } from "./menu"
@@ -7,6 +12,7 @@ import { useMenuButton } from "./use-menu"
 export interface MenuButtonProps extends HTMLChakraProps<"button"> {}
 
 const StyledMenuButton = forwardRef<MenuButtonProps, "button">((props, ref) => {
+  const _focusVisible = useStyleConfig("Button", {})?.["_focusVisible"]
   const styles = useMenuStyles()
   return (
     <chakra.button
@@ -17,6 +23,7 @@ const StyledMenuButton = forwardRef<MenuButtonProps, "button">((props, ref) => {
         appearance: "none",
         alignItems: "center",
         outline: 0,
+        ...{ _focusVisible },
         ...styles.button,
       }}
     />


### PR DESCRIPTION
## 📝 Description

Add keyboard focus indicator to MenuButton component

This pull request adds a default focus style to the MenuButton component so that it is visible when it receives keyboard focus. This change was made to improve the accessibility of the component and to comply with the WCAG Level AA guidelines.

## ⛳️ Current behavior (updates)

Currently, the MenuButton component does not have a default focus style when the as prop is not passed with the value "Button". This means that users who rely on the keyboard to navigate the page may have difficulty determining which component they are interacting with.

## 🚀 New behavior

With this pull request, the MenuButton component now has a default focus style that is visible when it receives keyboard focus. This ensures that all users, including those who rely on the keyboard, can easily determine which component they are interacting with.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

N/A.
