### PR TITLE
refactor(toast): export toastStore from toast package

### DIFF
--- a/.changeset/old-kids-smile.md
+++ b/.changeset/old-kids-smile.md
@@ -1,5 +1,6 @@
 ---
 "@chakra-ui/toast": minor
+"@chakra-ui/react": minor
 ---
 
 Export toastStore from toast package index

--- a/.changeset/old-kids-smile.md
+++ b/.changeset/old-kids-smile.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/toast": minor
+---
+
+Export toastStore from toast package index

--- a/packages/components/toast/src/index.ts
+++ b/packages/components/toast/src/index.ts
@@ -12,6 +12,7 @@ export type {
   ToastOptions,
   ToastState,
 } from "./toast.types"
+export { toastStore } from "./toast.store"
 export { getToastPlacement } from "./toast.placement"
 export type {
   ToastPosition,


### PR DESCRIPTION
## 📝 Description

Currently there is no way to get `toastStore` singleton instance which may be useful to track toast changes.

## ⛳️ Current behavior (updates)

Not changing any current behaviour.

## 🚀 New behavior

Export `toastStore` from `toast` package index.

## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information
