### PR TITLE
fix: Select element :focus style is missing on Firefox browser

### DIFF
--- a/packages/components/css-reset/src/css-reset.tsx
+++ b/packages/components/css-reset/src/css-reset.tsx
@@ -293,6 +293,12 @@ export const CSSReset = ({ scope = "" }: CSSResetProps) => (
         display: none;
       }
 
+      @-moz-document url-prefix() {
+        ${scope} select:focus {
+          outline: auto;
+        }
+      }
+
       ${vhPolyfill}
     `}
   />

--- a/packages/components/select/stories/select.stories.tsx
+++ b/packages/components/select/stories/select.stories.tsx
@@ -1,6 +1,7 @@
 import { Container, Stack } from "@chakra-ui/layout"
 import * as React from "react"
 import { Select } from "../src"
+import { FormControl, FormLabel } from "@chakra-ui/form-control"
 
 export default {
   title: "Components / Forms / Select",
@@ -130,6 +131,15 @@ export const FocusAndErrorColors = () => (
       placeholder="Here is a sample placeholder"
     />
   </Stack>
+)
+
+export const LabelFocus = () => (
+  <FormControl>
+    <FormLabel>Label</FormLabel>
+    <Select>
+      <option>Option 1</option>
+    </Select>
+  </FormControl>
 )
 
 export const OverrideStyles = () => (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #7990

## 📝 Description

When I click on a label assigned to a Select element, I expected the Select element to have some visual feedback (blue outline, as it happens with Inputs) but nothing happened instead.

## ⛳️ Current behavior (updates)

When using Firefox Browser, clicking on a label of a Select element does not focus on the element.

## 🚀 New behavior

When using Firefox Browser, clicking on a label of a Select element now focuses on the element.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
