### PR TITLE
fix: link overlay target

### DIFF
--- a/.changeset/wet-wombats-dream.md
+++ b/.changeset/wet-wombats-dream.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix issue where target was not passed to link overlay

--- a/packages/react/src/components/link/link-box.tsx
+++ b/packages/react/src/components/link/link-box.tsx
@@ -8,7 +8,7 @@ export interface LinkOverlayProps extends HTMLChakraProps<"a"> {}
 
 export const LinkOverlay = forwardRef<HTMLAnchorElement, LinkOverlayProps>(
   function LinkOverlay(props, ref) {
-    const { target, rel, className, ...rest } = props
+    const { rel, className, ...rest } = props
     return (
       <chakra.a
         {...rest}


### PR DESCRIPTION
## 📝 Description

Passing the `target` prop to `LinkOverlay` does not work.

## ⛳️ Current behavior (updates)

The `target` prop is ignored.

## 🚀 New behavior

`target` passed along to `chakra.a` element.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
