### PR TITLE
CLI support for semantic tokens color scheme

### DIFF
--- a/.changeset/grumpy-badgers-sniff.md
+++ b/.changeset/grumpy-badgers-sniff.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Add CLI flag `--allow-semantic-token-colors-in-color-schemes` to include
+semantic token colors in color schemes type

--- a/tooling/cli/README.md
+++ b/tooling/cli/README.md
@@ -26,6 +26,7 @@ Options:
   --no-format               Disable auto formatting
   --watch [path]            Watch directory for changes and rebuild
   --template <template>     Choose the template to use for the generation (choices: "default", "augmentation", default: "default"
+  --allow-semantic-token-colors-in-color-schemes Include semantic token colors in color schemes types
   -h, --help                display help for command
 
 Example call:

--- a/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
+++ b/tooling/cli/src/command/tokens/create-theme-typings-interface.ts
@@ -46,6 +46,7 @@ export interface CreateThemeTypingsInterfaceOptions {
   format?: boolean
   strictTokenTypes?: boolean
   template?: TypingsTemplate
+  allowSemanticTokenColorsInColorSchemes?: boolean
 }
 
 function applyThemeTypingTemplate(
@@ -83,6 +84,7 @@ export async function createThemeTypingsInterface(
     format = true,
     strictTokenTypes = false,
     template = "default",
+    allowSemanticTokenColorsInColorSchemes = false,
   }: CreateThemeTypingsInterfaceOptions,
 ) {
   const unions = config.reduce(
@@ -115,7 +117,10 @@ export async function createThemeTypingsInterface(
 
   const textStyles = extractPropertyKeys(theme, "textStyles")
   const layerStyles = extractPropertyKeys(theme, "layerStyles")
-  const colorSchemes = extractColorSchemeTypes(theme)
+  const colorSchemes = extractColorSchemeTypes(
+    theme,
+    allowSemanticTokenColorsInColorSchemes,
+  )
   const componentTypes = extractComponentTypes(theme)
 
   const typingContent = `${printUnionMap(

--- a/tooling/cli/src/command/tokens/extract-color-schemes.ts
+++ b/tooling/cli/src/command/tokens/extract-color-schemes.ts
@@ -5,20 +5,36 @@ import { isObject } from "../../utils/is-object"
  * Extract color scheme names
  * by validating that every property of type ColorHue is in the object
  */
-export function extractColorSchemeTypes(theme: Record<string, unknown>) {
-  const { colors } = theme
-  if (!isObject(colors)) {
-    return []
-  }
+export function extractColorSchemeTypes(
+  theme: Record<string, unknown>,
+  allowSemanticTokenColorsInColorSchemes: boolean,
+) {
+  const { colors, semanticTokens } = theme
+  const colorSchemeNames: string[] = []
 
-  return Object.entries(colors).reduce(
-    (acc: string[], [colorName, colorValues]) => {
+  if (isObject(colors)) {
+    Object.entries(colors).reduce((acc: string[], [colorName, colorValues]) => {
       if (isColorHue(colorValues)) {
         acc.push(colorName)
       }
 
       return acc
-    },
-    [],
-  )
+    }, colorSchemeNames)
+  }
+
+  if (allowSemanticTokenColorsInColorSchemes && isObject(semanticTokens)) {
+    const semanticColors = semanticTokens?.colors
+
+    if (isObject(semanticColors)) {
+      Object.entries(semanticColors).reduce((acc: string[], [colorName]) => {
+        if (!colorSchemeNames.includes(colorName)) {
+          acc.push(colorName)
+        }
+
+        return acc
+      }, colorSchemeNames)
+    }
+  }
+
+  return colorSchemeNames
 }

--- a/tooling/cli/src/command/tokens/index.ts
+++ b/tooling/cli/src/command/tokens/index.ts
@@ -17,6 +17,7 @@ export async function generateThemeTypings({
   format,
   strictTokenTypes,
   template,
+  allowSemanticTokenColorsInColorSchemes,
   onError,
 }: {
   theme: Record<string, any>
@@ -25,6 +26,7 @@ export async function generateThemeTypings({
   format?: boolean
   strictTokenTypes?: boolean
   template?: TypingsTemplate
+  allowSemanticTokenColorsInColorSchemes?: boolean
   onError?: () => void
 }) {
   const spinner = ora("Generating Theme Typings").start()
@@ -38,6 +40,7 @@ export async function generateThemeTypings({
       format,
       strictTokenTypes,
       template,
+      allowSemanticTokenColorsInColorSchemes,
     })
 
     const outPath = await resolveOutputPath(out)

--- a/tooling/cli/src/index.ts
+++ b/tooling/cli/src/index.ts
@@ -15,6 +15,7 @@ type OptionsType = {
   watch?: string
   strictTokenTypes?: boolean
   template?: "default" | "augmentation"
+  allowSemanticTokenColorsInColorSchemes?: boolean
 }
 
 export async function run() {
@@ -36,6 +37,10 @@ export async function run() {
       "--strict-token-types",
       "Generate strict types for theme tokens (e.g. color, spacing)",
     )
+    .option(
+      "--allow-semantic-token-colors-in-color-schemes",
+      "Include semantic token colors in color schemes types",
+    )
     .addOption(
       new Option(
         "--template <template>",
@@ -52,6 +57,7 @@ export async function run() {
         strictTokenTypes,
         watch,
         template,
+        allowSemanticTokenColorsInColorSchemes,
       } = options
 
       const read = async () => {
@@ -70,6 +76,7 @@ export async function run() {
           format,
           strictTokenTypes,
           template,
+          allowSemanticTokenColorsInColorSchemes,
         })
 
         if (watch) {

--- a/tooling/cli/test/theme-typings.test.ts
+++ b/tooling/cli/test/theme-typings.test.ts
@@ -519,4 +519,62 @@ describe("Theme typings", () => {
       "
     `)
   })
+
+  it.only("should include semanticToken colors in colorScheme", async () => {
+    const themeInterface = await createThemeTypingsInterface(
+      {
+        semanticTokens: {
+          colors: {
+            primary: {
+              default: { default: "#64FFDA" },
+              strong: { default: "#42A28F" },
+              medium: { default: "#24514D" },
+              weak: { default: "#152A2D" },
+            },
+            secondary: {
+              default: { default: "#00B0FF" },
+              strong: { default: "#0777AA" },
+              medium: { default: "#0D3E55" },
+              weak: { default: "#11303F" },
+            },
+          },
+        },
+      },
+      {
+        config: themeKeyConfiguration,
+        strictTokenTypes: true,
+        allowSemanticTokenColorsInColorSchemes: true,
+      },
+    )
+
+    expect(themeInterface).toMatchInlineSnapshot(`
+      "// regenerate by running
+      // npx @chakra-ui/cli tokens path/to/your/theme.(js|ts)
+      import { BaseThemeTypings } from "./shared.types.js"
+      export interface ThemeTypings extends BaseThemeTypings {
+        blur: never
+        borders: never
+        borderStyles: never
+        borderWidths: never
+        breakpoints: never
+        colors: "primary" | "secondary"
+        colorSchemes: "primary" | "secondary"
+        fonts: never
+        fontSizes: never
+        fontWeights: never
+        layerStyles: never
+        letterSpacings: never
+        lineHeights: never
+        radii: never
+        shadows: never
+        sizes: never
+        space: never
+        textStyles: never
+        transition: never
+        zIndices: never
+        components: {}
+      }
+      "
+    `)
+  })
 })


