### PR TITLE
feat: adding the dotted style to separator

### DIFF
--- a/packages/props-docs/generated/divider.json
+++ b/packages/props-docs/generated/divider.json
@@ -16,7 +16,7 @@
     },
     "variant": {
       "defaultValue": "solid",
-      "type": "\"solid\" | \"dashed\"",
+      "type": "\"solid\" | \"dashed\" | \"dotted\"",
       "required": false,
       "description": "The variant of the Divider"
     }

--- a/packages/props-docs/generated/separator.json
+++ b/packages/props-docs/generated/separator.json
@@ -13,7 +13,7 @@
       "description": "The orientation of the component"
     },
     "variant": {
-      "type": "\"solid\" | \"dashed\"",
+      "type": "\"solid\" | \"dashed\" | \"dotted\"",
       "defaultValue": "solid",
       "required": false,
       "description": "The variant of the component"

--- a/packages/react/__stories__/separator.stories.tsx
+++ b/packages/react/__stories__/separator.stories.tsx
@@ -19,3 +19,7 @@ export const Vertical = () => <Separator orientation="vertical" />
 export const DashedVariant = () => (
   <Separator orientation="horizontal" variant="dashed" />
 )
+
+export const DottedVariant = () => (
+  <Separator orientation="horizontal" variant="dotted" />
+)

--- a/packages/react/src/styled-system/generated/recipes.gen.ts
+++ b/packages/react/src/styled-system/generated/recipes.gen.ts
@@ -43,7 +43,7 @@ export interface LinkVariantProps {
 export interface MarkVariantProps {}
 
 export interface SeparatorVariantProps {
-  variant?: "solid" | "dashed"
+  variant?: "solid" | "dashed" | "dotted"
   orientation?: "vertical" | "horizontal"
 }
 

--- a/packages/react/src/theme/recipes/divider.ts
+++ b/packages/react/src/theme/recipes/divider.ts
@@ -13,6 +13,9 @@ export const separatorRecipe = defineRecipe({
       dashed: {
         borderStyle: "dashed",
       },
+      dotted: {
+        borderStyle: "dotted",
+      },
     },
     orientation: {
       vertical: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Adding `dotted` style to the Separator. (aka Divider)

## ⛳️ Current behavior (updates)

Need to provide the style to the separator for `dotted` style.

## 🚀 New behavior

Accepts `dotted` as a variant for the separator.

## 💣 Is this a breaking change (Yes/No):

No
## 📝 Additional Information
