### PR TITLE
fix: passive event warning on mobile

### DIFF
--- a/.changeset/fast-cherries-flash.md
+++ b/.changeset/fast-cherries-flash.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/radio": patch
+---
+
+- Fix issue where shows console warning due to `preventDefault` call in pointer
+  event on mobile
+
+- Add deprecation warning for `getCheckboxProps` in favor of `getRadioProps`

--- a/.changeset/modern-ads-glow.md
+++ b/.changeset/modern-ads-glow.md
@@ -1,6 +1,5 @@
 ---
 "@chakra-ui/checkbox": patch
-"@chakra-ui/radio": patch
 ---
 
 Fix issue where shows console warning due to `preventDefault` call in pointer

--- a/.changeset/modern-ads-glow.md
+++ b/.changeset/modern-ads-glow.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/checkbox": patch
+"@chakra-ui/radio": patch
+---
+
+Fix issue where shows console warning due to `preventDefault` call in pointer
+event on mobile

--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -306,7 +306,6 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       ...props,
       ref: forwardedRef,
       onMouseDown: callAllHandlers(props.onMouseDown, stopEvent),
-      onTouchStart: callAllHandlers(props.onTouchStart, stopEvent),
       "data-disabled": dataAttr(isDisabled),
       "data-checked": dataAttr(isChecked),
       "data-invalid": dataAttr(isInvalid),

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -272,8 +272,7 @@ export function useRadio(props: UseRadioProps = {}) {
   const getLabelProps: PropGetter = (props = {}, ref = null) => ({
     ...props,
     ref,
-    onMouseDown: callAllHandlers(props.onMouseDown, stop),
-    onTouchStart: callAllHandlers(props.onTouchStart, stop),
+    onMouseDown: callAllHandlers(props.onMouseDown, stopEvent),
     "data-disabled": dataAttr(isDisabled),
     "data-checked": dataAttr(isChecked),
     "data-invalid": dataAttr(isInvalid),
@@ -300,8 +299,11 @@ export function useRadio(props: UseRadioProps = {}) {
 
   return {
     state,
-    // the function is renamed to getRadioProps to make the code more consistent. It is renamed towards outside because otherwise this would produce a breaking change
+    /**
+     * @deprecated - use `getRadioProps` instead
+     */
     getCheckboxProps: getRadioProps,
+    getRadioProps,
     getInputProps,
     getLabelProps,
     getRootProps,
@@ -312,7 +314,7 @@ export function useRadio(props: UseRadioProps = {}) {
 /**
  * Prevent `onBlur` being fired when the radio label is touched
  */
-function stop(event: React.SyntheticEvent) {
+function stopEvent(event: React.SyntheticEvent) {
   event.preventDefault()
   event.stopPropagation()
 }


### PR DESCRIPTION
Closes #7143
Closes #6924

## 📝 Description

This PR fixes an issue in which the browser shows a console warning due to the `event.preventDefault` call on touch start. This also surfaces as a critical bug when trying to scroll on mobile.

## 🚀 New behavior

It works as expected.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
