### PR TITLE
refactor(system): make chakra styled option interface generic

### DIFF
--- a/packages/core/system/src/factory.ts
+++ b/packages/core/system/src/factory.ts
@@ -5,7 +5,7 @@ import { As, ChakraComponent } from "./system.types"
 type ChakraFactory = {
   <T extends As, P extends object = {}>(
     component: T,
-    options?: ChakraStyledOptions,
+    options?: ChakraStyledOptions<P>,
   ): ChakraComponent<T, P>
 }
 

--- a/packages/core/system/src/system.ts
+++ b/packages/core/system/src/system.ts
@@ -16,12 +16,13 @@ import { DOMElements } from "./system.utils"
 const emotion_styled = ((createStyled as any).default ??
   createStyled) as typeof createStyled
 
-type StyleResolverProps = SystemStyleObject & {
-  __css?: SystemStyleObject
-  sx?: SystemStyleObject
-  theme: any
-  css?: CSSObject
-}
+type StyleResolverProps<P extends object = {}> = P &
+  SystemStyleObject & {
+    __css?: SystemStyleObject
+    sx?: SystemStyleObject
+    theme: any
+    css?: CSSObject
+  }
 
 interface GetStyleObject {
   (options: {
@@ -61,12 +62,12 @@ export const toCSSObject: GetStyleObject =
     return cssProp ? [computedCSS, cssProp] : computedCSS
   }
 
-export interface ChakraStyledOptions extends Dict {
+export interface ChakraStyledOptions<P extends object = {}> extends Dict {
   shouldForwardProp?(prop: string): boolean
   label?: string
   baseStyle?:
     | SystemStyleObject
-    | ((props: StyleResolverProps) => SystemStyleObject)
+    | ((props: StyleResolverProps<P>) => SystemStyleObject)
 }
 
 export function styled<T extends As, P extends object = {}>(

--- a/packages/core/system/tests/as-prop.test.tsx
+++ b/packages/core/system/tests/as-prop.test.tsx
@@ -40,6 +40,33 @@ describe("`as` prop typings", () => {
     expect(true).toBe(true)
   })
 
+  it("should have correct types for the ChakraComponent with custom props", () => {
+    type CustomProps = {
+      ["data-custom-boolean"]: boolean
+    }
+
+    const CustomCompWithRequired = chakra<typeof CompWithRequired, CustomProps>(
+      CompWithRequired,
+      {
+        baseStyle: (props) => ({
+          color: props["data-custom-boolean"] ? "red.500" : "blue.500",
+        }),
+      },
+    )
+
+    const invalidDueToMissingProp = (
+      // @ts-expect-error - Property '["data-custom-boolean"]' is missing
+      <CustomCompWithRequired thisIsARequiredProp />
+    )
+
+    const renderedCustomCompWithRequired = (
+      <CustomCompWithRequired data-custom-boolean thisIsARequiredProp />
+    )
+
+    // make jest happy
+    expect(true).toBe(true)
+  })
+
   it("should have correct types for the ChakraComponent with additional props", () => {
     const AdditionalPropComp: ChakraComponent<
       "div",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR introduces a type enhancement that allows passing the props type to `ChakraStyledOptions` for improved usage with chakra's factory function.

## ⛳️ Current behavior (updates)

Earlier, the ChakraStyledOptions wasn't accepting props type which led to limitations in accessing it using chakra's factory function:

```ts
const MyComponent = chakra<typeof Box, { custom: boolean }>({
  baseStyle: ({ custom }) => ({ ... });
                ^^^^^^ // 'custom' property does not exist in type `StyleResolverProps`
});
```

## 🚀 New behavior

Now, `ChakraStyledOptions` has been adjusted to accept prop types, allowing for direct access with chakra's factory function. This provides improved flexibility and type safety when creating chakra components with custom props.

```ts
const MyComponent = chakra<typeof Box, { custom: boolean }>({
  baseStyle: (props) => ({ opacity: props.custom ? 1 : 0 });
              ^^^^^ //: StyleResolverProps<{ custom: boolean }>
});
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I'm not sure how type tests are handled in this project, so I used `@ts-expect-error` in my test case.
