### PR TITLE
fix(cli): platform specific path imports

### DIFF
--- a/packages/cli/src/utils/context.ts
+++ b/packages/cli/src/utils/context.ts
@@ -1,7 +1,8 @@
 import { globbySync } from "globby"
 import { existsSync, readFileSync } from "node:fs"
-import { join } from "node:path"
-import { resolve } from "node:path/posix"
+import path from "node:path"
+
+const localePath = path[process.platform === `win32` ? `win32` : `posix`]
 
 export interface ProjectScope {
   framework: "next" | "remix" | "vite" | null
@@ -24,7 +25,10 @@ function getFramework(files: string[], cwd: string) {
   }
 
   if (files.find((file) => file.startsWith("vite.config"))) {
-    const viteConfig = readFileSync(resolve(cwd, "vite.config.js"), "utf-8")
+    const viteConfig = readFileSync(
+      localePath.resolve(cwd, "vite.config.js"),
+      "utf-8",
+    )
     const isRemix = viteConfig.includes("@remix-run/dev")
     return isRemix ? "remix" : "vite"
   }
@@ -33,27 +37,27 @@ function getFramework(files: string[], cwd: string) {
 }
 
 function getComponentsDir(scope: ProjectScope, cwd: string) {
-  const basePath = join("components", "ui")
+  const basePath = localePath.join("components", "ui")
 
   if (scope.framework === "remix") {
-    return join("app", basePath)
+    return localePath.join("app", basePath)
   }
 
   if (scope.framework === "next") {
-    const isSrcDir = existsSync(join(cwd, "src"))
-    return join(isSrcDir ? "src" : "", basePath)
+    const isSrcDir = existsSync(localePath.join(cwd, "src"))
+    return localePath.join(isSrcDir ? "src" : "", basePath)
   }
 
-  return join("src", basePath)
+  return localePath.join("src", basePath)
 }
 
 export async function getProjectContext(opts: ProjectContextOptions) {
   const { cwd = process.cwd() } = opts
-  const isTypeScript = existsSync(resolve(cwd, "tsconfig.json"))
+  const isTypeScript = existsSync(localePath.resolve(cwd, "tsconfig.json"))
 
   const scope: ProjectScope = {
     framework: "next",
-    componentsDir: join("src", "components", "ui"),
+    componentsDir: localePath.join("src", "components", "ui"),
   }
 
   const files = globbySync(["next.config.*", "vite.config.*"], { cwd })


### PR DESCRIPTION
## 📝 Description

Fixes an issue with not getting the correct path on Windows platforms.

## ⛳️ Current behavior (updates)

The CLI is not fetching paths correctly on current windows. 

## 🚀 New behavior

Fixed importing from `node:path/posix` to import per platform.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
