### PR TITLE
chore(stepper): add aria-current attribute

### DIFF
--- a/.changeset/yellow-kings-exercise.md
+++ b/.changeset/yellow-kings-exercise.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Add aria-current attribute to stepper

--- a/packages/react/src/components/steps/step-context.tsx
+++ b/packages/react/src/components/steps/step-context.tsx
@@ -8,7 +8,7 @@ export type StepItemStatus = "current" | "completed" | "incomplete"
 export interface StepContext {
   /**
    * The status of the step
-   * @type "active" | "complete" | "incomplete"
+   * @type "current" | "complete" | "incomplete"
    */
   status: StepItemStatus
   /**

--- a/packages/react/src/components/steps/step-item.tsx
+++ b/packages/react/src/components/steps/step-item.tsx
@@ -17,6 +17,7 @@ export const StepItem = forwardRef<HTMLDivElement, StepItemProps>(
         ref={ref}
         {...api.dataAttrs}
         {...props}
+        aria-current={api.status === "current" ? "step" : undefined}
         css={[styles["item"], props.css]}
         className={cx("chakra-step", props.className)}
       />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Added the `aria-current` attribute to the Stepper.

## ⛳️ Current behavior (updates)

The current step does not have the `aria-current` attribute.

## 🚀 New behavior

The current step now has `aria-current="step"` assigned.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

References:
- [aria-current - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current#values)
- [Using the aria-current attribute - Tink - Léonie Watson](https://tink.uk/using-the-aria-current-attribute/)
- [aria-current AT and Browser support](https://codepen.io/Deafinitive/pen/wvqJQxd)
