### PR TITLE
feat(v3): support as child composition

### DIFF
--- a/.changeset/ninety-humans-call.md
+++ b/.changeset/ninety-humans-call.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+Add support for `asChild` in chakra factory

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,23 @@
+# v3 Migration Guide
+
+## Changed
+
+## Added
+
+### `asChild` prop
+
+Removed support for `as` prop due to the type complexity involved.
+
+**Action:** Replace `asChild` in `chakra` factory and existing components.
+
+```tsx
+import { Button } from "@chakra-ui/react"
+
+const Demo = () => {
+  return (
+    <Button asChild>
+      <a href="#">Child</a>
+    </Button>
+  )
+}
+```

--- a/packages/components/src/system/merge-props.ts
+++ b/packages/components/src/system/merge-props.ts
@@ -1,0 +1,61 @@
+import { callAll } from "@chakra-ui/utils"
+
+interface Props {
+  [key: string]: any
+}
+
+const clsx = (...args: (string | undefined)[]) =>
+  args
+    .map((str) => str?.trim?.())
+    .filter(Boolean)
+    .join(" ")
+
+type TupleTypes<T extends any[]> = T[number]
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never
+
+const eventRegex = /^on[A-Z]/
+
+export function mergeProps<T extends Props>(
+  ...args: T[]
+): UnionToIntersection<TupleTypes<T[]>> {
+  let result: Props = {}
+
+  for (let props of args) {
+    for (let key in result) {
+      if (
+        eventRegex.test(key) &&
+        typeof result[key] === "function" &&
+        typeof props[key] === "function"
+      ) {
+        result[key] = callAll(result[key], props[key])
+        continue
+      }
+
+      if (key === "className" || key === "class") {
+        result[key] = clsx(result[key], props[key])
+        continue
+      }
+
+      if (key === "style") {
+        result[key] = Object.assign({}, result[key] ?? {}, props[key] ?? {})
+        continue
+      }
+
+      result[key] = props[key] !== undefined ? props[key] : result[key]
+    }
+
+    // Add props from b that are not in a
+    for (let key in props) {
+      if (result[key] === undefined) {
+        result[key] = props[key]
+      }
+    }
+  }
+
+  return result as any
+}

--- a/packages/components/src/system/system.stories.tsx
+++ b/packages/components/src/system/system.stories.tsx
@@ -8,6 +8,14 @@ export default {
 
 const MotionBox = motion(chakra.div)
 
+export const WithAsChild = () => {
+  return (
+    <chakra.button bg="red.200" asChild>
+      <a href="dfd">sdfsd</a>
+    </chakra.button>
+  )
+}
+
 export const WithFramerMotion = () => (
   <MotionBox
     mt="40px"

--- a/packages/components/src/system/system.types.tsx
+++ b/packages/components/src/system/system.types.tsx
@@ -64,10 +64,14 @@ export type MergeWithAs<
   as?: AsComponent
 }
 
+export interface AsChildProps {
+  asChild?: boolean
+}
+
 export type ComponentWithAs<Component extends As, Props extends object = {}> = {
   <AsComponent extends As = Component>(
     props: MergeWithAs<
-      React.ComponentProps<Component>,
+      React.ComponentProps<Component> & AsChildProps,
       React.ComponentProps<AsComponent>,
       Props,
       AsComponent


### PR DESCRIPTION
## 📝 Description

In the styled factory, we're now supporting the use of `asChild` for better composition with other components.

## ⛳️ Current behavior (updates)

Type complexity around the `as` prop

## 🚀 New behavior

Prefer to use `asChild`

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
