### PR TITLE
feature: export CreateIconOptions interface

### DIFF
--- a/packages/react/src/components/icon/create-icon.tsx
+++ b/packages/react/src/components/icon/create-icon.tsx
@@ -3,7 +3,7 @@
 import { Children, forwardRef } from "react"
 import { Icon, type IconProps } from "./icon"
 
-interface CreateIconOptions {
+export interface CreateIconOptions {
   /**
    * The icon `svg` viewBox
    * @default "0 0 24 24"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description


When using `createIcon`, I found myself needing the `CreateIconOptions` interface.

In this scenario, I am defining and passing my own objects to the `createIcon` method, which should conform to the `CreateIconOptions` type. However, I had to copy and paste it from `@chakra-ui/icons`. Given that this is a real-world scenario, I believe the `CreateIconOptions` interface should be exported from `@chakra-ui/icons`.


## ⛳️ Current behavior (updates)

`CreateIconOptions` interface is not being exported from `@chakra-ui/icons`.

## 🚀 New behavior

exports `CreateIconOptions` interface from `@chakra-ui/icons`.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information
