### PR TITLE
fix(form-control): form-label requiredIndicator type

### DIFF
--- a/packages/components/form-control/src/form-label.tsx
+++ b/packages/components/form-control/src/form-label.tsx
@@ -13,9 +13,9 @@ export interface FormLabelProps
   extends HTMLChakraProps<"label">,
     ThemingProps<"FormLabel"> {
   /**
-   * @type React.ReactElement
+   * @type React.ReactNode
    */
-  requiredIndicator?: React.ReactElement
+  requiredIndicator?: React.ReactNode
   /**
    * @type React.ReactNode
    */


### PR DESCRIPTION


## 📝 Description

Align requiredIndicator type with optionalIndicator type. Allows for overriding requiredIndicator with `null`.

## ⛳️ Current behavior (updates)

FormLabel is not able to overwrite `requiredIndicator` to not be rendered.

## 🚀 New behavior

Aligns the type of requiredIndicator with optionalIndicator. Now requiredIndicator is also a ReactNode and can be overwritten with `null`.

## 💣 Is this a breaking change (Yes/No):

No
