### PR TITLE
feat(highlight): add case sensitive prop

### DIFF
--- a/.changeset/dry-dolls-beam.md
+++ b/.changeset/dry-dolls-beam.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": minor
+"@chakra-ui/props-docs": minor
+---
+
+add caseSensitive property to the Highlight component

--- a/packages/components/src/highlight/highlight-words.ts
+++ b/packages/components/src/highlight/highlight-words.ts
@@ -5,12 +5,13 @@ export interface Chunk {
 export interface HighlightOptions {
   text: string
   query: string | string[]
+  caseSensitive?: boolean
 }
 
 const escapeRegexp = (term: string): string =>
   term.replace(/[|\\{}()[\]^$+*?.-]/g, (char: string) => `\\${char}`)
 
-function buildRegex(query: string[]) {
+function buildRegex(query: string[], caseSensitive: boolean) {
   const _query = query
     .filter((text) => text.length !== 0)
     .map((text) => escapeRegexp(text.trim()))
@@ -18,11 +19,18 @@ function buildRegex(query: string[]) {
     return null
   }
 
-  return new RegExp(`(${_query.join("|")})`, "ig")
+  return new RegExp(`(${_query.join("|")})`, `${caseSensitive ? "" : "i"}g`)
 }
 
-export function highlightWords({ text, query }: HighlightOptions): Chunk[] {
-  const regex = buildRegex(Array.isArray(query) ? query : [query])
+export function highlightWords({
+  text,
+  query,
+  caseSensitive = false,
+}: HighlightOptions): Chunk[] {
+  const regex = buildRegex(
+    Array.isArray(query) ? query : [query],
+    caseSensitive,
+  )
   if (!regex) {
     return [{ text, match: false }]
   }

--- a/packages/components/src/highlight/highlight.stories.tsx
+++ b/packages/components/src/highlight/highlight.stories.tsx
@@ -84,3 +84,16 @@ export const MarketingExample = () => {
     </Heading>
   )
 }
+
+export const CaseSensitivity = () => (
+  <Text fontWeight="semibold">
+    <Highlight
+      query={["Human", "Dogs"]}
+      styles={{ px: "2", py: "1", rounded: "full", bg: "green.100" }}
+      caseSensitive
+    >
+      Human beings have many kinds of pets, of which dogs are one. Dogs are
+      often called human's best friends.
+    </Highlight>
+  </Text>
+)

--- a/packages/components/src/highlight/highlight.tsx
+++ b/packages/components/src/highlight/highlight.tsx
@@ -8,6 +8,7 @@ export interface HighlightProps {
   query: string | string[]
   children: string | ((props: Chunk[]) => React.ReactNode)
   styles?: SystemStyleObject
+  caseSensitive?: boolean
 }
 
 /**
@@ -16,13 +17,13 @@ export interface HighlightProps {
  * @see Docs https://chakra-ui.com/docs/components/highlight
  */
 export function Highlight(props: HighlightProps): JSX.Element {
-  const { children, query, styles } = props
+  const { children, query, styles, caseSensitive } = props
 
   if (typeof children !== "string") {
     throw new Error("The children prop of Highlight must be a string")
   }
 
-  const chunks = useHighlight({ query, text: children })
+  const chunks = useHighlight({ query, text: children, caseSensitive })
 
   return (
     <>

--- a/packages/components/src/highlight/use-highlight.test.ts
+++ b/packages/components/src/highlight/use-highlight.test.ts
@@ -43,4 +43,31 @@ describe("useHighlight", () => {
   ]
   `)
   })
+
+  test("useHighlight matches case-sensitively correctly", () => {
+    const query = ["", "text"]
+    const { result } = hooks.render(() =>
+      useHighlight({
+        query: query,
+        text: "Text: this is an ordinary text which should have one match ",
+        caseSensitive: true,
+      }),
+    )
+    expect(result.current).toMatchInlineSnapshot(`
+  [
+    {
+      "match": false,
+      "text": "Text: this is an ordinary ",
+    },
+    {
+      "match": true,
+      "text": "text",
+    },
+    {
+      "match": false,
+      "text": " which should have one match ",
+    },
+  ]
+  `)
+  })
 })

--- a/packages/components/src/highlight/use-highlight.ts
+++ b/packages/components/src/highlight/use-highlight.ts
@@ -4,6 +4,9 @@ import { HighlightOptions, highlightWords } from "./highlight-words"
 export interface UseHighlightProps extends HighlightOptions {}
 
 export function useHighlight(props: UseHighlightProps) {
-  const { text, query } = props
-  return useMemo(() => highlightWords({ text, query }), [text, query])
+  const { text, query, caseSensitive } = props
+  return useMemo(
+    () => highlightWords({ text, query, caseSensitive }),
+    [text, query, caseSensitive],
+  )
 }

--- a/packages/props-docs/generated/highlight.json
+++ b/packages/props-docs/generated/highlight.json
@@ -1,11 +1,13 @@
 {
   "Highlight": {
     "query": { "type": "string | string[]", "required": true },
+    "caseSensitive": { "type": "boolean", "required": false },
     "styles": { "type": "SystemStyleObject", "required": false }
   },
   "Mark": {},
   "UseHighlight": {
     "query": { "type": "string | string[]", "required": true },
-    "text": { "type": "string", "required": true }
+    "text": { "type": "string", "required": true },
+    "caseSensitive": { "type": "boolean", "required": false }
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The `Highlight` component currently uses a case-insensitive regex to perform matching. This adds a `caseSensitive` boolean property to the component (and underlying hook) to switch the behavior to case-sensitive matching.

## 🚀 New behavior

* Add a `caseSensitive` property to the `Highlight` component to allow for case-sensitive highlighting.
* Add a `caseSensitive` parameter to the `useHighlight` hook to allow for case-sensitive highlight group generation.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information

This is my first Chakra PR -- please let me know if I've missed anything! I understand that the `main` branch is currently the in-progress v3. If this PR is accepted, I'll create another PR to port it forward into v3 for parity.