### PR TITLE
fix(input): handle responsive sizing in input addons/elements

### DIFF
--- a/.changeset/clean-shrimps-flow.md
+++ b/.changeset/clean-shrimps-flow.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/theme": minor
+---
+
+Move all `Input` size styles to CSS variables and apply them to both the `field`
+part and the new `group` part so that said variables are available to both the
+field and elements/addons within an `InputGroup`.

--- a/.changeset/old-worms-punch.md
+++ b/.changeset/old-worms-punch.md
@@ -1,0 +1,11 @@
+---
+"@chakra-ui/input": patch
+---
+
+Fix `InputElement` and `InputAddon` sizing when using a responsive `size` value
+for `InputGroup`.
+
+_Note: this requires changes in the latest **@chakra-ui/theme** or, for custom
+themes, sizes to be driven with CSS variables. See the
+[default theme](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/theme/src/components/input.ts)
+for an example._

--- a/.changeset/unlucky-ways-rescue.md
+++ b/.changeset/unlucky-ways-rescue.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/anatomy": minor
+---
+
+Add `group` part to `inputAnatomy`

--- a/packages/components/anatomy/src/components.ts
+++ b/packages/components/anatomy/src/components.ts
@@ -73,7 +73,12 @@ export const formAnatomy = anatomy("form").parts(
 
 export const formErrorAnatomy = anatomy("formError").parts("text", "icon")
 
-export const inputAnatomy = anatomy("input").parts("addon", "field", "element")
+export const inputAnatomy = anatomy("input").parts(
+  "addon",
+  "field",
+  "element",
+  "group",
+)
 
 export const listAnatomy = anatomy("list").parts("container", "item", "icon")
 

--- a/packages/components/input/src/input-group.tsx
+++ b/packages/components/input/src/input-group.tsx
@@ -84,6 +84,7 @@ export const InputGroup = forwardRef<InputGroupProps, "div">(
           // Parts of inputs override z-index to ensure that they stack correctly on each other
           // Create a new stacking context so that these overrides don't leak out and conflict with other z-indexes
           isolation: "isolate",
+          ...styles.group,
         }}
         data-group
         {...rest}

--- a/packages/components/input/stories/input.stories.tsx
+++ b/packages/components/input/stories/input.stories.tsx
@@ -92,6 +92,14 @@ export const WithInputAddon = () => (
   </Stack>
 )
 
