### PR TITLE
fix(avatar): add crossOrigin prop to avatar and avatar image

### DIFF
--- a/.changeset/cold-pans-sort.md
+++ b/.changeset/cold-pans-sort.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/avatar": patch
+---
+
+Adding support for Avatar to specify "crossOrigin" prop for image

--- a/packages/components/avatar/src/avatar-image.tsx
+++ b/packages/components/avatar/src/avatar-image.tsx
@@ -26,6 +26,7 @@ export function AvatarImage(props: AvatarImageProps) {
     icon = <GenericAvatarIcon />,
     ignoreFallback,
     referrerPolicy,
+    crossOrigin,
   } = props
 
   /**
@@ -69,6 +70,7 @@ export function AvatarImage(props: AvatarImageProps) {
       alt={name}
       onLoad={onLoad}
       referrerPolicy={referrerPolicy}
+      crossOrigin={crossOrigin ?? undefined}
       className="chakra-avatar__img"
       loading={loading}
       __css={{

--- a/packages/components/avatar/src/avatar.tsx
+++ b/packages/components/avatar/src/avatar.tsx
@@ -30,6 +30,7 @@ export interface AvatarProps
   extends Omit<HTMLChakraProps<"span">, "onError">,
     AvatarOptions,
     ThemingProps<"Avatar"> {
+  crossOrigin?: HTMLChakraProps<"img">["crossOrigin"]
   iconLabel?: string
   /**
    * If `true`, opt out of the avatar's `fallback` logic and
@@ -63,6 +64,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
     children,
     borderColor,
     ignoreFallback,
+    crossOrigin,
     ...rest
   } = omitThemingProps(props)
 
@@ -100,6 +102,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
           icon={icon}
           iconLabel={iconLabel}
           ignoreFallback={ignoreFallback}
+          crossOrigin={crossOrigin}
         />
         {children}
       </AvatarStylesProvider>


### PR DESCRIPTION
Closes #7416 

## 📝 Description

Adds support for setting `crossOrigin` attribute on avatar image.

## ⛳️ Current behavior (updates)

No support for cross origin which is required when serving in ["cross origin isolation" mode](https://web.dev/coop-coep/).

## 🚀 New behavior

Adds optional prop for crossOrigin

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
