### PR TITLE
refactor: superfluous expression removed

### DIFF
--- a/packages/components/theme/src/components/tabs.ts
+++ b/packages/components/theme/src/components/tabs.ts
@@ -91,7 +91,7 @@ const sizes = {
 const variantLine = definePartsStyle((props) => {
   const { colorScheme: c, orientation } = props
   const isVertical = orientation === "vertical"
-  const borderProp = orientation === "vertical" ? "borderStart" : "borderBottom"
+  const borderProp = isVertical ? "borderStart" : "borderBottom"
   const marginProp = isVertical ? "marginStart" : "marginBottom"
 
   return {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description
I just read the source chakra found an extra expression there. 
You can see that we have isVertical constant on 93 line.
After that we also write the same expression on 94 line but we can use isVertical constant