### PR TITLE
feat: add css reset scope

### DIFF
--- a/.changeset/breezy-deers-judge.md
+++ b/.changeset/breezy-deers-judge.md
@@ -1,0 +1,22 @@
+---
+"@chakra-ui/css-reset": minor
+"@chakra-ui/provider": minor
+"@chakra-ui/theme": minor
+---
+
+Add support for scoping the css reset to specific selector.
+
+To use this feature, pass the `resetScope` prop to the `ChakraProvider` or
+`ChakraBaseProvider` component.
+
+```jsx live=false
+import { ChakraProvider } from "@chakra-ui/react"
+
+function App() {
+  return (
+    <ChakraProvider resetScope=".ck-reset">
+      <App />
+    </ChakraProvider>
+  )
+}
+```

--- a/packages/components/css-reset/src/css-reset.tsx
+++ b/packages/components/css-reset/src/css-reset.tsx
@@ -1,24 +1,30 @@
 import { Global } from "@emotion/react"
 
-const vhPolyfill = `
-  :root, :host {
+const css = String.raw
+
+const vhPolyfill = css`
+  :root,
+  :host {
     --chakra-vh: 100vh;
   }
 
   @supports (height: -webkit-fill-available) {
-    :root, :host {
+    :root,
+    :host {
       --chakra-vh: -webkit-fill-available;
     }
   }
 
   @supports (height: -moz-fill-available) {
-    :root, :host {
+    :root,
+    :host {
       --chakra-vh: -moz-fill-available;
     }
   }
 
   @supports (height: 100dvh) {
-    :root, :host {
+    :root,
+    :host {
       --chakra-vh: 100dvh;
     }
   }
@@ -26,9 +32,16 @@ const vhPolyfill = `
 
 export const CSSPolyfill = () => <Global styles={vhPolyfill} />
 
-export const CSSReset = () => (
+export type CSSResetProps = {
+  /**
+   * The selector to scope the css reset styles to.
+   */
+  scope?: string
+}
+
+export const CSSReset = ({ scope = "" }: CSSResetProps) => (
   <Global
-    styles={`
+    styles={css`
       html {
         line-height: 1.5;
         -webkit-text-size-adjust: 100%;
@@ -42,112 +55,103 @@ export const CSSReset = () => (
       body {
         position: relative;
         min-height: 100%;
-        font-feature-settings: 'kern';
+        margin: 0;
+        font-feature-settings: "kern";
       }
 
-      *,
-      *::before,
-      *::after {
+      ${scope} :where(*, *::before, *::after) {
         border-width: 0;
         border-style: solid;
         box-sizing: border-box;
+        word-wrap: break-word;
       }
 
       main {
         display: block;
       }
 
-      hr {
+      ${scope} hr {
         border-top-width: 1px;
         box-sizing: content-box;
         height: 0;
         overflow: visible;
       }
 
-      pre,
-      code,
-      kbd,
-      samp {
-        font-family: SFMono-Regular,  Menlo, Monaco, Consolas, monospace;
+      ${scope} :where(pre, code, kbd,samp) {
+        font-family: SFMono-Regular, Menlo, Monaco, Consolas, monospace;
         font-size: 1em;
       }
 
-      a {
+      ${scope} a {
         background-color: transparent;
         color: inherit;
         text-decoration: inherit;
       }
 
-      abbr[title] {
+      ${scope} abbr[title] {
         border-bottom: none;
         text-decoration: underline;
         -webkit-text-decoration: underline dotted;
         text-decoration: underline dotted;
       }
 
-      b,
-      strong {
+      ${scope} :where(b, strong) {
         font-weight: bold;
       }
 
-      small {
+      ${scope} small {
         font-size: 80%;
       }
 
-      sub,
-      sup {
+      ${scope} :where(sub,sup) {
         font-size: 75%;
         line-height: 0;
         position: relative;
         vertical-align: baseline;
       }
 
-      sub {
+      ${scope} sub {
         bottom: -0.25em;
       }
 
-      sup {
+      ${scope} sup {
         top: -0.5em;
       }
 
-      img {
+      ${scope} img {
         border-style: none;
       }
 
-      button,
-      input,
-      optgroup,
-      select,
-      textarea {
+      ${scope} :where(button, input, optgroup, select, textarea) {
         font-family: inherit;
         font-size: 100%;
         line-height: 1.15;
         margin: 0;
       }
 
-      button,
-      input {
+      ${scope} :where(button, input) {
         overflow: visible;
       }
 
-      button,
-      select {
+      ${scope} :where(button, select) {
         text-transform: none;
       }
 
-      button::-moz-focus-inner,
-      [type="button"]::-moz-focus-inner,
-      [type="reset"]::-moz-focus-inner,
-      [type="submit"]::-moz-focus-inner {
+      ${scope} :where(
+          button::-moz-focus-inner,
+          [type="button"]::-moz-focus-inner,
+          [type="reset"]::-moz-focus-inner,
+          [type="submit"]::-moz-focus-inner
+        ) {
         border-style: none;
         padding: 0;
       }
 
-      fieldset {
+      ${scope} fieldset {
         padding: 0.35em 0.75em 0.625em;
       }
 
-      legend {
+      ${scope} legend {
         box-sizing: border-box;
         color: inherit;
         display: table;
@@ -156,48 +160,49 @@ export const CSSReset = () => (
         white-space: normal;
       }
 
-      progress {
+      ${scope} progress {
         vertical-align: baseline;
       }
 
-      textarea {
+      ${scope} textarea {
         overflow: auto;
       }
 
-      [type="checkbox"],
-      [type="radio"] {
+      ${scope} :where([type="checkbox"], [type="radio"]) {
         box-sizing: border-box;
         padding: 0;
       }
 
-      [type="number"]::-webkit-inner-spin-button,
-      [type="number"]::-webkit-outer-spin-button {
+      ${scope} :where(
+          [type="number"]::-webkit-inner-spin-button,
+          [type="number"]::-webkit-outer-spin-button
+        ) {
         -webkit-appearance: none !important;
       }
 
-      input[type="number"] {
+      ${scope} input[type="number"] {
         -moz-appearance: textfield;
       }
 
-      [type="search"] {
+      ${scope} [type="search"] {
         -webkit-appearance: textfield;
         outline-offset: -2px;
       }
 
-      [type="search"]::-webkit-search-decoration {
+      ${scope} [type="search"]::-webkit-search-decoration {
         -webkit-appearance: none !important;
       }
 
-      ::-webkit-file-upload-button {
+      ${scope} ::-webkit-file-upload-button {
         -webkit-appearance: button;
         font: inherit;
       }
 
-      details {
+      ${scope} details {
         display: block;
       }
 
-      summary {
+      ${scope} summary {
         display: list-item;
       }
 
@@ -209,99 +214,84 @@ export const CSSReset = () => (
         display: none !important;
       }
 
-      body,
-      blockquote,
-      dl,
-      dd,
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6,
-      hr,
-      figure,
-      p,
-      pre {
+      ${scope} :where(
+          blockquote,
+          dl,
+          dd,
+          h1,
+          h2,
+          h3,
+          h4,
+          h5,
+          h6,
+          hr,
+          figure,
+          p,
+          pre
+        ) {
         margin: 0;
       }
 
-      button {
+      ${scope} button {
         background: transparent;
         padding: 0;
       }
 
-      fieldset {
+      ${scope} fieldset {
         margin: 0;
         padding: 0;
       }
 
-      ol,
-      ul {
+      ${scope} :where(ol, ul) {
         margin: 0;
         padding: 0;
       }
 
-      textarea {
+      ${scope} textarea {
         resize: vertical;
       }
 
-      button,
-      [role="button"] {
+      ${scope} :where(button, [role="button"]) {
         cursor: pointer;
       }
 
-      button::-moz-focus-inner {
+      ${scope} button::-moz-focus-inner {
         border: 0 !important;
       }
 
-      table {
+      ${scope} table {
         border-collapse: collapse;
       }
 
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
+      ${scope} :where(h1, h2, h3, h4, h5, h6) {
         font-size: inherit;
         font-weight: inherit;
       }
 
-      button,
-      input,
-      optgroup,
-      select,
-      textarea {
+      ${scope} :where(button, input, optgroup, select, textarea) {
         padding: 0;
         line-height: inherit;
         color: inherit;
       }
 
-      img,
-      svg,
-      video,
-      canvas,
-      audio,
-      iframe,
-      embed,
-      object {
+      ${scope} :where(img, svg, video, canvas, audio, iframe, embed, object) {
         display: block;
       }
 
-      img,
-      video {
+      ${scope} :where(img, video) {
         max-width: 100%;
         height: auto;
       }
 
-      [data-js-focus-visible] :focus:not([data-focus-visible-added]):not([data-focus-visible-disabled]) {
+      [data-js-focus-visible]
+        :focus:not([data-focus-visible-added]):not(
+          [data-focus-visible-disabled]
+        ) {
         outline: none;
         box-shadow: none;
       }
 
-      select::-ms-expand {
+      ${scope} select::-ms-expand {
         display: none;
       }
 

--- a/packages/components/provider/src/chakra-provider.tsx
+++ b/packages/components/provider/src/chakra-provider.tsx
@@ -33,6 +33,10 @@ export interface ChakraProviderProps
    */
   resetCSS?: boolean
   /**
+   * The selector to scope the css reset styles to.
+   */
+  resetScope?: string
+  /**
    * manager to persist a users color mode preference in
    *
    * omit if you don't render server-side
@@ -69,6 +73,7 @@ export const ChakraProvider: React.FC<ChakraProviderProps> = (props) => {
     children,
     colorModeManager,
     portalZIndex,
+    resetScope,
     resetCSS = true,
     theme = {},
     environment,
@@ -91,7 +96,7 @@ export const ChakraProvider: React.FC<ChakraProviderProps> = (props) => {
         colorModeManager={colorModeManager}
         options={theme.config}
       >
-        {resetCSS ? <CSSReset /> : <CSSPolyfill />}
+        {resetCSS ? <CSSReset scope={resetScope} /> : <CSSPolyfill />}
         <GlobalStyle />
         {portalZIndex ? (
           <PortalManager zIndex={portalZIndex}>{_children}</PortalManager>

--- a/packages/components/theme/src/styles.ts
+++ b/packages/components/theme/src/styles.ts
@@ -15,7 +15,6 @@ export const styles: Styles = {
     },
     "*, *::before, &::after": {
       borderColor: "chakra-border-color",
-      wordWrap: "break-word",
     },
   },
 }


### PR DESCRIPTION
Closes #6946

## 📝 Description

Add support for scoping the css reset to a specific selector.

To use this feature, pass the `resetScope` prop to the `ChakraProvider` or
`ChakraBaseProvider` component.

```jsx live=false
import { ChakraProvider } from "@chakra-ui/react"
function App() {
  return (
    <ChakraProvider resetScope=".ck-reset">
      <App />
    </ChakraProvider>
  )
}
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
