### PR TITLE
fix(next-js): add isExternal to link

### DIFF
--- a/packages/integrations/next-js/src/link.tsx
+++ b/packages/integrations/next-js/src/link.tsx
@@ -24,10 +24,12 @@ export type LinkProps = Merge<
 
 export const Link: LinkComponent = forwardRef(function Link(props, ref) {
   const styles = useStyleConfig("Link", props)
-  const { className, href, children, ...rest } = omitThemingProps(props)
+  const { className, isExternal, href, children, ...rest } =
+    omitThemingProps(props)
 
   return (
     <chakra.a
+      target={isExternal ? "_blank" : undefined}
       ref={ref}
       href={href as any}
       {...rest}


### PR DESCRIPTION
Closes #7676 

## 📝 Description

Add `isExternal` prop to @chakra-ui/next-js `Link`

## ⛳️ Current behavior (updates)

`Link` is missing the `isExternal` prop the core `Link` has.

## 🚀 New behavior

This makes both core and next-js `Link` component more consistent by adding the missing `isExternal` prop and behavior to next-js `Link`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
