### PR TITLE
Use array indices over array at method

### DIFF
--- a/packages/components/avatar/src/avatar-name.tsx
+++ b/packages/components/avatar/src/avatar-name.tsx
@@ -4,8 +4,8 @@ import { AvatarOptions } from "./avatar-types"
 
 export function initials(name: string) {
   const names = name.split(" ")
-  const firstName = names.at(0) ?? ""
-  const lastName = names.length > 1 ? names.at(-1) : ""
+  const firstName = names[0] ?? ""
+  const lastName = names.length > 1 ? names[names.length - 1] : ""
   return firstName && lastName
     ? `${firstName.charAt(0)}${lastName.charAt(0)}`
     : firstName.charAt(0)


### PR DESCRIPTION
Closes #7623

## 📝 Description
Using array indices has better compatibility over the Array method `at`

## 💣 Is this a breaking change (Yes/No):
No
