### PR TITLE
Support null in useBreakpointValue

### DIFF
--- a/.changeset/angry-dryers-laugh.md
+++ b/.changeset/angry-dryers-laugh.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/media-query": patch
+---
+
+Support `null` value in `useBreakpointValue` hook

--- a/packages/components/media-query/src/use-breakpoint-value.ts
+++ b/packages/components/media-query/src/use-breakpoint-value.ts
@@ -17,7 +17,7 @@ import { useBreakpoint, UseBreakpointOptions } from "./use-breakpoint"
  * @see Docs https://chakra-ui.com/docs/hooks/use-breakpoint-value
  */
 export function useBreakpointValue<T = any>(
-  values: Partial<Record<string, T>> | T[],
+  values: Partial<Record<string, T>> | Array<T | null>,
   arg?: UseBreakpointOptions | string,
 ): T | undefined {
   const opts = isObject(arg) ? arg : { fallback: arg ?? "base" }


### PR DESCRIPTION
Support null type in useBreakpointValue

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description
Add null type in useBreakpointValue

## ⛳️ Current behavior (updates)

just add type

## 🚀 New behavior

just add type

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

The null value in Chakra's responsive value indicates a wildcard with a small value. This rule is applied when using useBreakpointValue(). However, useBreakpointValue() does not support null values. Therefore, I added the null type to useBreakpointValue.
