### PR TITLE
fix: defaultValue is not passsed

### DIFF
--- a/.changeset/clean-tips-fry.md
+++ b/.changeset/clean-tips-fry.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react-context": patch
+---
+
+`createContext`: Fix issue where `defaultValue` is not passing

--- a/packages/hooks/context/src/index.ts
+++ b/packages/hooks/context/src/index.ts
@@ -29,9 +29,10 @@ export function createContext<T>(options: CreateContextOptions<T> = {}) {
     hookName = "useContext",
     providerName = "Provider",
     errorMessage,
+    defaultValue,
   } = options
 
-  const Context = createReactContext<T | undefined>(undefined)
+  const Context = createReactContext<T | undefined>(defaultValue)
 
   Context.displayName = name
 


### PR DESCRIPTION
Closes #7469 

## 📝 Description

Added passing defaultValue property to the createContext function

## ⛳️ Current behavior (updates)

createContext defaulValue property doesn't work.

## 🚀 New behavior

defaultValue is passing and works as expected.

## 💣 Is this a breaking change (Yes/No):

No
