### PR TITLE
Add loading props to the @chakra-ui/next-js.

### DIFF
--- a/.changeset/friendly-books-sin.md
+++ b/.changeset/friendly-books-sin.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/next-js": patch
+---
+
+Add loading props to the @chakra-ui/next-js.

--- a/packages/integrations/next-js/src/image.tsx
+++ b/packages/integrations/next-js/src/image.tsx
@@ -6,5 +6,5 @@ export type ImageProps = NextImageProps &
 
 export const Image: ChakraComponent<"img", NextImageProps> = chakra(NextImage, {
   shouldForwardProp: (prop) =>
-    ["width", "height", "src", "alt", "fill"].includes(prop),
+    ["width", "height", "src", "alt", "fill", "loading"].includes(prop),
 })


### PR DESCRIPTION
## 📝 Description
> Added loading props to the `@chakra-ui/next-js` package, currently the use of `loading="eager"` does not change the `loading="lazy"` included by default in `next/image`

## ⛳️ Current behavior (updates)
> The use of props loading does not produce any effect 

## 🚀 New behavior
> It is now possible to modify the props loading and thus put the images in "eager" mode

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information