### PR TITLE
feat: add getPortalRoot to Environment (v2.x)

### DIFF
--- a/packages/components/src/env/env.tsx
+++ b/packages/components/src/env/env.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useMemo, useReducer, useRef } from "react"
 interface Environment {
   getWindow: () => Window
   getDocument: () => Document
+  getPortalRoot: () => HTMLElement
 }
 
 const EnvironmentContext = createContext<Environment>({
@@ -13,6 +14,9 @@ const EnvironmentContext = createContext<Environment>({
   getWindow() {
     return window
   },
+  getPortalRoot() {
+    return document.body
+  }
 })
 
 EnvironmentContext.displayName = "EnvironmentContext"
@@ -43,6 +47,7 @@ export function EnvironmentProvider(props: EnvironmentProviderProps) {
     return {
       getDocument: () => ref.current?.ownerDocument ?? document,
       getWindow: () => ref.current?.ownerDocument.defaultView ?? window,
+      getPortalRoot: () => ref.current?.ownerDocument.body ?? document.body,
     }
   }, [environmentProp])
 

--- a/packages/components/src/portal/portal.tsx
+++ b/packages/components/src/portal/portal.tsx
@@ -3,6 +3,7 @@ import { createContext } from "@chakra-ui/utils/context"
 import { createPortal } from "react-dom"
 import { usePortalManager } from "./portal-manager"
 import { useEffect, useMemo, useRef, useState } from "react"
+import { useEnvironment } from "../env"
 
 type PortalContext = HTMLDivElement | null
 
@@ -106,8 +107,9 @@ interface ContainerPortalProps extends React.PropsWithChildren<{}> {
 const ContainerPortal = (props: ContainerPortalProps) => {
   const { children, containerRef, appendToParentPortal } = props
   const containerEl = containerRef.current
+  const { getPortalRoot } = useEnvironment()
   const host =
-    containerEl ?? (typeof window !== "undefined" ? document.body : undefined)
+    containerEl ?? (typeof window !== "undefined" ? getPortalRoot() : undefined)
 
   const portal = useMemo(() => {
     const node = containerEl?.ownerDocument.createElement("div")


### PR DESCRIPTION
Closes #2145

> [!WARNING]
> This is a draft: testing is needed.

## 📝 Description

This PR is an untested draft (a PoC, if you will) of a proposed solution to fix Chakra UI portals when using Shadow DOM.

This fix is targeting the 2.x branch.

## ⛳️ Current behavior (updates)

Currently, all portals are appended to `document.body`. This breaks styling for all popups, tooltips and dialogs if Shadow DOM is used.

## 🚀 New behavior

This PR adds `getPortalRoot` to `Environment` that will allow to customize the default element to use as root for portals, e.g.:

```tsx
const App = ({ el }: any) => {
  const shadowRoot = el.attachShadow({ mode: 'open' });
  const cache = createCache({ key: 'chakra-css', container: shadowRoot });
  const reactRoot = ReactDOM.createRoot(shadowRoot);
  reactRoot.render(
    <CacheProvider value={cache}>
      <ChakraProvider theme={lightTheme} environment={{
        getWindow: () => window,
        getDocument: () => document,
        getPortalRoot: () => shadowRoot, // New method
      }}>
        {/* ... */}
      </ChakraProvider>
    </CacheProvider>
  );
  return () => reactRoot.unmount();
}```

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information