### PR TITLE
fix(menu): fix click events in shadow dom

### DIFF
--- a/.changeset/hip-spiders-check.md
+++ b/.changeset/hip-spiders-check.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react-use-outside-click": patch
+"@chakra-ui/hooks": patch
+---
+
+Fix outside click detection in shadow doms by using `event.composedPath()`
+instead of `event.target`

--- a/.changeset/small-seals-complain.md
+++ b/.changeset/small-seals-complain.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/menu": patch
+---
+
+Fix menu button click detection in shadow doms by using `event.composedPath()`
+instead of `event.target`

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -56,6 +56,8 @@
     "@chakra-ui/portal": "workspace:*",
     "@chakra-ui/theme": "workspace:*",
     "@chakra-ui/button": "workspace:*",
+    "@emotion/cache": "^11.11.0",
+    "@emotion/react": "^11.11.1",
     "react-icons": "^4.10.1",
     "framer-motion": "^10.16.1",
     "react": "^18.2.0",

--- a/packages/components/menu/src/use-menu.ts
+++ b/packages/components/menu/src/use-menu.ts
@@ -217,7 +217,10 @@ export function useMenu(props: UseMenuProps = {}) {
     enabled: isOpen && closeOnBlur,
     ref: menuRef,
     handler: (event) => {
-      if (!buttonRef.current?.contains(event.target as HTMLElement)) {
+      if (
+        !buttonRef.current ||
+        !event.composedPath().includes(buttonRef.current)
+      ) {
         onClose()
       }
     },

--- a/packages/hooks/use-outside-click/src/index.ts
+++ b/packages/hooks/use-outside-click/src/index.ts
@@ -82,7 +82,7 @@ function isValidEvent(event: Event, ref: React.RefObject<HTMLElement>) {
     if (!doc.contains(target)) return false
   }
 
-  return !ref.current?.contains(target)
+  return !(ref.current && event.composedPath().includes(ref.current))
 }
 
 function getOwnerDocument(node?: Element | null): Document {

--- a/packages/legacy/hooks/src/use-outside-click.ts
+++ b/packages/legacy/hooks/src/use-outside-click.ts
@@ -85,5 +85,5 @@ function isValidEvent(event: Event, ref: React.RefObject<HTMLElement>) {
     if (!doc.contains(target)) return false
   }
 
-  return !ref.current?.contains(target)
+  return !(ref.current && event.composedPath().includes(ref.current))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1252,6 +1252,12 @@ importers:
       '@chakra-ui/theme':
         specifier: workspace:*
         version: link:../theme
+      '@emotion/cache':
+        specifier: ^11.11.0
+        version: 11.11.0
+      '@emotion/react':
+        specifier: ^11.11.1
+        version: 11.11.1(@types/react@18.2.20)(react@18.2.0)
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
@@ -2993,7 +2999,7 @@ packages:
       '@babel/core': 7.22.10
       '@babel/generator': 7.22.5
       '@babel/parser': 7.22.10
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@babel/traverse': 7.22.5
       '@babel/types': 7.22.10
       babel-preset-fbjs: 3.4.0(@babel/core@7.22.10)
@@ -4705,7 +4711,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
-    dev: false
 
   /@babel/standalone@7.22.10:
     resolution: {integrity: sha512-VmK2sWxUTfDDh9mPfCtFJPIehZToteqK+Zpwq8oJUjJ+WeeKIFTTQIrDzH7jEdom+cAaaguU7FI/FBsBWFkIeQ==}
@@ -5946,7 +5951,7 @@ packages:
     resolution: {integrity: sha512-Iniqvn2uREkyf6LC4Ge0NQE9EeVbACqDSFn2Fl4brl4obwcubwWxVyB4fof34r8yG7YuDIPWeyT6iuRocGqp8w==}
     engines: {node: '>=18.0.0', parcel: 2.x}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@parcel/namer-default': 2.8.3(@parcel/core@2.8.3)
       '@parcel/plugin': 2.8.3(@parcel/core@2.8.3)
       gatsby-core-utils: 4.11.0
@@ -6951,7 +6956,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -7984,7 +7989,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.20
       '@types/react-dom': 18.2.7
@@ -8336,7 +8341,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.20)(react@18.2.0)
@@ -8407,7 +8412,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.20)(react@18.2.0)
       '@types/react': 18.2.20
       react: 18.2.0
@@ -8447,7 +8452,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@radix-ui/rect': 1.0.1
       '@types/react': 18.2.20
       react: 18.2.0
@@ -8461,7 +8466,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.20)(react@18.2.0)
       '@types/react': 18.2.20
       react: 18.2.0
@@ -8489,7 +8494,7 @@ packages:
   /@radix-ui/rect@1.0.1:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
 
   /@remix-run/router@1.10.0:
     resolution: {integrity: sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==}
