### PR TITLE
fix: remove "use client" directive from non-component packages

### DIFF
--- a/.changeset/famous-forks-bathe.md
+++ b/.changeset/famous-forks-bathe.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/theme-tools": patch
+"@chakra-ui/anatomy": patch
+"@chakra-ui/theme": patch
+---
+
+remove "use client" directive

--- a/packages/components/anatomy/package.json
+++ b/packages/components/anatomy/package.json
@@ -39,5 +39,13 @@
   "devDependencies": {
     "clean-package": "2.2.0"
   },
-  "clean-package": "../../../clean-package.config.json"
+  "clean-package": "../../../clean-package.config.json",
+  "tsup": {
+    "format": [
+      "cjs",
+      "esm"
+    ],
+    "target": "es2019",
+    "sourcemap": true
+  }
 }

--- a/packages/components/theme-tools/package.json
+++ b/packages/components/theme-tools/package.json
@@ -50,5 +50,13 @@
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
-  "clean-package": "../../../clean-package.config.json"
+  "clean-package": "../../../clean-package.config.json",
+  "tsup": {
+    "format": [
+      "cjs",
+      "esm"
+    ],
+    "target": "es2019",
+    "sourcemap": true
+  }
 }

--- a/packages/components/theme/package.json
+++ b/packages/components/theme/package.json
@@ -48,5 +48,13 @@
     "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
+  },
+  "tsup": {
+    "format": [
+      "cjs",
+      "esm"
+    ],
+    "target": "es2019",
+    "sourcemap": true
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

This PR removes `"use client"` directive from non-component packages to allow them to be imported from server components.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

The dist of `theme`, `theme-tools` and `anatomy` have `"use client"` directive. This will cause an error when importing them from files other than client components.

For example, think the code below.

```ts
import { tagAnatomy } from '@chakra-ui/anatomy';
import { createMultiStyleConfigHelpers } from '~/components/elements/chakra';

const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(tagAnatomy.keys);

// ...
```

Then the error below is occurred.

```
Error: Cannot access .key on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.
```

## 🚀 New behavior

The dist of those packages don't have `"use client"` directive, so that we can import them from server components.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information
