### PR TITLE
fix: type error in readme

### DIFF
--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -116,7 +116,7 @@ The following values are allowed: **sm, md, lg**
 ```tsx
 const ControlledSelectExample = () => {
   const [value, setValue] = React.useState("")
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setValue(event.target.value)
   }
 


### PR DESCRIPTION
## 📝 Description

> When you use the Select Component, if you type your event param like the readme, an error occurs : 
![image](https://github.com/chakra-ui/chakra-ui/assets/13665765/ee60652f-3d75-4650-90c8-9e56802255a5)
![image](https://github.com/chakra-ui/chakra-ui/assets/13665765/8127d5b2-8f68-45fb-a5b8-205a4ab14c20)

## ⛳️ Current behavior (updates)

> Typescript error in doc

## 🚀 New behavior

> No more error 😄 

## 💣 Is this a breaking change (Yes/No):

> No
