### PR TITLE
fix(Tooltip): don't track scroll parent when `closeOnScroll` not set

### DIFF
--- a/.changeset/shaggy-donkeys-sip.md
+++ b/.changeset/shaggy-donkeys-sip.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tooltip": patch
+---
+
+Don't track tooltip scroll parent when `closeOnScroll` is not set

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -212,6 +212,7 @@ export function useTooltip(props: UseTooltipProps = {}) {
 
   useEventListener(
     () => {
+      if (!closeOnScroll) return null
       const node = ref.current
       if (!node) return null
       const scrollParent = getScrollParent(node)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Caused by https://github.com/chakra-ui/chakra-ui/commit/0bec820bd1ece0c4ba9538394fe2897ff1043c87

## 📝 Description

`getScrollParent` recursively works its way up the DOM calling `window.getComputedStyle` This isn't too bad in a real browser, but is horrible for performance in JSDOM (particularly versions before https://github.com/jsdom/jsdom/pull/3482)

This doubled the execution time of some of our tests, and is generally unnecessary unless we're actually using `closeOnScroll`

## ⛳️ Current behavior (updates)
Tooltips slow performance by recursive search for the scroll parent, even if that is unnecessary

## 🚀 New behavior
Tooltips only slow performance by scroll parent search when required

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
