### PR TITLE
feat(styled-system): allow users to extend theme with custom pseudos

### DIFF
--- a/.changeset/lucky-clocks-trade.md
+++ b/.changeset/lucky-clocks-trade.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Allow users to provide their custom pseudo selectors

--- a/packages/core/styled-system/src/css.ts
+++ b/packages/core/styled-system/src/css.ts
@@ -144,7 +144,7 @@ export function getCss(options: GetCSSOptions) {
 export const css = (styles: StyleObjectOrFn) => (theme: any) => {
   const cssFn = getCss({
     theme,
-    pseudos: pseudoSelectors,
+    pseudos: { ...pseudoSelectors, ...theme.pseudos },
     configs: systemPropConfigs,
   })
   return cssFn(styles)

--- a/packages/core/styled-system/src/pseudos.ts
+++ b/packages/core/styled-system/src/pseudos.ts
@@ -331,7 +331,9 @@ export const pseudoSelectors = {
   _vertical: "&[data-orientation=vertical]",
 }
 
-export type Pseudos = typeof pseudoSelectors
+export type Pseudos = typeof pseudoSelectors & {
+  [x: `_${string}`]: string
+}
 
 export const pseudoPropNames = Object.keys(
   pseudoSelectors,

--- a/packages/core/styled-system/stories/css.stories.tsx
+++ b/packages/core/styled-system/stories/css.stories.tsx
@@ -1,6 +1,6 @@
 import { Global, ThemeProvider, useTheme } from "@emotion/react"
 import styled from "@emotion/styled"
-import { css, SystemProps, toCSSVar } from "../src"
+import { SystemProps, css, toCSSVar } from "../src"
 
 export default {
   title: "System / Styled System",
@@ -94,5 +94,40 @@ export const peerSelector = () => {
         Test 2
       </Box>
     </div>
+  )
+}
+
+export const CustomPsuedos = () => {
+  const styles: Styles = {
+    card: {
+      _hover: {
+        bg: "green.300",
+      },
+      _closed: {
+        bg: "red.300",
+      },
+      _open: {
+        bg: "blue.300",
+      },
+    },
+  }
+
+  const theme = {
+    ...useTheme(),
+    pseudos: {
+      _open: "&:is([open], [data-state=open])",
+      _closed: "&:is([closed], [data-state=closed])",
+    },
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box css={styles.card} data-state="closed">
+        Closed Box
+      </Box>
+      <Box css={styles.card} data-state="open">
+        Open Box
+      </Box>
+    </ThemeProvider>
   )
 }


### PR DESCRIPTION
This PR allows users to extend the theme with custom conditions for example:

```tsx
// 1. Import `extendTheme`
import { extendTheme } from "@chakra-ui/react"

// 2. Call `extendTheme` and pass your custom values
const theme = extendTheme({
    pseudos: {
      _open: "&:is([open], [data-state=open])",
      _closed: "&:is([closed], [data-state=closed])",
    },
})

// 3. Pass the new theme to `ChakraProvider`
<ChakraProvider theme={theme}>
  <App />
</ChakraProvider>

 // 4. Now you can use these new pseduo selectors in your components
function App() {
  return (
    <>
      <Box css={styles.card} data-state="closed">
        Closed Box
      </Box>
      <Box css={styles.card} data-state="open">
        Open Box
      </Box>
    </>
  )
}
```

@segunadebayo 

I'm not 100% sure how to extend the `PseudoProps` since this `(string | {})` did not really work.

