### PR TITLE
fix: make use-image respect crossOrigin property

### DIFF
--- a/packages/components/avatar/src/avatar-image.tsx
+++ b/packages/components/avatar/src/avatar-image.tsx
@@ -32,7 +32,7 @@ export function AvatarImage(props: AvatarImageProps) {
   /**
    * use the image hook to only show the image when it has loaded
    */
-  const status = useImage({ src, onError, ignoreFallback })
+  const status = useImage({ src, onError, crossOrigin, ignoreFallback })
 
   const hasLoaded = status === "loaded"
 


### PR DESCRIPTION
fix: make use-image respect crossOrigin property in order to avoid errors when loading image without CORS, leading to false status.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
