### PR TITLE
Adds child types for popover in v1 branch

### DIFF
--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -76,11 +76,19 @@ if (__DEV__) {
   PopoverAnchor.displayName = "PopoverAnchor"
 }
 
+export interface PopoverTriggerProps {
+  /**
+   * The React child to use as the
+   * trigger for the popover
+   */
+  children: React.ReactNode
+}
+
 /**
  * PopoverTrigger opens the popover's content. It must be an interactive element
  * such as `button` or `a`.
  */
-export const PopoverTrigger: React.FC = (props) => {
+export const PopoverTrigger = (props: PopoverTriggerProps) => {
   // enforce a single child
   const child: any = React.Children.only(props.children)
   const { getTriggerProps } = usePopoverContext()


### PR DESCRIPTION
Closes #5844 for v1 branch.
This is exactly same change that @pomSense did, but for v1 branch

## 📝 Description

The `PopoverTrigger` component breaks with React 18.

## ⛳️ Current behavior (updates)

The child for PopoverTrigger isn't typed, which leads to the following error with react 18:

```
Type '{ children: any; }' has no properties in common with type 'IntrinsicAttributes'.
```

## 🚀 New behavior

Added type to the PopoverTrigger type and specified it accordingly to the PopoverTrigger component:

```typescript
interface PopoverTriggerProps {
  /**
   * The React child to use as the
   * trigger for the popover
   */
  children: React.ReactChild
}

export const PopoverTrigger: React.FC<React.PropsWithChildren<PopoverTriggerProps>> = (props) => {
  // enforce a single child
  const child: any = React.Children.only(props.children)
  const { getTriggerProps } = usePopoverContext()
  return React.cloneElement(child, getTriggerProps(child.props, child.ref))
}
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

Link to previous PR: https://github.com/chakra-ui/chakra-ui/pull/5845