### PR TITLE
docs(Popover): add description for `openDelay` and `closeDelay` properties

### DIFF
--- a/.changeset/polite-chicken-pump.md
+++ b/.changeset/polite-chicken-pump.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/popover": patch
+---
+
+Clarify the usage of `openDelay` and `closeDelay` properties of `Popover`
+component

--- a/packages/components/popover/src/use-popover.ts
+++ b/packages/components/popover/src/use-popover.ts
@@ -90,10 +90,16 @@ export interface UsePopoverProps extends Omit<UsePopperProps, "enabled"> {
    */
   trigger?: keyof typeof TRIGGER
   /**
+   * Delay in milliseconds before the popover opens after a trigger event.
+   * Only works when `trigger="hover"`
+   *
    * @default 200
    */
   openDelay?: number
   /**
+   * Delay in milliseconds before the popover closes after a trigger event.
+   * Only works when `trigger="hover"`
+   *
    * @default 200
    */
   closeDelay?: number


### PR DESCRIPTION
## 📝 Description

Clarify the usage of `openDelay` and `closeDelay` properties of `Popover` component.

## ⛳️ Current behavior (updates)

Only default values are specified.

## 🚀 New behavior

Provide simple descriptions about the functionality of the properties and inform the users they only work if trigger mode is `hover`.

## 💣 Is this a breaking change (Yes/No):

No, its primary goal is to prevent future users from misusing the props.

## 📝 Additional Information

N/A
