### PR TITLE
fix(button/style-system): stop layerStyles color props from being discarded when injected to component

### DIFF
--- a/.changeset/large-radios-invite.md
+++ b/.changeset/large-radios-invite.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/styled-system": patch
+"@chakra-ui/button": patch
+---
+
+Fixed a bug that would not consider color style props on the Button component
+when specified by layerStyles in the theme object. This was caused by the
+getWithPriority function which would discard any styles that are already
+included in the component styles props

--- a/packages/components/button/tests/button.test.tsx
+++ b/packages/components/button/tests/button.test.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
 import { render, testA11y, screen } from "@chakra-ui/test-utils"
+import { ThemeProvider } from "@chakra-ui/system"
 import { EmailIcon, ArrowForwardIcon } from "@chakra-ui/icons"
 import { Button, ButtonGroup } from "../src"
+import { theme as baseTheme } from "@chakra-ui/theme"
 
 it("passes a11y test", async () => {
   await testA11y(<Button>test</Button>)
@@ -144,4 +146,33 @@ test("Should be disabled", () => {
 
   const buttonAsDiv = getByTestId("btn")
   expect(buttonAsDiv).toHaveAttribute("disabled")
+})
+
+test("Should inherit the appropriate layerStyle props from the theme", () => {
+  const layerColor = "red"
+  const layerBg = "green"
+
+  const testTheme = {
+    ...baseTheme,
+    layerStyles: {
+      button: {
+        test: {
+          color: layerColor,
+          bg: layerBg,
+        },
+      },
+    },
+  }
+
+  const { getByTestId } = render(
+    <ThemeProvider theme={testTheme}>
+      <Button layerStyle="button.test" data-testid="btn">
+        Layered Button
+      </Button>
+    </ThemeProvider>,
+  )
+
+  const button = getByTestId("btn")
+  expect(button).toHaveStyle(`background-color: ${layerBg}`)
+  expect(button).toHaveStyle(`color: ${layerColor}`)
 })

--- a/packages/core/styled-system/src/config/others.ts
+++ b/packages/core/styled-system/src/config/others.ts
@@ -2,6 +2,8 @@ import { memoizedGet as get } from "../get"
 import { Config } from "../utils/prop-config"
 import { ResponsiveValue, Token } from "../utils/types"
 
+const allowedLayerPropsOverrides = ["bg", "bgColor", "backgroundColor", "color"]
+
 const srOnly = {
   border: "0px",
   clip: "rect(0, 0, 0, 0)",
@@ -30,7 +32,8 @@ const getWithPriority = (theme: any, key: any, styles: any) => {
   const obj = get(theme, key, {})
   for (const prop in obj) {
     const isInStyles = prop in styles && styles[prop] != null
-    if (!isInStyles) result[prop] = obj[prop]
+    const isAllowedProp = allowedLayerPropsOverrides.includes(prop)
+    if (!isInStyles || isAllowedProp) result[prop] = obj[prop]
   }
   return result
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # [7738](https://github.com/chakra-ui/chakra-ui/issues/7738)

## 📝 Description
This PR fixes an issue when using layerStyles in which the component would not inherit any color related props that are defined within the layerStyles object which exist already in the component's existing styles props.

## ⛳️ Current behavior (updates)
Currently, if `color` or `bg` styles are added to the layerStyles object, those values would be discarded via the function `getWithPriority` 

## 🚀 New behavior
This PR allows certain style keys to be overwritten if included in the layerStyles object.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
