### PR TITLE
feat: support custom conditions / psuedo props

### DIFF
--- a/.changeset/pretty-cougars-cough.md
+++ b/.changeset/pretty-cougars-cough.md
@@ -13,14 +13,20 @@ const theme = extendTheme({
   conditions: {
     _closed: "[data-state='closed']", // pseudo prop
   },
-  components: {
-    CustomComponent: {
-      baseStyle: {
-        _closed: {
-          bg: "red.200",
-        },
-      },
-    },
-  },
 })
+```
+
+This allows you to use the pseudo prop in your components
+
+```jsx
+<Box data-state="closed" _closed={{ bg: "red.200" }}>
+  This box is closed
+</Box>
+```
+
+**For TypeScript users**, you need to use the Chakra CLI to generate the types
+for your custom conditions.
+
+```sh
+pnpm chakra-cli tokens src/theme/index.ts
 ```

--- a/.changeset/pretty-cougars-cough.md
+++ b/.changeset/pretty-cougars-cough.md
@@ -1,0 +1,26 @@
+---
+"@chakra-ui/styled-system": minor
+"@chakra-ui/react": minor
+"@chakra-ui/theme": minor
+---
+
+Add support for custom theme conditions or pseudo props via `theme.conditions`
+
+```ts
+// theme.ts
+
+const theme = extendTheme({
+  conditions: {
+    _closed: "[data-state='closed']", // pseudo prop
+  },
+  components: {
+    CustomComponent: {
+      baseStyle: {
+        _closed: {
+          bg: "red.200",
+        },
+      },
+    },
+  },
+})
+```

--- a/.changeset/tasty-scissors-watch.md
+++ b/.changeset/tasty-scissors-watch.md
@@ -1,0 +1,20 @@
+---
+"@chakra-ui/styled-system": minor
+---
+
+Add support for `_open` and `_closed` pseudo props for styling their respective
+selectors.
+
+- `_open`: `&[data-state=open], &[open]`
+- `_closed`: `&[data-state=closed]`
+- `_groupOpen`: `[data-group][data-state=open] &`
+- `_groupClosed`: `[data-group][data-state=closed] &`
+
+Extend the existing pseudo props to support new selectors`
+
+- `_placeholder` now supports `&[data-placeholder]`
+- `_placeholderShow` now supports `&[data-placeholder-shown]`
+- `_fullscreen` now supports `&[data-fullscreen]`
+- `_empty` now supports `&[data-empty]`
+- `_expanded` now supports `&[data-state=expanded]`
+- `_checked` now supports `&[data-state-checked]`

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -18,4 +18,5 @@ export const themeKeyConfiguration: ThemeKeyOptions[] = [
   { key: "space", flatMap: (value) => [value, `-${value}`] },
   { key: "transition" },
   { key: "zIndices" },
+  { key: "conditions", flatMap: (value) => [`_${value}`] },
 ]

--- a/packages/cli/src/create-theme-typings-interface.ts
+++ b/packages/cli/src/create-theme-typings-interface.ts
@@ -123,9 +123,12 @@ export async function createThemeTypingsInterface(
 
   const typingContent = `${printUnionMap(
     { ...unions, textStyles, layerStyles, colorSchemes },
-    strictTokenTypes,
+    (targetKey) => (targetKey === "conditions" ? true : strictTokenTypes),
   )}
+
   ${printComponentTypes(componentTypes, strictComponentTypes)}`
+
   const themeTypings = applyThemeTypingTemplate(typingContent, template)
+
   return format ? formatWithPrettier(themeTypings) : themeTypings
 }

--- a/packages/cli/src/extract-property-paths.ts
+++ b/packages/cli/src/extract-property-paths.ts
@@ -7,13 +7,14 @@ import { printUnionType } from "./utils/print-union-type.js"
  */
 export function printUnionMap(
   unions: Record<string, string[]>,
-  strict = false,
+  strict: boolean | ((targetKey: string) => boolean) = false,
 ) {
   return Object.entries(unions)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(
-      ([targetKey, union]) => `${targetKey}: ${printUnionType(union, strict)};`,
-    )
+    .map(([targetKey, union]) => {
+      const isStrict = typeof strict === "function" ? strict(targetKey) : strict
+      return `${targetKey}: ${printUnionType(union, isStrict)};`
+    })
     .join("\n")
 }
 

