### PR TITLE
Refactor/8127 adding prop show value in progress bar

### DIFF
--- a/.changeset/green-geckos-accept.md
+++ b/.changeset/green-geckos-accept.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/progress": major
+---
+
+Added a prop called showValue which is of type boolean if true value will be
+displayed inside the progress bar

--- a/packages/components/progress/src/progress.tsx
+++ b/packages/components/progress/src/progress.tsx
@@ -103,6 +103,13 @@ interface ProgressOptions {
    * @default false
    */
   isIndeterminate?: boolean
+  /**
+   * If `true`, the progress will have `value` displayed
+   * prop will be ignored
+   *
+   * @default false
+   */
+  showValue?: boolean
 }
 
 export interface ProgressProps
@@ -136,8 +143,10 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
     "aria-valuetext": ariaValueText,
     title,
     role,
+    showValue,
+    size,
     ...rest
-  } = omitThemingProps(props)
+  } = props
 
   const styles = useMultiStyleConfig("Progress", props)
 
@@ -166,37 +175,45 @@ export const Progress = forwardRef<ProgressProps, "div">((props, ref) => {
       animation: `${progress} 1s ease infinite normal none running`,
     }),
   }
-
   const trackStyles: SystemStyleObject = {
     overflow: "hidden",
     position: "relative",
     ...styles.track,
   }
-
+  const valueStyles: SystemStyleObject = {
+    fontSize: size === "sm" ? "6px" : size === "md" ? "8px" : "10px",
+    fontWeight: "bolder",
+    paddingLeft: "5px",
+  }
   return (
-    <chakra.div
-      ref={ref}
-      borderRadius={borderRadius}
-      __css={trackStyles}
-      {...rest}
-    >
-      <ProgressStylesProvider value={styles}>
-        <ProgressFilledTrack
-          aria-label={ariaLabel}
-          aria-labelledby={ariaLabelledBy}
-          aria-valuetext={ariaValueText}
-          min={min}
-          max={max}
-          value={value}
-          isIndeterminate={isIndeterminate}
-          css={css}
-          borderRadius={borderRadius}
-          title={title}
-          role={role}
-        />
-        {children}
-      </ProgressStylesProvider>
-    </chakra.div>
+    <>
+      <chakra.div
+        ref={ref}
+        borderRadius={borderRadius}
+        __css={trackStyles}
+        style={showValue ? { display: "flex" } : {}}
+        {...rest}
+      >
+        <ProgressStylesProvider value={styles}>
+          <ProgressFilledTrack
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
+            aria-valuetext={ariaValueText}
+            min={min}
+            max={max}
+            value={value}
+            isIndeterminate={isIndeterminate}
+            css={css}
+            borderRadius={borderRadius}
+            title={title}
+            role={role}
+            showValue={showValue}
+          />
+          {children}
+        </ProgressStylesProvider>
+        {showValue ? <chakra.p __css={valueStyles}>{value}</chakra.p> : <></>}
+      </chakra.div>
+    </>
   )
 })
 

--- a/packages/components/progress/src/progress.utils.tsx
+++ b/packages/components/progress/src/progress.utils.tsx
@@ -48,6 +48,7 @@ export interface GetProgressPropsOptions {
   getValueText?(value: number, percent: number): string
   isIndeterminate?: boolean
   role?: React.AriaRole
+  showValue?: boolean
 }
 
 /**

--- a/packages/components/progress/stories/progress.stories.tsx
+++ b/packages/components/progress/stories/progress.stories.tsx
@@ -42,6 +42,16 @@ export const withSizes = () => (
   </div>
 )
 
+export const withValue = () => (
+  <div>
+    <Progress colorScheme="green" size="sm" value={20} showValue />
+    <br />
+    <Progress colorScheme="green" size="md" value={20} showValue />
+    <br />
+    <Progress colorScheme="green" size="lg" value={20} showValue />
+  </div>
+)
+
 export const withAnimation = () => (
   <Progress colorScheme="green" hasStripe isAnimated value={20} />
 )


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Added a ShowValue Prop on the linear progress bar which will render the value inside the progress bar upon request on this issue #8127

## ⛳️ Current behavior (updates)

> There is no ability which displays the value on progress bar currently

## 🚀 New behavior

> Created a prop called `showValue` which can passed in to display the value on progress bar

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
