### PR TITLE
refactor(use-interval): refactoring useInterval hook

### DIFF
--- a/packages/hooks/use-interval/src/index.ts
+++ b/packages/hooks/use-interval/src/index.ts
@@ -7,15 +7,13 @@ import { useCallbackRef } from "@chakra-ui/react-use-callback-ref"
  * @param callback the callback to execute at interval
  * @param delay the `setInterval` delay (in ms)
  */
-export function useInterval(callback: () => void, delay: number | null) {
+export function useInterval(callback: () => void, delay = 0) {
   const fn = useCallbackRef(callback)
 
   useEffect(() => {
-    let intervalId: number | null = null
     const tick = () => fn()
-    if (delay !== null) {
-      intervalId = window.setInterval(tick, delay)
-    }
+    const intervalId = window.setInterval(tick, delay)
+
     return () => {
       if (intervalId) {
         window.clearInterval(intervalId)


### PR DESCRIPTION
## 📝 Description

I've been refactoring the `useInterval` hook.

You can write ₩useInterval₩ more concisely than before by giving the `delay` argument of `useInterval` the default value. 

The actual default value for delay in setInterval is 0.
https://developer.mozilla.org/en-US/docs/Web/API/setInterval

## ⛳️ Current behavior (updates)

There is no change in behavior.

## 🚀 New behavior

There is no change in behavior.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
