### PR TITLE
fix(tabs): https://github.com/chakra-ui/chakra-ui/issues/7846

### DIFF
--- a/.changeset/soft-phones-fail.md
+++ b/.changeset/soft-phones-fail.md
@@ -1,0 +1,10 @@
+---
+"@chakra-ui/tabs": major
+---
+
+Distored UI when device orientation or width is changed - On changing the device
+width and change of device orientation, the tab indicator element which is
+position absolute aligns realtive to the outer container element. Hence, the
+position of immediate parent(tabs) is set to relative in this fix.This makes
+sure, if the orientation changes the tab indicator is aligned relative to its
+parent.

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -63,6 +63,11 @@ export const Tabs = forwardRef<TabsProps, "div">(function Tabs(props, ref) {
 
   const { isFitted: _, ...rootProps } = htmlProps as any
 
+  const tabsStyles: SystemStyleObject = {
+    position: "relative",
+    ...styles.root,
+  }
+
   return (
     <TabsDescendantsProvider value={descendants}>
       <TabsProvider value={context}>
@@ -71,7 +76,7 @@ export const Tabs = forwardRef<TabsProps, "div">(function Tabs(props, ref) {
             className={cx("chakra-tabs", className)}
             ref={ref}
             {...rootProps}
-            __css={styles.root}
+            __css={tabsStyles}
           >
             {children}
           </chakra.div>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7846

## 📝 Description

TabIndicator does not align with Tab when window is resized with center-aligned tabs

## ⛳️ Current behavior (updates)

Distored UI when device orientation or width is changed - On changing the device
width and change of device orientation, the tab indicator element which is
position absolute aligns realtive to the outer container element. 

## 🚀 New behavior

The position of immediate parent(tabs) is set to relative in this fix. This makes
sure, if the orientation changes the tab indicator is aligned relative to its
parent.

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