+export const WithInputAddonResponsive = () => (
+  <InputGroup size={{ base: "xs", sm: "sm", md: "md", lg: "lg" }}>
+    <InputLeftAddon children="https://" />
+    <Input placeholder="website.com" />
+    <InputRightAddon children=".com" />
+  </InputGroup>
+)
+
 export const WithInputElement = () => (
   <Stack align="start">
     <InputGroup>
@@ -105,6 +113,14 @@ export const WithInputElement = () => (
       <InputRightElement children={<CheckIcon color="green.500" />} />
     </InputGroup>
   </Stack>
+)
+
+export const WithInputElementResponsive = () => (
+  <InputGroup size={{ base: "xs", sm: "sm", md: "md", lg: "lg" }}>
+    <InputLeftElement color="gray.300" fontSize="1.2em" children="$" />
+    <Input placeholder="Enter amount" />
+    <InputRightElement children={<CheckIcon color="green.500" />} />
+  </InputGroup>
 )
 
 export function PasswordInput() {

--- a/packages/components/theme/src/components/input.ts
+++ b/packages/components/theme/src/components/input.ts
@@ -1,6 +1,7 @@
 import { inputAnatomy as parts } from "@chakra-ui/anatomy"
 import {
   createMultiStyleConfigHelpers,
+  cssVar,
   defineStyle,
 } from "@chakra-ui/styled-system"
 import { getColor, mode } from "@chakra-ui/theme-tools"
@@ -8,9 +9,24 @@ import { getColor, mode } from "@chakra-ui/theme-tools"
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
+const $height = cssVar("input-height")
+const $fontSize = cssVar("input-font-size")
+const $padding = cssVar("input-padding")
+const $borderRadius = cssVar("input-border-radius")
+
 const baseStyle = definePartsStyle({
+  addon: {
+    height: $height.reference,
+    fontSize: $fontSize.reference,
+    px: $padding.reference,
+    borderRadius: $borderRadius.reference,
+  },
   field: {
     width: "100%",
+    height: $height.reference,
+    fontSize: $fontSize.reference,
+    px: $padding.reference,
+    borderRadius: $borderRadius.reference,
     minWidth: 0,
     outline: 0,
     position: "relative",
@@ -26,47 +42,47 @@ const baseStyle = definePartsStyle({
 
 const size = {
   lg: defineStyle({
-    fontSize: "lg",
-    px: "4",
-    h: "12",
-    borderRadius: "md",
+    [$fontSize.variable]: "fontSizes.lg",
+    [$padding.variable]: "space.4",
+    [$borderRadius.variable]: "radii.md",
+    [$height.variable]: "sizes.12",
   }),
   md: defineStyle({
-    fontSize: "md",
-    px: "4",
-    h: "10",
-    borderRadius: "md",
+    [$fontSize.variable]: "fontSizes.md",
+    [$padding.variable]: "space.4",
+    [$borderRadius.variable]: "radii.md",
+    [$height.variable]: "sizes.10",
   }),
   sm: defineStyle({
-    fontSize: "sm",
-    px: "3",
-    h: "8",
-    borderRadius: "sm",
+    [$fontSize.variable]: "fontSizes.sm",
+    [$padding.variable]: "space.3",
+    [$borderRadius.variable]: "radii.sm",
+    [$height.variable]: "sizes.8",
   }),
   xs: defineStyle({
-    fontSize: "xs",
-    px: "2",
-    h: "6",
-    borderRadius: "sm",
+    [$fontSize.variable]: "fontSizes.xs",
+    [$padding.variable]: "space.2",
+    [$borderRadius.variable]: "radii.sm",
+    [$height.variable]: "sizes.6",
   }),
 }
 
 const sizes = {
   lg: definePartsStyle({
     field: size.lg,
-    addon: size.lg,
+    group: size.lg,
   }),
   md: definePartsStyle({
     field: size.md,
-    addon: size.md,
+    group: size.md,
   }),
   sm: definePartsStyle({
     field: size.sm,
-    addon: size.sm,
+    group: size.sm,
   }),
   xs: definePartsStyle({
     field: size.xs,
-    addon: size.xs,
+    group: size.xs,
   }),
 }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The support for responsive `size` values added in #6050 breaks down when a responsive `size` is supplied to an `InputGroup` that includes `InputElement` and/or `InputAddon` children. This is due to the way the dimensions for the input, element and addons are calculated: https://github.com/chakra-ui/chakra-ui/blob/fa62897ca65d2af82bbe07e50fb323415bfe974e/packages/components/input/src/input-group.tsx#L41-L74

I was hoping to be able to resolve this in our design system with a pure theme-driven solution, but because there's no root element "part" to target in the case of `InputGroup`, it was impossible. This change adds a new `group` part to the input theme allowing the responsive case to be handled via CSS variables. This was the least invasive change I could come up with, but am happy to entertain feedback and other ideas.

## ⛳️ Current behavior (updates)

Responsive sizing doesn't work at all for `InputElement` and `InputAddon`:

```tsx
<InputGroup size={{ base: 'xs', sm: 'sm', md: 'md', lg: 'lg' }}>
```

| Viewport | Element | Addon |
|------|---------|-------|
| `400px` | <img width="1063" alt="before--element-xs" src="https://github.com/chakra-ui/chakra-ui/assets/288160/b039ff1f-ef58-4566-95b9-203dd009ab56"> | <img width="1063" alt="before--addon-xs" src="https://github.com/chakra-ui/chakra-ui/assets/288160/2e570181-3d34-4192-88ae-69288d5d1a32"> |
| `600px` | <img width="1063" alt="before--element-sm" src="https://github.com/chakra-ui/chakra-ui/assets/288160/480b242a-79c3-41b1-9965-43e53a48c8df"> | <img width="1063" alt="before--adon-sm" src="https://github.com/chakra-ui/chakra-ui/assets/288160/84f3438e-bf21-4440-83d7-d6f9eed27fed"> |
| `800px` | <img width="1063" alt="before--element-md" src="https://github.com/chakra-ui/chakra-ui/assets/288160/5109d94a-88e7-48ea-9412-e46b65478705"> | <img width="1063" alt="before--addon-md" src="https://github.com/chakra-ui/chakra-ui/assets/288160/1b023098-1d2a-4339-b9c3-85ddf800add4"> |
| `1000px` | <img width="1063" alt="before--element-lg" src="https://github.com/chakra-ui/chakra-ui/assets/288160/cb17f2e7-b8e3-436e-98fa-8cb7df677e9e"> | <img width="1063" alt="before--addon-lg" src="https://github.com/chakra-ui/chakra-ui/assets/288160/6f00ef2e-f164-4ec4-aeed-a5a817a3b121"> |


## 🚀 New behavior

Responsive sizing works properly for `InputElement` and `InputAddon`:

```tsx
<InputGroup size={{ base: 'xs', sm: 'sm', md: 'md', lg: 'lg' }}>
```

| Viewport | Element | Addon |
|------|---------|-------|
| `400px` | <img width="1063" alt="after--element-xs" src="https://github.com/chakra-ui/chakra-ui/assets/288160/01123e6b-9b76-48d7-af31-991b0273b819"> | <img width="1063" alt="after--addon-xs" src="https://github.com/chakra-ui/chakra-ui/assets/288160/24b3c5ac-f57f-468b-9818-381ade8c510b"> |
| `600px` | <img width="1063" alt="after--element-sm" src="https://github.com/chakra-ui/chakra-ui/assets/288160/fd35ca70-7fdd-4661-a26d-48826f33f606"> | <img width="1063" alt="after--addon-sm" src="https://github.com/chakra-ui/chakra-ui/assets/288160/797c8087-66ba-4fe2-b8af-3c0d0093ef7b"> |
| `800px` | <img width="1063" alt="after--element-md" src="https://github.com/chakra-ui/chakra-ui/assets/288160/84bbe941-e4f9-4244-a1e0-8b0b1a46e676"> | <img width="1063" alt="after--addon-md" src="https://github.com/chakra-ui/chakra-ui/assets/288160/4d13686a-7513-4099-a971-800ad11a7892"> |
| `1000px` | <img width="1063" alt="after--element-lg" src="https://github.com/chakra-ui/chakra-ui/assets/288160/a3d41ea6-0ecd-407b-ac9c-798554114363"> |  <img width="1063" alt="after--addon-lg" src="https://github.com/chakra-ui/chakra-ui/assets/288160/2ae18f0e-01e8-4a9e-a385-0e0ea4bce671"> |


## 💣 Is this a breaking change (Yes/No):

Nope.

