### PR TITLE
Add missing import for App component in Chakra UI setup guide

### DIFF
--- a/website/content/getting-started/vite-guide.mdx
+++ b/website/content/getting-started/vite-guide.mdx
@@ -32,6 +32,7 @@ Go to the `src` directory and inside `main.jsx` or `main.tsx`, wrap
 import * as React from 'react'
 import { ChakraProvider } from '@chakra-ui/react'
 import * as ReactDOM from 'react-dom/client'
+import App from './App';
 
 const rootElement = document.getElementById('root')
 ReactDOM.createRoot(rootElement).render(


### PR DESCRIPTION
In the Chakra UI setup guide for Vite projects, included the missing import statement `import App from './App';` to ensure clarity and completeness of the example provided. This addition ensures that readers can correctly implement Chakra UI with Vite without encountering import errors.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Added the missing import statement `import App from './App';` to the Chakra UI setup example in the documentation.

## ⛳️ Current behavior (updates)

The current Chakra UI setup example in the documentation does not include the import statement for the App component.

## 🚀 New behavior

This PR adds the necessary import statement `import App from './App';` to the example code. This ensures that the App component is properly included when setting up ChakraProvider in Vite projects.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

No additional information.
