### PR TITLE
fix(use-menu): fix incorrect focus behaviors when `autoSelect` is false

### DIFF
--- a/.changeset/tall-paws-film.md
+++ b/.changeset/tall-paws-film.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fix an issue where `Menu` still focuses the menu item when `autoSelect` prop is
+false

--- a/packages/components/menu/src/use-menu.ts
+++ b/packages/components/menu/src/use-menu.ts
@@ -353,16 +353,29 @@ export function useMenuButton(
 ) {
   const menu = useMenuContext()
 
-  const { onToggle, popper, openAndFocusFirstItem, openAndFocusLastItem } = menu
+  const {
+    onToggle,
+    popper,
+    openAndFocusFirstItem,
+    openAndFocusLastItem,
+    openAndFocusMenu,
+    autoSelect,
+  } = menu
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       const eventKey = event.key
-      const keyMap: Record<string, React.KeyboardEventHandler> = {
-        Enter: openAndFocusFirstItem,
-        ArrowDown: openAndFocusFirstItem,
-        ArrowUp: openAndFocusLastItem,
-      }
+      const keyMap: Record<string, React.KeyboardEventHandler> = autoSelect
+        ? {
+            Enter: openAndFocusFirstItem,
+            ArrowDown: openAndFocusFirstItem,
+            ArrowUp: openAndFocusLastItem,
+          }
+        : {
+            Enter: openAndFocusMenu,
+            ArrowDown: openAndFocusMenu,
+            ArrowUp: openAndFocusMenu,
+          }
 
       const action = keyMap[eventKey]
 
@@ -372,7 +385,7 @@ export function useMenuButton(
         action(event)
       }
     },
-    [openAndFocusFirstItem, openAndFocusLastItem],
+    [autoSelect, openAndFocusFirstItem, openAndFocusLastItem, openAndFocusMenu],
   )
 
   return {

--- a/packages/components/menu/tests/menu.test.tsx
+++ b/packages/components/menu/tests/menu.test.tsx
@@ -30,6 +30,14 @@ const words = [
   "Hide Visual Studio Code",
   "Show All",
 ]
+const options = [
+  "Option 1",
+  "Option 2",
+  "Option 3",
+  "Option 4",
+  "Option 5",
+  "Option 6",
+]
 
 test("passes a11y test", async () => {
   await testA11y(
@@ -487,4 +495,222 @@ test("can override menu item type", async () => {
   await waitFor(() => expect(submitOption).toHaveFocus())
 
   expect(submitOption).toHaveAttribute("type", "submit")
+})
+
+test("focuses the first MenuItem after clicking MenuButton", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={true}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  await user.click(button)
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["0", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("focuses the first MenuItem after pressing Enter on MenuButton", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={true}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[Enter]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["0", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("focuses the first MenuItem after pressing Space on MenuButton", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={true}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[Space]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["0", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("focuses the first MenuItem after pressing ArrowDown on MenuButton", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={true}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[ArrowDown]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["0", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("focuses the last MenuItem after pressing ArrowUp on MenuButton", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={true}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[ArrowUp]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["-1", "-1", "-1", "-1", "-1", "0"])
+})
+
+test("does not focus any MenuItem after clicking MenuButton when autoSelect is false", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={false}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  await user.click(button)
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["-1", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("does not focus any MenuItem after pressing Enter on MenuButton when autoSelect is false", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={false}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[Enter]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["-1", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("does not focus any MenuItem after pressing Space on MenuButton when autoSelect is false", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={false}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[Space]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["-1", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("does not focus any MenuItem after pressing ArrowDown on MenuButton when autoSelect is false", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={false}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[ArrowDown]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["-1", "-1", "-1", "-1", "-1", "-1"])
+})
+
+test("does not focus any MenuItem after pressing ArrowUp on MenuButton when autoSelect is false", async () => {
+  const { user, getAllByText } = render(
+    <Menu autoSelect={false}>
+      <MenuButton as={Button}>Open menu</MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem key={option}>{option}</MenuItem>
+        ))}
+      </MenuList>
+    </Menu>,
+  )
+
+  const button = screen.getByRole("button")
+  button.focus()
+  await user.keyboard("[ArrowUp]")
+  expect(button).toHaveAttribute("data-active")
+
+  const menuItems = getAllByText(/Option /)
+  const tabIndexes = menuItems.map((item) => item.getAttribute("tabindex"))
+  expect(tabIndexes).toEqual(["-1", "-1", "-1", "-1", "-1", "-1"])
 })


### PR DESCRIPTION
Closes #7275 

## 📝 Description

This PR fixes an issue where the `Menu` component focuses the menu item even when `autoSelect` prop is
false.

## ⛳️ Current behavior (updates)

| MenuButton    | autoSelect | Behavior                     |
| ------------- | ---------- | ---------------------------- |
| Click         | false      | Open menu only               |
| Enter         | false      | Open menu & focus first item |
| Space         | false      | Open menu only               |
| ArrowDown     | false      | Open menu & focus first item |
| ArrowUp       | false      | Open menu & focus last item  |

## 🚀 New behavior

| MenuButton    | autoSelect | Behavior       |
| ------------- | ---------- | -------------- |
| Click         | false      | Open menu only |
| Enter         | false      | Open menu only |
| Space         | false      | Open menu only |
| ArrowDown     | false      | Open menu only |
| ArrowUp       | false      | Open menu only |

## 💣 Is this a breaking change (Yes/No):

No.
