### PR TITLE
[v3] fix(website/omni-search): update styling and apply correct disclosure to open and close dialog

### DIFF
--- a/website/src/components/algolia-search.tsx
+++ b/website/src/components/algolia-search.tsx
@@ -48,24 +48,25 @@ export const SearchButton = React.forwardRef(function SearchButton(
 
   return (
     <chakra.button
-      flex='1'
-      type='button'
-      mx='6'
-      ref={ref}
-      lineHeight='1.2'
-      w='100%'
-      bg='white'
-      whiteSpace='nowrap'
-      display={{ base: 'none', sm: 'flex' }}
       alignItems='center'
+      bg='white'
       color='gray.600'
-      _dark={{ bg: 'gray.700', color: 'gray.400' }}
-      py='3'
-      px='4'
+      cursor='pointer'
+      display={{ base: 'none', sm: 'flex' }}
+      flex='1'
+      lineHeight='1.2'
+      mx='6'
       outline='0'
-      _focus={{ shadow: 'outline' }}
-      shadow='xs'
+      px='4'
+      py='3'
+      ref={ref}
       rounded='md'
+      shadow='xs'
+      type='button'
+      w='100%'
+      whiteSpace='nowrap'
+      _dark={{ bg: 'gray.700', color: 'gray.400' }}
+      _focus={{ shadow: 'outline' }}
       {...props}
     >
       <SearchIcon />

--- a/website/src/components/omni-search.tsx
+++ b/website/src/components/omni-search.tsx
@@ -129,8 +129,7 @@ function OmniSearch() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // @ts-expect-error @segunadebayo not sure what this should be?!
-  useEventListener('keydown', (event) => {
+  useEventListener(null, 'keydown', (event) => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform)
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
     if (event?.key?.toLowerCase() === 'k' && event[hotkey]) {
@@ -230,7 +229,7 @@ function OmniSearch() {
       <Dialog.Root
         scrollBehavior='inside'
         open={modal.open}
-        onOpenChange={(e) => (e.open ? menu.onOpen() : menu.onClose())}
+        onOpenChange={(e) => (e.open ? modal.onOpen() : modal.onClose())}
       >
         <Dialog.Backdrop />
         <Dialog.Positioner>


### PR DESCRIPTION
Fixes keyboard interaction to open and close the search dialog. Also positively impact click outside to close dialog.

Other current bugs in the search dialog are handled separately.