@@ -12362,7 +12367,7 @@ packages:
       gatsby: ^5.0.0-next
     dependencies:
       '@babel/core': 7.22.10
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@babel/types': 7.22.10
       gatsby: 5.11.0(@swc/core@1.3.78)(babel-eslint@10.1.0)(esbuild@0.18.20)(eslint-plugin-testing-library@6.2.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
       gatsby-core-utils: 4.11.0
@@ -12456,7 +12461,7 @@ packages:
       '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.22.10)
       '@babel/preset-env': 7.22.10(@babel/core@7.22.10)
       '@babel/preset-react': 7.22.5(@babel/core@7.22.10)
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       babel-plugin-dynamic-import-node: 2.3.3
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -13634,7 +13639,7 @@ packages:
     resolution: {integrity: sha512-utDq4nb51h5GJeugSe4zDA3oWiXgxBECxa4d/raOvF/Aye6yJ9XBdIuVtvQpgqiKjD5w6wOHRz2SDDXL7siuig==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
 
   /create-react-class@15.7.0:
     resolution: {integrity: sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==}
@@ -14039,7 +14044,7 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -15360,7 +15365,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       aria-query: 5.1.3
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1
@@ -16687,7 +16692,7 @@ packages:
       '@babel/generator': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/preset-typescript': 7.22.5(@babel/core@7.22.10)
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@babel/template': 7.22.5
       '@babel/types': 7.22.10
       '@jridgewell/trace-mapping': 0.3.18
@@ -16731,7 +16736,7 @@ packages:
     resolution: {integrity: sha512-W7pfrKgBchdk19g802IuPkCA2iJ69lRR1GzkfYjB8d1TuIQqf0l1z0lv7e+2kQqO+uQ5Yt3sGMMN2qMYMWfLXg==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       ci-info: 2.0.0
       configstore: 5.0.1
       fastq: 1.15.0
@@ -16765,7 +16770,7 @@ packages:
   /gatsby-legacy-polyfills@3.11.0:
     resolution: {integrity: sha512-3NvNmrmmng28MS4KYAUEd1Vip4B1VJCyeGMof8OfQlMPxZMijHmeasjFDf1l5HSTUsaHotNe7gdLqITTP9CAKQ==}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       core-js-compat: 3.30.2
 
   /gatsby-link@5.11.0(@gatsbyjs/reach-router@2.0.1)(react-dom@18.2.0)(react@18.2.0):
@@ -16787,7 +16792,7 @@ packages:
     resolution: {integrity: sha512-mjVvO02YuG81g5vGDjmHz5P/UhDeqoXDfNKhcYPi6CygRklcpxNLuAMMA5crbBRzqbQZLP3sZHB5NXTDLtqlqg==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       bluebird: 3.7.2
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
@@ -16858,7 +16863,7 @@ packages:
     peerDependencies:
       gatsby: ^5.0.0-next
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@babel/traverse': 7.22.5
       '@sindresorhus/slugify': 1.1.2
       chokidar: 3.5.3
@@ -16923,7 +16928,7 @@ packages:
       '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.22.10)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.22.10)
       '@babel/preset-typescript': 7.22.5(@babel/core@7.22.10)
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       babel-plugin-remove-graphql-queries: 5.11.0(@babel/core@7.22.10)(gatsby@5.11.0)
       gatsby: 5.11.0(@swc/core@1.3.78)(babel-eslint@10.1.0)(esbuild@0.18.20)(eslint-plugin-testing-library@6.2.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
     transitivePeerDependencies:
@@ -16936,7 +16941,7 @@ packages:
       gatsby: ^5.0.0-next
       graphql: ^16.0.0
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       fastq: 1.15.0
       fs-extra: 11.1.1
       gatsby: 5.11.0(@swc/core@1.3.78)(babel-eslint@10.1.0)(esbuild@0.18.20)(eslint-plugin-testing-library@6.2.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)
@@ -16956,7 +16961,7 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@gatsbyjs/reach-router': 2.0.1(react-dom@18.2.0)(react@18.2.0)
       prop-types: 15.8.1
       react: 18.2.0
@@ -17004,7 +17009,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@babel/code-frame': 7.22.10
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@turist/fetch': 7.2.0(node-fetch@2.6.11)
       '@turist/time': 0.0.2
       boxen: 5.1.2
@@ -17045,7 +17050,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@babel/core': 7.22.10
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       fs-extra: 11.1.1
       signal-exit: 3.0.7
     transitivePeerDependencies:
@@ -23843,7 +23848,7 @@ packages:
   /redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
 
   /reflect.getprototypeof@1.0.3:
     resolution: {integrity: sha512-TTAOZpkJ2YLxl7mVHWrNo3iDMEkYlva/kgFcXndqMgbo/AZUmmavEkdXV+hXtE4P8xdyEKRzalaFqZVuwIk/Nw==}
@@ -23953,7 +23958,7 @@ packages:
   /relay-runtime@12.0.0:
     resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
     dependencies:
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       fbjs: 3.0.4
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -26987,7 +26992,7 @@ packages:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.11.0)
       '@babel/core': 7.22.10
       '@babel/preset-env': 7.22.10(@babel/core@7.22.10)
-      '@babel/runtime': 7.22.10
+      '@babel/runtime': 7.23.4
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.22.10)(rollup@2.77.0)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.77.0)
       '@rollup/plugin-replace': 2.4.2(rollup@2.77.0)


### PR DESCRIPTION
Closes #7419

## 📝 Description

`<Menu />` current will not work correctly when used in a shadow DOM.
Clicks on menu items will cause the menu to close (even if `closeOnSelect={false}` is used), as will repeated clicks on on the menu opener button, see linked issue.

## ⛳️ Current behavior (updates)

The current logic inside use-menu (and use-outside-click) relies on `element.contains(event.target)` to detect clicks outside the menu.
This causes problems if the menu is used inside a shadow DOM, since the events in question will no longer refer to the original `target` (e.g. a button) but the entire shadow root (or web component) as a result of the event bubbling up. 
Essentially, too many clicks (even clicks on menu items and on the menu opener button) will be treated as "outside" the menu, causing it to close.

## 🚀 New 

`event.composedPath().includes(element)` is used instead to detect whether an event's original target is inside `element`.

## 💣 Is this a breaking change (Yes/No):

This change should be compatible with all modern browsers (see [canisue](https://caniuse.com/mdn-api_event_composedpath)). I could not find any information about chakra support IE11 or not (i hope it's not required).

## 📝 Additional Information

See also
- https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
- https://lamplightdev.com/blog/2021/04/10/how-to-detect-clicks-outside-of-a-web-component/