### PR TITLE
fix(theme): allow for simplified input styling

### DIFF
--- a/.changeset/afraid-moons-teach.md
+++ b/.changeset/afraid-moons-teach.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/theme": patch
+---
+
+Prevented Input from overwriting InputGroup styling variables

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -4,15 +4,23 @@ import {
   cssVar,
   defineStyle,
 } from "@chakra-ui/styled-system"
-import { getColor, mode } from "@chakra-ui/theme-tools"
+import { type CSSVar, getColor, mode } from "@chakra-ui/theme-tools"
 
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
-const $height = cssVar("input-height")
-const $fontSize = cssVar("input-font-size")
-const $padding = cssVar("input-padding")
-const $borderRadius = cssVar("input-border-radius")
+const $fieldHeight = cssVar("input-field-height")
+const $fieldFontSize = cssVar("input-field-font-size")
+const $fieldPadding = cssVar("input-field-padding")
+const $fieldBorderRadius = cssVar("input-field-border-radius")
+
+const $height = cssVar("input-height", $fieldHeight.reference)
+const $fontSize = cssVar("input-font-size", $fieldFontSize.reference)
+const $padding = cssVar("input-padding", $fieldPadding.reference)
+const $borderRadius = cssVar(
+  "input-border-radius",
+  $fieldBorderRadius.reference,
+)
 
 const baseStyle = definePartsStyle({
   addon: {
@@ -40,49 +48,71 @@ const baseStyle = definePartsStyle({
   },
 })
 
+const toPartStyle = ({
+  $fontSize,
+  $padding,
+  $borderRadius,
+  $height,
+}: {
+  $fontSize: CSSVar
+  $padding: CSSVar
+  $borderRadius: CSSVar
+  $height: CSSVar
+}) => {
+  return {
+    lg: defineStyle({
+      [$fontSize.variable]: "fontSizes.lg",
+      [$padding.variable]: "space.4",
+      [$borderRadius.variable]: "radii.md",
+      [$height.variable]: "sizes.12",
+    }),
+    md: defineStyle({
+      [$fontSize.variable]: "fontSizes.md",
+      [$padding.variable]: "space.4",
+      [$borderRadius.variable]: "radii.md",
+      [$height.variable]: "sizes.10",
+    }),
+    sm: defineStyle({
+      [$fontSize.variable]: "fontSizes.sm",
+      [$padding.variable]: "space.3",
+      [$borderRadius.variable]: "radii.sm",
+      [$height.variable]: "sizes.8",
+    }),
+    xs: defineStyle({
+      [$fontSize.variable]: "fontSizes.xs",
+      [$padding.variable]: "space.2",
+      [$borderRadius.variable]: "radii.sm",
+      [$height.variable]: "sizes.6",
+    }),
+  }
+}
+
 const size = {
-  lg: defineStyle({
-    [$fontSize.variable]: "fontSizes.lg",
-    [$padding.variable]: "space.4",
-    [$borderRadius.variable]: "radii.md",
-    [$height.variable]: "sizes.12",
-  }),
-  md: defineStyle({
-    [$fontSize.variable]: "fontSizes.md",
-    [$padding.variable]: "space.4",
-    [$borderRadius.variable]: "radii.md",
-    [$height.variable]: "sizes.10",
-  }),
-  sm: defineStyle({
-    [$fontSize.variable]: "fontSizes.sm",
-    [$padding.variable]: "space.3",
-    [$borderRadius.variable]: "radii.sm",
-    [$height.variable]: "sizes.8",
-  }),
-  xs: defineStyle({
-    [$fontSize.variable]: "fontSizes.xs",
-    [$padding.variable]: "space.2",
-    [$borderRadius.variable]: "radii.sm",
-    [$height.variable]: "sizes.6",
+  group: toPartStyle({ $fontSize, $padding, $borderRadius, $height }),
+  field: toPartStyle({
+    $fontSize: $fieldFontSize,
+    $padding: $fieldPadding,
+    $borderRadius: $fieldBorderRadius,
+    $height: $fieldHeight,
   }),
 }
 
 const sizes = {
   lg: definePartsStyle({
-    field: size.lg,
-    group: size.lg,
+    field: size.field.lg,
+    group: size.group.lg,
   }),
   md: definePartsStyle({
-    field: size.md,
-    group: size.md,
+    field: size.field.md,
+    group: size.group.md,
   }),
   sm: definePartsStyle({
-    field: size.sm,
-    group: size.sm,
+    field: size.field.sm,
+    group: size.group.sm,
   }),
   xs: definePartsStyle({
-    field: size.xs,
-    group: size.xs,
+    field: size.field.xs,
+    group: size.group.xs,
   }),
 }
 


### PR DESCRIPTION
## 📝 Description
This change allows users to style `Input` components via `InputGroup` without those styles being overridden by the `Input` itself.

## ⛳️ Current behavior (updates)

The `Input` component can be styled by setting some custom CSS variables:
```
--input-height
--input-font-size
--input-padding
--input-border-radius
```
These CSS variables are also used by `InputGroup` and the `InputLeftAddon/InputRightAddon` and `InputLeftElement/InputRightElement` components to allow them to share size information with the `Input` to create a seamless end result.

Unfortunately, if you want to adjust any of these values in a one-off scenario, you have to apply the new value to the `InputGroup` **and** to the `Input`, because the `Input` has its own copy of the CSS variables which take precedence.

```typescript
<InputGroup sx={{ '--input-height': '50px' }}>
  <Input placeholder="Search for something..." sx={{ '--input-height': '50px' }} />
  <InputRightElement>
    <Search />
  </InputRightElement>
 </InputGroup>
```

## 🚀 New behavior

This PR changes the keys of the CSS variables set on the `Input` itself to this set:

```
--input-field-height
--input-field-font-size
--input-field-padding
--input-field-border-radius
```
It then adjusts the corresponding properties of an `Input` to use the original set with a fallback to the new set:

```css
height: var(--input-height, var(--input-field-height));
font-size: var(--input-font-size, var(--input-field-font-size));
padding-inline-start: var(--input-padding, var(--input-field-padding));
padding-inline-end: var(--input-padding, var(--input-field-padding));
border-radius: var(--input-border-radius, var(--input-field-border-radius));
```
This lets a user set the original variable once on the `InputGroup` and have it inherit throughout the other group components.

## 💣 Is this a breaking change (Yes/No):

No - if a user is already dealing with this issue by setting the original CSS vars in two places, that will continue to work due to the CSS variable fallback arrangement.

## 📝 Additional Information

It's my understanding that the reason this has to be solved with two CSS variables is because Chakra doesn't allow theme tokens in CSS variable fallback values. Having the fallback be another variable which _can_ be set with a theme token means we can avoid hard-coding any CSS values.