### PR TITLE
fix: theme takes precedence over component properties

### DIFF
--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -177,7 +177,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
       {children && (
         <chakra.span
           className="chakra-checkbox__label"
-          {...getLabelProps()}
+          {...getLabelProps(props, forwardRef)}
           __css={{
             marginStart: spacing,
             ...styles.label,

--- a/packages/components/checkbox/stories/checkbox.stories.tsx
+++ b/packages/components/checkbox/stories/checkbox.stories.tsx
@@ -1,3 +1,5 @@
+import { extendTheme } from "../../../utilities/theme-utils"
+import { ThemeProvider } from "../../../core/system"
 import { FormControl, FormLabel } from "@chakra-ui/form-control"
 import { Icon } from "@chakra-ui/icon"
 import {
@@ -336,5 +338,19 @@ export const WithFormControl = () => {
         </CheckboxGroup>
       </FormControl>
     </>
+  )
+}
+
+export const WithThemeAndProperties = () => {
+  const theme = extendTheme({
+    components: { Checkbox: { sizes: { md: { label: { color: "red" } } } } },
+  })
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Checkbox size="md" color="blue">
+        This text should be blue because properties override themes.
+      </Checkbox>
+    </ThemeProvider>
   )
 }


### PR DESCRIPTION
Fixes the bug reported at
https://github.com/chakra-ui/chakra-ui/discussions/8046

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # https://github.com/chakra-ui/chakra-ui/discussions/8046

## 📝 Description

This PR modifies the checkbox label behaviour taking inline props into account 

## ⛳️ Current behavior (updates)

Theme properties taking precedence over inline ones

## 🚀 New behavior

Inline ones take precedence

## 💣 Is this a breaking change (Yes/No):

It is a bugfix but might break some external apps. 

## 📝 Additional Information

I've added a test using storybook. I got ugly imports. I don't mind removing this file. 
I've also just passed the props to the `getLabelProps` function, not sure of the consecuences of that.
This is my first PR here 😅

Thx for this great project 🙏
