### PR TITLE
fix(next-js): add isExternal to types

### DIFF
--- a/.changeset/soft-doors-sell.md
+++ b/.changeset/soft-doors-sell.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/next-js": minor
+---
+
+add isExternal to types

--- a/packages/integrations/next-js/src/link.tsx
+++ b/packages/integrations/next-js/src/link.tsx
@@ -2,6 +2,7 @@ import {
   forwardRef,
   chakra,
   HTMLChakraProps,
+  LinkProps as ChakraLinkProps,
   ThemingProps,
   useStyleConfig,
   omitThemingProps,
@@ -18,7 +19,7 @@ type LegacyProps = "as" | "legacyBehavior" | "passHref"
 type LinkComponent = FC<RefAttributes<HTMLAnchorElement> & LinkProps>
 
 export type LinkProps = Merge<
-  HTMLChakraProps<"a"> & ThemingProps<"Link">,
+  HTMLChakraProps<"a"> & ThemingProps<"Link"> & ChakraLinkProps,
   Omit<NextLinkProps, LegacyProps>
 >
 


### PR DESCRIPTION
Closes #8027 

## 📝 Description

In #7677 I added isExternal to NextLink, but I missed adding it to types.

## ⛳️ Current behavior (updates)

TypeScript throws an error when using `isExternal` in `<Link isExternal [...]>`

## 🚀 New behavior

This adds the missing types.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

@trevorblades in https://github.com/chakra-ui/chakra-ui/pull/7677#issuecomment-1599672262 and @fzn0x in https://github.com/chakra-ui/chakra-ui/pull/7677#issuecomment-1680705252 correctly commented this in the original PR https://github.com/chakra-ui/chakra-ui/pull/7677 but it had been already merged.

Also, please be extra kind - this is my first TypeScript types contribution 😱 
