### PR TITLE
fix: avatar excess label

### DIFF
--- a/.changeset/fast-pans-happen.md
+++ b/.changeset/fast-pans-happen.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/theme": minor
+---
+
+Fixes #7666, where for "xs" and "2xs" sizes, the excess label for avatar groups
+is overflowing over the background.

--- a/.changeset/fast-pans-happen.md
+++ b/.changeset/fast-pans-happen.md
@@ -1,6 +1,6 @@
 ---
-"@chakra-ui/theme": minor
+"@chakra-ui/theme": patch
 ---
 
-Fixes #7666, where for "xs" and "2xs" sizes, the excess label for avatar groups
-is overflowing over the background.
+Fix issue where excess label looks inconsistent with the avatar initials for
+`xs` and `2xs` sizes

--- a/packages/components/avatar/stories/avatar.stories.tsx
+++ b/packages/components/avatar/stories/avatar.stories.tsx
@@ -22,10 +22,6 @@ export const Basic = () => (
   </Stack>
 )
 
-/**
- * You can use a custom generic avatar instead of
- * what we have in Chakra.
- */
 const GenericAvatar = (props: PropsOf<"svg">) => (
   <svg
     color="#fff"
@@ -41,10 +37,6 @@ const GenericAvatar = (props: PropsOf<"svg">) => (
   </svg>
 )
 
-/**
- * Without a `src` or `name` attribute, the avatar
- * will show a default svg avatar icon
- */
 export const WithCustomIcon = () => (
   <AvatarGroup>
     <Avatar icon={<GenericAvatar />} />
@@ -52,10 +44,6 @@ export const WithCustomIcon = () => (
   </AvatarGroup>
 )
 
-/**
- * You can change the size of the avatar
- * as defined in your component theme
- */
 export const WithSizes = () => (
   <Stack direction="row" spacing="24px">
     {["xs", "sm", "md", "lg", "xl", "2xl"].map((size) => (
@@ -90,15 +78,15 @@ export const WithSrcSet = () => {
   )
 }
 
-/**
- * Use the AvatarGroup component to stack
- * multiple avatars and add some space between them
- */
-export const avatarGroup = () => (
-  <AvatarGroup size="lg" max={3}>
-    <Avatar name="Ryan Florence" src="https://bit.ly/ryan-florence" />
-    <Avatar name="Kent Dodds" src="https://bit.ly/kent-c-dodds" />
-    <Avatar name="Prosper Otemuyiwa" src="https://bit.ly/prosper-baba" />
-    <Avatar name="Christian Nwamba" src="https://bit.ly/code-beast" />
-  </AvatarGroup>
+export const WithAvatarGroup = () => (
+  <Stack spacing="24px">
+    {["xs", "sm", "md", "lg", "xl", "2xl"].map((size) => (
+      <AvatarGroup size={size} max={3} key={size}>
+        <Avatar name="Ryan Florence" src="https://bit.ly/ryan-florence" />
+        <Avatar name="Kent Dodds" src="https://bit.ly/kent-c-dodds" />
+        <Avatar name="Prosper Otemuyiwa" src="https://bit.ly/prosper-baba" />
+        <Avatar name="Christian Nwamba" src="https://bit.ly/code-beast" />
+      </AvatarGroup>
+    ))}
+  </Stack>
 )

--- a/packages/components/theme/src/components/avatar.ts
+++ b/packages/components/theme/src/components/avatar.ts
@@ -63,7 +63,14 @@ const baseStyle = definePartsStyle((props) => ({
   container: runIfFn(baseStyleContainer, props),
 }))
 
-function getSize(size: keyof typeof themeSizes | "100%") {
+type GetSizeOpts = {
+  adjustExcessLabelFontSize?: boolean
+}
+
+function getSize(
+  size: keyof typeof themeSizes | "100%",
+  { adjustExcessLabelFontSize }: GetSizeOpts = {},
+) {
   const themeSize = size !== "100%" ? themeSizes[size] : undefined
   return definePartsStyle({
     container: {
@@ -74,6 +81,9 @@ function getSize(size: keyof typeof themeSizes | "100%") {
     excessLabel: {
       width: size,
       height: size,
+      ...(adjustExcessLabelFontSize && {
+        fontSize: `calc(${themeSize ?? size} / 2)`,
+      }),
     },
     label: {
       fontSize: `calc(${themeSize ?? size} / 2.5)`,
@@ -83,8 +93,8 @@ function getSize(size: keyof typeof themeSizes | "100%") {
 }
 
 const sizes = {
-  "2xs": getSize(4),
-  xs: getSize(6),
+  "2xs": getSize(4, { adjustExcessLabelFontSize: true }),
+  xs: getSize(6, { adjustExcessLabelFontSize: true }),
   sm: getSize(8),
   md: getSize(12),
   lg: getSize(16),

--- a/packages/components/theme/src/components/avatar.ts
+++ b/packages/components/theme/src/components/avatar.ts
@@ -19,14 +19,15 @@ const $size = cssVar("avatar-size")
 const baseStyleBadge = defineStyle({
   borderRadius: "full",
   border: "0.2em solid",
+  borderColor: $border.reference,
   [$border.variable]: "white",
   _dark: {
     [$border.variable]: "colors.gray.800",
   },
-  borderColor: $border.reference,
 })
 
 const baseStyleExcessLabel = defineStyle({
+  bg: $bg.reference,
   fontSize: $fs.reference,
   width: $size.reference,
   height: $size.reference,
@@ -35,7 +36,6 @@ const baseStyleExcessLabel = defineStyle({
   _dark: {
     [$bg.variable]: "colors.whiteAlpha.400",
   },
-  bgColor: $bg.reference,
 })
 
 const baseStyleContainer = defineStyle((props) => {

--- a/packages/components/theme/src/components/avatar.ts
+++ b/packages/components/theme/src/components/avatar.ts
@@ -13,6 +13,8 @@ const { definePartsStyle, defineMultiStyleConfig } =
 
 const $border = cssVar("avatar-border-color")
 const $bg = cssVar("avatar-bg")
+const $fs = cssVar("avatar-font-size")
+const $size = cssVar("avatar-size")
 
 const baseStyleBadge = defineStyle({
   borderRadius: "full",
@@ -25,14 +27,16 @@ const baseStyleBadge = defineStyle({
 })
 
 const baseStyleExcessLabel = defineStyle({
+  fontSize: $fs.reference,
+  width: $size.reference,
+  height: $size.reference,
+  lineHeight: "1",
   [$bg.variable]: "colors.gray.200",
   _dark: {
     [$bg.variable]: "colors.whiteAlpha.400",
   },
   bgColor: $bg.reference,
 })
-
-const $avatarBg = cssVar("avatar-background")
 
 const baseStyleContainer = defineStyle((props) => {
   const { name, theme } = props
@@ -43,58 +47,52 @@ const baseStyleContainer = defineStyle((props) => {
   if (!isBgDark) color = "gray.800"
 
   return {
-    bg: $avatarBg.reference,
-    "&:not([data-loaded])": {
-      [$avatarBg.variable]: bg,
-    },
+    bg: $bg.reference,
+    fontSize: $fs.reference,
     color,
+    borderColor: $border.reference,
+    verticalAlign: "top",
+    width: $size.reference,
+    height: $size.reference,
+    "&:not([data-loaded])": {
+      [$bg.variable]: bg,
+    },
     [$border.variable]: "colors.white",
     _dark: {
       [$border.variable]: "colors.gray.800",
     },
-    borderColor: $border.reference,
-    verticalAlign: "top",
   }
+})
+
+const baseStyleLabel = defineStyle({
+  fontSize: $fs.reference,
+  lineHeight: "1",
 })
 
 const baseStyle = definePartsStyle((props) => ({
   badge: runIfFn(baseStyleBadge, props),
   excessLabel: runIfFn(baseStyleExcessLabel, props),
   container: runIfFn(baseStyleContainer, props),
+  label: baseStyleLabel,
 }))
 
-type GetSizeOpts = {
-  adjustExcessLabelFontSize?: boolean
-}
-
-function getSize(
-  size: keyof typeof themeSizes | "100%",
-  { adjustExcessLabelFontSize }: GetSizeOpts = {},
-) {
+function getSize(size: keyof typeof themeSizes | "100%") {
   const themeSize = size !== "100%" ? themeSizes[size] : undefined
   return definePartsStyle({
     container: {
-      width: size,
-      height: size,
-      fontSize: `calc(${themeSize ?? size} / 2.5)`,
+      [$size.variable]: themeSize ?? size,
+      [$fs.variable]: `calc(${themeSize ?? size} / 2.5)`,
     },
     excessLabel: {
-      width: size,
-      height: size,
-      ...(adjustExcessLabelFontSize && {
-        fontSize: `calc(${themeSize ?? size} / 2)`,
-      }),
-    },
-    label: {
-      fontSize: `calc(${themeSize ?? size} / 2.5)`,
-      lineHeight: size !== "100%" ? themeSize ?? size : undefined,
+      [$size.variable]: themeSize ?? size,
+      [$fs.variable]: `calc(${themeSize ?? size} / 2.5)`,
     },
   })
 }
 
 const sizes = {
-  "2xs": getSize(4, { adjustExcessLabelFontSize: true }),
-  xs: getSize(6, { adjustExcessLabelFontSize: true }),
+  "2xs": getSize(4),
+  xs: getSize(6),
   sm: getSize(8),
   md: getSize(12),
   lg: getSize(16),
@@ -106,5 +104,7 @@ const sizes = {
 export const avatarTheme = defineMultiStyleConfig({
   baseStyle,
   sizes,
-  defaultProps: { size: "md" },
+  defaultProps: {
+    size: "md",
+  },
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7666

## 📝 Description

> Added a `fontSize` adjustment in the theme for `Avatar` excess label. Applicable for sizes `xs` and `2xs` only, as we don't want the label to grow beyond its default value for larger sizes, but need it to shrink for these small ones.

## ⛳️ Current behavior (updates)

> The excess label can tend to overflow from the background, as mentioned in the original issue.

## 🚀 New behavior

> Excess label no longer overflows, and shrinks for `xs` and `2xs` sizes, due to introduced changes in `Avatar` theme.

![Excess labels xs](https://github.com/chakra-ui/chakra-ui/assets/25982756/55d42282-a22e-48fe-9e65-ccbf98afbe8a)
![Excess labels 2xs](https://github.com/chakra-ui/chakra-ui/assets/25982756/77d861aa-1773-4166-993a-4c14b8447564)

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information: N/A