### PR TITLE
Fix bug where icon does not change its size by using iconSize in Checkbox with default size values

### DIFF
--- a/.changeset/good-goats-admire.md
+++ b/.changeset/good-goats-admire.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fixed bug with iconSize in checkbox
+
+Created new checkbox `WithIconSize` story for storybook

--- a/packages/components/src/checkbox/checkbox.stories.tsx
+++ b/packages/components/src/checkbox/checkbox.stories.tsx
@@ -57,6 +57,17 @@ export const WithIconColor = () => (
   <Checkbox iconColor="yellow.400">I love chakra</Checkbox>
 )
 
+export const WithIconSize = () => {
+  return (
+    <Stack direction="row">
+      <Checkbox>Default</Checkbox>
+      <Checkbox iconSize="1rem">Option</Checkbox>
+      <Checkbox iconSize="0.8rem">With big icon</Checkbox>
+      <Checkbox iconSize="0.4rem">With small icon</Checkbox>
+    </Stack>
+  )
+}
+
 export const WithColorScheme = () => {
   return (
     <Stack>

--- a/packages/components/src/checkbox/checkbox.tsx
+++ b/packages/components/src/checkbox/checkbox.tsx
@@ -145,9 +145,9 @@ export const Checkbox = forwardRef<CheckboxProps, "input">(
           : state.isIndeterminate
           ? `${indeterminateOpacityAnim} 20ms linear, ${indeterminateScaleAnim} 200ms linear`
           : `${checkAnim} 200ms linear`,
-        fontSize: iconSize,
-        color: iconColor,
         ...styles.icon,
+        fontSize: iconSize ?? styles.icon.fontSize,
+        color: iconColor ?? styles.icon.color,
       }),
       [iconColor, iconSize, shouldAnimate, state.isIndeterminate, styles.icon],
     )


### PR DESCRIPTION
Closes #8092

## 📝 Description

A supplementary story was created for the Storybook to demonstrate the functionality of the `iconSize` prop

Additionally, a bug with incorrect behavior of `iconSize` when used without specifying a `size` different from the defaults has been fixed

## ⛳️ Current behavior (updates)

As we can see in the screenshot, various `iconSize` values have no effect on the size of the icon because it is being overridden by the default `size`

Before:

![image](https://github.com/chakra-ui/chakra-ui/assets/67638952/4f1f680c-a9a4-4dd4-bc26-508bbcd03f31)

## 🚀 New behavior

After:

![image](https://github.com/chakra-ui/chakra-ui/assets/67638952/590192b4-9b58-4f08-ab08-78cbeb01d7c8)

## 💣 Is this a breaking change (Yes/No):

Yes, this is a breaking change. Developers who were using `iconSize` with default `size` may encounter display errors after the update