### PR TITLE
feat(styled-system): allow '.' in names for textStyles and layerStyles

### DIFF
--- a/packages/core/styled-system/src/config/others.ts
+++ b/packages/core/styled-system/src/config/others.ts
@@ -27,12 +27,25 @@ const srFocusable = {
 
 const getWithPriority = (theme: any, key: any, styles: any) => {
   const result: Record<string, any> = {}
-  const obj = get(theme, key, {})
+  let obj = get(theme, key, null)
+
+  if (!obj) {
+    obj = getSecondlyNested(theme, key, {})
+  }
+
   for (const prop in obj) {
     const isInStyles = prop in styles && styles[prop] != null
     if (!isInStyles) result[prop] = obj[prop]
   }
   return result
+}
+
+const getSecondlyNested = (obj: any, path: any, fallback: any) => {
+  const keys = path.split(".")
+  const firstKey = keys[0]
+  const secondKey = keys.slice(1).join(".")
+
+  return obj[firstKey] ? obj[firstKey][secondKey] : fallback
 }
 
 export const others: Config = {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7626

## 📝 Description

This PR adds the possibility to use '.' character in names for theme categories `textStyles` and `layerStyles`

## ⛳️ Current behavior (updates)
Names for theme categories `textStyles` and `layerStyles` don't allow the inclusion of '.' character

![image](https://github.com/chakra-ui/chakra-ui/assets/32570823/c42f9ef7-7258-42d4-ba19-3406efde1bbb)

## 🚀 New behavior
Now it works the same as in theme categories like `colors`

![image](https://github.com/chakra-ui/chakra-ui/assets/32570823/677f3c8a-1964-4471-894a-7780dc180d8c)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
My first contribution to chakra-ui 

