### PR TITLE
Opening Collapse correctly through many clicks

### DIFF
--- a/packages/components/transition/src/collapse.tsx
+++ b/packages/components/transition/src/collapse.tsx
@@ -114,8 +114,6 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
       message: `startingHeight and unmountOnExit are mutually exclusive. You can't use them together`,
     })
 
-    const hasStartingHeight = parseFloat(startingHeight.toString()) > 0
-
     const custom = {
       startingHeight,
       endingHeight,
@@ -123,12 +121,7 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
       transition: !mounted ? { enter: { duration: 0 } } : transition,
       transitionEnd: {
         enter: transitionEnd?.enter,
-        exit: unmountOnExit
-          ? transitionEnd?.exit
-          : {
-              ...transitionEnd?.exit,
-              display: hasStartingHeight ? "block" : "none",
-            },
+        exit: transitionEnd?.exit,
       },
     }
 


### PR DESCRIPTION
## 📝 Description

As @fidalgodev reported in #7775, the Collapse transition does not work when you rapidly click multiple times.
@segunadebayo, why do we set the `display` property to `block` or `none` depending on the `startingHeight`?.
Another solution for this is to set unmountOnExit to true, but it doesn't seem right to me.

## ⛳️ Current behavior (updates)

The exit animation doesn't happen.

## 🚀 New behavior

The exit animation runs smoothly.

## 💣 Is this a breaking change (Yes/No):

Not sure.
