### PR TITLE
fix(components) Avatar component doesn't get initials properly when string has leading and trailing spaces

### DIFF
--- a/.changeset/happy-falcons-guess.md
+++ b/.changeset/happy-falcons-guess.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix problem with leading and trailing spaces when getting initials for the
+Avatar component

--- a/packages/components/src/avatar/avatar-name.tsx
+++ b/packages/components/src/avatar/avatar-name.tsx
@@ -3,7 +3,7 @@ import { useAvatarStyles } from "./avatar-context"
 import { AvatarOptions } from "./avatar-types"
 
 export function initials(name: string) {
-  const names = name.split(" ")
+  const names = name.trim().split(" ")
   const firstName = names[0] ?? ""
   const lastName = names.length > 1 ? names[names.length - 1] : ""
   return firstName && lastName

--- a/packages/components/src/avatar/avatar.test.tsx
+++ b/packages/components/src/avatar/avatar.test.tsx
@@ -87,6 +87,24 @@ describe("fallback + loading strategy", () => {
     expect(intials).toBeInTheDocument()
   })
 
+  test("renders a name avatar if name has leading space", () => {
+    const tools = render(<Avatar name=" Dan Abramov" />)
+    const intials = tools.queryByText("DA")
+    expect(intials).toBeInTheDocument()
+  })
+
+  test("renders a name avatar if name has trailing space", () => {
+    const tools = render(<Avatar name="Dan Abramov " />)
+    const intials = tools.queryByText("DA")
+    expect(intials).toBeInTheDocument()
+  })
+
+  test("renders a name avatar if name has leading and trailing space", () => {
+    const tools = render(<Avatar name=" Dan Abramov " />)
+    const intials = tools.queryByText("DA")
+    expect(intials).toBeInTheDocument()
+  })
+
   test("renders a default avatar if no name or src", () => {
     const tools = render(<Avatar />)
     expect(tools.getByRole("img")).toHaveClass("chakra-avatar__svg")


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #8207

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
