### PR TITLE
docs: update edit url

### DIFF
--- a/.changeset/young-lizards-double.md
+++ b/.changeset/young-lizards-double.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/docs": minor
+---
+
+Fix edit url

--- a/website/configs/site-config.json
+++ b/website/configs/site-config.json
@@ -14,7 +14,7 @@
   },
   "repo": {
     "url": "https://github.com/chakra-ui/chakra-ui",
-    "editUrl": "https://github.com/chakra-ui/chakra-ui-docs/tree/main/content",
+    "editUrl": "https://github.com/chakra-ui/chakra-ui/tree/main/website/content",
     "blobUrl": "https://github.com/chakra-ui/chakra-ui/blob/main"
   },
   "openCollective": {


### PR DESCRIPTION
## 📝 Description

This PR update `editUrl` in the official documentation.

## ⛳️ Current behavior (updates)

The "Edit this page on GitHub" button does not navigate to the correct repository; instead, it is linked to the old repository.

<img width="276" alt="image" src="https://github.com/chakra-ui/chakra-ui/assets/32538736/7af47af1-be29-4c5f-829c-60979d91afc9">

## 🚀 New behavior

The button will navigate to correct repository.

## 💣 Is this a breaking change (Yes/No):

No.