### PR TITLE
fix(avatar): render a single initial when only one name is passed

### DIFF
--- a/.changeset/breezy-crabs-swim.md
+++ b/.changeset/breezy-crabs-swim.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/avatar": patch
+---
+
+Fix issue where the initial was incorrect when only one name is passed

--- a/packages/components/avatar/src/avatar-name.tsx
+++ b/packages/components/avatar/src/avatar-name.tsx
@@ -5,7 +5,7 @@ import { AvatarOptions } from "./avatar-types"
 export function initials(name: string) {
   const names = name.split(" ")
   const firstName = names.at(0) ?? ""
-  const lastName = names.at(-1) ?? ""
+  const lastName = names.length > 1 ? names.at(-1) : ""
   return firstName && lastName
     ? `${firstName.charAt(0)}${lastName.charAt(0)}`
     : firstName.charAt(0)

--- a/packages/components/avatar/tests/avatar.test.tsx
+++ b/packages/components/avatar/tests/avatar.test.tsx
@@ -72,8 +72,20 @@ describe("fallback + loading strategy", () => {
 
   test("renders a name avatar if no src", () => {
     const tools = render(<Avatar name="Dan Abramov" />)
-    const img = tools.queryByText("DA")
-    expect(img).toBeInTheDocument()
+    const intials = tools.queryByText("DA")
+    expect(intials).toBeInTheDocument()
+  })
+
+  test("renders a single character if only one name is passed", () => {
+    const tools = render(<Avatar name="Dan" />)
+    const intials = tools.queryByText("D")
+    expect(intials).toBeInTheDocument()
+  })
+
+  test("renders the first characters of the first and last name when more than two names are passed", () => {
+    const tools = render(<Avatar name="Dan React Abramov" />)
+    const intials = tools.queryByText("DA")
+    expect(intials).toBeInTheDocument()
   })
 
   test("renders a default avatar if no name or src", () => {


### PR DESCRIPTION
Closes #7602

## 📝 Description

This fixes the issue that the 'initials' are rendered twice when a single name is passed to the Avatar component

## ⛳️ Current behavior (updates)

```tsx
<Avatar name="Name" /> // => "NN"
```

## 🚀 New behavior

```tsx
<Avatar name="Name" /> // => "N"
```

This is how it worked before Chakra 2.6.0

## 💣 Is this a breaking change (Yes/No):

No