### PR TITLE
Feat: storybook theme override

### DIFF
--- a/.changeset/wild-tigers-worry.md
+++ b/.changeset/wild-tigers-worry.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/storybook-addon": patch
+---
+
+Updated storybook setup to allow custom theme override in composed version.
+Allow storing theme override in the local storage.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,20 @@
 import { extendTheme } from "@chakra-ui/react"
 
+const getThemeOverride = () => {
+  const theme = localStorage.getItem("chakra-theme-override")
+
+  if (!theme) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(theme)
+  } catch (e) {
+    console.log("Failed to parse custom theme override", e)
+    return {}
+  }
+}
+
 export const parameters = {
   options: {
     storySort: (a, b) =>
@@ -18,6 +33,7 @@ export const parameters = {
           },
         },
       },
+      ...getThemeOverride(),
     }),
   },
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,14 +1,10 @@
 import { extendTheme } from "@chakra-ui/react"
 
 const getThemeOverride = () => {
-  const theme = localStorage.getItem("chakra-theme-override")
-
-  if (!theme) {
-    return {}
-  }
-
   try {
-    return JSON.parse(theme)
+    const theme = window.opener.chakraTheme
+    console.log("Found theme: ", theme)
+    return theme || {}
   } catch (e) {
     console.log("Failed to parse custom theme override", e)
     return {}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
This is an attempt to allow theme override in the hosted Storybook as well as the composed storybook page.
Refs:
- https://github.com/chakra-ui/chakra-ui/discussions/6824
- https://github.com/chakra-ui/chakra-ui/discussions/5987#discussioncomment-4907794

And we have exactly the same issues as in the last link above. It's great to have your hosted Storybook page composed into the local version, but it's not so useful without the ability to override the default theme.

Current idea is to allow storing theme JSON in the Local Storage, so the consumer can write a custom theme there and it will be used in the remote, deployed Storybook.

## ⛳️ Current behavior (updates)

No way to override the default theme in the hosted Storybook

## 🚀 New behavior

Added ability to override default theme in the hosted Storybook

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
I will also update the docs if this idea is approved.

<img width="1726" alt="image" src="https://user-images.githubusercontent.com/23266928/232838123-030e22c0-e688-4b9c-8b83-665946f31d39.png">

Local version:
![image](https://user-images.githubusercontent.com/23266928/232838697-9ba38cba-aefa-485b-8c63-ad8ba6dbd473.png)


