### PR TITLE
docs: Update usage.mdx for Stepper component

### DIFF
--- a/website/content/docs/components/stepper/usage.mdx
+++ b/website/content/docs/components/stepper/usage.mdx
@@ -236,7 +236,7 @@ function Example() {
   return (
     <Steps.Root size='lg' index={activeStep}>
       {steps.map((step, index) => (
-        <Steps.Item key={index} onClick={() => setActiveStep(index)}>
+        <Steps.Item key={index} onClick={() => setActiveStep(index + 1)}>
           <Steps.Indicator />
 
           <Box flexShrink='0'>


### PR DESCRIPTION
Hello,

This useSteps hook provides an index prop that starts at 1. 

However, if you use the index from the map method to change the active step on click, it will equal 0 for the first step. 
This means you are setting step 0 as active, which doesn't exist.

