### PR TITLE
draft: add alpha modifier to color tokens

### DIFF
--- a/packages/styled-system/src/create-theme-vars/css-var.ts
+++ b/packages/styled-system/src/create-theme-vars/css-var.ts
@@ -32,6 +32,7 @@ export function toVarDefinition(value: string, prefix = "") {
 
 export function cssVar(name: string, fallback?: string, cssVarPrefix?: string) {
   const cssVariable = toVarDefinition(name, cssVarPrefix)
+
   return {
     variable: cssVariable,
     reference: toVarReference(cssVariable, fallback),

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -23,8 +23,12 @@ const resolveTokenValue = (theme: Record<string, any>, value: string) => {
   const getVar = (val: string) => theme.__cssMap?.[val]?.varRef
   const getValue = (val: string) => getVar(val) ?? val
 
-  const [tokenValue, fallbackValue] = splitByComma(value)
-  value = getVar(tokenValue) ?? getValue(fallbackValue) ?? getValue(value)
+  if (value.match(/^var\(--.+\)$/)) {
+    const [tokenValue, fallbackValue] = splitByComma(value)
+    value = getVar(tokenValue) ?? getValue(fallbackValue) ?? getValue(value)
+  } else {
+    value = getValue(value)
+  }
 
   return value
 }

--- a/packages/styled-system/src/css.ts
+++ b/packages/styled-system/src/css.ts
@@ -22,14 +22,20 @@ const resolveTokenValue = (theme: Record<string, any>, value: string) => {
 
   const getVar = (val: string) => theme.__cssMap?.[val]?.varRef
   const getValue = (val: string) => getVar(val) ?? val
-
-  if (value.match(/^var\(--.+\)$/)) {
+  console.log(value)
+  if (value.match(/^colors\..+\/[0-9]+$/)) {
+    const [tokenValue, opacity] = value.split("/")
+    const percentage = Math.max(Math.min(parseInt(opacity), 100), 0)
+    value = `color-mix(in srgb, ${getVar(
+      tokenValue,
+    )} ${percentage}%, transparent)`
+  } else if (value.match(/^var\(--.+\)$/)) {
     const [tokenValue, fallbackValue] = splitByComma(value)
     value = getVar(tokenValue) ?? getValue(fallbackValue) ?? getValue(value)
   } else {
     value = getValue(value)
   }
-
+  console.log(value)
   return value
 }
 

--- a/packages/theme-tools/src/color.ts
+++ b/packages/theme-tools/src/color.ts
@@ -1,8 +1,7 @@
-import { getCSSVar } from "@chakra-ui/styled-system"
+import { ThemeTypings, getCSSVar } from "@chakra-ui/styled-system"
 import {
   toHex,
   parseToRgba,
-  transparentize as setTransparency,
   mix,
   darken as reduceLightness,
   lighten as increaseLightness,
@@ -80,17 +79,18 @@ export const isLight = (color: string) => (theme: Dict) =>
   tone(color)(theme) === "light"
 
 /**
- * Make a color transparent
- * @param color - the color in hex, rgb, or hsl
- * @param opacity - the amount of opacity the color should have (0-1)
- *
- * @deprecated This will be removed in the next major release.
+ * Make a color token transparent
+ * @param color - Chakra UI color token
+ * @param opacity - Opacity value 0 to 1.
  */
-export const transparentize =
-  (color: string, opacity: number) => (theme: Dict) => {
-    const raw = getColor(theme, color)
-    return setTransparency(raw, 1 - opacity)
-  }
+export const transparentize = (
+  color: ThemeTypings["colors"],
+  value: number,
+) => {
+  const key = color.replaceAll(".", "-")
+  const opacity = Math.max(Math.min(value * 100, 100), 0)
+  return `color-mix(in srgb, var(--chakra-colors-${key}) ${opacity}%, transparent)`
+}
 
 /**
  * Add white to a color

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -44,11 +44,11 @@ const baseStyle = definePartsStyle({
 
 function getBg(props: StyleFunctionProps) {
   const { colorScheme: c } = props
-  const darkBg = transparentize(`${c}.200`, 0.16)
-  console.log("darkBg", darkBg)
+  // const darkBg = transparentize(`${c}.200`, 0.16)
+  // console.log("darkBg", darkBg)
   return {
     light: `colors.${c}.100`,
-    dark: darkBg,
+    dark: `colors.${c}.200/16`,
   }
 }
 
@@ -62,6 +62,7 @@ const variantSubtle = definePartsStyle((props) => {
       _dark: {
         [$fg.variable]: `colors.${c}.200`,
         [$bg.variable]: bg.dark,
+        color: `${c}.200/16`,
       },
     },
   }

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -43,8 +43,9 @@ const baseStyle = definePartsStyle({
 })
 
 function getBg(props: StyleFunctionProps) {
-  const { theme, colorScheme: c } = props
-  const darkBg = transparentize(`${c}.200`, 0.16)(theme)
+  const { colorScheme: c } = props
+  const darkBg = transparentize(`${c}.200`, 0.16)
+  console.log("darkBg", darkBg)
   return {
     light: `colors.${c}.100`,
     dark: darkBg,

--- a/packages/theme/src/components/badge.ts
+++ b/packages/theme/src/components/badge.ts
@@ -19,8 +19,8 @@ const baseStyle = defineStyle({
 })
 
 const variantSolid = defineStyle((props) => {
-  const { colorScheme: c, theme } = props
-  const dark = transparentize(`${c}.500`, 0.6)(theme)
+  const { colorScheme: c } = props
+  const dark = transparentize(`${c}.500`, 0.6)
   return {
     [vars.bg.variable]: `colors.${c}.500`,
     [vars.color.variable]: `colors.white`,
@@ -32,8 +32,8 @@ const variantSolid = defineStyle((props) => {
 })
 
 const variantSubtle = defineStyle((props) => {
-  const { colorScheme: c, theme } = props
-  const darkBg = transparentize(`${c}.200`, 0.16)(theme)
+  const { colorScheme: c } = props
+  const darkBg = transparentize(`${c}.200`, 0.16)
   return {
     [vars.bg.variable]: `colors.${c}.100`,
     [vars.color.variable]: `colors.${c}.800`,
@@ -45,8 +45,8 @@ const variantSubtle = defineStyle((props) => {
 })
 
 const variantOutline = defineStyle((props) => {
-  const { colorScheme: c, theme } = props
-  const darkColor = transparentize(`${c}.200`, 0.8)(theme)
+  const { colorScheme: c } = props
+  const darkColor = transparentize(`${c}.200`, 0.8)
   return {
     [vars.color.variable]: `colors.${c}.500`,
     _dark: {

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -24,7 +24,7 @@ const baseStyle = defineStyle({
 })
 
 const variantGhost = defineStyle((props) => {
-  const { colorScheme: c, theme } = props
+  const { colorScheme: c } = props
 
   if (c === "gray") {
     return {
@@ -36,8 +36,8 @@ const variantGhost = defineStyle((props) => {
     }
   }
 
-  const darkHoverBg = transparentize(`${c}.200`, 0.12)(theme)
-  const darkActiveBg = transparentize(`${c}.200`, 0.24)(theme)
+  const darkHoverBg = transparentize(`${c}.200`, 0.12)
+  const darkActiveBg = transparentize(`${c}.200`, 0.24)
 
   return {
     color: mode(`${c}.600`, `${c}.200`)(props),


### PR DESCRIPTION
## 📝 Description

This adds support for alpha modifier on color tokens

```
<Box color="green.500/10" />
```

CSS variables
```
const $bg = cssVar('bg')
const theme = {
 bg: $bg.reference,
 [$bg.variable]: 'colors.green.500/10'
}
```

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
