### PR TITLE
refactor: use-tabs prop interface

### DIFF
--- a/.changeset/clever-pandas-move.md
+++ b/.changeset/clever-pandas-move.md
@@ -1,0 +1,15 @@
+---
+"@chakra-ui/tabs": minor
+---
+
+Updates the `UseTabOptions` interface, potentially affecting code using
+`useTab()` or `<Tab />` components:
+
+- Removes the following unused fields: `id`, `panelId`, and `isSelected`.
+- Adds the field `isFocusable` which was being directly accessed and used, but
+  was not explicitly typed or documented.
+- Adds the default value of `false` for `isDisabled` and `isFocusable`. The
+  former was documented as defaulting to `false`, but both were defaulting to
+  `undefined`.
+
+Please review your codebase to ensure compatibility with these changes.

--- a/packages/components/tabs/docs.json
+++ b/packages/components/tabs/docs.json
@@ -1,18 +1,11 @@
 {
   "Tab": {
-    "id": { "type": "string", "required": false },
     "isDisabled": {
       "type": "boolean",
       "defaultValue": false,
       "required": false,
       "description": "If `true`, the `Tab` won't be toggleable"
-    },
-    "isSelected": {
-      "type": "boolean",
-      "defaultValue": false,
-      "required": false
-    },
-    "panelId": { "type": "string", "required": false }
+    }
   },
   "TabIndicator": {},
   "TabList": {

--- a/packages/components/tabs/docs.json
+++ b/packages/components/tabs/docs.json
@@ -5,6 +5,12 @@
       "defaultValue": false,
       "required": false,
       "description": "If `true`, the `Tab` won't be toggleable"
+    },
+    "isFocusable": {
+      "type": "boolean",
+      "defaultValue": false,
+      "required": false,
+      "description": "If `true` and `isDisabled`, the `Tab` will be focusable but not interactive."
     }
   },
   "TabIndicator": {},

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -278,7 +278,7 @@ export interface UseTabProps
  * hence the use of `useClickable` to handle this scenario
  */
 export function useTab<P extends UseTabProps>(props: P) {
-  const { isDisabled, isFocusable, ...htmlProps } = props
+  const { isDisabled = false, isFocusable = false, ...htmlProps } = props
 
   const { setSelectedIndex, isManual, id, setFocusedIndex, selectedIndex } =
     useTabsContext()

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -260,6 +260,11 @@ export interface UseTabOptions {
    * @default false
    */
   isDisabled?: boolean
+  /**
+   * If `true` and `isDisabled`, the `Tab` will be focusable but not interactive.
+   * @default false
+   */
+  isFocusable?: boolean
 }
 
 export interface UseTabProps

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -255,12 +255,6 @@ export function useTabList<P extends UseTabListProps>(props: P) {
 export type UseTabListReturn = ReturnType<typeof useTabList>
 
 export interface UseTabOptions {
-  id?: string
-  /**
-   * @default false
-   */
-  isSelected?: boolean
-  panelId?: string
   /**
    * If `true`, the `Tab` won't be toggleable
    * @default false


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->
NA
## 📝 Description
### Problem
API documentation is not up to date. Technically, the solution is not just a documentation update, but a refactor, since it's concerned with APIs and not just internals.

### Affected code
`useTab()`, `<Tab />`, and their common `UseTabOptions` interface.

## ⛳️ Current behavior (updates)
- Props are documented but unused: Documentation shows that `useTab()` and `<Tab />` may receive props `id`, `panelId`, and `isSelected`. I expected to get some use from these props, but they are unused.
- Used prop `isFocusable` is not documented.
- Prop `isDisabled` is documented as defaulting to `false` in `useTab()`, but it actually defaults to `undefined`.

## 🚀 New behavior
- Unused props `id`, `panelId`, and `isSelected` are no longer documented.
- Prop `isDisabled` defaults to `false`, and this is consistent with the current documentation.
- Prop `isFocusable` has been documented and it defaults to `false`.

## 💣 Is this a breaking change (Yes/No):
Potentially, yes. It depends on how the code is structured and how strict the build or compilation process is.

Removing unused props from a component can potentially break a user's code build if their code relies on those props. This change warrants a SemVer minor version increment to indicate backward-compatible changes that may require code updates, but I don't think a major bump is necessary given that no functionality was changed and only _unused_ props were affected.
