### PR TITLE
docs(side-bar): update sidebar title from 'Forms' to 'Form' for consi…

### DIFF
--- a/website/configs/components.sidebar.json
+++ b/website/configs/components.sidebar.json
@@ -50,7 +50,7 @@
           ]
         },
         {
-          "title": "Forms",
+          "title": "Form",
           "path": "/docs/components/form",
           "sort": true,
           "open": true,


### PR DESCRIPTION
## 📝 Description

This PR updates the sidebar of the [components pages](https://v2.chakra-ui.com/docs/components) from 'Forms' to 'Form' to ensure consistency across the documentation. The [main page](https://v2.chakra-ui.com/docs/components) already uses the title 'Form' in the list of components in the main content, and this change aligns the sidebar title accordingly. Additionally, all other category names are singular, so this update maintains uniformity in naming conventions.

## ⛳️ Current behavior

Currently, the sidebar title is 'Forms', which is inconsistent with the components page main content title 'Form' and other category names, which are all in the singular form.

## 🚀 New behavior

After this change, the sidebar title will be updated to 'Form', which will align with the main content title and the singular naming convention of other categories.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

![Screenshot](https://github.com/user-attachments/assets/e2a05fd8-f3bc-4d4d-a7cd-975fe68a869c)

