### PR TITLE
refactor: improve type safety for event handlers in useNumberInput

### DIFF
--- a/packages/components/number-input/src/use-number-input.ts
+++ b/packages/components/number-input/src/use-number-input.ts
@@ -346,7 +346,9 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
     [isValidCharacter, stepProp, increment, decrement, updateFn, min, max],
   )
 
-  const getStepFactor = <Event extends React.KeyboardEvent | React.WheelEvent>(
+  const getStepFactor = <
+    Event extends React.KeyboardEvent | React.WheelEvent | WheelEvent,
+  >(
     event: Event,
   ) => {
     let ratio = 1
@@ -415,7 +417,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
   }, [focusInputOnChange])
 
   const spinUp = useCallback(
-    (event: any) => {
+    (event: React.PointerEvent) => {
       event.preventDefault()
       spinner.up()
       focusInput()
@@ -424,7 +426,7 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
   )
 
   const spinDown = useCallback(
-    (event: any) => {
+    (event: React.PointerEvent) => {
       event.preventDefault()
       spinner.down()
       focusInput()
@@ -435,14 +437,14 @@ export function useNumberInput(props: UseNumberInputProps = {}) {
   useEventListener(
     () => inputRef.current,
     "wheel",
-    (event) => {
+    (event: WheelEvent) => {
       const doc = inputRef.current?.ownerDocument ?? document
       const isInputFocused = doc.activeElement === inputRef.current
       if (!allowMouseWheel || !isInputFocused) return
 
       event.preventDefault()
 
-      const stepFactor = getStepFactor(event as any) * stepProp
+      const stepFactor = getStepFactor(event) * stepProp
       const direction = Math.sign(event.deltaY)
 
       if (direction === -1) {


### PR DESCRIPTION
## 📝 Description

Improve type safety for event handlers in useNumberInput 

## ⛳️ Current behavior (updates)

Currently, the `getStepFactor` function is limited to handling `React.KeyboardEvent` and `React.WheelEvent` instances, and the `spinUp` and `spinDown` functions use a type of `any` for their event parameter. Furthermore, the event listener for "wheel" events uses an unnecessary type assertion when calling `getStepFactor`.

## 🚀 New behavior

With the changes in this PR:

- The `getStepFactor` function is now able to handle standard `WheelEvent`s along with `React.KeyboardEvent` and `React.WheelEvent`.
- The `spinUp` and `spinDown` functions have had their event parameter type specified as `React.PointerEvent`, providing more accurate typing.
- The "wheel" event listener now has a specified type of `WheelEvent` for its event parameter, and the unnecessary type assertion in the `getStepFactor` call has been removed.

This PR enhances the type safety of our codebase, ensuring correct usage of functions and event handlers while minimizing the potential for runtime errors.

## 💣 Is this a breaking change (Yes/No):

No, this PR should not introduce breaking changes as it mainly involves type annotations and doesn't alter the fundamental behavior of the functions.
