### PR TITLE
fix(menu): update menu z-index for defined dropdown theme variable

### DIFF
--- a/.changeset/blue-masks-tell.md
+++ b/.changeset/blue-masks-tell.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Fix hard-coded z-index for Menu in favor of one defined from the theme

--- a/packages/components/theme/src/components/menu.ts
+++ b/packages/components/theme/src/components/menu.ts
@@ -21,7 +21,7 @@ const baseStyleList = defineStyle({
   color: "inherit",
   minW: "3xs",
   py: "2",
-  zIndex: 1,
+  zIndex: "dropdown",
   borderRadius: "md",
   borderWidth: "1px",
   bg: $bg.reference,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Modifies the `Menu` theme properties to use the variable `dropdown` for z-indices, which is defined in the theme here: https://chakra-ui.com/docs/styled-system/theme#z-index-values.

## ⛳️ Current behavior (updates)

The Menu's z-index property is currently hardcoded to "1", which would sometimes cause open menu elements to appear behind other z-indexed elements.

## 🚀 New behavior

Menu's elements inherit the proper z-index value, making it more difficult to accidentally appear behind other UI elements.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information

Tested / verified this update locally in Storybook.

I didn't see an issue filed for this specifically, but it was close enough to [this issue](https://github.com/chakra-ui/chakra-ui/issues/7408). If dedicated issues are preferred, let me know and I can create one.

https://github.com/chakra-ui/chakra-ui/pull/7778