### PR TITLE
feat(menu): extend menu theme with icon part

### DIFF
--- a/.changeset/swift-yaks-shop.md
+++ b/.changeset/swift-yaks-shop.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/anatomy": patch
+"@chakra-ui/theme": patch
+"@chakra-ui/menu": patch
+---
+
+Allow styling `MenuIcon` as part of `Menu` theme

--- a/packages/components/anatomy/src/components.ts
+++ b/packages/components/anatomy/src/components.ts
@@ -79,7 +79,7 @@ export const listAnatomy = anatomy("list").parts("container", "item", "icon")
 
 export const menuAnatomy = anatomy("menu")
   .parts("button", "list", "item")
-  .extend("groupTitle", "command", "divider")
+  .extend("groupTitle", "icon", "command", "divider")
 
 export const modalAnatomy = anatomy("modal")
   .parts("overlay", "dialogContainer", "dialog")

--- a/packages/components/menu/src/menu-icon.tsx
+++ b/packages/components/menu/src/menu-icon.tsx
@@ -2,9 +2,12 @@ import { HTMLChakraProps, chakra } from "@chakra-ui/system"
 import { cx } from "@chakra-ui/shared-utils"
 
 import { Children, cloneElement, isValidElement } from "react"
+import { useMenuStyles } from "./menu"
 
 export const MenuIcon: React.FC<HTMLChakraProps<"span">> = (props) => {
   const { className, children, ...rest } = props
+
+  const styles = useMenuStyles()
 
   const child = Children.only(children)
 
@@ -19,16 +22,7 @@ export const MenuIcon: React.FC<HTMLChakraProps<"span">> = (props) => {
   const _className = cx("chakra-menu__icon-wrapper", className)
 
   return (
-    <chakra.span
-      className={_className}
-      {...rest}
-      __css={{
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        flexShrink: 0,
-      }}
-    >
+    <chakra.span className={_className} {...rest} __css={styles.icon}>
       {clone}
     </chakra.span>
   )

--- a/packages/components/theme/src/components/menu.ts
+++ b/packages/components/theme/src/components/menu.ts
@@ -66,6 +66,13 @@ const baseStyleGroupTitle = defineStyle({
   fontSize: "sm",
 })
 
+const baseStyleIcon = defineStyle({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+})
+
 const baseStyleCommand = defineStyle({
   opacity: 0.6,
 })
@@ -88,6 +95,7 @@ const baseStyle = definePartsStyle({
   list: baseStyleList,
   item: baseStyleItem,
   groupTitle: baseStyleGroupTitle,
+  icon: baseStyleIcon,
   command: baseStyleCommand,
   divider: baseStyleDivider,
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR extends the menu theme to accept `icon` as part of the theme.

## ⛳️ Current behavior (updates)

Currently, the base style of `MenuIcon` is hardcoded in the component so there is no clean way to customize menu icon styles.

## 🚀 New behavior

You can style the menu icon the same way as other parts of the menu theme.

## 💣 Is this a breaking change (Yes/No):

No. The base styles are still here but are moved to the theme.

## 📝 Additional Information
