### PR TITLE
fix: tag component not reading badge color and badge bg css variables

### DIFF
--- a/.changeset/late-pandas-own.md
+++ b/.changeset/late-pandas-own.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/theme": major
+"@chakra-ui/tag": major
+---
+
+- Fix issue where the tag component is not setting bg and color css variables
+  the variables are called `--badge-bg` and `--badge-color`. Those values are
+  already passed as CSS variable but not read. Editing the tag.ts file and make
+  a reference for those variables

--- a/packages/components/tag/stories/tag.stories.tsx
+++ b/packages/components/tag/stories/tag.stories.tsx
@@ -22,7 +22,7 @@ export default {
   ],
 }
 
-export const basic = () => <Tag>Gray</Tag>
+export const basic = () => <Tag colorScheme="teal">Teal</Tag>
 
 export const withSizes = () => (
   <>

--- a/packages/components/theme/src/components/tag.ts
+++ b/packages/components/theme/src/components/tag.ts
@@ -1,9 +1,13 @@
 import { tagAnatomy as parts } from "@chakra-ui/anatomy"
 import {
   createMultiStyleConfigHelpers,
+  cssVar,
   defineStyle,
 } from "@chakra-ui/styled-system"
 import { badgeTheme } from "./badge"
+
+const $bg = cssVar("badge-bg")
+const $fg = cssVar("badge-color")
 
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(parts.keys)
@@ -12,6 +16,8 @@ const baseStyleContainer = defineStyle({
   fontWeight: "medium",
   lineHeight: 1.2,
   outline: 0,
+  color: $fg.reference,
+  bg: $bg.reference,
   borderRadius: "md",
   _focusVisible: {
     boxShadow: "outline",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7485 

## 📝 Description
Add support for the colorScheme values for the tag component
> Add a brief description


## ⛳️ Current behavior (updates)
Tag component not reading `var(--badge-color)` and `var(--badge-bg)` CSS variables
> Please describe the current behavior that you are modifying


## 🚀 New behavior
Tag component reading colorScheme prop and setting the value for `color` and `bg` with the `--badge-bg` and `badge-color`CSS variables just like in the Chakra example in the official docs

![Screen Shot 2023-03-23 at 12 34 09](https://user-images.githubusercontent.com/14258139/227314093-77045899-c9d8-453d-b714-bb76c8174448.png)

 > Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
