### PR TITLE
fix(checkbox): animate icon only when transitioning to checked state

### DIFF
--- a/.changeset/perfect-spies-cry.md
+++ b/.changeset/perfect-spies-cry.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+Animate check icon only when transitioning to a checked state

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -10,7 +10,7 @@ import {
   useMultiStyleConfig,
 } from "@chakra-ui/system"
 import { callAll, cx } from "@chakra-ui/shared-utils"
-import { cloneElement, useMemo } from "react"
+import { cloneElement, useMemo, useState } from "react"
 import { useCheckboxGroupContext } from "./checkbox-context"
 import { CheckboxIcon } from "./checkbox-icon"
 import { CheckboxOptions, UseCheckboxProps } from "./checkbox-types"
@@ -134,16 +134,26 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
     onChange,
   })
 
+  const [previousIsChecked, setPreviousIsChecked] = useState(state.isChecked)
+  const [animateIcon, setAnimateIcon] = useState(false)
+
+  if (state.isChecked !== previousIsChecked) {
+    setAnimateIcon(true)
+    setPreviousIsChecked(state.isChecked)
+  }
+
   const iconStyles: SystemStyleObject = useMemo(
     () => ({
-      animation: state.isIndeterminate
-        ? `${indeterminateOpacityAnim} 20ms linear, ${indeterminateScaleAnim} 200ms linear`
-        : `${checkAnim} 200ms linear`,
+      animation: animateIcon
+        ? state.isIndeterminate
+          ? `${indeterminateOpacityAnim} 20ms linear, ${indeterminateScaleAnim} 200ms linear`
+          : `${checkAnim} 200ms linear`
+        : undefined,
       fontSize: iconSize,
       color: iconColor,
       ...styles.icon,
     }),
-    [iconColor, iconSize, state.isIndeterminate, styles.icon],
+    [iconColor, iconSize, state.isIndeterminate, styles.icon, animateIcon],
   )
 
   const clonedIcon = cloneElement(icon, {

--- a/packages/components/checkbox/tests/checkbox.test.tsx
+++ b/packages/components/checkbox/tests/checkbox.test.tsx
@@ -548,3 +548,55 @@ test("On resetting form, checkbox should reset to its default state i.e., unchec
   fireEvent.click(resetBtn)
   expect(checkbox).not.toBeChecked()
 })
+
+test("animate icon only when transitioning to checked state", () => {
+  const { container, getByRole } = render(<Checkbox defaultChecked />)
+
+  const checkbox = getByRole("checkbox")
+
+  // `getComputedStyle` requires querying the DOM node to receive
+  // up-to-date computed styles, so icon can't be cached in a variable
+  const getIcon = () => {
+    return container.querySelector(".chakra-checkbox__control svg")!
+  }
+
+  // There shouldn't be an animation on initial render
+  expect(getComputedStyle(getIcon()).animation).toEqual("")
+
+  fireEvent.click(checkbox)
+
+  // There is no icon in unchecked state
+  expect(checkbox).not.toBeChecked()
+
+  fireEvent.click(checkbox)
+
+  // There should be an animation when transitioning to checked state
+  expect(getComputedStyle(getIcon()).animation).toBeTruthy()
+})
+
+test("animate icon in indeterminate checkbox only when transitioning to checked state", () => {
+  const { container, getByRole } = render(
+    <Checkbox isIndeterminate defaultChecked />,
+  )
+
+  const checkbox = getByRole("checkbox")
+
+  // `getComputedStyle` requires querying the DOM node to receive
+  // up-to-date computed styles, so icon can't be cached in a variable
+  const getIcon = () => {
+    return container.querySelector(".chakra-checkbox__control svg")!
+  }
+
+  // There shouldn't be an animation on initial render
+  expect(getComputedStyle(getIcon()).animation).toEqual("")
+
+  fireEvent.click(checkbox)
+
+  // There is no icon in unchecked state
+  expect(checkbox).not.toBeChecked()
+
+  fireEvent.click(checkbox)
+
+  // There should be an animation when transitioning to checked state
+  expect(getComputedStyle(getIcon()).animation).toBeTruthy()
+})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/7193

## 📝 Description

> `Checkbox` animates the check icon on first render when `isChecked` or `defaultChecked` is `true`. This creates a wrong impression as if checkbox has just transitioned from unchecked to checked state without user's interaction and causes confusion.

## ⛳️ Current behavior (updates)

> `Checkbox` always assigns an animation to the check icon, regardless whether state has changed or not.

## 🚀 New behavior

> This PR updates `Checkbox` to track whether state has changed and assign an animation to the check icon only when it did. This avoids animation of the check icon on the initial render.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No.

## 📝 Additional Information

Before:


https://user-images.githubusercontent.com/697676/228465005-8e5b7d3c-391f-49d9-8f63-d2bd59f4d35e.mp4



After:


https://user-images.githubusercontent.com/697676/228464838-863cba94-16bb-4a78-b609-78188b21999f.mp4

