### PR TITLE
fix(alert): status colors wcag compliant

### DIFF
--- a/.changeset/short-taxis-boil.md
+++ b/.changeset/short-taxis-boil.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/alert": patch
+---
+
+Set the standard color for toasts and alerts to a slightly darker color to make
+i WCAG compatible

--- a/packages/components/theme/src/components/alert.ts
+++ b/packages/components/theme/src/components/alert.ts
@@ -56,7 +56,7 @@ const variantSubtle = definePartsStyle((props) => {
   const bg = getBg(props)
   return {
     container: {
-      [$fg.variable]: `colors.${c}.500`,
+      [$fg.variable]: `colors.${c}.600`,
       [$bg.variable]: bg.light,
       _dark: {
         [$fg.variable]: `colors.${c}.200`,
@@ -71,7 +71,7 @@ const variantLeftAccent = definePartsStyle((props) => {
   const bg = getBg(props)
   return {
     container: {
-      [$fg.variable]: `colors.${c}.500`,
+      [$fg.variable]: `colors.${c}.600`,
       [$bg.variable]: bg.light,
       _dark: {
         [$fg.variable]: `colors.${c}.200`,
@@ -89,7 +89,7 @@ const variantTopAccent = definePartsStyle((props) => {
   const bg = getBg(props)
   return {
     container: {
-      [$fg.variable]: `colors.${c}.500`,
+      [$fg.variable]: `colors.${c}.600`,
       [$bg.variable]: bg.light,
       _dark: {
         [$fg.variable]: `colors.${c}.200`,
@@ -107,7 +107,7 @@ const variantSolid = definePartsStyle((props) => {
   return {
     container: {
       [$fg.variable]: `colors.white`,
-      [$bg.variable]: `colors.${c}.500`,
+      [$bg.variable]: `colors.${c}.600`,
       _dark: {
         [$fg.variable]: `colors.gray.900`,
         [$bg.variable]: `colors.${c}.200`,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #8002 <!-- Github issue # here -->

## 📝 Description
This PR changes the standard colors used for the alert and toast components. Making the background color slightly darker to make it WCAG AA compatible (a contrast ratio of 4.5:1).
> Add a brief description

## ⛳️ Current behavior (updates)
Currently for example the "success" status had a contrast ratio of 3.24:1.
> Please describe the current behavior that you are modifying

## 🚀 New behavior
Now it has contrast ratio of 4.54:1 making it WCAG AA compatible.
> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No.
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
This affects both the alert and toast component.