### PR TITLE
fix(toast): remove invalid role

### DIFF
--- a/.changeset/nervous-beans-exist.md
+++ b/.changeset/nervous-beans-exist.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Remove invalid role in toast

--- a/packages/components/toast/src/toast.provider.tsx
+++ b/packages/components/toast/src/toast.provider.tsx
@@ -123,7 +123,6 @@ export const ToastProvider = (props: ToastProviderProps) => {
 
     return (
       <ul
-        role="region"
         aria-live="polite"
         key={position}
         id={`chakra-toast-manager-${position}`}


### PR DESCRIPTION

Closes #7324 

## 📝 Description

- `region` is not a valid `role` for `ul`
- the default role is appropriate for this use (`list`)

## ⛳️ Current behavior (updates)

role is `region`

## 🚀 New behavior

role is `list`

## 💣 Is this a breaking change (Yes/No):

no