### PR TITLE
fix(docs): replace button group with group on flex page

### DIFF
--- a/website/content/docs/components/flex/usage.mdx
+++ b/website/content/docs/components/flex/usage.mdx
@@ -123,9 +123,9 @@ doubled when the spacer is completely collapsed.
     <Heading size='md'>Chakra App</Heading>
   </Box>
   <Spacer />
-  <ButtonGroup gap='2'>
+  <Group gap='2'>
     <Button colorPalette='teal'>Sign Up</Button>
     <Button colorPalette='teal'>Log in</Button>
-  </ButtonGroup>
+  </Group>
 </Flex>
 ```


### PR DESCRIPTION
## 📝 Description

The `ButtonGroup` component no longer exists

## ⛳️ Current behavior (updates)

"ReferenceError: ButtonGroup is not defined" is displayed on flex page

## 🚀 New behavior

Removes error message

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
