### PR TITLE
docs(card): mark props as optional

### DIFF
--- a/.changeset/honest-pens-matter.md
+++ b/.changeset/honest-pens-matter.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/card": patch
+---
+
+Document props as optional

--- a/packages/components/card/docs.json
+++ b/packages/components/card/docs.json
@@ -2,17 +2,17 @@
   "Card": {
     "align": {
       "type": "ResponsiveValue<AlignItems>",
-      "required": true,
+      "required": false,
       "description": "The flex alignment of the card"
     },
     "direction": {
       "type": "ResponsiveValue<FlexDirection>",
-      "required": true,
+      "required": false,
       "description": "The flex direction of the card"
     },
     "justify": {
       "type": "ResponsiveValue<JustifyContent>",
-      "required": true,
+      "required": false,
       "description": "The flex distribution of the card"
     },
     "colorScheme": {
@@ -35,7 +35,7 @@
   },
   "CardBody": {},
   "CardFooter": {
-    "justify": { "type": "ResponsiveValue<JustifyContent>", "required": true }
+    "justify": { "type": "ResponsiveValue<JustifyContent>", "required": false }
   },
   "CardHeader": {}
 }


### PR DESCRIPTION
## 📝 Description

Simple doc fix for `Card` and `CardFooter`

## ⛳️ Current behavior (updates)

`Card` and `CardFooter` props were incorrectly marked as required.

## 🚀 New behavior

They're correctly marked as optional.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
