### PR TITLE
fix(menubutton): extend button props

### DIFF
--- a/.changeset/violet-bats-itch.md
+++ b/.changeset/violet-bats-itch.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fix MenuButton prop types

--- a/packages/components/menu/src/menu-button.tsx
+++ b/packages/components/menu/src/menu-button.tsx
@@ -1,10 +1,11 @@
-import { forwardRef, HTMLChakraProps, chakra } from "@chakra-ui/system"
+import { forwardRef, chakra } from "@chakra-ui/system"
+import type { ButtonProps } from "@chakra-ui/button"
 import { cx } from "@chakra-ui/shared-utils"
 
 import { useMenuStyles } from "./menu"
 import { useMenuButton } from "./use-menu"
 
-export interface MenuButtonProps extends HTMLChakraProps<"button"> {}
+export interface MenuButtonProps extends ButtonProps {}
 
 const StyledMenuButton = forwardRef<MenuButtonProps, "button">((props, ref) => {
   const styles = useMenuStyles()


### PR DESCRIPTION
Closes #7369

## 📝 Description

We shouldn't need to pass in `as={Button}` to `MenuButton` in order to use `Button`'s props.

## ⛳️ Current behavior (updates)

Need to pass in `as={Button}` in order to pass in props like `isDisabled`.

## 🚀 New behavior

Can freely pass in Button props like `isDisabled` without the need for `as={Button}`.

## 💣 Is this a breaking change:

No.

## 📝 Additional Information

None.
