### PR TITLE
'as' prop failure: Accordian

### DIFF
--- a/.changeset/sour-imly-paint.md
+++ b/.changeset/sour-imly-paint.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/accordion": minor
+---
+
+Fixed AccordionIconProps failure with 'as' prop

--- a/.changeset/toast-beans-exist.md
+++ b/.changeset/toast-beans-exist.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Remove invalid role in toast

--- a/packages/components/accordion/src/accordion-icon.tsx
+++ b/packages/components/accordion/src/accordion-icon.tsx
@@ -1,5 +1,5 @@
-import { Icon, IconProps } from "@chakra-ui/icon"
-import { SystemStyleObject } from "@chakra-ui/system"
+import { Icon } from "@chakra-ui/icon"
+import { PropsOf, SystemStyleObject } from "@chakra-ui/system"
 import { cx } from "@chakra-ui/shared-utils"
 import {
   useAccordionItemContext,
@@ -7,7 +7,7 @@ import {
 } from "./accordion-context"
 import { useAccordionContext } from "./use-accordion"
 
-export type AccordionIconProps = IconProps
+export type AccordionIconProps = PropsOf<typeof Icon>
 
 /**
  * AccordionIcon that gives a visual cue of the open/close state of the accordion item.

--- a/packages/components/theme/src/components/modal.ts
+++ b/packages/components/theme/src/components/modal.ts
@@ -21,7 +21,7 @@ const baseStyleDialogContainer = defineStyle((props) => {
   const { isCentered, scrollBehavior } = props
 
   return {
-    display: "flex",
+    display: scrollBehavior === "inside" ? "flex" : "grid",
     zIndex: "modal",
     justifyContent: "center",
     alignItems: isCentered ? "center" : "flex-start",

--- a/packages/components/toast/src/toast.provider.tsx
+++ b/packages/components/toast/src/toast.provider.tsx
@@ -123,7 +123,6 @@ export const ToastProvider = (props: ToastProviderProps) => {
 
     return (
       <ul
-        role="region"
         aria-live="polite"
         key={position}
         id={`chakra-toast-manager-${position}`}


### PR DESCRIPTION
Closes # https://github.com/chakra-ui/chakra-ui/issues/7630

## 📝 Description

> Fixed Type AccordionIconProps failure with 'as' prop but supports it.

## ⛳️ Current behavior (updates)

> It is possible to use the as prop with AccordionIcon but TypeScript does not recognize it. The type is not built properly.

## 🚀 New behavior

> as prop is now recognized.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
