### PR TITLE
fix: plop and metadata

### DIFF
--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -27,7 +27,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "examples/nextjs-typescript"
+    "directory": "examples/next-app"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/examples/next-pages/package.json
+++ b/examples/next-pages/package.json
@@ -28,7 +28,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "examples/nextjs-typescript"
+    "directory": "examples/next-pages"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "packages/card"
+    "directory": "packages/components/card"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/components/provider/package.json
+++ b/packages/components/provider/package.json
@@ -29,7 +29,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/chakra-ui/chakra-ui",
-    "directory": "packages/components/react"
+    "directory": "packages/components/provider"
   },
   "keywords": [
     "react",

--- a/packages/components/stepper/package.json
+++ b/packages/components/stepper/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "components/stepper"
+    "directory": "packages/components/stepper"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/core/styled-system/package.json
+++ b/packages/core/styled-system/package.json
@@ -27,7 +27,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "packages/components/styled-system"
+    "directory": "packages/core/styled-system"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -26,7 +26,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "packages/components/system"
+    "directory": "packages/core/system"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/context/package.json
+++ b/packages/hooks/context/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "description": "",
   "keywords": [
-    "react-use-callback-ref"
+    "react-context"
   ],
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "packages/hooks/react-use-callback-ref"
+    "directory": "packages/hooks/context"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-animation-state/package.json
+++ b/packages/hooks/use-animation-state/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-animation-state"
+    "directory": "packages/hooks/use-animation-state"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-callback-ref/package.json
+++ b/packages/hooks/use-callback-ref/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-callback-ref"
+    "directory": "packages/hooks/use-callback-ref"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-controllable-state/package.json
+++ b/packages/hooks/use-controllable-state/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "description": "",
   "keywords": [
-    "react-use-callback-ref"
+    "react-use-controllable-state"
   ],
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-callback-ref"
+    "directory": "packages/hooks/use-controllable-state"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-disclosure/package.json
+++ b/packages/hooks/use-disclosure/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-disclosure"
+    "directory": "packages/hooks/use-disclosure"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-event-listener/package.json
+++ b/packages/hooks/use-event-listener/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-event-listener"
+    "directory": "packages/hooks/use-event-listener"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-focus-effect/package.json
+++ b/packages/hooks/use-focus-effect/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-focus-effect"
+    "directory": "packages/hooks/use-focus-effect"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-focus-on-pointer-down/package.json
+++ b/packages/hooks/use-focus-on-pointer-down/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-focus-on-pointer-down"
+    "directory": "packages/hooks/use-focus-on-pointer-down"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-interval/package.json
+++ b/packages/hooks/use-interval/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-interval"
+    "directory": "packages/hooks/use-interval"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-latest-ref/package.json
+++ b/packages/hooks/use-latest-ref/package.json
@@ -20,7 +20,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-latest-ref"
+    "directory": "packages/hooks/use-latest-ref"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-merge-refs/package.json
+++ b/packages/hooks/use-merge-refs/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-merge-refs"
+    "directory": "packages/hooks/use-merge-refs"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-outside-click/package.json
+++ b/packages/hooks/use-outside-click/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-outside-click"
+    "directory": "packages/hooks/use-outside-click"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-pan-event/package.json
+++ b/packages/hooks/use-pan-event/package.json
@@ -21,7 +21,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-pan-event"
+    "directory": "packages/hooks/use-pan-event"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-previous/package.json
+++ b/packages/hooks/use-previous/package.json
@@ -20,7 +20,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-previous"
+    "directory": "packages/hooks/use-previous"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-safe-layout-effect/package.json
+++ b/packages/hooks/use-safe-layout-effect/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-safe-layout-effect"
+    "directory": "packages/hooks/use-safe-layout-effect"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-size/package.json
+++ b/packages/hooks/use-size/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-size"
+    "directory": "packages/hooks/use-size"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-timeout/package.json
+++ b/packages/hooks/use-timeout/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/react-use-timeout"
+    "directory": "packages/hooks/use-timeout"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/hooks/use-update-effect/package.json
+++ b/packages/hooks/use-update-effect/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "hooks/use-update-effect"
+    "directory": "packages/hooks/use-update-effect"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/integrations/next-js/package.json
+++ b/packages/integrations/next-js/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "integrations/next-js"
+    "directory": "packages/integrations/next-js"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/packages/utilities/event-utils/package.json
+++ b/packages/utilities/event-utils/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.8",
   "description": "",
   "keywords": [
-    "number-utils"
+    "event-utils"
   ],
   "author": "Segun Adebayo <sage@adebayosegun.com>",
   "homepage": "https://github.com/chakra-ui/chakra-ui#readme",
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "packages/utilities/number-utils"
+    "directory": "packages/utilities/event-utils"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"

--- a/plop/component/package.json.hbs
+++ b/plop/component/package.json.hbs
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/chakra-ui.git",
-    "directory": "{{outDir}}/{{componentName}}"
+    "directory": "packages/{{outDir}}/{{componentName}}"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/chakra-ui/issues"


### PR DESCRIPTION
## 📝 Description

Plop package generator was not updated correctly for the new folder structure for the `directory` property in `repository`.

## ⛳️ Current behavior (updates)

Many typos after structure change, incorrectly generated `directory` property.

![bad dir](https://github.com/chakra-ui/chakra-ui/assets/6079265/a9391ec5-1998-43f5-8bda-0a0c8e053387)

## 🚀 New behavior

Typos corrected (also some keywords). Generates package.json with appropriate `directory` property.

![obraz](https://github.com/chakra-ui/chakra-ui/assets/6079265/6ee5f811-7799-4cfd-ae6a-195a4b353fed)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Maybe this is unnecessary