### PR TITLE
fix(toast.types): ToastOptions callbacks are actually this-bound free, so mark as this:void

### DIFF
--- a/packages/components/src/toast/toast.types.ts
+++ b/packages/components/src/toast/toast.types.ts
@@ -35,7 +35,7 @@ export interface ToastOptions {
   /**
    * Function that removes the toast from manager's state.
    */
-  onRequestRemove(): void
+  onRequestRemove(this: void): void
 
   /**
    * The position of the toast
@@ -45,7 +45,7 @@ export interface ToastOptions {
   /**
    * Callback function to run side effects after the toast has closed.
    */
-  onCloseComplete?(): void
+  onCloseComplete?(this: void): void
 
   /**
    * Internally used to queue closing a toast. Should probably not be used by


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # (partial resolving)
Partially resolving https://github.com/chakra-ui/chakra-ui/issues/8779
This PR is not fully resolving all problems, but it's good to describe the idea what should we do to solve the issue.

## 📝 Description

As we can see `packages/components/src/toast/toast.tsx`, the render parameter object is not class, and these values are destructed right before to pass. That means, the props' callback are this-bound free.

```ts
  const renderToast: React.FC<RenderProps> = (props) => {
    if (typeof render === "function") {
      return render({ ...props, ...options }) as JSX.Element
    }
    return <ToastComponent {...props} {...options} />
  }
```

## ⛳️ Current behavior (updates)


## 🚀 New behavior

No runtime behaviour change.
Now, ToastOptions can be destructed this-bound freely.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
