### PR TITLE
Fix syntax error in Highlight usage section

### DIFF
--- a/website/content/docs/components/highlight/usage.mdx
+++ b/website/content/docs/components/highlight/usage.mdx
@@ -99,7 +99,7 @@ import { useHighlight } from '@chakra-ui/react'
 
 ```jsx
 // prettier-ignore
-;() => {
+() => {
   const chunks = useHighlight({
     text: 'With the Highlight component, you can spotlight, emphasize and accentuate words instantly',
     query: ['spotlight', 'emphasize', 'accentuate', 'instantly']


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Extra semi-colon causing syntax error.

## ⛳️ Current behavior (updates)

Syntax error on "[Customizing rendered elements](https://v2.chakra-ui.com/docs/components/highlight#customizing-rendered-elements)"

## 🚀 New behavior

Render "[Customizing rendered elements](https://v2.chakra-ui.com/docs/components/highlight#customizing-rendered-elements)" properly on Highlight page


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
