### PR TITLE
revert(theme): revert `getColorVar` to `getColor`

### DIFF
--- a/.changeset/stale-clouds-applaud.md
+++ b/.changeset/stale-clouds-applaud.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Revert `getColorVar` usage to `getColor`

--- a/packages/components/theme/src/components/input.ts
+++ b/packages/components/theme/src/components/input.ts
@@ -3,7 +3,7 @@ import {
   createMultiStyleConfigHelpers,
   defineStyle,
 } from "@chakra-ui/styled-system"
-import { getColorVar, mode } from "@chakra-ui/theme-tools"
+import { getColor, mode } from "@chakra-ui/theme-tools"
 
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
@@ -95,13 +95,13 @@ const variantOutline = definePartsStyle((props) => {
         userSelect: "all",
       },
       _invalid: {
-        borderColor: getColorVar(theme, ec),
-        boxShadow: `0 0 0 1px ${getColorVar(theme, ec)}`,
+        borderColor: getColor(theme, ec),
+        boxShadow: `0 0 0 1px ${getColor(theme, ec)}`,
       },
       _focusVisible: {
         zIndex: 1,
-        borderColor: getColorVar(theme, fc),
-        boxShadow: `0 0 0 1px ${getColorVar(theme, fc)}`,
+        borderColor: getColor(theme, fc),
+        boxShadow: `0 0 0 1px ${getColor(theme, fc)}`,
       },
     },
     addon: {
@@ -129,11 +129,11 @@ const variantFilled = definePartsStyle((props) => {
         userSelect: "all",
       },
       _invalid: {
-        borderColor: getColorVar(theme, ec),
+        borderColor: getColor(theme, ec),
       },
       _focusVisible: {
         bg: "transparent",
-        borderColor: getColorVar(theme, fc),
+        borderColor: getColor(theme, fc),
       },
     },
     addon: {
@@ -160,12 +160,12 @@ const variantFlushed = definePartsStyle((props) => {
         userSelect: "all",
       },
       _invalid: {
-        borderColor: getColorVar(theme, ec),
-        boxShadow: `0px 1px 0px 0px ${getColorVar(theme, ec)}`,
+        borderColor: getColor(theme, ec),
+        boxShadow: `0px 1px 0px 0px ${getColor(theme, ec)}`,
       },
       _focusVisible: {
-        borderColor: getColorVar(theme, fc),
-        boxShadow: `0px 1px 0px 0px ${getColorVar(theme, fc)}`,
+        borderColor: getColor(theme, fc),
+        boxShadow: `0px 1px 0px 0px ${getColor(theme, fc)}`,
       },
     },
     addon: {

--- a/packages/components/theme/src/components/progress.ts
+++ b/packages/components/theme/src/components/progress.ts
@@ -3,7 +3,7 @@ import {
   createMultiStyleConfigHelpers,
   defineStyle,
 } from "@chakra-ui/styled-system"
-import { generateStripe, getColorVar, mode } from "@chakra-ui/theme-tools"
+import { generateStripe, getColor, mode } from "@chakra-ui/theme-tools"
 
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(parts.keys)
@@ -21,7 +21,7 @@ const filledStyle = defineStyle((props) => {
   const gradient = `linear-gradient(
     to right,
     transparent 0%,
-    ${getColorVar(t, bgColor)} 50%,
+    ${getColor(t, bgColor)} 50%,
     transparent 100%
   )`
 


### PR DESCRIPTION
Reverts the usage of `getColorVar` to `getColor`.