### PR TITLE
fix(avatar): pass referrerPolicy from Avatar to AvatarImage instead of span

### DIFF
--- a/.changeset/late-kangaroos-hope.md
+++ b/.changeset/late-kangaroos-hope.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/avatar": patch
+---
+
+Pass referrerPolicy to AvatarImage instead of keeping it on the parent span

--- a/packages/components/avatar/src/avatar.tsx
+++ b/packages/components/avatar/src/avatar.tsx
@@ -65,6 +65,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
     borderColor,
     ignoreFallback,
     crossOrigin,
+    referrerPolicy,
     ...rest
   } = omitThemingProps(props)
 
@@ -103,6 +104,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
           iconLabel={iconLabel}
           ignoreFallback={ignoreFallback}
           crossOrigin={crossOrigin}
+          referrerPolicy={referrerPolicy}
         />
         {children}
       </AvatarStylesProvider>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7825

## 📝 Description

> Adding referrerPolicy to Avatar puts the referrerPolicy attribute on the surrounding `span`, not the `img` tag, this prevents it from working.

## 🚀 New behavior

> referrerPolicy is passed down to the `AvatarImage` component in `Avatar`.

## 💣 Is this a breaking change (Yes/No): No