### PR TITLE
[v3] fix(cli/theme-output-dir): fix theme typing output dir by converting file URL into path

### DIFF
--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -5,7 +5,7 @@ import chokidar from "chokidar"
 import { existsSync, mkdirSync, rm } from "node:fs"
 import { writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { fileURLToPath } from "url"
+import { fileURLToPath } from "node:url"
 
 interface ReadResult {
   mod: SystemContext

--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -5,6 +5,7 @@ import chokidar from "chokidar"
 import { existsSync, mkdirSync, rm } from "node:fs"
 import { writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "url"
 
 interface ReadResult {
   mod: SystemContext
@@ -33,7 +34,13 @@ export const read = async (file: string): Promise<ReadResult> => {
 const getBasePath = () => {
   if (!process.env.LOCAL) {
     const root = import.meta.resolve("@chakra-ui/react")
-    return resolve(dirname(root), "..", "types", "styled-system", "generated")
+    return resolve(
+      fileURLToPath(dirname(root)),
+      "..",
+      "types",
+      "styled-system",
+      "generated",
+    )
   }
 
   const root = join(process.cwd(), "packages", "react", "src")


### PR DESCRIPTION
## 📝 Description

The v3 `npx chakra-cli tokens </path/to/theme.ts>` command is currently writing token typing files into the wrong directory.

This is because `import.meta.resolve("@chakra-ui/react")` returns a file URL, with `file://` at beginning, not a path.

## ⛳️ Current behavior (updates)

The CLI is writing the files to: `/path/to/my-chakra-project/file:/path/to/my-chakra-project/node_modules/@chakra-ui/react/dist/types/styled-system/generated`

## 🚀 New behavior

The CLI should write files to: `/path/to/my-chakra-project/node_modules/@chakra-ui/react/dist/types/styled-system/generated`

## 💣 Is this a breaking change (Yes/No):

No