### PR TITLE
fix: type issues with TS 5.0

### DIFF
--- a/.changeset/tall-lies-tap.md
+++ b/.changeset/tall-lies-tap.md
@@ -1,0 +1,14 @@
+---
+"@chakra-ui/transition": patch
+"@chakra-ui/next-js": patch
+"@chakra-ui/styled-system": patch
+"@chakra-ui/avatar": patch
+"@chakra-ui/button": patch
+"@chakra-ui/layout": patch
+"@chakra-ui/icons": patch
+"@chakra-ui/menu": patch
+"@chakra-ui/system": patch
+"@chakra-ui/test-utils": patch
+---
+
+Fix issues with TS 5.0

--- a/.changeset/tall-lies-tap.md
+++ b/.changeset/tall-lies-tap.md
@@ -3,6 +3,7 @@
 "@chakra-ui/next-js": patch
 "@chakra-ui/styled-system": patch
 "@chakra-ui/avatar": patch
+"@chakra-ui/checkbox": patch
 "@chakra-ui/button": patch
 "@chakra-ui/layout": patch
 "@chakra-ui/icons": patch

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -15,12 +15,12 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@types/jest": "^28.1.1",
-    "@types/react": "^18.0.1",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^18.0.30",
+    "@types/react-dom": "^18.0.11",
     "eslint": "8.19.0",
     "eslint-config-react-app": "^7.0.1",
     "react-scripts": "^5.0.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.0.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -16,13 +16,13 @@
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@types/node": "^18.0.0",
-    "@types/react": "^18.0.1",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^18.0.30",
+    "@types/react-dom": "^18.0.11",
     "framer-motion": "^6.2.9",
     "next": "^13.0.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^4.7.4"
