### PR TITLE
fix: Allow 0 as valid child label of form input components - radio, checkbox, switch

### DIFF
--- a/.changeset/angry-lies-study.md
+++ b/.changeset/angry-lies-study.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/react-children-utils": patch
+"@chakra-ui/checkbox": patch
+"@chakra-ui/switch": patch
+"@chakra-ui/radio": patch
+---
+
+Do explicit nullish children check for checkbox, switch, and radio input for
+more consistent labels when child is 0

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -48,6 +48,7 @@
     "@chakra-ui/shared-utils": "workspace:*"
   },
   "devDependencies": {
+    "@chakra-ui/react-children-utils": "workspace:*",
     "@chakra-ui/object-utils": "workspace:*",
     "@chakra-ui/system": "workspace:*",
     "@chakra-ui/layout": "workspace:*",

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -1,4 +1,5 @@
 import { callAll, cx } from "@chakra-ui/shared-utils"
+import { isNullishChildren } from "@chakra-ui/react-children-utils"
 import {
   HTMLChakraProps,
   PropsOf,
@@ -174,7 +175,7 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(function Checkbox(
       >
         {clonedIcon}
       </chakra.span>
-      {children && (
+      {!isNullishChildren(children) && (
         <chakra.span
           className="chakra-checkbox__label"
           {...getLabelProps()}

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -38,6 +38,7 @@
     "@chakra-ui/shared-utils": "workspace:*"
   },
   "devDependencies": {
+    "@chakra-ui/react-children-utils": "workspace:*",
     "@chakra-ui/object-utils": "workspace:*",
     "@chakra-ui/visually-hidden": "workspace:*",
     "@chakra-ui/system": "workspace:*",

--- a/packages/components/radio/src/radio.tsx
+++ b/packages/components/radio/src/radio.tsx
@@ -11,6 +11,8 @@ import {
 } from "@chakra-ui/system"
 import { callAll } from "@chakra-ui/shared-utils"
 import { split } from "@chakra-ui/object-utils"
+import { isNullishChildren } from "@chakra-ui/react-children-utils"
+
 import { useRadioGroupContext } from "./radio-group"
 import { useRadio, UseRadioProps } from "./use-radio"
 
@@ -121,7 +123,7 @@ export const Radio = forwardRef<RadioProps, "input">((props, ref) => {
         {...checkboxProps}
         __css={checkboxStyles}
       />
-      {children && (
+      {!isNullishChildren(children) && (
         <chakra.span
           className="chakra-radio__label"
           {...labelProps}

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -35,6 +35,7 @@
     "@chakra-ui/shared-utils": "workspace:*"
   },
   "devDependencies": {
+    "@chakra-ui/react-children-utils": "workspace:*",
     "@chakra-ui/form-control": "workspace:*",
     "@chakra-ui/layout": "workspace:*",
     "@chakra-ui/system": "workspace:*",

--- a/packages/components/switch/src/switch.tsx
+++ b/packages/components/switch/src/switch.tsx
@@ -10,6 +10,7 @@ import {
   ThemingProps,
   useMultiStyleConfig,
 } from "@chakra-ui/system"
+import { isNullishChildren } from "@chakra-ui/react-children-utils"
 import { useMemo } from "react"
 
 export interface SwitchProps
@@ -96,7 +97,7 @@ export const Switch = forwardRef<SwitchProps, "input">(function Switch(
           {...getIndicatorProps()}
         />
       </chakra.span>
-      {children && (
+      {!isNullishChildren(children) && (
         <chakra.span
           className="chakra-switch__label"
           {...getLabelProps()}

--- a/packages/utilities/react-children-utils/src/index.ts
+++ b/packages/utilities/react-children-utils/src/index.ts
@@ -13,8 +13,7 @@ export function getValidChildren(children: React.ReactNode) {
 }
 
 /**
- * Gets only the valid children of a component,
- * and ignores any nullish or falsy child.
+ * Checks if children is a valid renderable value.
  *
  * @param children the children
  */

--- a/packages/utilities/react-children-utils/src/index.ts
+++ b/packages/utilities/react-children-utils/src/index.ts
@@ -11,3 +11,13 @@ export function getValidChildren(children: React.ReactNode) {
     isValidElement(child),
   ) as React.ReactElement[]
 }
+
+/**
+ * Gets only the valid children of a component,
+ * and ignores any nullish or falsy child.
+ *
+ * @param children the children
+ */
+export function isNullishChildren(children: React.ReactNode) {
+  return children === null || children === undefined || children === ""
+}

--- a/packages/utilities/react-children-utils/src/index.ts
+++ b/packages/utilities/react-children-utils/src/index.ts
@@ -13,7 +13,7 @@ export function getValidChildren(children: React.ReactNode) {
 }
 
 /**
- * Checks if children is an non-renderable value.
+ * Checks if children is a non-renderable value.
  *
  * @param children the children
  */

--- a/packages/utilities/react-children-utils/src/index.ts
+++ b/packages/utilities/react-children-utils/src/index.ts
@@ -13,7 +13,7 @@ export function getValidChildren(children: React.ReactNode) {
 }
 
 /**
- * Checks if children is a valid renderable value.
+ * Checks if children is an non-renderable value.
  *
  * @param children the children
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -762,6 +762,9 @@ importers:
       '@chakra-ui/object-utils':
         specifier: workspace:*
         version: link:../../utilities/object-utils
+      '@chakra-ui/react-children-utils':
+        specifier: workspace:*
+        version: link:../../utilities/react-children-utils
       '@chakra-ui/system':
         specifier: workspace:*
         version: link:../../core/system
@@ -1618,6 +1621,9 @@ importers:
       '@chakra-ui/object-utils':
         specifier: workspace:*
         version: link:../../utilities/object-utils
+      '@chakra-ui/react-children-utils':
+        specifier: workspace:*
+        version: link:../../utilities/react-children-utils
       '@chakra-ui/system':
         specifier: workspace:*
         version: link:../../core/system
@@ -2019,6 +2025,9 @@ importers:
       '@chakra-ui/layout':
         specifier: workspace:*
         version: link:../layout
+      '@chakra-ui/react-children-utils':
+        specifier: workspace:*
+        version: link:../../utilities/react-children-utils
       '@chakra-ui/system':
         specifier: workspace:*
         version: link:../../core/system


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- The conditional render check for `children` is too broad of a falsy check which doesn't allow for the number 0 to be rendered with a label. This disrupts the formatting compared to any other value (or number) passed as the child. 
- This change affects `checkbox`, `radio` and `switch` labels.
- Added new helper function for checking 'nullish' children which are not renderable.

## ⛳️ Current behavior (updates)

- Sandbox demoing current behavior: 
https://codesandbox.io/s/serene-shamir-z8sx54?file=/src/index.js

## 🚀 New behavior

- Renders label for children with the value of 0 without disrupting none label render for nullish children

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
