### PR TITLE
feat(styled-system): reinstate use of custom class selectors in semantic tokens

### DIFF
--- a/.changeset/witty-dolls-pull.md
+++ b/.changeset/witty-dolls-pull.md
@@ -1,0 +1,69 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Reinstate the use of custom class selectors in semantic tokens
+
+Prior to the added feature of nested semantic tokens, a user had the ability to
+supply a custom class selector in the semantic.
+
+For example, if the semantic was
+
+```ts
+colors: {
+  text: {
+    default: 'gray.900',
+    ['.myClass']: 'red.500'
+  }
+}
+```
+
+This would render the following CSS
+
+```css
+:root {
+  --colors-text: var(--colors-gray-900);
+}
+
+.myClass {
+  --colors-text: var(--colors-red-500);
+}
+```
+
+Which would then be used in a component like
+
+```tsx live=false
+<Box className="myClass">
+  <Text color="text"> Some Text </Text>
+</Box>
+```
+
+In updating the semantic tokens theming to support nested tokens, restrictions
+had to be placed on the naming of keys, eliminating the use of the class
+selector as a key such as the example above.
+
+Now, we can apply a class name similar to pseudo props by naming it using the
+convention of the underscore prefix and pascalCase text.
+
+So this will work!
+
+```ts
+colors: {
+  text: {
+    default: 'gray.900',
+    _myClass: 'red.500'
+  },
+  // OR...
+  body: {
+    base: {
+      default: 'gray.200',
+      _myClass: 'yellow.300'
+    }
+  }
+}
+```
+
+> 🚨 IMPORTANT: This is only for class names. And when using the custom class in
+> a component's `className` prop, you would have to also write it in pascalCase.
+>
+> i.e. `className="myClass"`

--- a/packages/core/styled-system/src/create-theme-vars/create-theme-vars.ts
+++ b/packages/core/styled-system/src/create-theme-vars/create-theme-vars.ts
@@ -93,7 +93,7 @@ export function createThemeVars(
           }
 
           /**
-           * @example { _myClass: "yellow.500" } =>
+           * @example { tokenName: { _myClass: "yellow.500" } } =>
            * {
            *   '.myClass': {
            *     "--colors-tokenName": "var(--colors-yellow-500)"

--- a/packages/core/styled-system/src/create-theme-vars/create-theme-vars.ts
+++ b/packages/core/styled-system/src/create-theme-vars/create-theme-vars.ts
@@ -4,6 +4,7 @@ import { cssVar } from "./css-var"
 import { FlatToken, FlatTokens } from "./flatten-tokens"
 import { pseudoSelectors } from "../pseudos"
 import mergeWith from "lodash.mergewith"
+import { isCustomSelector } from "../utils/create-transform"
 
 export interface CreateThemeVarsOptions {
   cssVarPrefix?: string
@@ -88,6 +89,21 @@ export function createThemeVars(
 
           if (conditionAlias === "default") {
             acc[variable] = tokenReference
+            return acc
+          }
+
+          /**
+           * @example { _myClass: "yellow.500" } =>
+           * {
+           *   '.myClass': {
+           *     "--colors-tokenName": "var(--colors-yellow-500)"
+           *   }
+           * }
+           */
+          if (isCustomSelector(conditionAlias)) {
+            const classSelector = conditionAlias.replace("_", ".")
+
+            acc[classSelector] = { [variable]: tokenReference }
             return acc
           }
 

--- a/packages/core/styled-system/src/create-theme-vars/flatten-tokens.ts
+++ b/packages/core/styled-system/src/create-theme-vars/flatten-tokens.ts
@@ -1,6 +1,7 @@
 import { walkObject } from "@chakra-ui/object-utils"
 import { pseudoPropNames } from "../pseudos"
 import { Union } from "../utils"
+import { isCustomSelector } from "../utils/create-transform"
 
 export type SemanticValue<
   Conditions extends string,
@@ -27,7 +28,9 @@ export type FlattenTokensParam = {
 }
 
 const isSemanticCondition = (key: string) =>