### PR DESCRIPTION
## 📝 Description

This is an opt-in addition to CLI to support inclusion of semantic tokens as `colorScheme` types.

The problem:
Sometimes semantic-tokes could be a complex objects and Designer can use them for defining some some component states:
```ts
 {
        semanticTokens: {
          colors: {
            primary: {
              default: { default: "#64FFDA" },
              strong: { default: "#42A28F" },
              medium: { default: "#24514D" },
              weak: { default: "#152A2D" },
            },
            secondary: {
              default: { default: "#00B0FF" },
              strong: { default: "#0777AA" },
              medium: { default: "#0D3E55" },
              weak: { default: "#11303F" },
            },
          },
        },
      },
```

And if you want to use those colors in for example Button theme, you can define variant like this
```ts
import { defineStyle, defineStyleConfig } from '@chakra-ui/react';
const commonStyles = defineStyle({
	fontSize: '0.6875rem',
	borderRadius: 'base',
	bg: 'neutral.default',
	color: 'background',
});

const baseStyle = defineStyle(({ colorScheme }) => {
	return {
		bg: `${colorScheme}.weak`,
		color: 'white',
		_hover: {
		   bg: `${colorScheme}.medium`,
		},
		_active: {
		  bg: `${colorScheme}.strong`,
		},
	};
});



export const Badge = defineStyleConfig({
	baseStyle
});
```

And then use Button component like this
```tsx
<Button colorScheme="primary" />
```

## ⛳️ Current behavior (updates)

It's not possible.

## 🚀 New behavior

Explained above

## 💣 Is this a breaking change (Yes/No):

No, because it's an opt-in flag.
