### PR TITLE
fix: #8131 adds nonce to created emotion style element

### DIFF
--- a/.changeset/lucky-donuts-burn.md
+++ b/.changeset/lucky-donuts-burn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/next-js": patch
+---
+
+adds nonce to added style from emotion cache

--- a/packages/integrations/next-js/src/use-emotion-cache.ts
+++ b/packages/integrations/next-js/src/use-emotion-cache.ts
@@ -18,6 +18,7 @@ export function useEmotionCache(options?: EmotionCacheOptions) {
     createElement("style", {
       key: cache.key,
       "data-emotion": `${cache.key} ${Object.keys(cache.inserted).join(" ")}`,
+      nonce: cache.nonce,
       dangerouslySetInnerHTML: {
         __html: Object.values(cache.inserted).join(" "),
       },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #8131

## 📝 Description

> Adds missing nonce that is passed to `CacheProvider` from package `@chakra-ui/next-js` to the emotion cache style that is created

## ⛳️ Current behavior (updates)

> Sandbox demoing current behavior [codesandbox](https://codesandbox.io/p/devbox/mystifying-shadow-x2qgvs?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clp9xpakk00093b5wt3n8wv6v%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clp9xpakk00033b5wg2q9o3t6%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clp9xpakk00063b5wpg11j7z7%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clp9xpakk00083b5wpceggtfo%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clp9xpakk00033b5wg2q9o3t6%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clp9xpakk00023b5wz9gqxr8k%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%257D%255D%252C%2522id%2522%253A%2522clp9xpakk00033b5wg2q9o3t6%2522%252C%2522activeTabId%2522%253A%2522clp9xpakk00023b5wz9gqxr8k%2522%257D%252C%2522clp9xpakk00083b5wpceggtfo%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clp9xpakk00073b5we0jhmm96%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A3000%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clp9xpakk00083b5wpceggtfo%2522%252C%2522activeTabId%2522%253A%2522clp9xpakk00073b5we0jhmm96%2522%257D%252C%2522clp9xpakk00063b5wpg11j7z7%2522%253A%257B%2522id%2522%253A%2522clp9xpakk00063b5wpg11j7z7%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clp9xpakk00043b5wvavoh3hd%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%257D%252C%257B%2522id%2522%253A%2522clp9xq4bz007j3b5w7e7cj091%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clp9xq4hy005deefm3fj94gke%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clp9xpakk00043b5wvavoh3hd%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

## 🚀 New behavior

> Inserts the nonce to the emotion styled element missing:
<img width="1504" alt="missing-nonce" src="https://github.com/chakra-ui/chakra-ui/assets/1855668/6e0d3755-6556-402c-824f-30da9e12b986">


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
