### PR TITLE
docs: update link for list of elements

### DIFF
--- a/website/content/docs/styled-system/chakra-factory.mdx
+++ b/website/content/docs/styled-system/chakra-factory.mdx
@@ -33,7 +33,7 @@ chakra styles, you can write `<chakra.button />`.
 
 This reduces the need to create custom component wrappers and name them. This
 syntax is available for common html elements. See the reference for the full
-[list of elements](https://github.com/chakra-ui/chakra-ui/blob/main/packages/core/system/src/system.utils.ts#L7)
+[list of elements](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/src/system/system.utils.ts#L7)
 supported.
 
 ```jsx live=false


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here --> N/A

## 📝 Description

This docs section https://chakra-ui.com/docs/styled-system/chakra-factory#chakra-jsx-elements seems to have a broken link for list of elements. I looked in the repository for a similar `system.utils.ts` file and found it at a new location.

## ⛳️ Current behavior (updates)

Link currently goes to a 404.

## 🚀 New behavior

Fixes the link to go to new location.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A