### PR TITLE
fix(css-reset): attach variable to :host as well

### DIFF
--- a/.changeset/loud-socks-sing.md
+++ b/.changeset/loud-socks-sing.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/css-reset": patch
+---
+
+Attach `--chakra-vh` variable to :host as well

--- a/packages/components/css-reset/src/css-reset.tsx
+++ b/packages/components/css-reset/src/css-reset.tsx
@@ -1,24 +1,24 @@
 import { Global } from "@emotion/react"
 
 const vhPolyfill = `
-  :root {
+  :root, :host {
     --chakra-vh: 100vh;
   }
 
   @supports (height: -webkit-fill-available) {
-    :root {
+    :root, :host {
       --chakra-vh: -webkit-fill-available;
     }
   }
 
   @supports (height: -moz-fill-available) {
-    :root {
+    :root, :host {
       --chakra-vh: -moz-fill-available;
     }
   }
 
   @supports (height: 100dvh) {
-    :root {
+    :root, :host {
       --chakra-vh: 100dvh;
     }
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

When working inside a Shadow DOM, the `--chakra-vh` variable is not set properly because it attaches to :root

Modals with `closeOnOverlayClick` do not trigger because the `content_container` has a height of 0px.

## ⛳️ Current behavior (updates)

Modals with `closeOnOverlayClick` do not trigger because the `content_container` has a height of 0px.

## 🚀 New behavior

Setting the css variable to the `:host` selector as well will fix issue abovve. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