+    "typescript": "^5.0.2"
   },
   "repository": {
     "type": "git",

--- a/examples/next-pages/package.json
+++ b/examples/next-pages/package.json
@@ -16,14 +16,14 @@
     "@emotion/styled": "^11.8.1",
     "@faker-js/faker": "^7.1.0",
     "@types/node": "^18.0.0",
-    "@types/react": "^18.0.1",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^18.0.30",
+    "@types/react-dom": "^18.0.11",
     "framer-motion": "^6.2.9",
     "next": "^13.0.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.2.0",
-    "typescript": "^4.7.4"
+    "typescript": "^5.0.2"
   },
   "repository": {
     "type": "git",

--- a/examples/vite-ts/package.json
+++ b/examples/vite-ts/package.json
@@ -13,10 +13,10 @@
   },
   "devDependencies": {
     "@chakra-ui/react": "workspace:*",
-    "@types/react": "^18.0.1",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^18.0.30",
+    "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.0.0",
-    "typescript": "^4.7.4",
+    "typescript": "^5.0.2",
     "vite": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "@types/jest": "^28.1.1",
     "@types/mkdirp": "1.0.2",
     "@types/node": "^18.0.0",
-    "@types/react": "^18.0.1",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^18.0.30",
+    "@types/react-dom": "^18.0.11",
     "@types/testing-library__jest-dom": "5.14.5",
     "@typescript-eslint/eslint-plugin": "5.30.3",
     "@typescript-eslint/parser": "5.30.3",
@@ -117,7 +117,7 @@
     "tsup": "^6.5.0",
     "tsx": "^3.8.1",
     "turbo": "1.3.4",
-    "typescript": "^4.7.4",
+    "typescript": "^5.0.2",
     "unbuild": "0.7.4"
   },
   "pnpm": {

--- a/packages/components/avatar/src/avatar-group.tsx
+++ b/packages/components/avatar/src/avatar-group.tsx
@@ -65,7 +65,7 @@ export const AvatarGroup = forwardRef<AvatarGroupProps, "div">(
     /**
      * get the remaining avatar count
      */
-    const excess = max != null && validChildren.length - max
+    const excess = max != null ? validChildren.length - max : 0
 
     /**
      * Reversing the children is a great way to avoid using zIndex

--- a/packages/components/button/src/button-icon.tsx
+++ b/packages/components/button/src/button-icon.tsx
@@ -6,7 +6,7 @@ export function ButtonIcon(props: HTMLChakraProps<"span">) {
   const { children, className, ...rest } = props
 
   const _children = isValidElement(children)
-    ? cloneElement(children, {
+    ? cloneElement<any>(children, {
         "aria-hidden": true,
         focusable: false,
       })

--- a/packages/components/checkbox/src/checkbox-icon.tsx
+++ b/packages/components/checkbox/src/checkbox-icon.tsx
@@ -1,4 +1,4 @@
-import { chakra, PropsOf } from "@chakra-ui/system"
+import { chakra, HTMLChakraProps, PropsOf } from "@chakra-ui/system"
 
 function CheckIcon(props: PropsOf<typeof chakra.svg>) {
   return (
@@ -31,7 +31,7 @@ function IndeterminateIcon(props: PropsOf<typeof chakra.svg>) {
   )
 }
 
-export interface CheckboxIconProps extends PropsOf<typeof chakra.svg> {
+export interface CheckboxIconProps extends HTMLChakraProps<"svg"> {
   /**
    * @default false
    */

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -26,7 +26,7 @@
     "react": ">=18"
   },
   "devDependencies": {
-    "@types/react": "^18.0.1",
+    "@types/react": "^18.0.30",
     "@chakra-ui/system": "workspace:*",
     "@chakra-ui/layout": "workspace:*",
     "react": "^18.0.0",

--- a/packages/components/layout/stories/container.stories.tsx
+++ b/packages/components/layout/stories/container.stories.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-// import { ChakraProvider, extendTheme } from "@chakra-ui/react"
 import { Container } from "../src"
 
 export default {
@@ -21,33 +19,3 @@ export const basic = () => (
     </p>
   </Container>
 )
-
-// const theme = extendTheme({
-//   components: {
-//     Container: {
-//       variants: {
-//         customBackground: {
-//           bgColor: "red.500",
-//         },
-//       },
-//     },
-//   },
-// })
-
-// export const withVariant = () => (
-//   <ChakraProvider theme={theme}>
-//     <Container maxWidth="md" variant="customBackground">
-//       <p>
-//         Lorem Ipsum is simply dummy text of the printing and typesetting
-//         industry. Lorem Ipsum has been the industry's standard dummy text ever
-//         since the 1500s, when an unknown printer took a galley of type and
-//         scrambled it to make a type specimen book. It has survived not only five
-//         centuries, but also the leap into electronic typesetting, remaining
-//         essentially unchanged. It was popularised in the 1960s with the release
-//         of Letraset sheets containing Lorem Ipsum passages, and more recently
-//         with desktop publishing software like Aldus PageMaker including versions
-//         of Lorem Ipsum.
-//       </p>
-//     </Container>
-//   </ChakraProvider>
-// )

--- a/packages/components/menu/src/menu-icon.tsx
+++ b/packages/components/menu/src/menu-icon.tsx
@@ -9,7 +9,7 @@ export const MenuIcon: React.FC<HTMLChakraProps<"span">> = (props) => {
   const child = Children.only(children)
 
   const clone = isValidElement(child)
-    ? cloneElement(child, {
+    ? cloneElement<any>(child, {
         focusable: "false",
         "aria-hidden": true,
         className: cx("chakra-menu__icon", child.props.className),

--- a/packages/components/transition/src/collapse.tsx
+++ b/packages/components/transition/src/collapse.tsx
@@ -110,7 +110,7 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
      * for the height to take effect.
      */
     warn({
-      condition: Boolean(startingHeight > 0 && unmountOnExit),
+      condition: Number(startingHeight) > 0 && !!unmountOnExit,
       message: `startingHeight and unmountOnExit are mutually exclusive. You can't use them together`,
     })
 

--- a/packages/core/styled-system/src/create-theme-vars/create-theme-vars.ts
+++ b/packages/core/styled-system/src/create-theme-vars/create-theme-vars.ts
@@ -79,7 +79,7 @@ export function createThemeVars(
       cssVars,
       Object.entries(normalizedValue).reduce(
         (acc, [conditionAlias, conditionValue]) => {
-          const maybeReference = lookupToken(conditionValue)
+          const maybeReference = lookupToken(conditionValue!.toString())
           if (conditionAlias === "default") {
             acc[variable] = maybeReference
             return acc

--- a/packages/core/system/src/factory.ts
+++ b/packages/core/system/src/factory.ts
@@ -3,7 +3,7 @@ import { ChakraStyledOptions, HTMLChakraComponents, styled } from "./system"
 import { As, ChakraComponent } from "./system.types"
 
 type ChakraFactory = {
-  <T extends As, P extends Record<string, unknown> = {}>(
+  <T extends As, P extends object = {}>(
     component: T,
     options?: ChakraStyledOptions,
   ): ChakraComponent<T, P>

--- a/packages/core/system/src/factory.ts
+++ b/packages/core/system/src/factory.ts
@@ -3,7 +3,7 @@ import { ChakraStyledOptions, HTMLChakraComponents, styled } from "./system"
 import { As, ChakraComponent } from "./system.types"
 
 type ChakraFactory = {
-  <T extends As, P = {}>(
+  <T extends As, P extends Record<string, unknown> = {}>(
     component: T,
     options?: ChakraStyledOptions,
   ): ChakraComponent<T, P>

--- a/packages/core/system/src/system.ts
+++ b/packages/core/system/src/system.ts
@@ -69,7 +69,7 @@ export interface ChakraStyledOptions extends Dict {
     | ((props: StyleResolverProps) => SystemStyleObject)
 }
 
-export function styled<T extends As, P = {}>(
+export function styled<T extends As, P extends object = {}>(
   component: T,
   options?: ChakraStyledOptions,
 ) {

--- a/packages/core/system/src/system.types.tsx
+++ b/packages/core/system/src/system.types.tsx
@@ -50,15 +50,19 @@ export type RightJoinProps<
   OverrideProps extends object = {},
 > = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps
 
+type Assign<T, U> = Omit<T, keyof U> & U
+
 export type MergeWithAs<
   ComponentProps extends object,
   AsProps extends object,
   AdditionalProps extends object = {},
   AsComponent extends As = As,
-> = RightJoinProps<ComponentProps, AdditionalProps> &
-  RightJoinProps<AsProps, AdditionalProps> & {
-    as?: AsComponent
-  }
+> = (
+  | RightJoinProps<ComponentProps, AdditionalProps>
+  | RightJoinProps<Partial<AsProps>, AdditionalProps>
+) & {
+  as?: AsComponent
+}
 
 export type ComponentWithAs<Component extends As, Props extends object = {}> = {
   <AsComponent extends As = Component>(
@@ -77,5 +81,5 @@ export type ComponentWithAs<Component extends As, Props extends object = {}> = {
   id?: string
 }
 
-export interface ChakraComponent<T extends As, P = {}>
-  extends ComponentWithAs<T, ChakraProps & P> {}
+export interface ChakraComponent<T extends As, P extends object = {}>
+  extends ComponentWithAs<T, Assign<ChakraProps, P>> {}

--- a/packages/core/system/src/system.types.tsx
+++ b/packages/core/system/src/system.types.tsx
@@ -26,7 +26,7 @@ export interface ChakraProps extends SystemProps {
   css?: Interpolation<{}>
 }
 
-export type As<Props = any> = React.ElementType<Props>
+export type As = React.ElementType
 
 /**
  * Extract the props of a React element or component

--- a/packages/core/system/src/system.types.tsx
+++ b/packages/core/system/src/system.types.tsx
@@ -59,7 +59,7 @@ export type MergeWithAs<
   AsComponent extends As = As,
 > = (
   | RightJoinProps<ComponentProps, AdditionalProps>
-  | RightJoinProps<Partial<AsProps>, AdditionalProps>
+  | RightJoinProps<AsProps, AdditionalProps>
 ) & {
   as?: AsComponent
 }

--- a/packages/integrations/next-js/src/link.tsx
+++ b/packages/integrations/next-js/src/link.tsx
@@ -22,22 +22,20 @@ export type LinkProps = Merge<
   Omit<NextLinkProps, LegacyProps>
 >
 
-export const Link: LinkComponent = forwardRef<LinkProps, typeof NextLink>(
-  function Link(props, ref) {
-    const styles = useStyleConfig("Link", props)
-    const { className, href, children, ...rest } = omitThemingProps(props)
+export const Link: LinkComponent = forwardRef(function Link(props, ref) {
+  const styles = useStyleConfig("Link", props)
+  const { className, href, children, ...rest } = omitThemingProps(props)
 
-    return (
-      <chakra.a
-        ref={ref}
-        href={href as any}
-        {...rest}
-        className={cx("chakra-link", className)}
-        __css={styles}
-        as={NextLink}
-      >
-        {children}
-      </chakra.a>
-    )
-  },
-)
+  return (
+    <chakra.a
+      ref={ref}
+      href={href as any}
+      {...rest}
+      className={cx("chakra-link", className)}
+      __css={styles}
+      as={NextLink}
+    >
+      {children}
+    </chakra.a>
+  )
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
       '@types/jest': ^28.1.1
       '@types/mkdirp': 1.0.2
       '@types/node': ^18.0.0
-      '@types/react': ^18.0.1
-      '@types/react-dom': ^18.0.0
+      '@types/react': ^18.0.30
+      '@types/react-dom': ^18.0.11
       '@types/testing-library__jest-dom': 5.14.5
       '@typescript-eslint/eslint-plugin': 5.30.3
       '@typescript-eslint/parser': 5.30.3
@@ -79,7 +79,7 @@ importers:
       tsup: ^6.5.0
       tsx: ^3.8.1
       turbo: 1.3.4
-      typescript: ^4.7.4
+      typescript: ^5.0.2
       unbuild: 0.7.4
     dependencies:
       '@babel/core': 7.18.9
@@ -101,14 +101,14 @@ importers:
       '@commitlint/config-conventional': 14.1.0
       '@octokit/rest': 19.0.5
       '@storybook/addon-a11y': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-essentials': 6.5.15_vgvudjoe3cuxklba64h26nku3a
+      '@storybook/addon-essentials': 6.5.15_irdonh7hca5spf3f2gxjutd3ha
       '@storybook/addon-storysource': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
-      '@storybook/cli': 6.5.15_laxx7oajycrjekgfbzprteir3i
-      '@storybook/manager-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
-      '@storybook/react': 6.5.15_3apbmfmoura73q5zgiaot4axza
+      '@storybook/builder-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
+      '@storybook/cli': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
+      '@storybook/manager-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
+      '@storybook/react': 6.5.15_qgrq2eauwbgzqnxuglagifq4hy
       '@storybook/theming': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@swc-node/jest': 1.5.5_bzpoqjpthcj2u4f3g3uovkghle
+      '@swc-node/jest': 1.5.5_oaveibztp3aac3djewansrqdf4
       '@swc/core': 1.3.24
       '@testing-library/jest-dom': 5.16.5
       '@types/edit-json-file': 1.7.0
@@ -116,11 +116,11 @@ importers:
       '@types/jest': 28.1.6
       '@types/mkdirp': 1.0.2
       '@types/node': 18.11.17
-      '@types/react': 18.0.26
-      '@types/react-dom': 18.0.10
+      '@types/react': 18.0.30
+      '@types/react-dom': 18.0.11
       '@types/testing-library__jest-dom': 5.14.5
-      '@typescript-eslint/eslint-plugin': 5.30.3_xuuykav7urhdozug7htlfgar3u
-      '@typescript-eslint/parser': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/eslint-plugin': 5.30.3_fpsgnhykgmdds465wqgph3hbsu
+      '@typescript-eslint/parser': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       dotenv: 16.0.3
       edit-json-file: 1.6.0
       eslint: 8.19.0
@@ -132,7 +132,7 @@ importers:
       eslint-plugin-prettier: 4.2.1_p5wztxp7of3xepsymp2thqnjem
       eslint-plugin-react: 7.30.1_eslint@8.19.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.19.0
-      eslint-plugin-testing-library: 5.5.1_4x5o4skxv6sl53vpwefgt23khm
+      eslint-plugin-testing-library: 5.5.1_wzajlvpeyqkhd33zas4sol2fg4
       find-packages: 9.0.13
       find-up: 6.3.0
       fs-extra: 11.1.0
@@ -150,10 +150,10 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       rimraf: 3.0.2
-      tsup: 6.5.0_bzpoqjpthcj2u4f3g3uovkghle
+      tsup: 6.5.0_oaveibztp3aac3djewansrqdf4
       tsx: 3.8.1
       turbo: 1.3.4
-      typescript: 4.7.4
+      typescript: 5.0.2
       unbuild: 0.7.4
 
   examples/create-react-app:
@@ -164,8 +164,8 @@ importers:
       '@testing-library/jest-dom': ^5.16.4
       '@testing-library/react': ^13.3.0
       '@types/jest': ^28.1.1
-      '@types/react': ^18.0.1
-      '@types/react-dom': ^18.0.0
+      '@types/react': ^18.0.30
+      '@types/react-dom': ^18.0.11
       eslint: 8.19.0
       eslint-config-react-app: ^7.0.1
       framer-motion: ^6.2.9
@@ -173,11 +173,11 @@ importers:
       react-dom: ^18.2.0
       react-icons: ^4.2.0
       react-scripts: ^5.0.1
-      typescript: ^4.7.4
+      typescript: ^5.0.2
     dependencies:
       '@chakra-ui/react': link:../../packages/components/react
-      '@emotion/react': 11.9.3_3hx2ussxxho4jajbwrd6gq34qe
-      '@emotion/styled': 11.9.3_t4da3hocwt6ljcf3o6em4qwqzm
+      '@emotion/react': 11.9.3_2thlp7g7odiqm7dwhn3rlhxaa4
+      '@emotion/styled': 11.9.3_t3k3ki72qkdnkybccnpnbkrsja
       framer-motion: 6.5.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -186,12 +186,12 @@ importers:
       '@testing-library/jest-dom': 5.16.4
       '@testing-library/react': 13.3.0_biqbaboplfbrettd7655fr4n2y
       '@types/jest': 28.1.6
-      '@types/react': 18.0.15
-      '@types/react-dom': 18.0.6
+      '@types/react': 18.0.30
+      '@types/react-dom': 18.0.11
       eslint: 8.19.0
-      eslint-config-react-app: 7.0.1_4x5o4skxv6sl53vpwefgt23khm
-      react-scripts: 5.0.1_gqi5qmibjkogsznwcpqmzq76tq
-      typescript: 4.7.4
+      eslint-config-react-app: 7.0.1_wzajlvpeyqkhd33zas4sol2fg4
+      react-scripts: 5.0.1_xjlewhdyk7kqujzx3pkqrde7jy
+      typescript: 5.0.2
 
   examples/gatsby:
     specifiers:
@@ -243,28 +243,28 @@ importers:
       '@emotion/react': ^11.9.0
       '@emotion/styled': ^11.8.1
       '@types/node': ^18.0.0
-      '@types/react': ^18.0.1
-      '@types/react-dom': ^18.0.0
+      '@types/react': ^18.0.30
+      '@types/react-dom': ^18.0.11
       framer-motion: ^6.2.9
       next: ^13.0.7
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^4.7.4
+      typescript: ^5.0.2
     dependencies:
       '@chakra-ui/icons': link:../../packages/components/icons
       '@chakra-ui/next-js': link:../../packages/integrations/next-js
       '@chakra-ui/react': link:../../packages/components/react
       '@chakra-ui/theme-tools': link:../../packages/components/theme-tools
-      '@emotion/react': 11.9.3_3hx2ussxxho4jajbwrd6gq34qe
-      '@emotion/styled': 11.9.3_t4da3hocwt6ljcf3o6em4qwqzm
+      '@emotion/react': 11.9.3_2thlp7g7odiqm7dwhn3rlhxaa4
+      '@emotion/styled': 11.9.3_t3k3ki72qkdnkybccnpnbkrsja
       '@types/node': 18.0.6
-      '@types/react': 18.0.15
-      '@types/react-dom': 18.0.6
+      '@types/react': 18.0.30
+      '@types/react-dom': 18.0.11
       framer-motion: 6.5.1_biqbaboplfbrettd7655fr4n2y
       next: 13.0.7_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
 
   examples/next-pages:
     specifiers:
@@ -275,30 +275,30 @@ importers:
       '@emotion/styled': ^11.8.1
       '@faker-js/faker': ^7.1.0
       '@types/node': ^18.0.0
-      '@types/react': ^18.0.1
-      '@types/react-dom': ^18.0.0
+      '@types/react': ^18.0.30
+      '@types/react-dom': ^18.0.11
       framer-motion: ^6.2.9
       next: ^13.0.7
       react: ^18.2.0
       react-dom: ^18.2.0
       react-icons: ^4.2.0
-      typescript: ^4.7.4
+      typescript: ^5.0.2
     dependencies:
       '@chakra-ui/icons': link:../../packages/components/icons
       '@chakra-ui/react': link:../../packages/components/react
       '@chakra-ui/theme-tools': link:../../packages/components/theme-tools
-      '@emotion/react': 11.9.3_3hx2ussxxho4jajbwrd6gq34qe
-      '@emotion/styled': 11.9.3_t4da3hocwt6ljcf3o6em4qwqzm
+      '@emotion/react': 11.9.3_2thlp7g7odiqm7dwhn3rlhxaa4
+      '@emotion/styled': 11.9.3_t3k3ki72qkdnkybccnpnbkrsja
       '@faker-js/faker': 7.3.0
       '@types/node': 18.0.6
-      '@types/react': 18.0.15
-      '@types/react-dom': 18.0.6
+      '@types/react': 18.0.30
+      '@types/react-dom': 18.0.11
       framer-motion: 6.5.1_biqbaboplfbrettd7655fr4n2y
       next: 13.0.7_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-icons: 4.4.0_react@18.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
 
   examples/storybook-addon:
     specifiers:
@@ -322,22 +322,22 @@ importers:
   examples/vite-ts:
     specifiers:
       '@chakra-ui/react': workspace:*
-      '@types/react': ^18.0.1
-      '@types/react-dom': ^18.0.0
+      '@types/react': ^18.0.30
+      '@types/react-dom': ^18.0.11
       '@vitejs/plugin-react': ^3.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^4.7.4
+      typescript: ^5.0.2
       vite: ^4.0.2
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@chakra-ui/react': link:../../packages/components/react
-      '@types/react': 18.0.15
-      '@types/react-dom': 18.0.6
+      '@types/react': 18.0.30
+      '@types/react-dom': 18.0.11
       '@vitejs/plugin-react': 3.0.0_vite@4.0.2
-      typescript: 4.7.4
+      typescript: 5.0.2
       vite: 4.0.2
 
   packages/components/accordion:
@@ -740,7 +740,7 @@ importers:
       '@chakra-ui/icon': workspace:*
       '@chakra-ui/layout': workspace:*
       '@chakra-ui/system': workspace:*
-      '@types/react': ^18.0.1
+      '@types/react': ^18.0.30
       clean-package: 2.2.0
       react: ^18.2.0
     dependencies:
@@ -748,7 +748,7 @@ importers:
     devDependencies:
       '@chakra-ui/layout': link:../layout
       '@chakra-ui/system': link:../../core/system
-      '@types/react': 18.0.15
+      '@types/react': 18.0.30
       clean-package: 2.2.0
       react: 18.2.0
 
@@ -5470,7 +5470,7 @@ packages:
       hoist-non-react-statics: 3.3.2
     dev: true
 
-  /@emotion/react/11.9.3_3hx2ussxxho4jajbwrd6gq34qe:
+  /@emotion/react/11.9.3_2thlp7g7odiqm7dwhn3rlhxaa4:
     resolution: {integrity: sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -5488,7 +5488,7 @@ packages:
       '@emotion/serialize': 1.0.4
       '@emotion/utils': 1.1.0
       '@emotion/weak-memoize': 0.2.5
-      '@types/react': 18.0.15
+      '@types/react': 18.0.30
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
     dev: false
@@ -5593,7 +5593,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /@emotion/styled/11.9.3_t4da3hocwt6ljcf3o6em4qwqzm:
+  /@emotion/styled/11.9.3_t3k3ki72qkdnkybccnpnbkrsja:
     resolution: {integrity: sha512-o3sBNwbtoVz9v7WB1/Y/AmXl69YHmei2mrVnK7JgyBJ//Rst5yqPZCecEJlMlJrFeWHp+ki/54uN265V2pEcXA==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -5609,10 +5609,10 @@ packages:
       '@babel/runtime': 7.18.9
       '@emotion/babel-plugin': 11.9.2
       '@emotion/is-prop-valid': 1.1.3
-      '@emotion/react': 11.9.3_3hx2ussxxho4jajbwrd6gq34qe
+      '@emotion/react': 11.9.3_2thlp7g7odiqm7dwhn3rlhxaa4
       '@emotion/serialize': 1.0.4
       '@emotion/utils': 1.1.0
-      '@types/react': 18.0.15
+      '@types/react': 18.0.30
       react: 18.2.0
     dev: false
 
@@ -8769,7 +8769,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.15_laxx7oajycrjekgfbzprteir3i:
+  /@storybook/addon-controls/6.5.15_p2vejkeqivoeua7xl5ds6smhgm:
     resolution: {integrity: sha512-q5y0TvD0stvQoJZ2PnFmmKIRNSOI4/k2NKyZq//J2cBUBcP1reYlFxdsNwLZWmAFpSIkc2+nsliEzNxU1WByoA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8784,7 +8784,7 @@ packages:
       '@storybook/api': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.15
       '@storybook/components': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.15
       '@storybook/store': 6.5.15_biqbaboplfbrettd7655fr4n2y
@@ -8835,7 +8835,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.5.15_kivpkshadtweonoo4cc34evt6i:
+  /@storybook/addon-docs/6.5.15_no3gt6r6zsji56nwss56lxpqlm:
     resolution: {integrity: sha512-k3LAu+wVp6pNhfh6B1soCRl6+7sNTNxtqy6WTrIeVJVCGbXbyc5s7gQ48gJ4WAk6meoDEZbypiP4NK1El03YLg==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -8856,7 +8856,7 @@ packages:
       '@storybook/addons': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/api': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/components': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/core-events': 6.5.15
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.15_biqbaboplfbrettd7655fr4n2y
@@ -8943,7 +8943,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.15_vgvudjoe3cuxklba64h26nku3a:
+  /@storybook/addon-essentials/6.5.15_irdonh7hca5spf3f2gxjutd3ha:
     resolution: {integrity: sha512-m3EY6BhUk6Z9Et7P5wGaRGNoEDHzJIOsLbGS/4IXvIoDfrqmNIilqUQl8kfDqpVdBSFprvpacHpKpLosu9H37w==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -9003,16 +9003,16 @@ packages:
       '@babel/core': 7.18.9
       '@storybook/addon-actions': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-backgrounds': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-controls': 6.5.15_laxx7oajycrjekgfbzprteir3i
-      '@storybook/addon-docs': 6.5.15_kivpkshadtweonoo4cc34evt6i
+      '@storybook/addon-controls': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
+      '@storybook/addon-docs': 6.5.15_no3gt6r6zsji56nwss56lxpqlm
       '@storybook/addon-measure': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-outline': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-toolbars': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-viewport': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/addons': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/api': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/builder-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/node-logger': 6.5.15
       core-js: 3.23.5
       react: 18.2.0
@@ -9485,7 +9485,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.5.15_laxx7oajycrjekgfbzprteir3i:
+  /@storybook/builder-webpack4/6.5.15_p2vejkeqivoeua7xl5ds6smhgm:
     resolution: {integrity: sha512-1ZkMECUUdiYplhlgyUF5fqW3XU7eWNDJbuPUguyDOeidgJ111WZzBcLuKj+SNrzdNNgXwROCWAFybiNnX33YHQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -9503,7 +9503,7 @@ packages:
       '@storybook/client-api': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.15
       '@storybook/components': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/core-events': 6.5.15
       '@storybook/node-logger': 6.5.15
       '@storybook/preview-web': 6.5.15_biqbaboplfbrettd7655fr4n2y
@@ -9521,12 +9521,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_cvgkw7n4pbxdcdb3db3eo7u2fm
+      fork-ts-checker-webpack-plugin: 4.1.6_bs6tfkpduwqe3cj2w3blzdhtiy
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.7.4
+      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
@@ -9537,7 +9537,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -9620,7 +9620,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/builder-webpack5/6.5.15_yxlsvnbzvlucivrm4vximpvvjm:
+  /@storybook/builder-webpack5/6.5.15_slneb2wh664ajicohokrdb77bi:
     resolution: {integrity: sha512-BnSoAmI02pvbGBSyzCx+voXb/d5EopQ78zx/lYv4CeOspBFOYEfGvAgYHILFo04V12S2/k8aSOc/tCYw5AqPtw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -9638,7 +9638,7 @@ packages:
       '@storybook/client-api': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.15
       '@storybook/components': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/core-events': 6.5.15
       '@storybook/node-logger': 6.5.15
       '@storybook/preview-web': 6.5.15_biqbaboplfbrettd7655fr4n2y
@@ -9653,7 +9653,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.23.5
       css-loader: 5.2.7_webpack@5.73.0
-      fork-ts-checker-webpack-plugin: 6.5.2_vzvrbkqxq2uhuknms22gvb2xwq
+      fork-ts-checker-webpack-plugin: 6.5.2_5bkz3bk4lhnjgdu4btmdnowl7i
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       html-webpack-plugin: 5.5.0_webpack@5.73.0
@@ -9665,7 +9665,7 @@ packages:
       style-loader: 2.0.0_webpack@5.73.0
       terser-webpack-plugin: 5.3.3_y6gdyrheyrzgnh57myfqisiqzm
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.3.24
       webpack-dev-middleware: 4.3.0_webpack@5.73.0
@@ -9740,18 +9740,18 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/cli/6.5.15_laxx7oajycrjekgfbzprteir3i:
+  /@storybook/cli/6.5.15_p2vejkeqivoeua7xl5ds6smhgm:
     resolution: {integrity: sha512-oXmT6okxNsHFHTfc+fxkbnTn08ccZV1c9frVnKZt6v2+raq0B81A2DPBgh1LPZ3RHSii+U8DhbigxnyTS/CmGg==}
     hasBin: true
     dependencies:
       '@babel/core': 7.20.5
       '@babel/preset-env': 7.18.9_@babel+core@7.20.5
       '@storybook/codemod': 6.5.15_@babel+preset-env@7.18.9
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/csf-tools': 6.5.15
       '@storybook/node-logger': 6.5.15
       '@storybook/semver': 7.3.2
-      '@storybook/telemetry': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/telemetry': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       boxen: 5.1.2
       chalk: 4.1.2
       commander: 6.2.1
@@ -9935,7 +9935,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client/6.5.15_c3hoyc4loabfhtyuh36vjkyyai:
+  /@storybook/core-client/6.5.15_ya45otn6rkalgmmwrtbmo45g7i:
     resolution: {integrity: sha512-i9t4WONy2MxJwLI1FIp5ck7b52EXyJfALnxUn4O/3GTkw09J0NOKi2DPjefUsi7IB5MzFpDjDH9vw/XiTM+OZw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -9966,13 +9966,13 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
     dev: false
 
-  /@storybook/core-client/6.5.15_fmoa52rat4euvvdoa5odwjikjm:
+  /@storybook/core-client/6.5.15_zlafshnwa53e574skpdovqm3sa:
     resolution: {integrity: sha512-i9t4WONy2MxJwLI1FIp5ck7b52EXyJfALnxUn4O/3GTkw09J0NOKi2DPjefUsi7IB5MzFpDjDH9vw/XiTM+OZw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -10003,7 +10003,7 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.3.24
@@ -10077,7 +10077,7 @@ packages:
       webpack: 5.73.0
     dev: false
 
-  /@storybook/core-common/6.5.15_laxx7oajycrjekgfbzprteir3i:
+  /@storybook/core-common/6.5.15_p2vejkeqivoeua7xl5ds6smhgm:
     resolution: {integrity: sha512-uits9o6qwHTPnjsNZP25f7hWmUBGRJ7FXtxxtEaNSmtiwk50KWxBaro7wt505lJ1Gb9vOhpNPhS7y3IxdsXNmQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -10121,7 +10121,7 @@ packages:
       express: 4.18.1
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_cvgkw7n4pbxdcdb3db3eo7u2fm
+      fork-ts-checker-webpack-plugin: 6.5.2_bs6tfkpduwqe3cj2w3blzdhtiy
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -10137,7 +10137,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -10226,7 +10226,7 @@ packages:
     dependencies:
       core-js: 3.23.5
 
-  /@storybook/core-server/6.5.15_hnjzzcpnaw6hdnfn5tuevbka6a:
+  /@storybook/core-server/6.5.15_we62u6nwivc43u5azcvfs7vhgm:
     resolution: {integrity: sha512-m+pZwHhCjwryeqTptyyKHSbIjnnPGKoRSnkqLTOpKQf8llZMnNQWUFrn4fx6UDKzxFQ2st2+laV8O2QbMs8qwQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -10243,19 +10243,19 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.15_laxx7oajycrjekgfbzprteir3i
-      '@storybook/builder-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
-      '@storybook/core-client': 6.5.15_c3hoyc4loabfhtyuh36vjkyyai
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/builder-webpack4': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
+      '@storybook/builder-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
+      '@storybook/core-client': 6.5.15_ya45otn6rkalgmmwrtbmo45g7i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/core-events': 6.5.15
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.15
-      '@storybook/manager-webpack4': 6.5.15_laxx7oajycrjekgfbzprteir3i
-      '@storybook/manager-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
+      '@storybook/manager-webpack4': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
+      '@storybook/manager-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
       '@storybook/node-logger': 6.5.15
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/telemetry': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/telemetry': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@types/node': 16.11.45
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
@@ -10286,7 +10286,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.46.0
@@ -10379,7 +10379,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/core/6.5.15_ycj3plvmtx5gjgktimmkotewbq:
+  /@storybook/core/6.5.15_dkxo5rd2hjk4fco65vjxpfocam:
     resolution: {integrity: sha512-T9TjLxbb5P/XvLEoj0dnbtexJa0V3pqCifRlIUNkTJO0nU3PdGLMcKMSyIYWjkthAJ9oBrajnodV0UveM/epTg==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -10396,13 +10396,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
-      '@storybook/core-client': 6.5.15_fmoa52rat4euvvdoa5odwjikjm
-      '@storybook/core-server': 6.5.15_hnjzzcpnaw6hdnfn5tuevbka6a
-      '@storybook/manager-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
+      '@storybook/builder-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
+      '@storybook/core-client': 6.5.15_zlafshnwa53e574skpdovqm3sa
+      '@storybook/core-server': 6.5.15_we62u6nwivc43u5azcvfs7vhgm
+      '@storybook/manager-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       webpack: 5.73.0_@swc+core@1.3.24
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -10538,7 +10538,7 @@ packages:
       - react-dom
       - supports-color
 
-  /@storybook/manager-webpack4/6.5.15_laxx7oajycrjekgfbzprteir3i:
+  /@storybook/manager-webpack4/6.5.15_p2vejkeqivoeua7xl5ds6smhgm:
     resolution: {integrity: sha512-zRvBTMoaFO6MvHDsDLnt3tsFENhpY3k+e/UIPdqbIDMbUPGGQzxJucAM9aS/kbVSO5IVs8IflVxbeeB/uTIIfA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -10552,8 +10552,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.20.5
       '@babel/preset-react': 7.18.6_@babel+core@7.20.5
       '@storybook/addons': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.5.15_c3hoyc4loabfhtyuh36vjkyyai
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-client': 6.5.15_ya45otn6rkalgmmwrtbmo45g7i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/node-logger': 6.5.15
       '@storybook/theming': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.5.15_biqbaboplfbrettd7655fr4n2y
@@ -10570,7 +10570,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.7.4
+      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       read-pkg-up: 7.0.1
@@ -10580,7 +10580,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -10651,7 +10651,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/manager-webpack5/6.5.15_yxlsvnbzvlucivrm4vximpvvjm:
+  /@storybook/manager-webpack5/6.5.15_slneb2wh664ajicohokrdb77bi:
     resolution: {integrity: sha512-yrHVFUHGdVRWq/oGJwQu+UOZzxELH5SS+Lpn5oIQ/Dblam9piQC0KmBZtFuA9X8acaw4BBVnXgF/aiqs9fOp/Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -10665,8 +10665,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.20.5
       '@babel/preset-react': 7.18.6_@babel+core@7.20.5
       '@storybook/addons': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.5.15_fmoa52rat4euvvdoa5odwjikjm
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-client': 6.5.15_zlafshnwa53e574skpdovqm3sa
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/node-logger': 6.5.15
       '@storybook/theming': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.5.15_biqbaboplfbrettd7655fr4n2y
@@ -10691,7 +10691,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 5.3.3_y6gdyrheyrzgnh57myfqisiqzm
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.3.24
       webpack-dev-middleware: 4.3.0_webpack@5.73.0
@@ -10825,7 +10825,7 @@ packages:
       unfetch: 4.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_3o2jfq6vfqxns3sz6wn2nnc3ei:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_o7anxqytzq5omasdgrdv3qg3o4:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -10836,9 +10836,9 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@4.7.4
+      react-docgen-typescript: 2.2.2_typescript@5.0.2
       tslib: 2.4.1
-      typescript: 4.7.4
+      typescript: 5.0.2
       webpack: 5.73.0_@swc+core@1.3.24
     transitivePeerDependencies:
       - supports-color
@@ -10862,7 +10862,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/react/6.5.15_3apbmfmoura73q5zgiaot4axza:
+  /@storybook/react/6.5.15_qgrq2eauwbgzqnxuglagifq4hy:
     resolution: {integrity: sha512-iQta2xOs/oK0sw/zpn3g/huvOmvggzi8z2/WholmUmmRiSQRo9lOhRXH0u13T4ja4fEa+u7m58G83xOG6i73Kw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -10895,15 +10895,15 @@ packages:
       '@babel/preset-react': 7.18.6_@babel+core@7.18.9
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_aumhct55s6lhceplyc622fxoum
       '@storybook/addons': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
+      '@storybook/builder-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
       '@storybook/client-logger': 6.5.15
-      '@storybook/core': 6.5.15_ycj3plvmtx5gjgktimmkotewbq
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core': 6.5.15_dkxo5rd2hjk4fco65vjxpfocam
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.15_biqbaboplfbrettd7655fr4n2y
-      '@storybook/manager-webpack5': 6.5.15_yxlsvnbzvlucivrm4vximpvvjm
+      '@storybook/manager-webpack5': 6.5.15_slneb2wh664ajicohokrdb77bi
       '@storybook/node-logger': 6.5.15
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_3o2jfq6vfqxns3sz6wn2nnc3ei
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_o7anxqytzq5omasdgrdv3qg3o4
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.15_biqbaboplfbrettd7655fr4n2y
       '@types/estree': 0.0.51
@@ -10928,7 +10928,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.3.24
     transitivePeerDependencies:
@@ -11173,11 +11173,11 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/telemetry/6.5.15_laxx7oajycrjekgfbzprteir3i:
+  /@storybook/telemetry/6.5.15_p2vejkeqivoeua7xl5ds6smhgm:
     resolution: {integrity: sha512-WHMRG6xMkEGscn1q4SotwzV8hxM1g3zHyXPN77iosY5zpOIn/qAzvkmW28V1DPH9jPWMZMizBgG1TIQvUpduXg==}
     dependencies:
       '@storybook/client-logger': 6.5.15
-      '@storybook/core-common': 6.5.15_laxx7oajycrjekgfbzprteir3i
+      '@storybook/core-common': 6.5.15_p2vejkeqivoeua7xl5ds6smhgm
       chalk: 4.1.2
       core-js: 3.23.5
       detect-package-manager: 2.0.1
@@ -11438,21 +11438,21 @@ packages:
       '@swc/core': 1.3.24
     dev: false
 
-  /@swc-node/jest/1.5.5_bzpoqjpthcj2u4f3g3uovkghle:
+  /@swc-node/jest/1.5.5_oaveibztp3aac3djewansrqdf4:
     resolution: {integrity: sha512-DUf0XMk5xuwt4x+BiZ++KlPxa0H9lvjhFdXU2c8lsu+UztGRUAUtI5nhNTqjS9PXw0zzf3gEFP7M8hNUo52YhQ==}
     peerDependencies:
       '@swc/core': '>= 1.3'
     dependencies:
       '@node-rs/xxhash': 1.2.1
       '@swc-node/core': 1.9.1_@swc+core@1.3.24
-      '@swc-node/register': 1.5.4_bzpoqjpthcj2u4f3g3uovkghle
+      '@swc-node/register': 1.5.4_oaveibztp3aac3djewansrqdf4
       '@swc/core': 1.3.24
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@swc-node/register/1.5.4_bzpoqjpthcj2u4f3g3uovkghle:
+  /@swc-node/register/1.5.4_oaveibztp3aac3djewansrqdf4:
     resolution: {integrity: sha512-cM5/A63bO6qLUFC4gcBnOlQO5yd8ObSdFUIp7sXf11Oq5mPVAnJy2DqjbWMUsqUaHuNk+lOIt76ie4DEseUIyA==}
     peerDependencies:
       '@swc/core': '>= 1.3'
@@ -11465,7 +11465,7 @@ packages:
       debug: 4.3.4
       pirates: 4.0.5
       tslib: 2.4.1
-      typescript: 4.7.4
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -11844,7 +11844,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.9
       '@testing-library/dom': 8.16.0
-      '@types/react-dom': 18.0.6
+      '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: true
@@ -11858,7 +11858,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.9
       '@testing-library/dom': 8.16.0
-      '@types/react-dom': 18.0.6
+      '@types/react-dom': 18.0.11
       react: 18.2.0
     dev: false
 
@@ -12302,39 +12302,26 @@ packages:
   /@types/reach__router/1.3.10:
     resolution: {integrity: sha512-iHAFGaVOrWi00/q7oBybggGsz5TOmwOW4M1H9sT7i9lly4qFC8XOgsdf6jUsoaOz2sknFHALEtZqCoDbokdJ2Q==}
     dependencies:
-      '@types/react': 18.0.26
+      '@types/react': 18.0.30
 
-  /@types/react-dom/18.0.10:
-    resolution: {integrity: sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==}
+  /@types/react-dom/18.0.11:
+    resolution: {integrity: sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==}
     dependencies:
-      '@types/react': 18.0.26
-    dev: false
-
-  /@types/react-dom/18.0.6:
-    resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
-    dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.30
 
   /@types/react-frame-component/4.1.3:
     resolution: {integrity: sha512-Ol0pg5m35vTMlam9IJW2iY0O+Qh+5jbeZmVJ2OR/mokWN7AYoMN9FFxj5AmHfwij8bGQctQhbe7o0FoG+axLGA==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.30
     dev: true
 
   /@types/react-syntax-highlighter/11.0.5:
     resolution: {integrity: sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==}
     dependencies:
-      '@types/react': 18.0.26
+      '@types/react': 18.0.30
 
-  /@types/react/18.0.15:
-    resolution: {integrity: sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.0
-
-  /@types/react/18.0.26:
-    resolution: {integrity: sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==}
+  /@types/react/18.0.30:
+    resolution: {integrity: sha512-AnME2cHDH11Pxt/yYX6r0w448BfTwQOLEhQEjCdwB7QskEI7EKtxhGUsExTQe/MsY3D9D5rMtu62WRocw9A8FA==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -12526,7 +12513,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/eslint-plugin/5.30.3_xuuykav7urhdozug7htlfgar3u:
+  /@typescript-eslint/eslint-plugin/5.30.3_fpsgnhykgmdds465wqgph3hbsu:
     resolution: {integrity: sha512-QEgE1uahnDbWEkZlidq7uKB630ny1NN8KbLPmznX+8hYsYpoV1/quG1Nzvs141FVuumuS7O0EpqYw3RB4AVzRg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12537,18 +12524,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/parser': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       '@typescript-eslint/scope-manager': 5.30.3
-      '@typescript-eslint/type-utils': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
-      '@typescript-eslint/utils': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/type-utils': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
+      '@typescript-eslint/utils': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       debug: 4.3.4
       eslint: 8.19.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12569,13 +12556,13 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/experimental-utils/5.30.7_4x5o4skxv6sl53vpwefgt23khm:
+  /@typescript-eslint/experimental-utils/5.30.7_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-r218ZVL0zFBYzEq8/9K2ZhRgsmKUhm8xd3sWChgvTbmP98kHGuY83IUl64SS9fx9OSBM9vMLdzBfox4eDdm/ZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.30.7_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/utils': 5.30.7_wzajlvpeyqkhd33zas4sol2fg4
       eslint: 8.19.0
     transitivePeerDependencies:
       - supports-color
@@ -12600,7 +12587,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser/5.30.3_4x5o4skxv6sl53vpwefgt23khm:
+  /@typescript-eslint/parser/5.30.3_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-ddwGEPC3E49DduAUC8UThQafHRE5uc1NE8jdOgl+w8/NrYF50MJQNeD3u4JZrqAXdY9rJz0CdQ9HpNME20CzkA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12612,10 +12599,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.30.3
       '@typescript-eslint/types': 5.30.3
-      '@typescript-eslint/typescript-estree': 5.30.3_typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.30.3_typescript@5.0.2
       debug: 4.3.4
       eslint: 8.19.0
-      typescript: 4.7.4
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12648,7 +12635,7 @@ packages:
       '@typescript-eslint/types': 5.47.0
       '@typescript-eslint/visitor-keys': 5.47.0
 
-  /@typescript-eslint/type-utils/5.30.3_4x5o4skxv6sl53vpwefgt23khm:
+  /@typescript-eslint/type-utils/5.30.3_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-IIzakE7OXOqdwPaXhRiPnaZ8OuJJYBLufOffd9fqzkI4IMFIYq8KC7bghdnF7QUJTirURRErQFrJ/w5UpwIqaw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12658,11 +12645,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/utils': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       debug: 4.3.4
       eslint: 8.19.0
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12702,7 +12689,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/5.30.3_typescript@4.7.4:
+  /@typescript-eslint/typescript-estree/5.30.3_typescript@5.0.2:
     resolution: {integrity: sha512-jqVh5N9AJx6+7yRgoA+ZelAFrHezgI9pzI9giv7s84DDOmtpFwTgURcpICDHyz9x6vAeOu91iACZ4dBTVfzIyA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12717,12 +12704,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/5.30.7_typescript@4.7.4:
+  /@typescript-eslint/typescript-estree/5.30.7_typescript@5.0.2:
     resolution: {integrity: sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12737,13 +12724,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.47.0_typescript@4.7.4:
+  /@typescript-eslint/typescript-estree/5.47.0_typescript@5.0.2:
     resolution: {integrity: sha512-LxfKCG4bsRGq60Sqqu+34QT5qT2TEAHvSCCJ321uBWywgE2dS0LKcu5u+3sMGo+Vy9UmLOhdTw5JHzePV/1y4Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12758,12 +12745,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils/5.30.3_4x5o4skxv6sl53vpwefgt23khm:
+  /@typescript-eslint/utils/5.30.3_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-OEaBXGxxdIy35H+jyXfYAMQ66KMJczK9hEhL3gR6IRbWe5PyK+bPDC9zbQNVII6rNFTfF/Mse0z21NlEU+vOMw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12772,7 +12759,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.30.3
       '@typescript-eslint/types': 5.30.3
-      '@typescript-eslint/typescript-estree': 5.30.3_typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.30.3_typescript@5.0.2
       eslint: 8.19.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.19.0
@@ -12780,7 +12767,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils/5.30.7_4x5o4skxv6sl53vpwefgt23khm:
+  /@typescript-eslint/utils/5.30.7_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-Z3pHdbFw+ftZiGUnm1GZhkJgVqsDL5CYW2yj+TB2mfXDFOMqtbzQi2dNJIyPqPbx9mv2kUxS1gU+r2gKlKi1rQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12789,7 +12776,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.30.7
       '@typescript-eslint/types': 5.30.7
-      '@typescript-eslint/typescript-estree': 5.30.7_typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.30.7_typescript@5.0.2
       eslint: 8.19.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.19.0
@@ -12798,7 +12785,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.47.0_4x5o4skxv6sl53vpwefgt23khm:
+  /@typescript-eslint/utils/5.47.0_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-U9xcc0N7xINrCdGVPwABjbAKqx4GK67xuMV87toI+HUqgXj26m6RBp9UshEXcTrgCkdGYFzgKLt8kxu49RilDw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -12808,7 +12795,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.47.0
       '@typescript-eslint/types': 5.47.0
-      '@typescript-eslint/typescript-estree': 5.47.0_typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.47.0_typescript@5.0.2
       eslint: 8.19.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.19.0
@@ -17379,8 +17366,8 @@ packages:
       eslint: ^7.32.0 || ^8.2.0
       eslint-plugin-import: ^2.25.3
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.30.3_xuuykav7urhdozug7htlfgar3u
-      '@typescript-eslint/parser': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/eslint-plugin': 5.30.3_fpsgnhykgmdds465wqgph3hbsu
+      '@typescript-eslint/parser': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       eslint: 8.19.0
       eslint-config-airbnb-base: 15.0.0_q2xwze32dd33a2fc2qubwr4ie4
       eslint-plugin-import: 2.26.0_xgi3rtbx7oxkcq3vxqkef6isyu
@@ -17429,7 +17416,7 @@ packages:
       eslint-plugin-react: 7.30.1_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
 
-  /eslint-config-react-app/7.0.1_4x5o4skxv6sl53vpwefgt23khm:
+  /eslint-config-react-app/7.0.1_6ttip4nvqc6t6bbkhqegry7zpa:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -17442,19 +17429,19 @@ packages:
       '@babel/core': 7.18.9
       '@babel/eslint-parser': 7.18.9_fh4y75b3ljlrwycdrafhbkphau
       '@rushstack/eslint-patch': 1.1.4
-      '@typescript-eslint/eslint-plugin': 5.30.3_xuuykav7urhdozug7htlfgar3u
-      '@typescript-eslint/parser': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/eslint-plugin': 5.30.3_fpsgnhykgmdds465wqgph3hbsu
+      '@typescript-eslint/parser': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
       eslint: 8.19.0
       eslint-plugin-flowtype: 8.0.3_eslint@8.19.0
       eslint-plugin-import: 2.26.0_xgi3rtbx7oxkcq3vxqkef6isyu
-      eslint-plugin-jest: 25.7.0_owzbkbqytgpmvvbd3mdtsvrn3i
+      eslint-plugin-jest: 25.7.0_2nazwofwl6wuzb3vjlondchcga
       eslint-plugin-jsx-a11y: 6.6.0_eslint@8.19.0
       eslint-plugin-react: 7.30.1_eslint@8.19.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.19.0
-      eslint-plugin-testing-library: 5.5.1_4x5o4skxv6sl53vpwefgt23khm
-      typescript: 4.7.4
+      eslint-plugin-testing-library: 5.5.1_wzajlvpeyqkhd33zas4sol2fg4
+      typescript: 5.0.2
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
       - '@babel/plugin-transform-react-jsx'
@@ -17464,7 +17451,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-react-app/7.0.1_vveddai22guzfmv7jcqwmi76su:
+  /eslint-config-react-app/7.0.1_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -17477,19 +17464,19 @@ packages:
       '@babel/core': 7.18.9
       '@babel/eslint-parser': 7.18.9_fh4y75b3ljlrwycdrafhbkphau
       '@rushstack/eslint-patch': 1.1.4
-      '@typescript-eslint/eslint-plugin': 5.30.3_xuuykav7urhdozug7htlfgar3u
-      '@typescript-eslint/parser': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/eslint-plugin': 5.30.3_fpsgnhykgmdds465wqgph3hbsu
+      '@typescript-eslint/parser': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
       eslint: 8.19.0
       eslint-plugin-flowtype: 8.0.3_eslint@8.19.0
       eslint-plugin-import: 2.26.0_xgi3rtbx7oxkcq3vxqkef6isyu
-      eslint-plugin-jest: 25.7.0_ihuzelhhtkbc6flslkqvoawxxy
+      eslint-plugin-jest: 25.7.0_5xxz3ebapyxgroocp3fx67yh5y
       eslint-plugin-jsx-a11y: 6.6.0_eslint@8.19.0
       eslint-plugin-react: 7.30.1_eslint@8.19.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.19.0
-      eslint-plugin-testing-library: 5.5.1_4x5o4skxv6sl53vpwefgt23khm
-      typescript: 4.7.4
+      eslint-plugin-testing-library: 5.5.1_wzajlvpeyqkhd33zas4sol2fg4
+      typescript: 5.0.2
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
       - '@babel/plugin-transform-react-jsx'
@@ -17529,7 +17516,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/parser': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -17642,7 +17629,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.30.3_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/parser': 5.30.3_wzajlvpeyqkhd33zas4sol2fg4
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -17662,7 +17649,7 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-plugin-jest/25.7.0_ihuzelhhtkbc6flslkqvoawxxy:
+  /eslint-plugin-jest/25.7.0_2nazwofwl6wuzb3vjlondchcga:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -17675,8 +17662,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.30.3_xuuykav7urhdozug7htlfgar3u
-      '@typescript-eslint/experimental-utils': 5.30.7_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/eslint-plugin': 5.30.3_fpsgnhykgmdds465wqgph3hbsu
+      '@typescript-eslint/experimental-utils': 5.30.7_wzajlvpeyqkhd33zas4sol2fg4
       eslint: 8.19.0
       jest: 27.5.1
     transitivePeerDependencies:
@@ -17684,7 +17671,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jest/25.7.0_owzbkbqytgpmvvbd3mdtsvrn3i:
+  /eslint-plugin-jest/25.7.0_5xxz3ebapyxgroocp3fx67yh5y:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -17697,8 +17684,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.30.3_xuuykav7urhdozug7htlfgar3u
-      '@typescript-eslint/experimental-utils': 5.30.7_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/eslint-plugin': 5.30.3_fpsgnhykgmdds465wqgph3hbsu
+      '@typescript-eslint/experimental-utils': 5.30.7_wzajlvpeyqkhd33zas4sol2fg4
       eslint: 8.19.0
     transitivePeerDependencies:
       - supports-color
@@ -17824,13 +17811,13 @@ packages:
       semver: 6.3.0
       string.prototype.matchall: 4.0.8
 
-  /eslint-plugin-testing-library/5.5.1_4x5o4skxv6sl53vpwefgt23khm:
+  /eslint-plugin-testing-library/5.5.1_wzajlvpeyqkhd33zas4sol2fg4:
     resolution: {integrity: sha512-plLEkkbAKBjPxsLj7x4jNapcHAg2ernkQlKKrN2I8NrQwPISZHyCUNvg5Hv3EDqOQReToQb5bnqXYbkijJPE/g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.47.0_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/utils': 5.47.0_wzajlvpeyqkhd33zas4sol2fg4
       eslint: 8.19.0
     transitivePeerDependencies:
       - supports-color
@@ -18726,7 +18713,7 @@ packages:
       signal-exit: 3.0.7
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6_cvgkw7n4pbxdcdb3db3eo7u2fm:
+  /fork-ts-checker-webpack-plugin/4.1.6_bs6tfkpduwqe3cj2w3blzdhtiy:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -18747,7 +18734,7 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.7.4
+      typescript: 5.0.2
       webpack: 4.46.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
@@ -18780,7 +18767,7 @@ packages:
       - supports-color
     dev: false
 
-  /fork-ts-checker-webpack-plugin/6.5.2_cvgkw7n4pbxdcdb3db3eo7u2fm:
+  /fork-ts-checker-webpack-plugin/6.5.2_5bkz3bk4lhnjgdu4btmdnowl7i:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -18808,7 +18795,38 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.7.4
+      typescript: 5.0.2
+      webpack: 5.73.0_@swc+core@1.3.24
+
+  /fork-ts-checker-webpack-plugin/6.5.2_bs6tfkpduwqe3cj2w3blzdhtiy:
+    resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
+    engines: {node: '>=10', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@types/json-schema': 7.0.11
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 6.0.0
+      deepmerge: 4.2.2
+      eslint: 8.19.0
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      memfs: 3.4.7
+      minimatch: 3.1.2
+      schema-utils: 2.7.0
+      semver: 7.3.7
+      tapable: 1.1.3
+      typescript: 5.0.2
       webpack: 4.46.0
     dev: false
 
@@ -18841,37 +18859,6 @@ packages:
       semver: 7.3.7
       tapable: 1.1.3
       webpack: 5.73.0
-
-  /fork-ts-checker-webpack-plugin/6.5.2_vzvrbkqxq2uhuknms22gvb2xwq:
-    resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@types/json-schema': 7.0.11
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.2.2
-      eslint: 8.19.0
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      memfs: 3.4.7
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.3.7
-      tapable: 1.1.3
-      typescript: 4.7.4
-      webpack: 5.73.0_@swc+core@1.3.24
 
   /fork-ts-checker-webpack-plugin/6.5.2_webpack@4.46.0:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
@@ -25306,11 +25293,11 @@ packages:
       - typescript
     dev: false
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.7.4:
+  /pnp-webpack-plugin/1.6.4_typescript@5.0.2:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.7.4
+      ts-pnp: 1.2.0_typescript@5.0.2
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -26614,6 +26601,48 @@ packages:
       react: 18.2.0
     dev: false
 
+  /react-dev-utils/12.0.1_5bkz3bk4lhnjgdu4btmdnowl7i:
+    resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      address: 1.2.0
+      browserslist: 4.21.2
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      detect-port-alt: 1.1.6
+      escape-string-regexp: 4.0.0
+      filesize: 8.0.7
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 6.5.2_5bkz3bk4lhnjgdu4btmdnowl7i
+      global-modules: 2.0.0
+      globby: 11.1.0
+      gzip-size: 6.0.0
+      immer: 9.0.15
+      is-root: 2.1.0
+      loader-utils: 3.2.0
+      open: 8.4.0
+      pkg-up: 3.1.0
+      prompts: 2.4.2
+      react-error-overlay: 6.0.11
+      recursive-readdir: 2.2.2
+      shell-quote: 1.7.3
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+      typescript: 5.0.2
+      webpack: 5.73.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - vue-template-compiler
+    dev: true
+
   /react-dev-utils/12.0.1_oxnz3ipaot6yjz2b7jqxkugcdm:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
@@ -26654,60 +26683,18 @@ packages:
       - supports-color
       - vue-template-compiler
 
-  /react-dev-utils/12.0.1_vzvrbkqxq2uhuknms22gvb2xwq:
-    resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      address: 1.2.0
-      browserslist: 4.21.2
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      detect-port-alt: 1.1.6
-      escape-string-regexp: 4.0.0
-      filesize: 8.0.7
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_vzvrbkqxq2uhuknms22gvb2xwq
-      global-modules: 2.0.0
-      globby: 11.1.0
-      gzip-size: 6.0.0
-      immer: 9.0.15
-      is-root: 2.1.0
-      loader-utils: 3.2.0
-      open: 8.4.0
-      pkg-up: 3.1.0
-      prompts: 2.4.2
-      react-error-overlay: 6.0.11
-      recursive-readdir: 2.2.2
-      shell-quote: 1.7.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-      typescript: 4.7.4
-      webpack: 5.73.0
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
-    dev: true
-
   /react-docgen-typescript/2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dev: false
 
-  /react-docgen-typescript/2.2.2_typescript@4.7.4:
+  /react-docgen-typescript/2.2.2_typescript@5.0.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.7.4
+      typescript: 5.0.2
     dev: false
 
   /react-docgen/5.4.3:
@@ -26959,7 +26946,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /react-scripts/5.0.1_gqi5qmibjkogsznwcpqmzq76tq:
+  /react-scripts/5.0.1_xjlewhdyk7kqujzx3pkqrde7jy:
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -26987,7 +26974,7 @@ packages:
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       eslint: 8.19.0
-      eslint-config-react-app: 7.0.1_vveddai22guzfmv7jcqwmi76su
+      eslint-config-react-app: 7.0.1_6ttip4nvqc6t6bbkhqegry7zpa
       eslint-webpack-plugin: 3.2.0_igyxuo6aowm47q7qpsjguqpfay
       file-loader: 6.2.0_webpack@5.73.0
       fs-extra: 10.1.0
@@ -27005,7 +26992,7 @@ packages:
       prompts: 2.4.2
       react: 18.2.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_vzvrbkqxq2uhuknms22gvb2xwq
+      react-dev-utils: 12.0.1_5bkz3bk4lhnjgdu4btmdnowl7i
       react-refresh: 0.11.0
       resolve: 1.22.1
       resolve-url-loader: 4.0.0
@@ -27015,7 +27002,7 @@ packages:
       style-loader: 3.3.1_webpack@5.73.0
       tailwindcss: 3.1.6
       terser-webpack-plugin: 5.3.3_webpack@5.73.0
-      typescript: 4.7.4
+      typescript: 5.0.2
       webpack: 5.73.0
       webpack-dev-server: 4.9.3_webpack@5.73.0
       webpack-manifest-plugin: 4.1.1_webpack@5.73.0
@@ -29525,7 +29512,7 @@ packages:
         optional: true
     dev: false
 
-  /ts-pnp/1.2.0_typescript@4.7.4:
+  /ts-pnp/1.2.0_typescript@5.0.2:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -29534,7 +29521,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.7.4
+      typescript: 5.0.2
     dev: false
 
   /ts-toolbelt/9.6.0:
@@ -29575,7 +29562,7 @@ packages:
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
-  /tsup/6.5.0_bzpoqjpthcj2u4f3g3uovkghle:
+  /tsup/6.5.0_oaveibztp3aac3djewansrqdf4:
     resolution: {integrity: sha512-36u82r7rYqRHFkD15R20Cd4ercPkbYmuvRkz3Q1LCm5BsiFNUgpo36zbjVhCOgvjyxNBWNKHsaD5Rl8SykfzNA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -29606,7 +29593,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.24.0
       tree-kill: 1.2.2
-      typescript: 4.7.4
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -29620,14 +29607,14 @@ packages:
     dependencies:
       tslib: 1.14.1
 
-  /tsutils/3.21.0_typescript@4.7.4:
+  /tsutils/3.21.0_typescript@5.0.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.7.4
+      typescript: 5.0.2
 
   /tsx/3.8.1:
     resolution: {integrity: sha512-YA2fDf1V9j/6qX/QSnapMmzulbqlx7FeVL6d9ySHDJoECkslAlZO38UuyFCiNPjam74hbyHbJfUF+n2ZT14KDA==}
@@ -29870,6 +29857,12 @@ packages:
   /typescript/4.7.4:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: false
+
+  /typescript/5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
 
   /ua-parser-js/0.7.31:

--- a/tooling/test-utils/src/accessibility.tsx
+++ b/tooling/test-utils/src/accessibility.tsx
@@ -12,6 +12,6 @@ export async function testA11y(
 ) {
   const { axeOptions, ...rest } = options
   const container = React.isValidElement(ui) ? render(ui, rest).container : ui
-  const results = await axe(container, axeOptions)
+  const results = await axe(container as HTMLElement, axeOptions)
   expect(results).toHaveNoViolations()
 }

--- a/tooling/test-utils/src/utils.ts
+++ b/tooling/test-utils/src/utils.ts
@@ -4,9 +4,10 @@ export function queue(): Promise<void> {
   return act(() => Promise.resolve())
 }
 
-export function nextTick(): Promise<void> {
+export function nextTick(): Promise<any> {
   return act(
-    () => new Promise((resolve) => requestAnimationFrame(() => resolve())),
+    () =>
+      new Promise((resolve) => requestAnimationFrame(() => resolve(void 0))),
   )
 }
 


### PR DESCRIPTION
Closes #7459

## 📝 Description

This PR attempts to fix the TypeScript issues with 5.0 and Chakra UI. I managed to get the errors down to 2 from about 50 😅. The last 2 are proving to be quite cumbersome, but we'll see

## ⛳️ Current behavior (updates)

With 5.0, you get a weird TS error along the lines of "too deep to resolve types."

## 🚀 New behavior

Should work (or at least for the majority of cases)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

The alternative is to introduce the `asChild` prop to circumvent the problem. I really hope we don't have to use this, but we'll see.
