### PR TITLE
fix(use-outside-click) change mouse to pointer events

### DIFF
--- a/.changeset/rude-bugs-try.md
+++ b/.changeset/rude-bugs-try.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react-use-outside-click": patch
+---
+
+use-outside-click change mouse to pointer events to handle boarder use-cases
+(when mouse event are prevented such as in Reactflow)

--- a/packages/hooks/use-outside-click/src/index.ts
+++ b/packages/hooks/use-outside-click/src/index.ts
@@ -39,7 +39,7 @@ export function useOutsideClick(props: UseOutsideClickProps) {
       }
     }
 
-    const onMouseUp: any = (event: MouseEvent) => {
+    const onPointerUp: any = (event: MouseEvent) => {
       if (state.ignoreEmulatedMouseEvents) {
         state.ignoreEmulatedMouseEvents = false
         return
@@ -60,14 +60,14 @@ export function useOutsideClick(props: UseOutsideClickProps) {
     }
 
     const doc = getOwnerDocument(ref.current)
-    doc.addEventListener("mousedown", onPointerDown, true)
-    doc.addEventListener("mouseup", onMouseUp, true)
+    doc.addEventListener("pointerdown", onPointerDown, true)
+    doc.addEventListener("pointerup", onPointerUp, true)
     doc.addEventListener("touchstart", onPointerDown, true)
     doc.addEventListener("touchend", onTouchEnd, true)
 
     return () => {
-      doc.removeEventListener("mousedown", onPointerDown, true)
-      doc.removeEventListener("mouseup", onMouseUp, true)
+      doc.removeEventListener("pointerdown", onPointerDown, true)
+      doc.removeEventListener("pointerup", onPointerUp, true)
       doc.removeEventListener("touchstart", onPointerDown, true)
       doc.removeEventListener("touchend", onTouchEnd, true)
     }


### PR DESCRIPTION
## 📝 Description

- To make it works with some Graph library (Reactflow) that prevent mouseUp/mouseDown events

## ⛳️ Current behavior (updates)

- When clicking outside, on some cases (on Reactflow Graph for example) when the mouseUp/mouseDown events are prevented, the menu will not close

## 🚀 New behavior

- In every case, the click outside works and the menu it closed properly

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- https://github.com/xyflow/xyflow/issues/2401
- https://github.com/xyflow/xyflow/issues/2341
