### PR TITLE
feat: export useAlertContext

### DIFF
--- a/.changeset/funny-foxes-tease.md
+++ b/.changeset/funny-foxes-tease.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+Export `useAlertContext` hook

--- a/packages/components/src/alert/index.ts
+++ b/packages/components/src/alert/index.ts
@@ -1,6 +1,6 @@
 export { Alert } from "./alert"
 export type { AlertProps } from "./alert"
-export { useAlertStyles } from "./alert-context"
+export { useAlertStyles, useAlertContext } from "./alert-context"
 export type { AlertStatus } from "./alert-context"
 export { AlertDescription } from "./alert-description"
 export type { AlertDescriptionProps } from "./alert-description"


### PR DESCRIPTION
Closes #8104 

## 📝 Description

This PR exports the `useAlertContext` hook. This increases the flexibility users have for customizing the Alert and the Toast component that depends on it. A specific example is that this allows users to customize which icons are used for different Alert statuses by implementing a custom AlertIcon component without also implementing custom Alert and Toast components. There are more details in the linked issue. 

## ⛳️ Current behavior (updates)

`useAlertContext` is not exported.

## 🚀 New behavior

`useAlertContext` is exported.

## 💣 Is this a breaking change (Yes/No):

Not a breaking change, but an addition to the API surface.

## 📝 Additional Information

Hopefully I'm targeting the correct branch. I copied the format of this other PR that made a similar change: https://github.com/chakra-ui/chakra-ui/pull/6142.
