### PR TITLE
fix: add turbo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ draft*
 .yarn
 .vercel
 
+# Turbo
+.turbo
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## 📝 Description

After running `pnpm build:fast` there are 90 generated empty turbo logs named `turbo-build` which are not ignored.
`pnpm build` runs with no problems because files like `turbo-build.log` are ignored (strange behaviour with these names, by the way). 

## ⛳️ Current behavior (updates)
![gitignore bug](https://github.com/chakra-ui/chakra-ui/assets/6079265/a41bdabd-01c6-4ef7-b1ea-284bcc1d2bee)

## 🚀 New behavior

Fixed gitignore

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
