### PR TITLE
fix(components/color-mode): Include `nonce` from `EmotionCache` inside injected style tag

### DIFF
--- a/.changeset/little-experts-do.md
+++ b/.changeset/little-experts-do.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Include "nonce" from "EmotionCache" inside style tag injected by color-mode.util
+to resolve Content Security Policy error

--- a/packages/components/src/color-mode/color-mode-provider.test.tsx
+++ b/packages/components/src/color-mode/color-mode-provider.test.tsx
@@ -8,6 +8,9 @@ import {
   mockLocalStorage,
   mockMatchMedia,
 } from "./test.fixture"
+import { CacheProvider } from "@emotion/react"
+
+vi.spyOn(document.head, "appendChild")
 
 describe("<ColorModeProvider /> localStorage browser", () => {
   it.each(
@@ -61,6 +64,25 @@ describe("Config options", () => {
 
     expect(getColorModeButton()).toHaveTextContent(
       defaultThemeOptions.initialColorMode,
+    )
+  })
+
+  test("by default, picks up nonce from emotion cache", async () => {
+    const mockNonce = "testNonce"
+
+    render(
+      // @ts-ignore - we are only testing the nonce prop
+      <CacheProvider value={{ nonce: mockNonce }}>
+        <ColorModeProvider options={defaultThemeOptions}>
+          <DummyComponent />
+        </ColorModeProvider>
+      </CacheProvider>,
+    )
+
+    expect(document.head.appendChild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nonce: mockNonce,
+      }),
     )
   })
 

--- a/packages/components/src/color-mode/color-mode-provider.tsx
+++ b/packages/components/src/color-mode/color-mode-provider.tsx
@@ -14,6 +14,7 @@ import {
 } from "./color-mode-types"
 import { getColorModeUtils } from "./color-mode.utils"
 import { StorageManager, localStorageManager } from "./storage-manager"
+import { EmotionCache, withEmotionCache } from "@emotion/react"
 
 const noop = () => {}
 
@@ -36,7 +37,10 @@ function getTheme(manager: StorageManager, fallback?: ColorMode) {
  * Provides context for the color mode based on config in `theme`
  * Returns the color mode and function to toggle the color mode
  */
-export function ColorModeProvider(props: ColorModeProviderProps) {
+export const ColorModeProvider = withEmotionCache(function ColorModeProvider(
+  props: ColorModeProviderProps,
+  cache: EmotionCache,
+) {
   const {
     value,
     children,
@@ -59,8 +63,12 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
   )
 
   const { getSystemTheme, setClassName, setDataset, addListener } = useMemo(
-    () => getColorModeUtils({ preventTransition: disableTransitionOnChange }),
-    [disableTransitionOnChange],
+    () =>
+      getColorModeUtils({
+        preventTransition: disableTransitionOnChange,
+        nonce: cache?.nonce,
+      }),
+    [disableTransitionOnChange, cache?.nonce],
   )
 
   const resolvedValue =
@@ -128,7 +136,7 @@ export function ColorModeProvider(props: ColorModeProviderProps) {
       {children}
     </ColorModeContext.Provider>
   )
-}
+})
 
 ColorModeProvider.displayName = "ColorModeProvider"
 

--- a/packages/components/src/color-mode/color-mode.utils.test.tsx
+++ b/packages/components/src/color-mode/color-mode.utils.test.tsx
@@ -1,0 +1,43 @@
+import { renderHook } from "@testing-library/react"
+import { getColorModeUtils } from "./color-mode.utils"
+
+vi.spyOn(document.head, "appendChild")
+
+describe("getColorModeUtils", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe("preventTransition", () => {
+    test("sets nonce on the injected stylesheet if nonce argument was provided", () => {
+      const mockNonce = "testNonce"
+
+      const { result } = renderHook(() =>
+        getColorModeUtils({
+          nonce: mockNonce,
+        }),
+      )
+
+      // Trigger the preventTransition function
+      result.current.setDataset("dark")
+
+      expect(document.head.appendChild).toHaveBeenCalledTimes(1)
+      expect(document.head.appendChild).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nonce: mockNonce,
+        }),
+      )
+    })
+
+    test("does not set nonce on the injected stylesheet if nonce argument was omitted", () => {
+      const { result } = renderHook(() => getColorModeUtils())
+
+      // Trigger the preventTransition function
+      result.current.setDataset("dark")
+
+      const element = document.createElement("style")
+      element.innerHTML = `*{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`
+      expect(document.head.appendChild).toHaveBeenCalledWith(element)
+    })
+  })
+})

--- a/packages/components/src/color-mode/color-mode.utils.ts
+++ b/packages/components/src/color-mode/color-mode.utils.ts
@@ -7,10 +7,11 @@ const classNames = {
 
 type UtilOptions = {
   preventTransition?: boolean
+  nonce?: string
 }
 
 export function getColorModeUtils(options: UtilOptions = {}) {
-  const { preventTransition = true } = options
+  const { preventTransition = true, nonce } = options
 
   const utils = {
     setDataset: (value: ColorMode) => {
@@ -52,6 +53,11 @@ export function getColorModeUtils(options: UtilOptions = {}) {
           `*{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`,
         ),
       )
+
+      if (nonce !== undefined) {
+        css.nonce = nonce
+      }
+
       document.head.appendChild(css)
 
       return () => {


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/8043

## 📝 Description

This PR adds the functionality to pass the `nonce` from `EmotionCache` inside the style tag injected by `color-mode.utils.ts` 
 
## ⛳️ Current behavior (updates)

Previously, when Chakra Ui was used in a project with a Content Security Policy in place, the following error would be thrown:
```
Refused to apply inline style because it violates the following Content Security Policy directive: "style-src http://my-domain.test/ 'nonce-LBVC3WAK89jF6Nh0lWF7IQ=='". Either the 'unsafe-inline' keyword, a hash ('sha256-GNF74DLkXb0fH3ILHgILFjk1ozCF3SNXQ5mQb7WLu/Y='), or a nonce ('nonce-...') is required to enable inline execution.

preventTransition @ color-mode.utils.ts:55
setDataset @ color-mode.utils.ts:17
(anonymous) @ color-mode-provider.tsx:68
(anonymous) @ color-mode-provider.tsx:86
```

The issue was happening due to the `css` element missing the `nonce` property required for projects using CSP.

You can find more details about this issue along with steps to reproduce the error in [the following GitHub issue](https://github.com/chakra-ui/chakra-ui/issues/8043).

## 🚀 New behavior

- The `ColorModeProvider` now accepts cache from `EmotionCache` and passes the `nonce` value from it down to `getColorModeUtils` exported from `color-mode.utils.test.tsx`
- The `getColorModeUtils` now accepts the optional `nonce` argument that will get applied to the style tag injected when calling `preventTransition()`
- Added additional tests for `ColorModeProvider` and `getColorModeUtils` to verify described functionality

The above changes ensure that the injected style tag has an appropriate `nonce` value to satisfy the Content Security Policy set inside the project.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Please do let me know if you think there is any way to improve the following PR!