-  pseudoPropNames.includes(key as any) || "default" === key
+  pseudoPropNames.includes(key as any) ||
+  "default" === key ||
+  isCustomSelector(key)
 
 export function flattenTokens<T extends FlattenTokensParam>({
   tokens,

--- a/packages/core/styled-system/src/utils/create-transform.ts
+++ b/packages/core/styled-system/src/utils/create-transform.ts
@@ -1,12 +1,23 @@
 import { isObject } from "@chakra-ui/shared-utils"
 import type { ThemeScale } from "../create-theme-vars"
 import type { Transform } from "./types"
+import { pseudoPropNames } from "../pseudos"
 
 interface CreateTransformOptions {
   scale: ThemeScale
   compose?: Transform
   transform?: Transform
 }
+
+/**
+ * Check for use of a prop in the semanticTokens object
+ * That is not a pseudo but uses the underscore prefix.
+ * Also only returns true if it is pascalCase.
+ *
+ * @example `_myClass` is true
+ */
+export const isCustomSelector = (key: string) =>
+  !pseudoPropNames.includes(key as any) && key.match(/^_[a-z]+[A-Z]?[a-z]*$/)
 
 const isImportant = (value: string) => /!(important)?$/.test(value)
 

--- a/packages/core/styled-system/tests/css-var.test.ts
+++ b/packages/core/styled-system/tests/css-var.test.ts
@@ -390,6 +390,11 @@ test("should convert transition tokens", () => {
 test("should convert semantic tokens", () => {
   const theme = {
     colors: {
+      gray: {
+        200: "#E2E8F0",
+        800: "#1A202C",
+        900: "#171923",
+      },
       green: {
         500: "#38A169",
       },
@@ -399,6 +404,9 @@ test("should convert semantic tokens", () => {
         500: "#ff0050",
         700: "#ff0070",
         800: "#ff0080",
+      },
+      yellow: {
+        300: "#F6E05E",
       },
     },
     semanticTokens: {
@@ -433,6 +441,18 @@ test("should convert semantic tokens", () => {
             },
           },
         },
+        label: {
+          default: "gray.900",
+          _dark: "gray.200",
+          _customClass: "red.500",
+        },
+        body: {
+          base: {
+            default: "white",
+            _dark: "gray.800",
+            _customClass: "yellow.300",
+          },
+        },
       },
     },
   }
@@ -446,15 +466,40 @@ test("should convert semantic tokens", () => {
           "var": "--colors-background-green-normal",
           "varRef": "var(--colors-background-green-normal)",
         },
+        "colors.body.base": Object {
+          "value": "var(--colors-body-base)",
+          "var": "--colors-body-base",
+          "varRef": "var(--colors-body-base)",
+        },
         "colors.error": Object {
           "value": "var(--colors-error)",
           "var": "--colors-error",
           "varRef": "var(--colors-error)",
         },
+        "colors.gray.200": Object {
+          "value": "#E2E8F0",
+          "var": "--colors-gray-200",
+          "varRef": "var(--colors-gray-200)",
+        },
+        "colors.gray.800": Object {
+          "value": "#1A202C",
+          "var": "--colors-gray-800",
+          "varRef": "var(--colors-gray-800)",
+        },
+        "colors.gray.900": Object {
+          "value": "#171923",
+          "var": "--colors-gray-900",
+          "varRef": "var(--colors-gray-900)",
+        },
         "colors.green.500": Object {
           "value": "#38A169",
           "var": "--colors-green-500",
           "varRef": "var(--colors-green-500)",
+        },
+        "colors.label": Object {
+          "value": "var(--colors-label)",
+          "var": "--colors-label",
+          "varRef": "var(--colors-label)",
         },
         "colors.primary": Object {
           "value": "var(--colors-primary)",
@@ -511,6 +556,11 @@ test("should convert semantic tokens", () => {
           "var": "--colors-text-red-subtle",
           "varRef": "var(--colors-text-red-subtle)",
         },
+        "colors.yellow.300": Object {
+          "value": "#F6E05E",
+          "var": "--colors-yellow-300",
+          "varRef": "var(--colors-yellow-300)",
+        },
       },
       "__cssVars": Object {
         "--chakra-ring-color": "rgba(66, 153, 225, 0.6)",
@@ -522,8 +572,13 @@ test("should convert semantic tokens", () => {
         "--chakra-space-x-reverse": "0",
         "--chakra-space-y-reverse": "0",
         "--colors-background-green-normal": "var(--colors-green-500)",
+        "--colors-body-base": "white",
         "--colors-error": "var(--colors-red-500)",
+        "--colors-gray-200": "#E2E8F0",
+        "--colors-gray-800": "#1A202C",
+        "--colors-gray-900": "#171923",
         "--colors-green-500": "#38A169",
+        "--colors-label": "var(--colors-gray-900)",
         "--colors-primary": "var(--colors-red-500)",
         "--colors-red-100": "#ff0010",
         "--colors-red-400": "#ff0040",
@@ -535,14 +590,26 @@ test("should convert semantic tokens", () => {
         "--colors-text-green": "var(--colors-green-500)",
         "--colors-text-red-bold": "var(--colors-red-800)",
         "--colors-text-red-subtle": "var(--colors-red-500)",
+        "--colors-yellow-300": "#F6E05E",
         ".chakra-ui-dark &:not([data-theme]),[data-theme=dark] &:not([data-theme]),&[data-theme=dark]": Object {
+          "--colors-body-base": "var(--colors-gray-800)",
+          "--colors-label": "var(--colors-gray-200)",
           "--colors-primary": "var(--colors-red-400)",
           "--colors-secondary": "var(--colors-red-700)",
           "--colors-text-red-bold": "var(--colors-red-700)",
           "--colors-text-red-subtle": "var(--colors-red-400)",
         },
+        ".customClass": Object {
+          "--colors-body-base": "var(--colors-yellow-300)",
+          "--colors-label": "var(--colors-red-500)",
+        },
       },
       "colors": Object {
+        "gray": Object {
+          "200": "#E2E8F0",
+          "800": "#1A202C",
+          "900": "#171923",
+        },
         "green": Object {
           "500": "#38A169",
         },
@@ -553,6 +620,9 @@ test("should convert semantic tokens", () => {
           "700": "#ff0070",
           "800": "#ff0080",
         },
+        "yellow": Object {
+          "300": "#F6E05E",
+        },
       },
       "semanticTokens": Object {
         "colors": Object {
@@ -561,7 +631,19 @@ test("should convert semantic tokens", () => {
               "normal": "green.500",
             },
           },
+          "body": Object {
+            "base": Object {
+              "_customClass": "yellow.300",
+              "_dark": "gray.800",
+              "default": "white",
+            },
+          },
           "error": "red.500",
+          "label": Object {
+            "_customClass": "red.500",
+            "_dark": "gray.200",
+            "default": "gray.900",
+          },
           "primary": Object {
             "_dark": "red.400",
             "default": "red.500",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Reinstate the use of custom class selectors in semantic tokens

## ⛳️ Current behavior (updates)

Prior to the added feature of nested semantic tokens, a user had the ability to
supply a custom class selector in the semantic.

For example, if the semantic was

```ts
colors: {
  text: {
    default: 'gray.900',
    ['.myClass']: 'red.500'
  }
}
```

This would render the following CSS

```css
:root {
  --colors-text: var(--colors-gray-900);
}

.myClass {
  --colors-text: var(--colors-red-500);
}
```

Which would then be used in a component like

```tsx live=false
<Box className="myClass">
  <Text color="text"> Some Text </Text>
</Box>
```

In updating the semantic tokens theming to support nested tokens, restrictions
had to be placed on the naming of keys, eliminating the use of the class
selector as a key such as the example above.

## 🚀 New behavior

Now, we can apply a class name similar to pseudo props by naming it using the
convention of the underscore prefix and pascalCase text.

So this will work!

```ts
colors: {
  text: {
    default: 'gray.900',
    _myClass: 'red.500'
  },
  // OR...
  body: {
    base: {
      default: 'gray.200',
      _myClass: 'yellow.300'
    }
  }
}
```

## 💣 Is this a breaking change (Yes/No):

No. This is an addition to existing behavior.

## 📝 Additional Information
🚨 IMPORTANT: This is only for class names. And when using the custom class in a component's `className` prop, you would have to also write it in pascalCase.

i.e. `className="myClass"`