### PR TITLE
fix: add default preserveScrollBarGap

### DIFF
--- a/.changeset/spotty-buckets-know.md
+++ b/.changeset/spotty-buckets-know.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": major
+---
+
+Add default preserveScrollBarGap

--- a/packages/components/src/modal/modal.tsx
+++ b/packages/components/src/modal/modal.tsx
@@ -148,6 +148,7 @@ export const Modal: React.FC<ModalProps> = (props) => {
     returnFocusOnClose: true,
     blockScrollOnMount: true,
     allowPinchZoom: false,
+    preserveScrollBarGap: true,
     motionPreset: "scale",
     ...props,
     lockFocusAcrossFrames: props.lockFocusAcrossFrames || true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Although the documentation (https://chakra-ui.com/docs/components/modal/props) says that the default value of  `preserveScrollBarGap` in `<Modal/>` is `true`, the default value is not set in the code. This pull request sets `true` as the default value of `preserveScrollBarGap`. Another option is to modify the documentation.

## ⛳️ Current behavior (updates)
The default value of `preserveScrollBarGap` in `<Modal/>` is not set and it is not consistent with the documentation.

## 🚀 New behavior
A `padding-right` will be applied to the body element that's equal to the width of the scrollbar as the documentation says.

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
