### PR TITLE
Fix modal overflow

### DIFF
--- a/.changeset/toast-beans-exist.md
+++ b/.changeset/toast-beans-exist.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Remove invalid role in toast

--- a/packages/components/theme/src/components/modal.ts
+++ b/packages/components/theme/src/components/modal.ts
@@ -21,7 +21,7 @@ const baseStyleDialogContainer = defineStyle((props) => {
   const { isCentered, scrollBehavior } = props
 
   return {
-    display: "flex",
+    display: scrollBehavior === "inside" ? "flex" : "grid",
     zIndex: "modal",
     justifyContent: "center",
     alignItems: isCentered ? "center" : "flex-start",

--- a/packages/components/toast/src/toast.provider.tsx
+++ b/packages/components/toast/src/toast.provider.tsx
@@ -123,7 +123,6 @@ export const ToastProvider = (props: ToastProviderProps) => {
 
     return (
       <ul
-        role="region"
         aria-live="polite"
         key={position}
         id={`chakra-toast-manager-${position}`}


### PR DESCRIPTION

Closes https://github.com/chakra-ui/chakra-ui/issues/7224 and https://github.com/chakra-ui/chakra-ui/issues/4832

## 📝 Description

> When I create a modal (centered or not), I expect to be able to see all the contents of it.

> As soon as my centered modal is too big, the top disappears. Everything else works normally and the bottom is displayed correctly when I scroll, just the top is cut off.

## ⛳️ Current behavior (updates)

> Top content is trimmed.

## 🚀 New behavior

> Top content of modal will be visible.

## 💣 Is this a breaking change (Yes/No): NO

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
