### PR TITLE
revert(gatsby-plugin): revert implementation of `baseTheme`

### DIFF
--- a/.changeset/pretty-pumpkins-sin.md
+++ b/.changeset/pretty-pumpkins-sin.md
@@ -1,0 +1,15 @@
+---
+"@chakra-ui/gatsby-plugin": patch
+---
+
+Reverts the use of the `baseTheme` in the plugin
+
+With the added features of `extendBaseTheme` and `ChakraBaseProvider`, it was
+determined that the provider is considered unnecessary.
+
+> Custom theming is to be expected for components when there are no defaults
+> rendered.
+
+For Gatsby, this means that the plugin can be reverted back to it's original
+setup, and still be able to accept `extendBaseTheme` to reduce the payload of
+the component themes when customizing them.

--- a/tooling/gatsby-plugin/README.md
+++ b/tooling/gatsby-plugin/README.md
@@ -79,12 +79,6 @@ module.exports = {
          * if your app uses a lot z-index to position elements.
          */
         portalZIndex: 40,
-        /**
-         * @property {boolean} [isBaseProvider=false]
-         * Setting this to true will render the `ChakraBaseProvider`
-         * which only uses theme tokens initially and not default component themes
-         */
-        isBaseProvider: false,
       },
     },
   ],
@@ -105,7 +99,7 @@ const theme = {
   },
 }
 
-export default extendTheme(theme)
+export default extendTheme(theme) // or extendBaseTheme
 ```
 
 You can learn more about custom theme at

--- a/tooling/gatsby-plugin/src/provider.js
+++ b/tooling/gatsby-plugin/src/provider.js
@@ -1,19 +1,15 @@
 import * as React from "react"
-import { ChakraProvider, ChakraBaseProvider } from "@chakra-ui/react"
-import theme, { baseTheme } from "./theme"
+import { ChakraProvider } from "@chakra-ui/react"
+import theme from "./theme"
 
-export const WrapRootElement = ({
-  element,
-  isBaseProvider = false,
-  resetCSS = true,
-  portalZIndex,
-}) => {
-  const Provider = isBaseProvider ? ChakraBaseProvider : ChakraProvider
-
-  const _theme = isBaseProvider ? baseTheme : theme
+export const WrapRootElement = ({ element, resetCSS = true, portalZIndex }) => {
   return (
-    <Provider theme={_theme} resetCSS={resetCSS} portalZIndex={portalZIndex}>
+    <ChakraProvider
+      theme={theme}
+      resetCSS={resetCSS}
+      portalZIndex={portalZIndex}
+    >
       {element}
-    </Provider>
+    </ChakraProvider>
   )
 }

--- a/tooling/gatsby-plugin/src/theme.js
+++ b/tooling/gatsby-plugin/src/theme.js
@@ -1,4 +1,3 @@
-import { theme, baseTheme } from "@chakra-ui/react"
+import { theme } from "@chakra-ui/react"
 
 export default theme
-export { baseTheme }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7179 <!-- Github issue # here -->

## 📝 Description

This PR reverts the Gatsby plugin back to the version prior to adding the `ChakraBaseProvider` as an option with the `baseTheme`. 

This is a two-fold change

## ⛳️ Current behavior (updates)

Console warning `Attempted import error: 'baseTheme' is not exported from './theme' (imported as 'baseTheme')` when attempting to use `extendBaseTheme` in the project 

## 🚀 New behavior

Warning is gone because the `baseTheme` import is removed from the plugin.

## 💣 Is this a breaking change (Yes/No):

No. Use of the `extendBaseTheme` is still valid, and only the added option `isBaseProvider` is removed.

## 📝 Additional Information

In using the added features of `extendBaseTheme` and `ChakraBaseProvider` and from the discussion in the related issue, the provider seems unnecessary. 

With the component default theming stripped away initially from `ChakraBaseProvider`, the user might already be inclined to create custom theming. In doing so, with `extendTheme` or `extendBaseTheme`, the merging of the `theme` or `baseTheme` objects from the respective functions into the custom theming will override whatever object is initially rendered in the provider. 

So long as the user uses `extendBaseTheme`, the entire set of default component theme will not be apart of the payload aside from defaults the user decides to import.

> DISCLAIMER: The above statement is assuming that this is the only behavior occurring and not predisposed to any other purpose of the `ChakraBaseProvider` alone in improving the build.
