### PR TITLE
fix(MenuList): fix props order not to overwrite className

### DIFF
--- a/.changeset/flat-chicken-scream.md
+++ b/.changeset/flat-chicken-scream.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Change props order not to overwrite className

--- a/packages/components/menu/src/menu-list.tsx
+++ b/packages/components/menu/src/menu-list.tsx
@@ -68,8 +68,8 @@ export const MenuList = forwardRef<MenuListProps, "div">(function MenuList(
         animate={isOpen ? "enter" : "exit"}
         __css={{ outline: 0, ...styles.list }}
         {...motionProps}
-        className={cx("chakra-menu__menu-list", listProps.className)}
         {...listProps}
+        className={cx("chakra-menu__menu-list", listProps.className)}
         onUpdate={onTransitionEnd}
         onAnimationComplete={callAll(
           animated.onComplete,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In the `MenuList` component, changed the order of props to keep `chakra-menu__menu-list` as className.

## ⛳️ Current behavior (updates)

In the `MenuList` component, `chakra-menu__menu-list` and `listProps.className` are combined and then overwritten with listProps.className. As a result, `chakra-menu__menu-list` may be lost.

```ts
      <MenuTransition
        ...
        className={cx("chakra-menu__menu-list", listProps.className)}
        {...listProps} // overwrite className
        ...
      />
```

## 🚀 New behavior

Changing the order of props prevented `chakra-menu__menu-list` from being lost from the className.

```ts
      <MenuTransition
        ...
        className={cx("chakra-menu__menu-list", listProps.className)}
        {...listProps}
        ...
      />
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Nothing
