### PR TITLE
feature: support anchorRef on PopoverAnchor

### DIFF
--- a/.changeset/witty-files-rescue.md
+++ b/.changeset/witty-files-rescue.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/popover": major
+---
+
+PopoverAnchor can either accept children or anchorRef to position the Popover.
+anchorRef can be an element on a 3rd party library which dispatched a click
+event, and we want to display the popover for that element.

--- a/packages/components/popover/src/popover-anchor.tsx
+++ b/packages/components/popover/src/popover-anchor.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement } from "react"
+import React, {Children, cloneElement, FC, useEffect} from "react"
 import { usePopoverContext } from "./popover-context"
 
 /**
@@ -6,12 +6,38 @@ import { usePopoverContext } from "./popover-context"
  * for the popover.
  */
 
-export function PopoverAnchor(props: React.PropsWithChildren<{}>) {
+type PopoverAnchorWithChildrenProps = React.PropsWithChildren;
+
+type PopoverAnchorRefProps = { anchorRef: React.RefObject<HTMLElement | null> };
+
+type PopoverAnchorProps = PopoverAnchorWithChildrenProps | PopoverAnchorRefProps;
+
+export const PopoverAnchor: FC<PopoverAnchorProps> = (props) => {
+  if ("children" in props) {
+    return <PopoverAnchorWithChildren {...props} />
+  } else if("anchorRef" in props) {
+    return <PopoverRefAnchor {...props} />
+  } else {
+    throw new Error("PopoverAnchor missing anchorRef or children!")
+  }
+}
+
+PopoverAnchor.displayName = "PopoverAnchor"
+
+const PopoverAnchorWithChildren: FC<React.PropsWithChildren> = ({children}) => {
   // enforce a single child
-  const child: any = Children.only(props.children)
+  const child: any = Children.only(children)
   const { getAnchorProps } = usePopoverContext()
 
   return cloneElement(child, getAnchorProps(child.props, child.ref))
 }
 
-PopoverAnchor.displayName = "PopoverAnchor"
+const PopoverRefAnchor: FC<PopoverAnchorRefProps> = (props) => {
+  const { setAnchorRef } = usePopoverContext()
+
+  useEffect(() => {
+    setAnchorRef(props.anchorRef);
+  }, [props.anchorRef, setAnchorRef]);
+
+  return <></>
+}

--- a/packages/components/popover/src/use-popover.ts
+++ b/packages/components/popover/src/use-popover.ts
@@ -10,7 +10,7 @@ import { DOMAttributes, PropGetter } from "@chakra-ui/react-types"
 import { mergeRefs } from "@chakra-ui/react-use-merge-refs"
 import { callAllHandlers } from "@chakra-ui/shared-utils"
 import { lazyDisclosure, LazyMode } from "@chakra-ui/lazy-utils"
-import { useCallback, useEffect, useId, useRef, useState } from "react"
+import { RefObject, useCallback, useEffect, useId, useRef, useState } from "react"
 
 const TRIGGER = {
   click: "click",
@@ -155,7 +155,7 @@ export function usePopover(props: UsePopoverProps = {}) {
 
   const { isOpen, onClose, onOpen, onToggle } = useDisclosure(props)
 
-  const anchorRef = useRef<HTMLElement>(null)
+  const anchorRef = useRef<HTMLElement | null>(null)
   const triggerRef = useRef<HTMLElement>(null)
   const popoverRef = useRef<HTMLElement>(null)
 
@@ -316,6 +316,13 @@ export function usePopover(props: UsePopoverProps = {}) {
     [anchorRef, referenceRef],
   )
 
+  const setAnchorRef = useCallback((ref: RefObject<HTMLElement | null>) => {
+    const node = ref.current;
+    if (node){
+      mergeRefs(anchorRef, referenceRef)(node);
+    }
+  }, [anchorRef, referenceRef]);
+
   const openTimeout = useRef<number>()
   const closeTimeout = useRef<number>()
 
@@ -390,7 +397,7 @@ export function usePopover(props: UsePopoverProps = {}) {
           }
 
           closeTimeout.current = window.setTimeout(() => {
-            if (isHoveringRef.current === false) {
+            if (!isHoveringRef.current) {
               onClose()
             }
           }, closeDelay)
@@ -460,6 +467,7 @@ export function usePopover(props: UsePopoverProps = {}) {
     getTriggerProps,
     getHeaderProps,
     getBodyProps,
+    setAnchorRef
   }
 }
 

--- a/packages/components/popover/stories/popover.stories.tsx
+++ b/packages/components/popover/stories/popover.stories.tsx
@@ -261,7 +261,7 @@ export function WithPopoverAnchor() {
   )
 }
 
-export function WithCustomPopoverAnchor() {
+export function WithPopoverAnchorRef() {
   const [isEditing, setIsEditing] = useBoolean()
   const [color, setColor] = React.useState("red");
 

--- a/packages/components/popover/stories/popover.stories.tsx
+++ b/packages/components/popover/stories/popover.stories.tsx
@@ -16,8 +16,8 @@ import {
   PopoverTrigger,
   usePopover,
 } from "../src"
-import { useRef } from "react";
-import { Box } from "@chakra-ui/layout";
+import { useRef } from "react"
+import { Box } from "@chakra-ui/layout"
 
 export default {
   title: "Components / Overlay / Popover - Click",
@@ -263,39 +263,43 @@ export function WithPopoverAnchor() {
 
 export function WithPopoverAnchorRef() {
   const [isEditing, setIsEditing] = useBoolean()
-  const [color, setColor] = React.useState("red");
+  const [color, setColor] = React.useState("red")
 
   const anchorRef = useRef(null)
 
   return (
-      <>
-        <Box w="200px" h="200px" bg={color} ref={anchorRef}></Box>
-        <Popover
-            isOpen={isEditing}
-            onOpen={setIsEditing.on}
-            onClose={setIsEditing.off}
-            closeOnBlur={false}
-            isLazy
-            lazyBehavior="keepMounted"
-        >
-          <PopoverAnchor anchorRef={anchorRef} />
+    <>
+      <Box w="200px" h="200px" bg={color} ref={anchorRef}></Box>
+      <Popover
+        isOpen={isEditing}
+        onOpen={setIsEditing.on}
+        onClose={setIsEditing.off}
+        closeOnBlur={false}
+        isLazy
+        lazyBehavior="keepMounted"
+      >
+        <PopoverAnchor anchorRef={anchorRef} />
 
-          <PopoverTrigger>
-            <Button colorScheme="pink">{isEditing ? "Save" : "Edit"}</Button>
-          </PopoverTrigger>
+        <PopoverTrigger>
+          <Button colorScheme="pink">{isEditing ? "Save" : "Edit"}</Button>
+        </PopoverTrigger>
 
-          <PopoverContent>
-            <PopoverBody>
-              Colors:
-              <RadioGroup value={color} onChange={(newColor) => setColor(newColor)}>
-                <Radio value="red">red</Radio>
-                <Radio value="blue">blue</Radio>
-                <Radio value="green">green</Radio>
-                <Radio value="purple">purple</Radio>
-              </RadioGroup>
-            </PopoverBody>
-          </PopoverContent>
-        </Popover></>
+        <PopoverContent>
+          <PopoverBody>
+            Colors:
+            <RadioGroup
+              value={color}
+              onChange={(newColor) => setColor(newColor)}
+            >
+              <Radio value="red">red</Radio>
+              <Radio value="blue">blue</Radio>
+              <Radio value="green">green</Radio>
+              <Radio value="purple">purple</Radio>
+            </RadioGroup>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+    </>
   )
 }
 

--- a/packages/components/popover/stories/popover.stories.tsx
+++ b/packages/components/popover/stories/popover.stories.tsx
@@ -16,6 +16,8 @@ import {
   PopoverTrigger,
   usePopover,
 } from "../src"
+import { useRef } from "react";
+import { Box } from "@chakra-ui/layout";
 
 export default {
   title: "Components / Overlay / Popover - Click",
@@ -256,6 +258,44 @@ export function WithPopoverAnchor() {
         </PopoverBody>
       </PopoverContent>
     </Popover>
+  )
+}
+
+export function WithCustomPopoverAnchor() {
+  const [isEditing, setIsEditing] = useBoolean()
+  const [color, setColor] = React.useState("red");
+
+  const anchorRef = useRef(null)
+
+  return (
+      <>
+        <Box w="200px" h="200px" bg={color} ref={anchorRef}></Box>
+        <Popover
+            isOpen={isEditing}
+            onOpen={setIsEditing.on}
+            onClose={setIsEditing.off}
+            closeOnBlur={false}
+            isLazy
+            lazyBehavior="keepMounted"
+        >
+          <PopoverAnchor anchorRef={anchorRef} />
+
+          <PopoverTrigger>
+            <Button colorScheme="pink">{isEditing ? "Save" : "Edit"}</Button>
+          </PopoverTrigger>
+
+          <PopoverContent>
+            <PopoverBody>
+              Colors:
+              <RadioGroup value={color} onChange={(newColor) => setColor(newColor)}>
+                <Radio value="red">red</Radio>
+                <Radio value="blue">blue</Radio>
+                <Radio value="green">green</Radio>
+                <Radio value="purple">purple</Radio>
+              </RadioGroup>
+            </PopoverBody>
+          </PopoverContent>
+        </Popover></>
   )
 }
 


### PR DESCRIPTION
## 📝 Description

> Adds a possibility on PopoverAnchor component to pass `anchorRef`. This ensures us we can reuse the same popover with different anchors on different use cases.

![image](https://github.com/chakra-ui/chakra-ui/assets/50703441/72656a07-c7ce-4dcc-9b9a-36f29122b165)


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying
There are third party libraries whose we cannot wrap inside PopoverAnchor to display a Popover on a click event.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds
PopoverAnchor can either accept `children` or `anchorRef` to position the Popover. `anchorRef` can be an element on a 3rd party library which dispatched a click event and we want to display the popover for that element.

## 💣 Is this a breaking change (Yes/No):
- No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
