### PR TITLE
Use clipboard imperative usage

### DIFF
--- a/packages/legacy/hooks/src/use-clipboard.ts
+++ b/packages/legacy/hooks/src/use-clipboard.ts
@@ -13,6 +13,13 @@ export interface UseClipboardOptions {
   format?: string
 }
 
+interface UseClipboardReturn {
+  value: string
+  setValue: (value: string) => void
+  onCopy: (value?: string) => void
+  hasCopied: boolean
+}
+
 /**
  * React hook to copy content to clipboard
  *
@@ -24,18 +31,24 @@ export interface UseClipboardOptions {
  *
  * @see Docs https://chakra-ui.com/docs/hooks/use-clipboard
  */
+export function useClipboard(): Pick<UseClipboardReturn, "hasCopied" | "onCopy">
 export function useClipboard(
-  valueOrOptionsOrTimeout: string | number | UseClipboardOptions = {},
-  optionsOrTimeoutArgument: number | UseClipboardOptions = {},
+  optionsOrTimeout: number | UseClipboardOptions,
+): Pick<UseClipboardReturn, "hasCopied" | "onCopy">
+export function useClipboard(value: string): UseClipboardReturn
+export function useClipboard(
+  value: string,
+  optionsOrTimeout: number | UseClipboardOptions,
+): UseClipboardReturn
+export function useClipboard(
+  ...args:
+    | []
+    | [string | number | UseClipboardOptions]
+    | [string, number | UseClipboardOptions]
 ) {
-  const value =
-    typeof valueOrOptionsOrTimeout === "string"
-      ? valueOrOptionsOrTimeout
-      : undefined
+  const value = typeof args[0] === "string" ? args[0] : undefined
   const optionsOrTimeout =
-    typeof valueOrOptionsOrTimeout === "string"
-      ? optionsOrTimeoutArgument
-      : valueOrOptionsOrTimeout
+    typeof args[0] === "string" ? args[1] ?? {} : args[0] ?? {}
 
   const [hasCopied, setHasCopied] = useState(false)
 
@@ -81,9 +94,16 @@ export function useClipboard(
     }
   }, [timeout, hasCopied])
 
+  if (typeof valueState === "string") {
+    return {
+      value: valueState,
+      setValue: setValueState,
+      onCopy,
+      hasCopied,
+    } as UseClipboardReturn
+  }
+
   return {
-    value: valueState,
-    setValue: setValueState,
     onCopy,
     hasCopied,
   }

--- a/packages/legacy/hooks/src/use-clipboard.ts
+++ b/packages/legacy/hooks/src/use-clipboard.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react"
 import copy from "copy-to-clipboard"
-import { __DEV__, warn } from "@chakra-ui/utils"
+import { warn } from "@chakra-ui/utils"
 
 export interface UseClipboardOptions {
   /**

--- a/packages/legacy/hooks/tests/use-clipboard.test.tsx
+++ b/packages/legacy/hooks/tests/use-clipboard.test.tsx
@@ -66,6 +66,6 @@ test("sets new copy value imperatively", () => {
   })
 
   expect(copy).toBeCalledWith(text, {})
-  expect(result.current["value"]).toEqual(undefined)
-  expect(result.current["setValue"]).toEqual(undefined)
+  expect(result.current).not.toHaveProperty("value")
+  expect(result.current).not.toHaveProperty("setValue")
 })

--- a/packages/legacy/hooks/tests/use-clipboard.test.tsx
+++ b/packages/legacy/hooks/tests/use-clipboard.test.tsx
@@ -55,3 +55,17 @@ test("sets new copy value", () => {
 
   expect(copy).toBeCalledWith(newText, {})
 })
+
+test("sets new copy value imperatively", () => {
+  ;(copy as jest.Mock).mockReturnValue(true)
+
+  const { result } = hooks.render(() => useClipboard())
+
+  hooks.act(() => {
+    result.current.onCopy(text)
+  })
+
+  expect(copy).toBeCalledWith(text, {})
+  expect(result.current.value).toEqual(undefined)
+  expect(result.current.setValue).toEqual(undefined)
+})

--- a/packages/legacy/hooks/tests/use-clipboard.test.tsx
+++ b/packages/legacy/hooks/tests/use-clipboard.test.tsx
@@ -66,6 +66,6 @@ test("sets new copy value imperatively", () => {
   })
 
   expect(copy).toBeCalledWith(text, {})
-  expect(result.current.value).toEqual(undefined)
-  expect(result.current.setValue).toEqual(undefined)
+  expect(result.current["value"]).toEqual(undefined)
+  expect(result.current["setValue"]).toEqual(undefined)
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7754

## 📝 Description

Added possibility to call `copy` from `useClipboard` imperatively. 

## ⛳️ Current behavior (updates)

To pass in a value that is obtained imperatively, e.g. `prompt` or value from a global object, you would need to either rely on `useEffect` and violate [chains of computations](https://react.dev/learn/you-might-not-need-an-effect#chains-of-computations) or in SSR do a two-pass render to get access to the global object.

## 🚀 New behavior

By calling the `useClipboard` without `value` arguments, i.e. no arguments on only `optionsOrTimeout` argument you are able to pass in value to `onCopy` callback.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

I will link docs PR here as well once I create it.

-----

Hey @segunadebayo! Here is the PR. Please checkout other `feat` commits as I had multiple ideas on how to solve the DX. I find this the best, but I would like to hear your opinion on this one.
