### PR TITLE
docs: fixed github broken link on the docs page

### DIFF
--- a/packages/gatsby-plugin/README.md
+++ b/packages/gatsby-plugin/README.md
@@ -106,5 +106,5 @@ You can learn more about custom theme at
 [Chakra UI's documentation](https://chakra-ui.com/theme).
 
 By default, Chakra provides a sensible
-[default theme](https://github.com/chakra-ui/chakra-ui/tree/main/packages/theme)
+[default theme](https://github.com/chakra-ui/chakra-ui/tree/v2/packages/theme)
 inspired by Tailwind CSS.

--- a/website/content/docs/styled-system/customize-theme.mdx
+++ b/website/content/docs/styled-system/customize-theme.mdx
@@ -57,7 +57,7 @@ You can also use the color for the `colorScheme` prop like this:
 
 > If you're curious as to what theme styles you can override, please reference
 > the
-> [default theme foundation style files](https://github.com/chakra-ui/chakra-ui/tree/main/packages/theme/src/foundations).
+> [default theme foundation style files](https://github.com/chakra-ui/chakra-ui/tree/v2/packages/theme/src/foundations).
 
 ## Customizing component styles
 
@@ -170,7 +170,7 @@ automatically applied.
 
 > If you're curious as to what component styles you can override, please
 > reference the
-> [default component style files](https://github.com/chakra-ui/chakra-ui/tree/main/packages/components).
+> [default component style files](https://github.com/chakra-ui/chakra-ui/tree/v2/packages/components).
 
 ### Customizing global styles
 

--- a/website/content/docs/styled-system/theme.mdx
+++ b/website/content/docs/styled-system/theme.mdx
@@ -46,7 +46,7 @@ export default {
 ```
 
 Chakra provides a sensible
-[default theme](https://github.com/chakra-ui/chakra-ui/tree/main/packages/theme/src/components)
+[default theme](https://github.com/chakra-ui/chakra-ui/tree/v2/packages/theme/src/components)
 inspired by Tailwind CSS, but you can customize it to fit your design.
 
 ### Black & White


### PR DESCRIPTION
Closes #8395

## 📝 Description

Some github links present on chakra UI docs are broken. The reason is the github link contain `main` branch, but currently we have changed file structure of `main` branch so old github link is not working. To fix this, I changed the github link from `main` to `v2` so it will be independent from the main branch and the issue will be fixed.

Old Link on docs - https://github.com/chakra-ui/chakra-ui/tree/main/packages/theme/src/foundations
New LInk on docs - https://github.com/chakra-ui/chakra-ui/tree/v2/packages/theme/src/foundations

## ⛳️ Current behavior (updates)

Links opens 404 error page.

https://github.com/chakra-ui/chakra-ui/assets/44361140/18ac70ee-69ef-43ca-b14f-4627b3a1ea6d

## 🚀 New behavior

Links opens the correct page.

https://github.com/chakra-ui/chakra-ui/assets/44361140/78e95500-d6a6-4436-bf1c-23c3e1be3450

## 💣 Is this a breaking change (Yes/No):

No