### PR TITLE
fix: Undo Breaking Change by re-allowing disabled prop on button

### DIFF
--- a/.changeset/nine-bags-rest.md
+++ b/.changeset/nine-bags-rest.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Revert breaking change by re-allowing disabled prop on button

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -76,6 +76,7 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
 
   return (
     <chakra.button
+      disabled={isDisabled || isLoading}
       ref={useMergeRefs(ref, _ref)}
       as={as}
       type={type ?? defaultType}
@@ -84,7 +85,6 @@ export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
       __css={buttonStyles}
       className={cx("chakra-button", className)}
       {...rest}
-      disabled={isDisabled || isLoading}
     >
       {isLoading && spinnerPlacement === "start" && (
         <ButtonSpinner


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Closes #7269
Closes #7816
Closes #7905

Also re-enables the only currently known workaround for the accessibility problem described in  #7965. 

Removing the ability to use the disabled-prop posed a breaking change, which is hereby fixed.

## ⛳️ Current behavior (updates)

Despite the `disabled` prop being exposed in the type system, any value given will be discarded and overwritten by `isDisabled || isLoading`.

## 🚀 New behavior

Values given to `disabled`-prop are now respected again. 

One use case (which was possible in 1.x up until 2.0.15) is the combination of `isLoading disabled={false}` to ensure that a button does not lose focus while in loading-state. 

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

This reverts a breaking change.

## 📝 Additional Information

This closes #7907, effectively replacing it.