### PR TITLE
fix: missing label key in switch anatomy

### DIFF
--- a/packages/components/anatomy/src/components.ts
+++ b/packages/components/anatomy/src/components.ts
@@ -137,6 +137,7 @@ export const switchAnatomy = anatomy("switch").parts(
   "container",
   "track",
   "thumb",
+  "label"
 )
 
 export const tableAnatomy = anatomy("table").parts(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes [Issue](https://github.com/chakra-ui/chakra-ui/issues/8032)

## 📝 Description

Switch component is using [link](https://github.com/chakra-ui/chakra-ui/blob/6d12ea81f4791f4df2953533b570178f59551b74/packages/components/switch/src/switch.tsx#L103) in codebase, meanwhile, it is not defined in anatomy.

## ⛳️ Current behavior (updates)

Adding new part inside switch anatomy

## 🚀 New behavior



## 💣 Is this a breaking change (Yes/No):



## 📝 Additional Information

current workaround to use label key, is this:
```ts
const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers([
	...switchAnatomy.keys,
	'label',
]);
```


