### PR TITLE
fix(popover): use correct popover z-index

### DIFF
--- a/.changeset/funny-lies-try.md
+++ b/.changeset/funny-lies-try.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Fix incorrect popover z-index

--- a/packages/components/theme/src/components/popover.ts
+++ b/packages/components/theme/src/components/popover.ts
@@ -12,7 +12,7 @@ const $popperBg = cssVar("popper-bg")
 const $arrowBg = cssVar("popper-arrow-bg")
 const $arrowShadowColor = cssVar("popper-arrow-shadow-color")
 
-const baseStylePopper = defineStyle({ zIndex: 10 })
+const baseStylePopper = defineStyle({ zIndex: "popover" })
 
 const baseStyleContent = defineStyle({
   [$popperBg.variable]: `colors.white`,


### PR DESCRIPTION
Closes #7408

## 📝 Description

The popover z-index property is hardcoded to `10`. It should be using the z-index defined for popovers.

## ⛳️ Current behavior (updates)

Popovers can erroneously appear beneath other elements.

## 🚀 New behavior

Popovers are positioned correctly in the stacking order.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Tested and verified locally.