### PR TITLE
Allow to set a style-src CSP without unsafe-inline

### DIFF
--- a/packages/components/src/checkbox/checkbox-icon.tsx
+++ b/packages/components/src/checkbox/checkbox-icon.tsx
@@ -5,12 +5,10 @@ function CheckIcon(props: PropsOf<typeof chakra.svg>) {
     <chakra.svg
       width="1.2em"
       viewBox="0 0 12 10"
-      style={{
-        fill: "none",
-        strokeWidth: 2,
-        stroke: "currentColor",
-        strokeDasharray: 16,
-      }}
+      fill="none"
+      stroke="currentColor"
+      strokeDasharray={16}
+      strokeWidth={2}
       {...props}
     >
       <polyline points="1.5 6 4.5 9 10.5 1" />
@@ -23,7 +21,8 @@ function IndeterminateIcon(props: PropsOf<typeof chakra.svg>) {
     <chakra.svg
       width="1.2em"
       viewBox="0 0 24 24"
-      style={{ stroke: "currentColor", strokeWidth: 4 }}
+      stroke="currentColor"
+      strokeWidth={4}
       {...props}
     >
       <line x1="21" x2="3" y1="12" y2="12" />
@@ -54,12 +53,10 @@ export function CheckboxIcon(props: CheckboxIconProps) {
 
   return isChecked || isIndeterminate ? (
     <chakra.div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        height: "100%",
-      }}
+      alignItems="center"
+      display="flex"
+      height="100%"
+      justifyContent="center"
     >
       <BaseIcon {...rest} />
     </chakra.div>

--- a/packages/components/src/color-mode/color-mode-provider.tsx
+++ b/packages/components/src/color-mode/color-mode-provider.tsx
@@ -44,6 +44,7 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
       useSystemColorMode,
       initialColorMode,
       disableTransitionOnChange,
+      nonce,
     } = {},
     colorModeManager = localStorageManager,
   } = props
@@ -59,7 +60,11 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   )
 
   const { getSystemTheme, setClassName, setDataset, addListener } = useMemo(
-    () => getColorModeUtils({ preventTransition: disableTransitionOnChange }),
+    () =>
+      getColorModeUtils({
+        nonce,
+        preventTransition: disableTransitionOnChange,
+      }),
     [disableTransitionOnChange],
   )
 

