### PR TITLE
fix(toast-landmark-issue): Add toast manager position to aria-label for a11y compliance

### DIFF
--- a/.changeset/twenty-crabs-jump.md
+++ b/.changeset/twenty-crabs-jump.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": patch
+---
+
+Unique aria-labels for toast-manager divs

--- a/packages/components/toast/src/toast.provider.tsx
+++ b/packages/components/toast/src/toast.provider.tsx
@@ -125,7 +125,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
       <div
         role="region"
         aria-live="polite"
-        aria-label="Notifications"
+        aria-label={`Notifications-${position}`}
         key={position}
         id={`chakra-toast-manager-${position}`}
         style={getToastListStyle(position)}


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/8006

## 📝 Description

Chakra toast notification manager divs all have the same aria-label of "Notifications" but they need to have a unique label. The proposed fix appends "-{position}" to the aria-label name.

This PR addresses Issue 8006 [https://github.com/chakra-ui/chakra-ui/issues/8006](https://github.com/chakra-ui/chakra-ui/issues/8006)

Reference:
`If a page includes more than one region landmark, each should have a unique label.` [https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/region.html](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/region.html)

## ⛳️ Current behavior (updates)

> Our accessibility testing tool axe raises an error for the presence of duplicate aria-labels for the toast manager divs

## 🚀 New behavior

> Assign unique names to the toast id managers so that no accessibility errors are raised when scanning with an accessibility tool like axe.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

[https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/region.html](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/region.html)
