### PR TITLE
docs: added link to guide in MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@ Renamed all `container` parts to `root`. Kindly update your theme to reflect
 ### Removed Components and Packages
 
 - Removed `ControlBox` component
-- Removed `@chakra-ui/icons` package. Prefer to use `lucide-react` or
+- Removed `@chakra-ui/icons` package. Prefer to use [`lucide-react`](https://lucide.dev/guide/packages/lucide-react) or
   `react-icons` instead.
 
 ### Root component and types


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Just adds a link to https://lucide.dev/guide/packages/lucide-react

## ⛳️ Current behavior (updates)

It's just text: `lucide-react`

## 🚀 New behavior

Now it's a link: [`lucide-react`](https://lucide.dev/guide/packages/lucide-react)

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
