### PR TITLE
fix: colorScheme is not passed in the toast component

### DIFF
--- a/.changeset/late-trees-smile.md
+++ b/.changeset/late-trees-smile.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/toast": major
+---
+
+fix: Support colorScheme prop for the Toast component
+
+The colorScheme prop is supported for the Toast component Now you can pass the
+prop using useToast hook

--- a/packages/components/toast/src/toast.tsx
+++ b/packages/components/toast/src/toast.tsx
@@ -33,6 +33,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
     isClosable,
     onClose,
     description,
+    colorScheme,
     icon,
   } = props
 
@@ -56,6 +57,7 @@ export const Toast: React.FC<ToastProps> = (props) => {
       paddingEnd={8}
       textAlign="start"
       width="auto"
+      colorScheme={colorScheme}
     >
       <AlertIcon>{icon}</AlertIcon>
       <chakra.div flex="1" maxWidth="100%">

--- a/packages/components/toast/stories/toast.stories.tsx
+++ b/packages/components/toast/stories/toast.stories.tsx
@@ -27,6 +27,7 @@ export function ToastExample() {
             status: "error",
             duration: null,
             isClosable: true,
+            colorScheme: "red",
             onCloseComplete: () => {
               console.log("hello")
             },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # [7472](https://github.com/chakra-ui/chakra-ui/issues/7472)

## 📝 Description
Add colorScheme prop support for the toast component

> Add a brief description
The colorScheme prop is passed now for the toast component in order to change the color
of the Alert component.

The colorScheme prop is not defined in the toast stories.

## ⛳️ Current behavior (updates)
The Toast component is not supported the colorScheme prop


> Please describe the current behavior that you are modifying
Implement the  Toast component and called with useToast
pass the colorScheme prop in the useToast hook
The color for the Alert is not updated


## 🚀 New behavior
> Please describe the behavior or changes this PR adds

Implement the  Toast component and called with useToast
pass the colorScheme prop in the useToast hook
The color for the Alert is updated based on the prop


## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
