### PR TITLE
fix(components): suppress unnecessary re-renders of Checkbox and Radio component

### DIFF
--- a/.changeset/metal-mangos-judge.md
+++ b/.changeset/metal-mangos-judge.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+Suppress unnecessary re-renders of Checkbox and Radio component

--- a/packages/components/src/checkbox/use-checkbox.ts
+++ b/packages/components/src/checkbox/use-checkbox.ts
@@ -55,12 +55,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   const [isActive, setActive] = useState(false)
 
   useEffect(() => {
-    if (!isFocused) {
-      setIsFocusVisible(false)
-      return
-    }
-
-    return trackFocusVisible(setIsFocusVisible)
+    return trackFocusVisible((value) => setIsFocusVisible(value && isFocused))
   }, [isFocused])
 
   const inputRef = useRef<HTMLInputElement>(null)

--- a/packages/components/src/checkbox/use-checkbox.ts
+++ b/packages/components/src/checkbox/use-checkbox.ts
@@ -55,8 +55,13 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   const [isActive, setActive] = useState(false)
 
   useEffect(() => {
+    if (!isFocused) {
+      setIsFocusVisible(false)
+      return
+    }
+
     return trackFocusVisible(setIsFocusVisible)
-  }, [])
+  }, [isFocused])
 
   const inputRef = useRef<HTMLInputElement>(null)
   const [rootIsLabelElement, setRootIsLabelElement] = useState(true)
@@ -175,7 +180,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
         "data-hover": dataAttr(isHovered),
         "data-checked": dataAttr(isChecked),
         "data-focus": dataAttr(isFocused),
-        "data-focus-visible": dataAttr(isFocused && isFocusVisible),
+        "data-focus-visible": dataAttr(isFocusVisible),
         "data-indeterminate": dataAttr(isIndeterminate),
         "data-disabled": dataAttr(isDisabled),
         "data-invalid": dataAttr(isInvalid),

--- a/packages/components/src/radio-group/use-radio.ts
+++ b/packages/components/src/radio-group/use-radio.ts
@@ -140,12 +140,7 @@ export function useRadio(props: UseRadioProps = {}) {
   const isChecked = isControlled ? isCheckedProp : isCheckedState
 
   useEffect(() => {
-    if (!isFocused) {
-      setIsFocusVisible(false)
-      return
-    }
-
-    return trackFocusVisible(setIsFocusVisible)
+    return trackFocusVisible((value) => setIsFocusVisible(value && isFocused))
   }, [isFocused])
 
   const handleChange = useCallback(

--- a/packages/components/src/radio-group/use-radio.ts
+++ b/packages/components/src/radio-group/use-radio.ts
@@ -140,8 +140,13 @@ export function useRadio(props: UseRadioProps = {}) {
   const isChecked = isControlled ? isCheckedProp : isCheckedState
 
   useEffect(() => {
+    if (!isFocused) {
+      setIsFocusVisible(false)
+      return
+    }
+
     return trackFocusVisible(setIsFocusVisible)
-  }, [])
+  }, [isFocused])
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -187,7 +192,7 @@ export function useRadio(props: UseRadioProps = {}) {
       "data-invalid": dataAttr(isInvalid),
       "data-checked": dataAttr(isChecked),
       "data-focus": dataAttr(isFocused),
-      "data-focus-visible": dataAttr(isFocused && isFocusVisible),
+      "data-focus-visible": dataAttr(isFocusVisible),
       "data-readonly": dataAttr(isReadOnly),
       "aria-hidden": true,
       onMouseDown: callAllHandlers(props.onMouseDown, () => setActive(true)),


### PR DESCRIPTION
Fixes #7702

## 📝 Description

This PR improves runtime performance of Checkbox and Radio component by reducing re-renders caused by state changes for calculating `data-focus-visible` attribute.

Although the original issue was closed as it is regarded an expected behavior, this causes a significant performance hit in my project where I use checkboxes to select rows in tables with many rows.

## ⛳️ Current behavior (updates)

All checkboxes/radio buttons from Chakra UI on the screen re-renders whenever input modality changes

## 🚀 New behavior

Re-renders via the modality change do not happen when the component isn't focused

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
