### PR TITLE
Refactor/Optimize Media Query Module

### DIFF
--- a/packages/components/media-query/src/media-query.utils.ts
+++ b/packages/components/media-query/src/media-query.utils.ts
@@ -30,3 +30,5 @@ export function getClosestValue<T = any>(
 
   return undefined
 }
+
+export const toArray = (item: any) => (Array.isArray(item) ? item : [item])

--- a/packages/components/media-query/src/use-media-query.ts
+++ b/packages/components/media-query/src/use-media-query.ts
@@ -1,5 +1,6 @@
 import { useEnvironment } from "@chakra-ui/react-env"
 import { useEffect, useMemo, useState } from "react"
+import { toArray } from "./media-query.utils"
 
 export type UseMediaQueryOptions = {
   fallback?: boolean | boolean[]
@@ -21,8 +22,6 @@ export function useMediaQuery(
   const { ssr = true, fallback } = options
 
   const { getWindow } = useEnvironment()
-
-  const toArray = (item: any) => (Array.isArray(item) ? item : [item])
 
   const queries = useMemo(() => toArray(query), [query])
 

--- a/packages/components/media-query/src/use-media-query.ts
+++ b/packages/components/media-query/src/use-media-query.ts
@@ -55,7 +55,7 @@ export function useMediaQuery(
 
     const handler = (evt: MediaQueryListEvent) => {
       setValue((prev) => {
-        return prev.slice().map((item) => {
+        return prev.map((item) => {
           if (item.media === evt.media) return { ...item, matches: evt.matches }
           return item
         })

--- a/packages/components/media-query/src/use-media-query.ts
+++ b/packages/components/media-query/src/use-media-query.ts
@@ -1,5 +1,5 @@
 import { useEnvironment } from "@chakra-ui/react-env"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 export type UseMediaQueryOptions = {
   fallback?: boolean | boolean[]
@@ -22,9 +22,12 @@ export function useMediaQuery(
 
   const { getWindow } = useEnvironment()
 
-  const queries = Array.isArray(query) ? query : [query]
+  const toArray = (item: any) => (Array.isArray(item) ? item : [item])
 
-  let fallbackValues = Array.isArray(fallback) ? fallback : [fallback]
+  const queries = useMemo(() => toArray(query), [query])
+
+  let fallbackValues = useMemo(() => toArray(fallback), [fallback])
+
   fallbackValues = fallbackValues.filter((v) => v != null) as boolean[]
 
   const [value, setValue] = useState(() => {
@@ -45,7 +48,7 @@ export function useMediaQuery(
       })),
     )
 
-    const mql = queries.map((query) => win.matchMedia(query))
+    const mediaQueryLists = queries.map((query) => win.matchMedia(query))
 
     const handler = (evt: MediaQueryListEvent) => {
       setValue((prev) => {
@@ -56,16 +59,16 @@ export function useMediaQuery(
       })
     }
 
-    mql.forEach((mql) => {
-      if (typeof mql.addListener === "function") {
-        mql.addListener(handler)
+    mediaQueryLists.forEach((mediaQueryList) => {
+      if (typeof mediaQueryList.addListener === "function") {
+        mediaQueryList.addListener(handler)
       } else {
-        mql.addEventListener("change", handler)
+        mediaQueryList.addEventListener("change", handler)
       }
     })
 
     return () => {
-      mql.forEach((mql) => {
+      mediaQueryLists.forEach((mql) => {
         if (typeof mql.removeListener === "function") {
           mql.removeListener(handler)
         } else {
@@ -73,8 +76,7 @@ export function useMediaQuery(
         }
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getWindow])
+  }, [getWindow, queries])
 
   return value.map((item) => item.matches)
 }

--- a/packages/components/media-query/src/use-media-query.ts
+++ b/packages/components/media-query/src/use-media-query.ts
@@ -71,11 +71,11 @@ export function useMediaQuery(
     })
 
     return () => {
-      mediaQueryLists.forEach((mql) => {
-        if (typeof mql.removeListener === "function") {
-          mql.removeListener(handler)
+      mediaQueryLists.forEach((mediaQueryList) => {
+        if (typeof mediaQueryList.removeListener === "function") {
+          mediaQueryList.removeListener(handler)
         } else {
-          mql.removeEventListener("change", handler)
+          mediaQueryList.removeEventListener("change", handler)
         }
       })
     }

--- a/packages/components/media-query/src/use-media-query.ts
+++ b/packages/components/media-query/src/use-media-query.ts
@@ -28,7 +28,10 @@ export function useMediaQuery(
 
   let fallbackValues = useMemo(() => toArray(fallback), [fallback])
 
-  fallbackValues = fallbackValues.filter((v) => v != null) as boolean[]
+  fallbackValues = useMemo(
+    () => fallbackValues.filter((v) => v != null) as boolean[],
+    [fallbackValues],
+  )
 
   const [value, setValue] = useState(() => {
     return queries.map((query, index) => ({


### PR DESCRIPTION
## 📝 Description

- making use of 'useMemo' in media-query module and passing exhaustive deps to corresponding useEffect hook (where previously linter-ignore statement was needed to pass linter check);
- removing redudant slicing in MediaQueryListEvent handler (line 57 of packages/components/media-query/src/use-media-query.ts)
- using verbose mediaQueryLists (plural) and  mediaQueryList (singular) instead of 'mql' to avoid cases like `mql.forEach(mql => ...)`

