### PR TITLE
fix(next-js): forward some props

### DIFF
--- a/.changeset/wicked-parrots-relax.md
+++ b/.changeset/wicked-parrots-relax.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/next-js": patch
+---
+
+Fix issue where some prop was not forwarded to the underlying component.

--- a/packages/integrations/next-js/src/image.tsx
+++ b/packages/integrations/next-js/src/image.tsx
@@ -6,5 +6,19 @@ export type ImageProps = NextImageProps &
 
 export const Image: ChakraComponent<"img", NextImageProps> = chakra(NextImage, {
   shouldForwardProp: (prop) =>
-    ["width", "height", "src", "alt", "fill", "loading"].includes(prop),
+    [
+      "src",
+      "alt",
+      "width",
+      "height",
+      "fill",
+      "loader",
+      "quality",
+      "priority",
+      "loading",
+      "placeholder",
+      "blurDataURL",
+      "unoptimized",
+      "onLoadingComplete",
+    ].includes(prop),
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This pull request adds missing props (`loader`, `quality`, `unoptimized`, etc...) to `shouldForwardProp` for the `NextImage` component Previously, these props were being discarded due to `shouldForwardProp` not including them. 

https://github.com/vercel/next.js/blob/1c007cee2f100a7a15a3fdb02ca7e86e60208cc8/packages/next/src/client/image.tsx#L99

## ⛳️ Current behavior (updates)

The `loader`, `quality`, etc props were not being forwarded to the `NextImage` component.

## 🚀 New behavior

The `loader`, `quality`, etc props are now being forwarded to the `NextImage` component.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
