### PR TITLE
Add for attribute to Radio and Checkbox label if ID is available (v2.x)

### DIFF
--- a/.changeset/sweet-owls-eat.md
+++ b/.changeset/sweet-owls-eat.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+Add for attribute to Radio and Checkbox label if id is available for the input

--- a/packages/components/src/checkbox/checkbox.test.tsx
+++ b/packages/components/src/checkbox/checkbox.test.tsx
@@ -535,3 +535,11 @@ test("On resetting form, all checkboxes in the form should reset to its default 
   expect(checkbox1).toBeChecked()
   expect(checkbox2).not.toBeChecked()
 })
+
+test("Checkbox with an ID should have a for on the label", () => {
+  const { getByRole, container } = render(<Checkbox id="my-checkbox" />)
+  const checkbox = getByRole("checkbox")
+  const label = container.querySelector("label")
+  expect(checkbox).toHaveAttribute("id", "my-checkbox")
+  expect(label).toHaveAttribute("for", "my-checkbox")
+})

--- a/packages/components/src/checkbox/use-checkbox.ts
+++ b/packages/components/src/checkbox/use-checkbox.ts
@@ -252,6 +252,12 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
         if (!node) return
         setRootIsLabelElement(node.tagName === "LABEL")
       }),
+      htmlFor:
+        props.htmlFor !== undefined
+          ? props.htmlFor
+          : rootIsLabelElement
+          ? id
+          : undefined,
       onClick: callAllHandlers(props.onClick, () => {
         /**
          * Accessibility:
@@ -274,7 +280,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       "data-checked": dataAttr(isChecked),
       "data-invalid": dataAttr(isInvalid),
     }),
-    [htmlProps, isDisabled, isChecked, isInvalid, rootIsLabelElement],
+    [htmlProps, isDisabled, isChecked, isInvalid, rootIsLabelElement, id],
   )
 
   const getInputProps: PropGetter = useCallback(

--- a/packages/components/src/radio/radio.test.tsx
+++ b/packages/components/src/radio/radio.test.tsx
@@ -35,6 +35,7 @@ test("has proper aria and data attributes", async () => {
   expect(checkbox).not.toHaveAttribute("data-readonly")
   expect(container).not.toHaveAttribute("data-invalid")
   expect(container).not.toHaveAttribute("data-disabled")
+  expect(container).toHaveAttribute("for", "id")
 
   // render with various flags enabled
   utils.rerender(<Component isDisabled isInvalid isReadOnly isRequired />)
@@ -130,7 +131,7 @@ test("should derive values from surrounding FormControl", () => {
   const onFocus = vi.fn()
   const onBlur = vi.fn()
 
-  render(
+  const { getByRole, container } = render(
     <FormControl
       id="radio"
       isRequired
@@ -146,13 +147,16 @@ test("should derive values from surrounding FormControl", () => {
     </FormControl>,
   )
 
-  const radio = screen.getByRole("radio")
+  const radio = getByRole("radio")
+  const [label1, label2] = container.querySelectorAll("label")
 
   expect(radio).toHaveAttribute("id", "radio")
   expect(radio).toHaveAttribute("aria-invalid", "true")
   expect(radio).toHaveAttribute("aria-required", "true")
   expect(radio).toHaveAttribute("data-readonly", "")
   expect(radio).toHaveAttribute("aria-invalid", "true")
+  expect(label1).toHaveAttribute("for", "radio")
+  expect(label2).toHaveAttribute("for", "radio")
 
   fireEvent.focus(radio)
   expect(onFocus).toHaveBeenCalled()

--- a/packages/components/src/radio/use-radio.ts
+++ b/packages/components/src/radio/use-radio.ts
@@ -280,6 +280,7 @@ export function useRadio(props: UseRadioProps = {}) {
   })
 
   const getRootProps: PropGetter = (props, ref = null) => ({
+    htmlFor: id,
     ...props,
     ref,
     "data-disabled": dataAttr(isDisabled),


### PR DESCRIPTION
## 📝 Description

Add for attribute to Radio and Checkbox label if ID is available

## ⛳️ Current behavior (updates)

Radio and Checkbox nest within the label but are not linked by `for` attribute on the label. Our screenreader (userway) does not read the associated text as a result of that (and the fact that the label text is nested in a span).

## 🚀 New behavior

Label now contains the `for`

## 💣 Is this a breaking change (Yes/No):

No, I have also attempted not to overwrite any provided `htmlFor` (even though it's not valid TS to have provided `for` or `htmlFor` to Radio or Checkbox)

## 📝 Additional Information
