### PR TITLE
fix(icon-button): changed the definition of padding

### DIFF
--- a/.changeset/fresh-kangaroos-divide.md
+++ b/.changeset/fresh-kangaroos-divide.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/button": patch
+---
+
+fix(icon-button): changed the definition of padding to ensure the responsiveness
+of the size worked

--- a/packages/components/button/src/icon-button.tsx
+++ b/packages/components/button/src/icon-button.tsx
@@ -51,7 +51,7 @@ export const IconButton = forwardRef<IconButtonProps, "button">(
 
     return (
       <Button
-        padding="0"
+        style={{ padding: "0" }}
         borderRadius={isRound ? "full" : undefined}
         ref={ref}
         aria-label={ariaLabel}


### PR DESCRIPTION
Closes [#7627](https://github.com/chakra-ui/chakra-ui/issues/7627)

## 📝 Description

Changed the definition of padding to ensure the responsiveness
of the size worked

## ⛳️ Current behavior (updates)

When using a responsive size value (either array or object syntax) for an IconButton, the button padding is different compared to using the same size value directly

## 🚀 New behavior

Priority was given to padding that had iconbutton passing it with style

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
