### PR TITLE
feat: add optional toastStore prop to ToastProvider

### DIFF
--- a/.changeset/cool-dryers-tap.md
+++ b/.changeset/cool-dryers-tap.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": minor
+---
+
+Add optional toastStore prop to ToastProvider

--- a/packages/components/toast/src/index.ts
+++ b/packages/components/toast/src/index.ts
@@ -6,6 +6,8 @@ export type {
   ToastProviderProps,
   CreateToastOptions,
 } from "./toast.provider"
+export { createToastStore } from "./toast.store"
+export type { ToastStore } from "./toast.store"
 export type {
   ToastId,
   ToastMessage,

--- a/packages/components/toast/src/toast.provider.tsx
+++ b/packages/components/toast/src/toast.provider.tsx
@@ -8,7 +8,7 @@ import type {
   ToastOptions,
 } from "./toast.types"
 import type { UseToastOptions } from "./use-toast"
-import { toastStore } from "./toast.store"
+import { ToastStore, toastStore as toastStoreSingleton } from "./toast.store"
 import { getToastListStyle } from "./toast.utils"
 import { useSyncExternalStore } from "react"
 import { createContext } from "@chakra-ui/react-context"
@@ -88,6 +88,10 @@ export type ToastProviderProps = React.PropsWithChildren<{
    * Props to be forwarded to the portal component
    */
   portalProps?: Pick<PortalProps, "appendToParentPortal" | "containerRef">
+  /**
+   * Optional toast store. Will use a singleton store if not provided
+   */
+  toastStore?: ToastStore
 }>
 
 /**
@@ -105,17 +109,18 @@ export const [ToastOptionProvider, useToastOptionContext] = createContext<
  * across all corners ("top", "bottom", etc.)
  */
 export const ToastProvider = (props: ToastProviderProps) => {
+  const {
+    motionVariants,
+    component: Component = ToastComponent,
+    toastStore = toastStoreSingleton,
+    portalProps,
+  } = props
+
   const state = useSyncExternalStore(
     toastStore.subscribe,
     toastStore.getState,
     toastStore.getState,
   )
-
-  const {
-    motionVariants,
-    component: Component = ToastComponent,
-    portalProps,
-  } = props
 
   const stateKeys = Object.keys(state) as Array<keyof typeof state>
   const toastList = stateKeys.map((position) => {

--- a/packages/components/toast/src/toast.store.ts
+++ b/packages/components/toast/src/toast.store.ts
@@ -4,7 +4,7 @@ import { CreateToastOptions, ToastMethods } from "./toast.provider"
 import type { ToastId, ToastMessage, ToastState } from "./toast.types"
 import { findToast, getToastPosition } from "./toast.utils"
 
-type ToastStore = ToastMethods & {
+export type ToastStore = ToastMethods & {
   getState: () => ToastState
   subscribe: (onStoreChange: () => void) => () => void
   removeToast: (id: ToastId, position: ToastPosition) => void
@@ -22,9 +22,9 @@ const initialState = {
 /**
  * Store to track all the toast across all positions
  */
-export const toastStore = createStore(initialState)
+export const toastStore = createToastStore(initialState)
 
-function createStore(initialState: ToastState): ToastStore {
+export function createToastStore(initialState: ToastState): ToastStore {
   let state = initialState
   const listeners = new Set<() => void>()
 

--- a/packages/components/toast/src/toast.store.ts
+++ b/packages/components/toast/src/toast.store.ts
@@ -10,22 +10,20 @@ export type ToastStore = ToastMethods & {
   removeToast: (id: ToastId, position: ToastPosition) => void
 }
 
-const defaultInitialState = {
-  top: [],
-  "top-left": [],
-  "top-right": [],
-  "bottom-left": [],
-  bottom: [],
-  "bottom-right": [],
-}
-
 /**
  * Store to track all the toast across all positions
  */
-export const toastStore = createToastStore(defaultInitialState)
+export const toastStore = createToastStore()
 
 export function createToastStore(
-  initialState: ToastState = defaultInitialState,
+  initialState: ToastState = {
+    top: [],
+    "top-left": [],
+    "top-right": [],
+    "bottom-left": [],
+    bottom: [],
+    "bottom-right": [],
+  },
 ): ToastStore {
   let state = initialState
   const listeners = new Set<() => void>()

--- a/packages/components/toast/src/toast.store.ts
+++ b/packages/components/toast/src/toast.store.ts
@@ -10,7 +10,7 @@ export type ToastStore = ToastMethods & {
   removeToast: (id: ToastId, position: ToastPosition) => void
 }
 
-const initialState = {
+const defaultInitialState = {
   top: [],
   "top-left": [],
   "top-right": [],
@@ -22,9 +22,11 @@ const initialState = {
 /**
  * Store to track all the toast across all positions
  */
-export const toastStore = createToastStore(initialState)
+export const toastStore = createToastStore(defaultInitialState)
 
-export function createToastStore(initialState: ToastState): ToastStore {
+export function createToastStore(
+  initialState: ToastState = defaultInitialState,
+): ToastStore {
   let state = initialState
   const listeners = new Set<() => void>()
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->
https://github.com/chakra-ui/chakra-ui/issues/6328 (Closed because a workaround was found, but I don't think that workaround is dependable or extends to all situations)

## 📝 Description

> Add a brief description

There are several cases where you may have multiple Toast Providers in your app. For example, you may be developing a small micro-frontend (e.g. a custom dialog) for other apps to consume. Or you may be developing micro-frontends, where you want to ensure that you only show and control your own toasts.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

The toastStore is currently a singleton. So if you have multiple ToastProviders in your app for whatever reason, you also get multiple instances of toasts being rendered.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

This PR adds `toastStore` optional prop to the `ToastProvider`, and exports the `createToastStore` (formerly `createStore`) factory function.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No. The new prop is optional, and without providing it the behaviour stays the same.

## 📝 Additional Information
