### PR TITLE
fix(docs): replace wrap with group on button page

### DIFF
--- a/website/content/docs/components/button/usage.mdx
+++ b/website/content/docs/components/button/usage.mdx
@@ -68,14 +68,14 @@ set the value to any of the color scales from your design system, like
 `whiteAlpha`, `blackAlpha`, `gray`, `red`, `blue`, or your custom color scale.
 
 ```jsx
-<Wrap gap={4}>
+<Group wrap='wrap' gap={4}>
   <Button colorPalette='gray'>Gray</Button>
   <Button colorPalette='red'>Red</Button>
   <Button colorPalette='orange'>Orange</Button>
   <Button colorPalette='yellow'>Yellow</Button>
   <Button colorPalette='green'>Green</Button>
   <Button colorPalette='teal'>Teal</Button>
-</Wrap>
+</Group>
 ```
 
 ### Using icons


### PR DESCRIPTION
## 📝 Description

The `Wrap` component no longer exists.

## ⛳️ Current behavior (updates)

"ReferenceError: Wrap is not defined" error message is displayed on button page.

## 🚀 New behavior

Removes error message

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