--- a/packages/components/src/color-mode/color-mode-types.ts
+++ b/packages/components/src/color-mode/color-mode-types.ts
@@ -11,6 +11,7 @@ export interface ColorModeOptions {
   initialColorMode?: ColorModeWithSystem
   useSystemColorMode?: boolean
   disableTransitionOnChange?: boolean
+  nonce?: string
 }
 
 export interface ColorModeContextType {

--- a/packages/components/src/color-mode/color-mode.utils.ts
+++ b/packages/components/src/color-mode/color-mode.utils.ts
@@ -6,6 +6,7 @@ const classNames = {
 }
 
 type UtilOptions = {
+  nonce?: string
   preventTransition?: boolean
 }
 
@@ -14,7 +15,9 @@ export function getColorModeUtils(options: UtilOptions = {}) {
 
   const utils = {
     setDataset: (value: ColorMode) => {
-      const cleanup = preventTransition ? utils.preventTransition() : undefined
+      const cleanup = preventTransition
+        ? utils.preventTransition(options.nonce)
+        : undefined
       document.documentElement.dataset.theme = value
       document.documentElement.style.colorScheme = value
       cleanup?.()
@@ -45,8 +48,9 @@ export function getColorModeUtils(options: UtilOptions = {}) {
         else mql.removeEventListener("change", listener)
       }
     },
-    preventTransition() {
+    preventTransition(nonce?: string) {
       const css = document.createElement("style")
+      css.nonce = nonce
       css.appendChild(
         document.createTextNode(
           `*{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`,

--- a/packages/components/src/menu/menu-item-option.tsx
+++ b/packages/components/src/menu/menu-item-option.tsx
@@ -1,7 +1,7 @@
 import { SystemProps } from "@chakra-ui/styled-system"
 import { cx } from "@chakra-ui/utils/cx"
 import { ComponentProps, HTMLAttributes, ReactElement } from "react"
-import { forwardRef } from "../system"
+import { chakra, forwardRef } from "../system"
 import { MenuIcon } from "./menu-icon"
 import { MenuItemProps } from "./menu-item"
 import { StyledMenuItem } from "./styled-menu-item"
@@ -50,7 +50,7 @@ export const MenuItemOption = forwardRef<MenuItemOptionProps, "button">(
             {icon || <CheckIcon />}
           </MenuIcon>
         )}
-        <span style={{ flex: 1 }}>{optionProps.children}</span>
+        <chakra.span flex={1}>{optionProps.children}</chakra.span>
       </StyledMenuItem>
     )
   },

--- a/packages/components/src/menu/menu-item.tsx
+++ b/packages/components/src/menu/menu-item.tsx
@@ -1,5 +1,5 @@
 import { SystemProps } from "@chakra-ui/styled-system"
-import { forwardRef, HTMLChakraProps } from "../system"
+import { chakra, forwardRef, HTMLChakraProps } from "../system"
 import { cx } from "@chakra-ui/utils/cx"
 import { MenuCommand } from "./menu-command"
 import { MenuIcon } from "./menu-icon"
@@ -60,7 +60,9 @@ export const MenuItem = forwardRef<MenuItemProps, "button">((props, ref) => {
   const shouldWrap = icon || command
 
   const _children = shouldWrap ? (
-    <span style={{ pointerEvents: "none", flex: 1 }}>{children}</span>
+    <chakra.span pointerEvents="none" flex={1}>
+      {children}
+    </chakra.span>
   ) : (
     children
   )

--- a/packages/components/src/native-select/select-icon.tsx
+++ b/packages/components/src/native-select/select-icon.tsx
@@ -9,12 +9,10 @@ const Icon = (props: HTMLChakraProps<"svg">) => (
     className="chakra-select__icon"
     focusable="false"
     aria-hidden="true"
+    color="currentColor"
+    height="1em"
+    width="1em"
     {...props}
-    style={{
-      width: "1em",
-      height: "1em",
-      color: "currentColor",
-    }}
   >
     <path
       fill="currentColor"

--- a/packages/components/src/portal/portal.tsx
+++ b/packages/components/src/portal/portal.tsx
@@ -3,6 +3,7 @@ import { createContext } from "@chakra-ui/utils/context"
 import { createPortal } from "react-dom"
 import { usePortalManager } from "./portal-manager"
 import { useEffect, useMemo, useRef, useState } from "react"
+import { chakra } from "../system"
 
 type PortalContext = HTMLDivElement | null
 
@@ -15,20 +16,18 @@ const PORTAL_CLASSNAME = "chakra-portal"
 const PORTAL_SELECTOR = `.chakra-portal`
 
 const Container = (props: React.PropsWithChildren<{ zIndex: number }>) => (
-  <div
+  <chakra.div
     className="chakra-portal-zIndex"
-    style={{
-      position: "absolute",
-      zIndex: props.zIndex,
-      top: 0,
-      left: 0,
-      right: 0,
-      // NB: Don't add `bottom: 0`, it makes the entire app unusable
-      // @see https://github.com/chakra-ui/chakra-ui/issues/3201
-    }}
+    position="absolute"
+    zIndex={props.zIndex}
+    top={0}
+    left={0}
+    right={0}
+    // NB: Don't add `bottom: 0`, it makes the entire app unusable
+    // @see https://github.com/chakra-ui/chakra-ui/issues/3201
   >
     {props.children}
-  </div>
+  </chakra.div>
 )
 
 /**

--- a/packages/components/src/progress/progress-filled-track.tsx
+++ b/packages/components/src/progress/progress-filled-track.tsx
@@ -16,7 +16,7 @@ export interface ProgressFilledTrackProps extends HTMLChakraProps<"div"> {}
  */
 export const ProgressFilledTrack = forwardRef<ProgressFilledTrackProps, "div">(
   function ProgressFilledTrack(props, ref) {
-    const { role, style, ...rest } = props
+    const { role, ...rest } = props
 
     const styles = useProgressStyles()
     const api = useProgressContext()
@@ -32,7 +32,7 @@ export const ProgressFilledTrack = forwardRef<ProgressFilledTrackProps, "div">(
     return (
       <chakra.div
         ref={ref}
-        style={{ width: `${api.computed.percent}%`, ...style }}
+        width={`${api.computed.percent}%`}
         data-animated={dataAttr(shouldAddStripe && api.isAnimated)}
         role="progressbar"
         data-indeterminate={dataAttr(api.isIndeterminate)}
@@ -41,7 +41,7 @@ export const ProgressFilledTrack = forwardRef<ProgressFilledTrackProps, "div">(
         aria-valuenow={api.isIndeterminate ? undefined : api.computed.value}
         aria-valuetext={api.computed.valueText}
         {...rest}
-        __css={trackStyles}
+        __css={{ ...trackStyles, ...style }}
         className={cx("chakra-progress__filled-track", props.className)}
       />
     )

--- a/packages/components/src/skip-nav/skip-nav.tsx
+++ b/packages/components/src/skip-nav/skip-nav.tsx
@@ -60,15 +60,7 @@ export interface SkipNavContentProps extends HTMLChakraProps<"div"> {}
 export const SkipNavContent = forwardRef<SkipNavContentProps, "div">(
   function SkipNavContent(props, ref) {
     const { id = fallbackId, ...rest } = props
-    return (
-      <chakra.div
-        ref={ref}
-        id={id}
-        tabIndex={-1}
-        style={{ outline: 0 }}
-        {...rest}
-      />
-    )
+    return <chakra.div ref={ref} id={id} tabIndex={-1} outline={0} {...rest} />
   },
 )
 

--- a/packages/components/src/tabs/tab-indicator.tsx
+++ b/packages/components/src/tabs/tab-indicator.tsx
@@ -21,8 +21,7 @@ export const TabIndicator = forwardRef<TabIndicatorProps, "div">(
         ref={ref}
         {...props}
         className={cx("chakra-tabs__tab-indicator", props.className)}
-        style={{ ...props.style, ...indicatorStyle }}
-        __css={styles.indicator}
+        __css={{ ...props.style, ...indicatorStyle, ...styles.indicator }}
       />
     )
   },

--- a/packages/components/src/toast/toast.provider.tsx
+++ b/packages/components/src/toast/toast.provider.tsx
@@ -12,6 +12,7 @@ import type {
 } from "./toast.types"
 import { getToastListStyle } from "./toast.utils"
 import type { UseToastOptions } from "./use-toast"
+import { chakra } from "../system"
 
 export interface ToastMethods {
   /**
@@ -122,13 +123,13 @@ export const ToastProvider = (props: ToastProviderProps) => {
     const toasts = state[position]
 
     return (
-      <div
+      <chakra.div
         role="region"
         aria-live="polite"
         aria-label={`Notifications-${position}`}
         key={position}
         id={`chakra-toast-manager-${position}`}
-        style={getToastListStyle(position)}
+        __css={getToastListStyle(position)}
       >
         <AnimatePresence initial={false}>
           {toasts.map((toast) => (
@@ -139,7 +140,7 @@ export const ToastProvider = (props: ToastProviderProps) => {
             />
           ))}
         </AnimatePresence>
-      </div>
+      </chakra.div>
     )
   })
 


### PR DESCRIPTION
Closes #8043, #7600

## 📝 Description

This PR allows to set a style-src CSP without unsafe-inline

## ⛳️ Current behavior (updates)

Chakra currently uses both the style attribute on HTML elements and an injected style element. Both require unsafe-inline style-src.

## 🚀 New behavior

*  Uses direct style props like `flex={1}` instead of `style={{ flex: 1 }}`.
*  Uses `__css` instead of `style` where an style object is used.
*  Adds the option to pass a `nonce` to the ColorModeProvider where the style element is injected.

## 💣 Is this a breaking change: 
No

## 📝 Additional Information
I was unable to test the behaviour locally, because I had issues linking to the local directory from my package.json. I haven't tested all changes myself, so please take a good look.

Also, there are some places where a style attribute is set on `motion.div`. I was not sure how to handle this, so I haven't fixed those issues.

