### PR TITLE
feat: add state style prop support for FormControl

### DIFF
--- a/.changeset/honest-tigers-study.md
+++ b/.changeset/honest-tigers-study.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/form-control": minor
+---
+
+Allow theming FormControl through state style props and its children through
+\_group\* style props

--- a/packages/components/form-control/src/form-control.tsx
+++ b/packages/components/form-control/src/form-control.tsx
@@ -168,8 +168,12 @@ function useFormControlProvider(props: FormControlContext) {
       ...htmlProps,
       ref: forwardedRef,
       role: "group",
+      "data-focus": dataAttr(isFocused),
+      "data-disabled": dataAttr(isDisabled),
+      "data-invalid": dataAttr(isInvalid),
+      "data-readonly": dataAttr(isReadOnly),
     }),
-    [htmlProps],
+    [htmlProps, isDisabled, isFocused, isInvalid, isReadOnly],
   )
 
   const getRequiredIndicatorProps = useCallback<PropGetter>(

--- a/packages/components/form-control/tests/form-control.test.tsx
+++ b/packages/components/form-control/tests/form-control.test.tsx
@@ -217,6 +217,12 @@ test("has the correct data attributes", async () => {
 
   fireEvent.focus(screen.getByLabelText(/Name/))
 
+  const control = screen.getByTestId("control")
+  expect(control).toHaveAttribute("data-focus")
+  expect(control).toHaveAttribute("data-disabled")
+  expect(control).toHaveAttribute("data-invalid")
+  expect(control).toHaveAttribute("data-readonly")
+
   const label = screen.getByTestId("label")
   expect(label).toHaveAttribute("data-focus")
   expect(label).toHaveAttribute("data-invalid")


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #8049, #7922

## 📝 Description

> Add a brief description

Allow theming and styling of FormControl and it's child components using `_group*` type [style props](https://chakra-ui.com/docs/styled-system/style-props).

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Only some of the child components, e.g. `FormInput`, can be styled based on the state of the FormControl, while e.g. `FormHelperText` cannot be.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Allow theming and styling of `FormControl` using `_disabled`, `_focus`, `_invalid`, `_readOnly`, and it's child components using `_groupDisabled`, `_groupFocus`, `_groupInvalid`.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No.
The only case I can foresee where some styling would break, is if a project has custom group components using these properties, AND nests them with the `FormControl` component.

## 📝 Additional Information

It seems `_groupReadOnly` is generally not supported.