### PR TITLE
fix(website/omni-search): correct the usage of `useEventListener`

### DIFF
--- a/website/src/components/omni-search.tsx
+++ b/website/src/components/omni-search.tsx
@@ -134,8 +134,7 @@ function OmniSearch() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // @ts-expect-error @segunadebayo not sure what this should be?!
-  useEventListener('keydown', (event) => {
+  useEventListener(null, 'keydown', (event) => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform)
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
     if (event?.key?.toLowerCase() === 'k' && event[hotkey]) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #8490 

## ⛳️ Current behavior (updates)

In the `omni-search` component of the docsite, the `useEventListener` hook for the keyboard shortcut to open the search modal has incorrect arguments applied to the first two parameters, resulting in the entire hook failing.

## 🚀 New behavior

Move the two arguments to the second and third param. The first param is looking for a target object which is not needed and can be defined `null`. The second param needs the string `keydown` because that is the mapped event name. And the third param needs the actual event handling.

## 📝 Additional Information

The current broken behavior will still impact the site when it shifts over to Chakra v3
