### PR TITLE
fix(use-steps): fix unbound method error with ESLint

### DIFF
--- a/packages/components/stepper/src/use-steps.ts
+++ b/packages/components/stepper/src/use-steps.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useCallback, useState } from "react"
 
 export type UseStepsProps = {
   index?: number
@@ -15,32 +15,51 @@ export function useSteps(props: UseStepsProps = {}) {
   const maxStep = typeof count === "number" ? count - 1 : 0
   const activeStepPercent = activeStep / maxStep
 
-  return {
-    activeStep,
-    setActiveStep,
-    activeStepPercent,
-    isActiveStep(step: number) {
-      return step === activeStep
-    },
-    isCompleteStep(step: number) {
-      return step < activeStep
-    },
-    isIncompleteStep(step: number) {
-      return step > activeStep
-    },
-    getStatus(step: number): StepStatus {
+  const isActiveStep = useCallback(
+    (step: number) => step === activeStep,
+    [activeStep],
+  )
+
+  const isCompleteStep = useCallback(
+    (step: number) => step < activeStep,
+    [activeStep],
+  )
+
+  const isIncompleteStep = useCallback(
+    (step: number) => step > activeStep,
+    [activeStep],
+  )
+
+  const getStatus = useCallback(
+    (step: number): StepStatus => {
       if (step < activeStep) return "complete"
       if (step > activeStep) return "incomplete"
       return "active"
     },
-    goToNext() {
-      setActiveStep((step) => {
-        return typeof count === "number" ? Math.min(count, step + 1) : step + 1
-      })
-    },
-    goToPrevious() {
-      setActiveStep((step) => Math.max(0, step - 1))
-    },
+    [activeStep],
+  )
+
+  const goToNext = useCallback(() => {
+    setActiveStep((step) => {
+      return typeof count === "number" ? Math.min(count, step + 1) : step + 1
+    })
+  }, [count])
+
+  const goToPrevious = useCallback(
+    () => setActiveStep((step) => Math.max(0, step - 1)),
+    [],
+  )
+
+  return {
+    activeStep,
+    setActiveStep,
+    activeStepPercent,
+    isActiveStep,
+    isCompleteStep,
+    isIncompleteStep,
+    getStatus,
+    goToNext,
+    goToPrevious,
   }
 }
 


### PR DESCRIPTION
## 📝 Description

When using the functions returned by the `useSteps` hook, ESLint (with @typescript-eslint) throw an error about [unbound methods](https://typescript-eslint.io/rules/unbound-method/).

![image](https://github.com/chakra-ui/chakra-ui/assets/27637158/b3142d13-a711-435a-958a-810addf13789)

This PR fixes this by moving the functions definitions outside the returned object of the hook, converting them into arrow functions, and incidentally wrapping them inside a `useCallback`.

<details>
    <summary>.eslintrc.json</summary>

```json
{
  "env": {
    "browser": true,
    "es2021": true,
    "node": true
  },
  "extends": [
    "next",
    "airbnb",
    "airbnb-typescript",
    "plugin:react/recommended",
    "plugin:react/jsx-runtime",
    "plugin:@typescript-eslint/recommended-type-checked",
    "plugin:@typescript-eslint/stylistic-type-checked",
    "plugin:prettier/recommended"
  ],
  "parser": "@typescript-eslint/parser",
  "ignorePatterns": [
    ".next",
    "node_modules",
    ".eslintrc.json",
    "next.config.js"
  ],
  "parserOptions": {
    "ecmaFeatures": {
      "jsx": true
    },
    "project": "./tsconfig.json",
    "ecmaVersion": "latest",
    "sourceType": "module"
  },
  "plugins": [
    "react",
    "@typescript-eslint",
    "prettier"
  ],
  "rules": {
    "react/require-default-props": [
      2,
      {
        "functions": "defaultArguments"
      }
    ]
  }
}
```

</details>

PS: This is my first PR for Chakra-UI, I hope I've made everything fine :smile: 

## 💣 Is this a breaking change (Yes/No):
No
