### PR TITLE
fix: update scrubber input type

### DIFF
--- a/apps/compositions/src/ui/scrubber-input.tsx
+++ b/apps/compositions/src/ui/scrubber-input.tsx
@@ -2,13 +2,13 @@ import { Group, Icon, InputElement, NumberInput } from "@chakra-ui/react"
 import { Tooltip } from "compositions/ui/tooltip"
 import { forwardRef } from "react"
 
-export interface StepperInputProps extends NumberInput.InputProps {
+export interface ScrubberInputProps extends NumberInput.InputProps {
   label: React.ReactNode
   icon: React.ReactNode
   rootProps?: NumberInput.RootProps
 }
 
-export const ScrubberInput = forwardRef<HTMLInputElement, StepperInputProps>(
+export const ScrubberInput = forwardRef<HTMLInputElement, ScrubberInputProps>(
   function ScrubberInput(props, ref) {
     const { label, icon, rootProps, ...rest } = props
     return (


### PR DESCRIPTION
## 📝 Description

ScrubberInput snippet has the same type name as StepperInput, which can lead to conflicts when both snippets are exported from the same file.

## 💣 Is this a breaking change

No