### PR TITLE
Add isFitted to Tabs defaultProps type

### DIFF
--- a/packages/core/styled-system/src/define-styles.ts
+++ b/packages/core/styled-system/src/define-styles.ts
@@ -110,6 +110,7 @@ export function createMultiStyleConfigHelpers<Part extends string>(
         size?: keyof Sizes
         variant?: keyof Variants
         colorScheme?: string
+        isFitted?: boolean
       }
     }) {
       return { parts: parts as Part[], ...config }


### PR DESCRIPTION
📝 Description
---
* https://github.com/chakra-ui/chakra-ui/issues/7646

The defaultProps type for the Tabs component theme doesn't include isFitted, so attempting to override it causes a Typescript error. However, the functionality works as expected when setting isFitted: true. It is desirable from a theming perspective to set all tabs to fitted, so I'm requesting to update the type to accommodate this.

```
const defaultProps = {
  isFitted: true
};
```

export const tabsTheme = defineMultiStyleConfig({ defaultProps });
This gives the following Typescript error:

```
Type '{ isFitted: boolean; }' has no properties in common with type '{ size?: string | number | undefined; variant?: string | number | undefined; colorScheme?: string | undefined; }'.ts(2559)
```

⛳️ Current behavior (updates)
---
https://codesandbox.io/s/weathered-frost-vpnism

🚀 New behavior
---
https://www.loom.com/share/a8253d7a4c9c4f1bb78b632e6eff3c06
Use this file to test the typescript error:  packages/components/theme/src/components/tabs.ts

💣 Is this a breaking change (Yes/No):
---
No 


---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.