### PR TITLE
fix: Backward comaptability of Button disabled attribute

### DIFF
--- a/.changeset/modern-ties-tickle.md
+++ b/.changeset/modern-ties-tickle.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/button": patch
+---
+
+fix: Backward comaptability of Button disabled attribute

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -46,6 +46,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
     spinnerPlacement = "start",
     className,
     as,
+    disabled,
     ...rest
   } = omitThemingProps(props)
 
@@ -87,7 +88,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       __css={buttonStyles}
       className={cx("chakra-button", className)}
       {...rest}
-      disabled={isDisabled || isLoading}
+      disabled={isDisabled || isLoading || disabled}
     >
       {isLoading && spinnerPlacement === "start" && (
         <ButtonSpinner


### PR DESCRIPTION
Closes #7905, closes #7816, closes #7269

## 📝 Description

`disabled` attribute can't be omitted because that requires BREAKING change

## ⛳️ Current behavior (updates)

All version @chakra-ui/button@>2.0.16 are incompatible with @chakra-ui/button@2.0.15

## 🚀 New behavior

It respects disabled attribute

## 💣 Is this a breaking change (Yes/No):

This is a revert of BREAKING change

## 📝 Additional Information

isDisabled can be a MINOR change but removing disabled prop behavior is a BRAKING change