### PR TITLE
fix(checkbox): fixing form reset on checkboxes when there are more than one

### DIFF
--- a/.changeset/silent-snails-rhyme.md
+++ b/.changeset/silent-snails-rhyme.md
@@ -2,5 +2,5 @@
 "@chakra-ui/checkbox": patch
 ---
 
-use addEventListener for form resets instead of override the onreset form
+use addEventListener for form resets instead of overriding the onreset form
 function.

--- a/.changeset/silent-snails-rhyme.md
+++ b/.changeset/silent-snails-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/checkbox": patch
+---
+
+use addEventListener for form resets instead of override the onreset form
+function.

--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -123,9 +123,11 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   useSafeLayoutEffect(() => {
     const el = inputRef.current
     if (!el?.form) return
-    el.form.onreset = () => {
+    const formResetListener = () => {
       setCheckedState(!!defaultChecked)
     }
+    el.form.addEventListener("reset", formResetListener)
+    return () => el.form?.removeEventListener("reset", formResetListener)
   }, [])
 
   const trulyDisabled = isDisabled && !isFocusable

--- a/packages/components/checkbox/tests/checkbox.test.tsx
+++ b/packages/components/checkbox/tests/checkbox.test.tsx
@@ -517,34 +517,21 @@ test("Uncontrolled FormControl - calls all onBlur EventHandler", () => {
   expect(checkboxOnBlurMock).toHaveBeenCalled()
 })
 
-test("On resetting form, checkbox should reset to its default state i.e., checked", () => {
-  const { getByRole } = render(
+test("On resetting form, all checkboxes in the form should reset to its default state i.e., checked/unchecked", () => {
+  const { getByRole, getAllByRole } = render(
     <form>
       <label htmlFor="myCheckbox">My Checkbox</label>
       <Checkbox id="myCheckbox" defaultChecked />
+      <label htmlFor="myCheckbox2">My Checkbox2</label>
+      <Checkbox id="myCheckbox2" />
       <button type="reset">Reset</button>
     </form>,
   )
   const resetBtn = getByRole("button")
-  const checkbox = getByRole("checkbox")
-  fireEvent.click(checkbox)
+  const [checkbox1, checkbox2] = getAllByRole("checkbox")
+  fireEvent.click(checkbox1)
+  fireEvent.click(checkbox2)
   fireEvent.click(resetBtn)
-  expect(checkbox).toBeChecked()
-})
-
-test("On resetting form, checkbox should reset to its default state i.e., unchecked", () => {
-  const { getByRole } = render(
-    <form>
-      <label htmlFor="myCheckbox">My Checkbox</label>
-      <Checkbox id="myCheckbox" />
-      <button type="reset" name="resetBtn">
-        Reset
-      </button>
-    </form>,
-  )
-  const resetBtn = getByRole("button")
-  const checkbox = getByRole("checkbox")
-  fireEvent.click(checkbox)
-  fireEvent.click(resetBtn)
-  expect(checkbox).not.toBeChecked()
+  expect(checkbox1).toBeChecked()
+  expect(checkbox2).not.toBeChecked()
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

> If there are multiple checkboxes on a form and you call `form.reset`, only the last one gets reset. This is because we override the onreset instead of adding multiple listeners.

## ⛳️ Current behavior (updates)

> `form.reset` only resets the last checkbox in a form.

## 🚀 New behavior

> `form.reset` will reset all checkboxes to the original state because we are using listeners now.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
