### PR TITLE
Fix Slider track from dissapearing when providing `undefined` as prop for `orientation`

### DIFF
--- a/.changeset/tough-kings-double.md
+++ b/.changeset/tough-kings-double.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/slider": patch
+---
+
+Fix @chakra-ui/slider default orientation value

--- a/packages/components/slider/src/slider.tsx
+++ b/packages/components/slider/src/slider.tsx
@@ -46,8 +46,8 @@ export interface SliderProps
  */
 export const Slider = forwardRef<SliderProps, "div">((props, ref) => {
   const sliderProps: SliderProps = {
-    orientation: "horizontal",
     ...props,
+    orientation: props?.orientation ?? "horizontal",
   }
 
   const styles = useMultiStyleConfig("Slider", sliderProps)


### PR DESCRIPTION
## 📝 Description

Updated how the Slider's default value for `orientation' is set.

## ⛳️ Current behavior (updates)

Currently, when passing `undefined` to `orientation`, it makes the Slider track dissappear. This is happening because the "horizontal" default value is being rewritten by the provided props.
Reproduction sandbox: https://codesandbox.io/s/gifted-lucy-b35ll5?file=/src/index.js

## 🚀 New behavior

`<Slider orientation={undefined} />` will use the "horizontal" default value

## 💣 Is this a breaking change (Yes/No):

No
