### PR TITLE
fix: css inconsistence in input field appearence

### DIFF
--- a/packages/components/css-reset/src/css-reset.tsx
+++ b/packages/components/css-reset/src/css-reset.tsx
@@ -178,12 +178,14 @@ export const CSSReset = ({ scope = "" }: CSSResetProps) => (
         -webkit-appearance: none !important;
       }
 
+      ${scope} input[type="search"],   
       ${scope} input[type="number"] {
-        -moz-appearance: textfield;
+        -moz-appearance: none !important;
       }
 
-      ${scope} input[type="search"] {
-        -webkit-appearance: textfield;
+      ${scope} input[type="search"],   
+      ${scope} input[type="number"] {
+        -webkit-appearance: none !important;
         outline-offset: -2px;
       }
 


### PR DESCRIPTION
Closes #7939

## 📝 Description

Search (and number) input didn't have they appearance reset on IOS causing them to not update their border radius until clicked.

## ⛳️ Current behavior (updates)

Appearance not reset, border start IOS-like and on click re-render with the right style

## 🚀 New behavior

Appearance now get reset like every other input field, and the border is right at first render

## 💣 Is this a breaking change (Yes/No):

No