--- a/packages/cli/src/generate-theme-typings.test.ts
+++ b/packages/cli/src/generate-theme-typings.test.ts
@@ -7,6 +7,10 @@ const defaultRecord = {
 }
 
 const smallTheme: Record<string, unknown> = {
+  conditions: {
+    open: '[data-state="open"]',
+    closed: '[data-state="closed"]',
+  },
   colors: {
     niceColor: "",
     suchWowColor: "",
@@ -106,6 +110,7 @@ describe("Theme typings", () => {
           | "such.deep.color"
           | (string & {})
         colorSchemes: "onlyColorSchemeColor" | (string & {})
+        conditions: "_open" | "_closed" | (string & {})
         fonts: "sm" | "md" | (string & {})
         fontSizes: "sm" | "md" | (string & {})
         fontWeights: "sm" | "md" | (string & {})
@@ -150,6 +155,7 @@ describe("Theme typings", () => {
         breakpoints: string & {}
         colors: string & {}
         colorSchemes: string & {}
+        conditions: string & {}
         fonts: string & {}
         fontSizes: string & {}
         fontWeights: string & {}
@@ -201,6 +207,7 @@ describe("Theme typings", () => {
           | "such.deep.color"
           | (string & {})
         colorSchemes: "onlyColorSchemeColor" | (string & {})
+        conditions: "_open" | "_closed" | (string & {})
         fonts: "sm" | "md" | (string & {})
         fontSizes: "sm" | "md" | (string & {})
         fontWeights: "sm" | "md" | (string & {})
@@ -243,6 +250,7 @@ describe("Theme typings", () => {
       breakpoints: "sm" | "md" | (string & {});
       colors: "niceColor" | "suchWowColor" | "onlyColorSchemeColor.50" | "onlyColorSchemeColor.100" | "onlyColorSchemeColor.200" | "onlyColorSchemeColor.300" | "onlyColorSchemeColor.400" | "onlyColorSchemeColor.500" | "onlyColorSchemeColor.600" | "onlyColorSchemeColor.700" | "onlyColorSchemeColor.800" | "onlyColorSchemeColor.900" | "such.deep.color" | (string & {});
       colorSchemes: "onlyColorSchemeColor" | (string & {});
+      conditions: "_open" | "_closed" | (string & {});
       fonts: "sm" | "md" | (string & {});
       fontSizes: "sm" | "md" | (string & {});
       fontWeights: "sm" | "md" | (string & {});
@@ -332,6 +340,7 @@ describe("Theme typings", () => {
           | "feedback.error"
           | (string & {})
         colorSchemes: string & {}
+        conditions: string & {}
         fonts: string & {}
         fontSizes: string & {}
         fontWeights: string & {}
@@ -382,6 +391,7 @@ describe("Theme typings", () => {
           | "onlyColorSchemeColor.900"
           | "such.deep.color"
         colorSchemes: "onlyColorSchemeColor"
+        conditions: "_open" | "_closed"
         fonts: "sm" | "md"
         fontSizes: "sm" | "md"
         fontWeights: "sm" | "md"
@@ -438,6 +448,7 @@ describe("Theme typings", () => {
           | "onlyColorSchemeColor.900"
           | "such.deep.color"
         colorSchemes: "onlyColorSchemeColor"
+        conditions: "_open" | "_closed"
         fonts: "sm" | "md"
         fontSizes: "sm" | "md"
         fontWeights: "sm" | "md"
@@ -495,6 +506,7 @@ describe("Theme typings", () => {
             | "such.deep.color"
             | (string & {})
           colorSchemes: "onlyColorSchemeColor" | (string & {})
+          conditions: "_open" | "_closed" | (string & {})
           fonts: "sm" | "md" | (string & {})
           fontSizes: "sm" | "md" | (string & {})
           fontWeights: "sm" | "md" | (string & {})

--- a/packages/cli/src/generate-theme-typings.test.ts
+++ b/packages/cli/src/generate-theme-typings.test.ts
@@ -110,7 +110,7 @@ describe("Theme typings", () => {
           | "such.deep.color"
           | (string & {})
         colorSchemes: "onlyColorSchemeColor" | (string & {})
-        conditions: "_open" | "_closed" | (string & {})
+        conditions: "_open" | "_closed"
         fonts: "sm" | "md" | (string & {})
         fontSizes: "sm" | "md" | (string & {})
         fontWeights: "sm" | "md" | (string & {})
@@ -124,6 +124,7 @@ describe("Theme typings", () => {
         textStyles: "small" | "large" | (string & {})
         transition: "sm" | "md" | (string & {})
         zIndices: "sm" | "md" | (string & {})
+
         components: {
           Button: {
             sizes: "sm" | (string & {})
@@ -155,7 +156,7 @@ describe("Theme typings", () => {
         breakpoints: string & {}
         colors: string & {}
         colorSchemes: string & {}
-        conditions: string & {}
+        conditions: never
         fonts: string & {}
         fontSizes: string & {}
         fontWeights: string & {}
@@ -169,6 +170,7 @@ describe("Theme typings", () => {
         textStyles: string & {}
         transition: string & {}
         zIndices: string & {}
+
         components: {}
       }
       "
@@ -207,7 +209,7 @@ describe("Theme typings", () => {
           | "such.deep.color"
           | (string & {})
         colorSchemes: "onlyColorSchemeColor" | (string & {})
-        conditions: "_open" | "_closed" | (string & {})
+        conditions: "_open" | "_closed"
         fonts: "sm" | "md" | (string & {})
         fontSizes: "sm" | "md" | (string & {})
         fontWeights: "sm" | "md" | (string & {})
@@ -221,6 +223,7 @@ describe("Theme typings", () => {
         textStyles: "small" | "large" | (string & {})
         transition: "sm" | "md" | (string & {})
         zIndices: "sm" | "md" | (string & {})
+
         components: {
           Button: {
             sizes: "sm"
@@ -250,7 +253,7 @@ describe("Theme typings", () => {
       breakpoints: "sm" | "md" | (string & {});
       colors: "niceColor" | "suchWowColor" | "onlyColorSchemeColor.50" | "onlyColorSchemeColor.100" | "onlyColorSchemeColor.200" | "onlyColorSchemeColor.300" | "onlyColorSchemeColor.400" | "onlyColorSchemeColor.500" | "onlyColorSchemeColor.600" | "onlyColorSchemeColor.700" | "onlyColorSchemeColor.800" | "onlyColorSchemeColor.900" | "such.deep.color" | (string & {});
       colorSchemes: "onlyColorSchemeColor" | (string & {});
-      conditions: "_open" | "_closed" | (string & {});
+      conditions: "_open" | "_closed";
       fonts: "sm" | "md" | (string & {});
       fontSizes: "sm" | "md" | (string & {});
       fontWeights: "sm" | "md" | (string & {});
@@ -264,6 +267,7 @@ describe("Theme typings", () => {
       textStyles: "small" | "large" | (string & {});
       transition: "sm" | "md" | (string & {});
       zIndices: "sm" | "md" | (string & {});
+
         components: {
         Button: {
         sizes: "sm" | (string & {});
@@ -340,7 +344,7 @@ describe("Theme typings", () => {
           | "feedback.error"
           | (string & {})
         colorSchemes: string & {}
-        conditions: string & {}
+        conditions: never
         fonts: string & {}
         fontSizes: string & {}
         fontWeights: string & {}
@@ -354,6 +358,7 @@ describe("Theme typings", () => {
         textStyles: string & {}
         transition: string & {}
         zIndices: string & {}
+
         components: {}
       }
       "
@@ -405,6 +410,7 @@ describe("Theme typings", () => {
         textStyles: "small" | "large"
         transition: "sm" | "md"
         zIndices: "sm" | "md"
+
         components: {
           Button: {
             sizes: "sm" | (string & {})
@@ -462,6 +468,7 @@ describe("Theme typings", () => {
         textStyles: "small" | "large"
         transition: "sm" | "md"
         zIndices: "sm" | "md"
+
         components: {
           Button: {
             sizes: "sm"
@@ -506,7 +513,7 @@ describe("Theme typings", () => {
             | "such.deep.color"
             | (string & {})
           colorSchemes: "onlyColorSchemeColor" | (string & {})
-          conditions: "_open" | "_closed" | (string & {})
+          conditions: "_open" | "_closed"
           fonts: "sm" | "md" | (string & {})
           fontSizes: "sm" | "md" | (string & {})
           fontWeights: "sm" | "md" | (string & {})
@@ -520,6 +527,7 @@ describe("Theme typings", () => {
           textStyles: "small" | "large" | (string & {})
           transition: "sm" | "md" | (string & {})
           zIndices: "sm" | "md" | (string & {})
+
           components: {
             Button: {
               sizes: "sm" | (string & {})

--- a/packages/components/src/system/should-forward-prop.test.ts
+++ b/packages/components/src/system/should-forward-prop.test.ts
@@ -1,5 +1,7 @@
-import { propNames } from "@chakra-ui/styled-system"
+import { getPropNames } from "@chakra-ui/styled-system"
 import { shouldForwardProp } from "./should-forward-prop"
+
+const propNames = getPropNames({})
 
 describe("does not forward styled-system props", () => {
   test.each(propNames)("%s", (propName) => {

--- a/packages/components/src/system/should-forward-prop.ts
+++ b/packages/components/src/system/should-forward-prop.ts
@@ -1,11 +1,11 @@
-import { propNames } from "@chakra-ui/styled-system"
+import { getPropNames } from "@chakra-ui/styled-system"
 
 /**
  * List of props for emotion to omit from DOM.
  * It mostly consists of Chakra props
  */
 const allPropNames = new Set([
-  ...propNames,
+  ...getPropNames({}),
   "textStyle",
   "layerStyle",
   "apply",

--- a/packages/components/src/system/should-forward-prop.ts
+++ b/packages/components/src/system/should-forward-prop.ts
@@ -32,5 +32,7 @@ const validHTMLProps = new Set([
 ])
 
 export function shouldForwardProp(prop: string): boolean {
-  return validHTMLProps.has(prop) || !allPropNames.has(prop)
+  return (
+    (validHTMLProps.has(prop) || !allPropNames.has(prop)) && prop[0] !== "_"
+  )
 }

--- a/packages/components/src/system/system.ts
+++ b/packages/components/src/system/system.ts
@@ -1,6 +1,6 @@
 import {
   css,
-  isStyleProp,
+  isStylePropFn,
   StyleProps,
   SystemStyleObject,
 } from "@chakra-ui/styled-system"
@@ -50,8 +50,10 @@ interface GetStyleObject {
 export const toCSSObject: GetStyleObject =
   ({ baseStyle }) =>
   (props) => {
-    const { theme, css: cssProp, __css, sx, ...rest } = props
-    const [styleProps] = splitProps(rest, isStyleProp)
+    const { theme, css: cssProp, __css, sx, ...restProps } = props
+    const isStyleProp = isStylePropFn(theme)
+    const [styleProps] = splitProps(restProps, isStyleProp)
+
     const finalBaseStyle = runIfFn(baseStyle, props)
     const finalStyles = assignAfter(
       {},

--- a/packages/styled-system/src/create-theme-vars/flatten-tokens.ts
+++ b/packages/styled-system/src/create-theme-vars/flatten-tokens.ts
@@ -1,6 +1,7 @@
 import { walkObject } from "@chakra-ui/utils/walk-object"
-import { pseudoPropNames } from "../pseudos"
+import { getPseudoPropNames } from "../pseudos"
 import { Union } from "../utils"
+import { extractSemanticTokens, extractTokens } from "./theme-tokens"
 
 export type SemanticValue<
   Conditions extends string,
@@ -26,13 +27,14 @@ export type FlattenTokensParam = {
   semanticTokens?: object
 }
 
-const isSemanticCondition = (key: string) =>
-  pseudoPropNames.includes(key as any) || "default" === key
+export function flattenTokens(theme: Record<string, any>) {
+  const tokens = extractTokens(theme)
+  const semanticTokens = extractSemanticTokens(theme)
 
-export function flattenTokens<T extends FlattenTokensParam>({
-  tokens,
-  semanticTokens,
-}: T) {
+  const pseudoPropNames = getPseudoPropNames(theme)
+  const isSemanticCondition = (key: string) =>
+    pseudoPropNames.includes(key) || "default" === key
+
   const result: FlatTokens = {}
 
   walkObject(tokens, (value, path) => {

--- a/packages/styled-system/src/create-theme-vars/to-css-var.ts
+++ b/packages/styled-system/src/create-theme-vars/to-css-var.ts
@@ -1,8 +1,7 @@
 import { analyzeBreakpoints } from "@chakra-ui/utils/breakpoint"
 import type { WithCSSVar } from "../utils"
 import { createThemeVars } from "./create-theme-vars"
-import { flattenTokens } from "./flatten-tokens"
-import { extractSemanticTokens, extractTokens, omitVars } from "./theme-tokens"
+import { omitVars } from "./theme-tokens"
 
 export function toCSSVar<T extends Record<string, any>>(rawTheme: T) {
   /**
@@ -10,13 +9,6 @@ export function toCSSVar<T extends Record<string, any>>(rawTheme: T) {
    * we can omit the computed css vars and recompute it for the extended theme.
    */
   const theme = omitVars(rawTheme)
-
-  // omit components and breakpoints from css variable map
-  const tokens = extractTokens(theme)
-  const semanticTokens = extractSemanticTokens(theme)
-  const flatTokens = flattenTokens({ tokens, semanticTokens })
-
-  const cssVarPrefix = theme.config?.cssVarPrefix
 
   const {
     /**
@@ -29,7 +21,7 @@ export function toCSSVar<T extends Record<string, any>>(rawTheme: T) {
      * the emotion's <Global/> component to attach variables to `:root`
      */
     cssVars,
-  } = createThemeVars(flatTokens, { cssVarPrefix })
+  } = createThemeVars(theme)
 
   const defaultCssVars: Record<string, any> = {
     "--chakra-ring-inset": "var(--chakra-empty,/*!*/ /*!*/)",

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -2,7 +2,7 @@ import { isObject } from "@chakra-ui/utils/is"
 import { mergeWith } from "@chakra-ui/utils/merge"
 import { runIfFn } from "@chakra-ui/utils/run-if-fn"
 import * as CSS from "csstype"
-import { pseudoSelectors } from "./pseudos"
+import { getPseudoSelectors } from "./pseudos"
 import { systemProps as systemPropConfigs } from "./system"
 import { StyleObjectOrFn } from "./system.types"
 import { expandResponsive } from "./utils/expand-responsive"
@@ -145,7 +145,7 @@ export function getCss(options: GetCSSOptions) {
 export const css = (styles: StyleObjectOrFn) => (theme: any) => {
   const cssFn = getCss({
     theme,
-    pseudos: pseudoSelectors,
+    pseudos: getPseudoSelectors(theme),
     configs: systemPropConfigs,
   })
   return cssFn(styles)

--- a/packages/styled-system/src/pseudos.ts
+++ b/packages/styled-system/src/pseudos.ts
@@ -3,6 +3,10 @@ import { ThemeTypings } from "./theming.types"
 type AnyFunction<T = any> = (...args: T[]) => any
 
 const state = {
+  open: (str: string, post: string) =>
+    `${str}[data-open], ${str}[open], ${str}[data-state=open] ${post}`,
+  closed: (str: string, post: string) =>
+    `${str}[data-closed], ${str}[data-state=closed] ${post}`,
   hover: (str: string, post: string) =>
     `${str}:hover ${post}, ${str}[data-hover] ${post}`,
   focus: (str: string, post: string) =>
@@ -58,7 +62,7 @@ const pseudoSelectors = {
    * Styles to apply when a child of this element has received focus
    * - CSS Selector `&:focus-within`
    */
-  _focusWithin: "&:focus-within",
+  _focusWithin: "&:focus-within, &[data-focus-within]",
   /**
    * Styles to apply when this element has received focus via tabbing
    * - CSS Selector `&:focus-visible`
@@ -99,17 +103,17 @@ const pseudoSelectors = {
   /**
    * Styles for CSS selector `&:empty`
    */
-  _empty: "&:empty",
+  _empty: "&:empty, &[data-empty]",
   /**
    * Styles to apply when the ARIA attribute `aria-expanded` is `true`
    * - CSS selector `&[aria-expanded=true]`
    */
-  _expanded: "&[aria-expanded=true], &[data-expanded]",
+  _expanded: "&[aria-expanded=true], &[data-expanded], &[data-state=expanded]",
   /**
    * Styles to apply when the ARIA attribute `aria-checked` is `true`
    * - CSS selector `&[aria-checked=true]`
    */
-  _checked: "&[aria-checked=true], &[data-checked]",
+  _checked: "&[aria-checked=true], &[data-checked], &[data-state=checked]",
   /**
    * Styles to apply when the ARIA attribute `aria-grabbed` is `true`
    * - CSS selector `&[aria-grabbed=true]`
@@ -202,7 +206,15 @@ const pseudoSelectors = {
    * - CSS selector `&[aria-checked=mixed]`
    */
   _indeterminate:
-    "&:indeterminate, &[aria-checked=mixed], &[data-indeterminate]",
+    "&:indeterminate, &[aria-checked=mixed], &[data-indeterminate], &[data-state=indeterminate]",
+  /**
+   * Styles to apply when a parent element with `.group`, `data-group` or `role=group` is open
+   */
+  _groupOpen: toGroup(state.open),
+  /**
+   * Styles to apply when a parent element with `.group`, `data-group` or `role=group` is closed
+   */
+  _groupClosed: toGroup(state.closed),
   /**
    * Styles to apply when a parent element with `.group`, `data-group` or `role=group` is hovered
    */
@@ -274,15 +286,15 @@ const pseudoSelectors = {
   /**
    * Styles for CSS Selector `&::placeholder`.
    */
-  _placeholder: "&::placeholder",
+  _placeholder: "&::placeholder, &[data-placeholder]",
   /**
    * Styles for CSS Selector `&:placeholder-shown`.
    */
-  _placeholderShown: "&:placeholder-shown",
+  _placeholderShown: "&:placeholder-shown, &[data-placeholder-shown]",
   /**
    * Styles for CSS Selector `&:fullscreen`.
    */
-  _fullScreen: "&:fullscreen",
+  _fullScreen: "&:fullscreen, &[data-fullscreen]",
   /**
    * Styles for CSS Selector `&::selection`
    */
@@ -331,6 +343,14 @@ const pseudoSelectors = {
    * Styles for the CSS Selector `&[data-orientation=vertical]`
    */
   _vertical: "&[data-orientation=vertical]",
+  /**
+   * Styles for the CSS Selector `&[data-open], &[open], &[data-state=open]`
+   */
+  _open: "&[data-open], &[open], &[data-state=open]",
+  /**
+   * Styles for the CSS Selector `&[data-closed], &[data-state=closed]`
+   */
+  _closed: "&[data-closed], &[data-state=closed]",
 }
 
 export type Pseudos = typeof pseudoSelectors &

--- a/packages/styled-system/src/pseudos.ts
+++ b/packages/styled-system/src/pseudos.ts
@@ -333,20 +333,19 @@ const pseudoSelectors = {
   _vertical: "&[data-orientation=vertical]",
 }
 
-export type Pseudos = typeof pseudoSelectors & keyof ThemeTypings["conditions"]
-export type PseudoKey = RemoveStringNumber<keyof Pseudos>
+export type Pseudos = typeof pseudoSelectors &
+  Record<ThemeTypings["conditions"], string>
 
-// from a type like this 'sm' | 'lg' | 'md' | 'xl' | '2xl' | (string | number), remove the (string | number) part
-type RemoveStringNumber<T> = Exclude<T, keyof string | keyof number>
+export type PseudoKey = keyof Pseudos
 
 export function getPseudoSelectors(theme: any) {
-  return { ...pseudoSelectors, ...theme.conditions }
+  const __conds = theme.conditions ?? {}
+  const conditions = Object.fromEntries(
+    Object.entries(__conds).map(([key, value]) => [`_${key}`, value]),
+  )
+  return { ...pseudoSelectors, ...conditions }
 }
 
 export function getPseudoPropNames(theme: any) {
   return Object.keys(getPseudoSelectors(theme))
-}
-
-export function isSemanticCondition(key: string) {
-  return key in pseudoSelectors || key in state
 }

--- a/packages/styled-system/src/pseudos.ts
+++ b/packages/styled-system/src/pseudos.ts
@@ -1,3 +1,5 @@
+import { ThemeTypings } from "./theming.types"
+
 type AnyFunction<T = any> = (...args: T[]) => any
 
 const state = {
@@ -34,7 +36,7 @@ const toPeer = (fn: AnyFunction) =>
 const merge = (fn: AnyFunction, ...selectors: string[]) =>
   selectors.map(fn).join(", ")
 
-export const pseudoSelectors = {
+const pseudoSelectors = {
   /**
    * Styles for CSS selector `&:hover`
    */
@@ -331,8 +333,20 @@ export const pseudoSelectors = {
   _vertical: "&[data-orientation=vertical]",
 }
 
-export type Pseudos = typeof pseudoSelectors
+export type Pseudos = typeof pseudoSelectors & keyof ThemeTypings["conditions"]
+export type PseudoKey = RemoveStringNumber<keyof Pseudos>
 
-export const pseudoPropNames = Object.keys(
-  pseudoSelectors,
-) as (keyof typeof pseudoSelectors)[]
+// from a type like this 'sm' | 'lg' | 'md' | 'xl' | '2xl' | (string | number), remove the (string | number) part
+type RemoveStringNumber<T> = Exclude<T, keyof string | keyof number>
+
+export function getPseudoSelectors(theme: any) {
+  return { ...pseudoSelectors, ...theme.conditions }
+}
+
+export function getPseudoPropNames(theme: any) {
+  return Object.keys(getPseudoSelectors(theme))
+}
+
+export function isSemanticCondition(key: string) {
+  return key in pseudoSelectors || key in state
+}

--- a/packages/styled-system/src/shared.types.ts
+++ b/packages/styled-system/src/shared.types.ts
@@ -1,7 +1,5 @@
 export interface BaseThemeTypings {
-  conditions: {
-    [conditionName: string]: string
-  }
+  conditions: never
   borders: string
   colors: string
   breakpoints: string

--- a/packages/styled-system/src/shared.types.ts
+++ b/packages/styled-system/src/shared.types.ts
@@ -1,4 +1,7 @@
 export interface BaseThemeTypings {
+  conditions: {
+    [conditionName: string]: string
+  }
   borders: string
   colors: string
   breakpoints: string

--- a/packages/styled-system/src/system.ts
+++ b/packages/styled-system/src/system.ts
@@ -59,6 +59,6 @@ export const isStylePropFn = (theme: any) => {
   const pseudoSelectors = getPseudoSelectors(theme)
   return (prop: string) => {
     const styleProps = { ...systemProps, ...pseudoSelectors }
-    return Reflect.has(styleProps, prop)
+    return Object.hasOwnProperty.call(styleProps, prop)
   }
 }

--- a/packages/styled-system/src/system.ts
+++ b/packages/styled-system/src/system.ts
@@ -20,7 +20,7 @@ import {
   transition,
   typography,
 } from "./config"
-import { pseudoPropNames, pseudoSelectors } from "./pseudos"
+import { getPseudoPropNames, getPseudoSelectors } from "./pseudos"
 
 export const systemProps = mergeWith(
   {},
@@ -50,7 +50,15 @@ export const layoutPropNames = Object.keys(
   layoutSystem,
 ) as (keyof typeof layoutSystem)[]
 
-export const propNames = [...Object.keys(systemProps), ...pseudoPropNames]
-const styleProps = { ...systemProps, ...pseudoSelectors }
+export const getPropNames = (theme: any) => [
+  ...Object.keys(systemProps),
+  ...getPseudoPropNames(theme),
+]
 
-export const isStyleProp = (prop: string) => prop in styleProps
+export const isStylePropFn = (theme: any) => {
+  const pseudoSelectors = getPseudoSelectors(theme)
+  return (prop: string) => {
+    const styleProps = { ...systemProps, ...pseudoSelectors }
+    return Reflect.has(styleProps, prop)
+  }
+}

--- a/packages/styled-system/src/system.types.ts
+++ b/packages/styled-system/src/system.types.ts
@@ -20,7 +20,7 @@ import type {
   TypographyProps,
   ScrollProps,
 } from "./config"
-import { Pseudos } from "./pseudos"
+import { PseudoKey } from "./pseudos"
 import { ResponsiveValue } from "./utils/types"
 
 export interface StyleProps
@@ -60,7 +60,7 @@ export type CSSWithMultiValues = {
     : PropertyValue<K>
 }
 
-type PseudoKeys = keyof CSS.Pseudos | keyof Pseudos
+type PseudoKeys = keyof CSS.Pseudos | PseudoKey
 
 type PseudoSelectorDefinition<D> = D | RecursivePseudo<D>
 
@@ -79,19 +79,12 @@ export type RecursiveCSSObject<D> = D &
 
 export type SystemStyleObject = RecursiveCSSObject<CSSWithMultiValues>
 
-/**
- * @deprecated use `SystemStyleObject` instead
- */
-export type CSSObject = SystemStyleObject & {}
-
-export interface FunctionCSSInterpolation {
-  (theme: Record<string, any>): CSSObject
-}
-
-export type StyleObjectOrFn = SystemStyleObject | FunctionCSSInterpolation
+export type StyleObjectOrFn =
+  | SystemStyleObject
+  | ((theme: any) => SystemStyleObject)
 
 type PseudoProps = {
-  [K in keyof Pseudos]?: SystemStyleObject
+  [K in PseudoKey]?: SystemStyleObject
 }
 
 export interface SystemProps extends StyleProps, PseudoProps {}

--- a/packages/theme/src/theme.types.ts
+++ b/packages/theme/src/theme.types.ts
@@ -1,6 +1,6 @@
 import type {
   PartsStyleInterpolation,
-  Pseudos,
+  PseudoKey,
   SemanticValue,
   StyleObjectOrFn,
   SystemStyleInterpolation,
@@ -120,8 +120,9 @@ interface Foundations extends Typography {
 }
 
 export interface ChakraTheme extends Foundations {
+  conditions?: Record<string, string>
   semanticTokens?: Partial<
-    Record<keyof Foundations, Record<string, SemanticValue<keyof Pseudos>>>
+    Record<keyof Foundations, Record<string, SemanticValue<PseudoKey>>>
   >
   components: ThemeComponents
   config: ThemeConfig


### PR DESCRIPTION
## 📝 Description

Add support for custom theme conditions or pseudo props via `theme.conditions`

```ts
// theme.ts

const theme = extendTheme({
  conditions: {
    closed: "&[data-state='closed']", // pseudo prop
  }
})
```

## ⛳️ Current behavior (updates)

No way to add custom pseudo props or conditions

## 🚀 New behavior

Now possible

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
