### PR TITLE
Fix custom font code snippet typo on nextjs-pages-guide

### DIFF
--- a/website/content/getting-started/nextjs-pages-guide.mdx
+++ b/website/content/getting-started/nextjs-pages-guide.mdx
@@ -87,18 +87,20 @@ Next, you need to update your `_app.js` to include the font styles.
 import { fonts } from '../lib/fonts'
 
 const App = ({ Component, pageProps }: AppProps) => {
-  ;<>
-    <style jsx global>
-      {`
-        :root {
-          --font-rubik: ${fonts.rubik.style.fontFamily};
-        }
-      `}
-    </style>
-    <ChakraProvider theme={theme}>
-      <Component {...pageProps} />
-    </ChakraProvider>
-  </>
+  return (
+    <>
+      <style jsx global>
+        {`
+          :root {
+            --font-rubik: ${fonts.rubik.style.fontFamily};
+          }
+        `}
+      </style>
+      <ChakraProvider theme={theme}>
+        <Component {...pageProps} />
+      </ChakraProvider>
+    </>
+  );
 }
 ```
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

There's a small typo on the `_app.js` snippet for adding custom fonts with NextJS. This just fixes that to `return` the fragment instead of prefixing the fragment with a semicolon.

## ⛳️ Current behavior (updates)

typo 😭 
<img width="667" alt="image" src="https://github.com/chakra-ui/chakra-ui/assets/23159019/49a616af-69cb-4b6c-8e50-0c3778dc60d8">

## 🚀 New behavior

fixed the typo 🥳 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
