### PR TITLE
fix(Heading): using object syntax for fontsize not working in extendTheme (#7807)

### DIFF
--- a/packages/components/layout/stories/heading.stories.tsx
+++ b/packages/components/layout/stories/heading.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import { ChakraProvider, extendTheme } from "../../react/src"
+import { Heading } from "../src"
+
+export default {
+  title: "Components / Typography / Heading",
+}
+
+const theme = extendTheme({
+  components: {
+    Heading: {
+      variants: {
+        customCaps: {
+          textTransform: "uppercase",
+          fontSize: {
+            base: "4xl",
+            lg: "6xl",
+          },
+        },
+      },
+    },
+  },
+})
+
+// see https://github.com/chakra-ui/chakra-ui/issues/2464
+export const withVariant = () => (
+  <ChakraProvider theme={theme}>
+    <Heading variant="customCaps">
+      Heading ipsum dolor sit amet, consectetur adipisicing elit. Amet,
+      sapiente.
+    </Heading>
+  </ChakraProvider>
+)

--- a/packages/components/theme/src/components/heading.ts
+++ b/packages/components/theme/src/components/heading.ts
@@ -7,23 +7,32 @@ const baseStyle = defineStyle({
 
 const sizes = {
   "4xl": defineStyle({
-    fontSize: ["6xl", null, "7xl"],
+    fontSize: {
+      base: "6xl",
+      md: "7xl",
+    },
     lineHeight: 1,
   }),
   "3xl": defineStyle({
-    fontSize: ["5xl", null, "6xl"],
+    fontSize: {
+      base: "5xl",
+      md: "6xl",
+    },
     lineHeight: 1,
   }),
   "2xl": defineStyle({
-    fontSize: ["4xl", null, "5xl"],
+    fontsize: {
+      base: "4xl",
+      md: "5xl",
+    },
     lineHeight: [1.2, null, 1],
   }),
   xl: defineStyle({
-    fontSize: ["3xl", null, "4xl"],
+    fontSize: { base: "3xl", md: "6xl" },
     lineHeight: [1.33, null, 1.2],
   }),
   lg: defineStyle({
-    fontSize: ["2xl", null, "3xl"],
+    fontSize: { base: "2xl", md: "3xl" },
     lineHeight: [1.33, null, 1.2],
   }),
   md: defineStyle({


### PR DESCRIPTION
Closes #7807

## 📝 Description

> Replace array syntax with object syntax for fontSize in heading theme because mergeWith function was used inside useStyleConfigImpl was not merging the array from default Theme and new object from extended Theme.

## ⛳️ Current behavior (updates)

> fontSize: ["3xl", null, "4xl"] and fontSize: {base: "2xl",  xl: "6xl"} was not merging properly resulting fontSize: ['3xl', null, '6xl', base: '4xl', xl: '6xl']

## 🚀 New behavior

> fontSize: {base: "2xl", md: "4xl"} and fontSize: {base: "2xl",  xl: "6xl"} was merge properly resulting fontSize: {base: "2xl", "md": "4xl", xl: "6xl"}

## 💣 Is this a breaking change (Yes/No): No


