### PR TITLE
feat:(modal): Added "slideInTop" and "slideInLeft" motion preset

### DIFF
--- a/.changeset/nervous-moles-sit.md
+++ b/.changeset/nervous-moles-sit.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/modal": patch
+---
+
+Added "slideInTop" and "slideInLeft" options in motionPreset prop in modal
+component

--- a/packages/components/modal/src/modal-transition.tsx
+++ b/packages/components/modal/src/modal-transition.tsx
@@ -6,7 +6,13 @@ import { forwardRef } from "react"
 export interface ModalTransitionProps
   extends Omit<HTMLMotionProps<"section">, "color" | "transition">,
     ChakraProps {
-  preset?: "slideInBottom" | "slideInRight" | "scale" | "none"
+  preset?:
+    | "slideInBottom"
+    | "slideInRight"
+    | "slideInTop"
+    | "slideInLeft"
+    | "scale"
+    | "none"
   motionProps?: HTMLMotionProps<"section">
 }
 
@@ -18,6 +24,14 @@ const transitions = {
   slideInRight: {
     ...slideFadeConfig,
     custom: { offsetX: 16, reverse: true },
+  },
+  slideInTop: {
+    ...slideFadeConfig,
+    custom: { offsetY: -16, reverse: true },
+  },
+  slideInLeft: {
+    ...slideFadeConfig,
+    custom: { offsetX: -16, reverse: true },
   },
   scale: {
     ...scaleFadeConfig,

--- a/packages/components/modal/src/modal.tsx
+++ b/packages/components/modal/src/modal.tsx
@@ -79,7 +79,13 @@ interface ModalOptions extends Pick<FocusLockProps, "lockFocusAcrossFrames"> {
 
 type ScrollBehavior = "inside" | "outside"
 
-type MotionPreset = "slideInBottom" | "slideInRight" | "scale" | "none"
+type MotionPreset =
+  | "slideInBottom"
+  | "slideInRight"
+  | "slideInTop"
+  | "slideInLeft"
+  | "scale"
+  | "none"
 
 export interface ModalProps
   extends UseModalProps,


### PR DESCRIPTION
## 📝 Description

> Added `slideInTop` and `slideInLeft` options in motionPreset prop in modal component

## ⛳️ Current behavior (updates)

> motionPreset on modal component has only `slideInBottom` and `slideInRight` options


## 🚀 New behavior

> motionPreset on modal component has `slideInBottom`, `slideInRight`,  `slideInTop` and `slideInLeft` options

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
