### PR TITLE
fix: add tsconfig.json to next-js package (v2)

### DIFF
--- a/.changeset/late-seas-eat.md
+++ b/.changeset/late-seas-eat.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/next-js": patch
+---
+
+Add tsconfig.json to next-js package

--- a/packages/next-js/tsconfig.json
+++ b/packages/next-js/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->


## 📝 Description

Since the `chakra-ui/next-js` package lacks a `tsconfig.json` file, I created one by copying it from the `chakra-ui/react` package.

## ⛳️ Current behavior (updates)

Due to a likely mistake, the `tsconfig.json` file is missing from the `chakra-ui/next-js` package, leading to an incorrect build being provided since `@chakra-ui/next-js@2.2.1`. This build does not properly import React functions.

```javascript
// dist/esm/link.mjs

import { useStyleConfig, omitThemingProps, chakra } from '@chakra-ui/react';
import NextLink from 'next/link';
import { forwardRef } from 'react';
import { interopDefault } from './interop.mjs';

const LinkEl = interopDefault(NextLink);
const cx = (...classNames) => classNames.filter(Boolean).join(" ");
const Link = forwardRef(function Link2(props, ref) {
  const styles = useStyleConfig("Link", props);
  const { className, isExternal, href, children, ...rest } = omitThemingProps(props);
  return /* @__PURE__ */ React.createElement(
// ...
```

As a result, the following error occurs in the imported Next.js environment, preventing rendering.

```
 GET / 500 in 15034ms
 ⨯ Internal error: ReferenceError: React is not defined
    at Link2 (./node_modules/.pnpm/@chakra-ui+next-js@2.3.2_@chakra-ui+react@2.9.3_@emotion+react@11.13.3_next@14.2.1_react@18.2.0/node_modules/@chakra-ui/next-js/dist/esm/link.mjs:21:3)
    at au (/project/workspace/node_modules/.pnpm/next@14.2.1_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:10446)
```

Reproduction: https://codesandbox.io/p/devbox/dreamy-bush-7phq9p

## 🚀 New behavior

By creating a `tsconfig.json` file, I expect to generate a correct build.

```javascript
// dist/esm/link.mjs

import { jsx } from 'react/jsx-runtime';
import { useStyleConfig, omitThemingProps, chakra } from '@chakra-ui/react';
import NextLink from 'next/link';
import { forwardRef } from 'react';
import { interopDefault } from './interop.mjs';

const LinkEl = interopDefault(NextLink);
const cx = (...classNames) => classNames.filter(Boolean).join(" ");
const Link = forwardRef(function Link2(props, ref) {
  const styles = useStyleConfig("Link", props);
  const { className, isExternal, href, children, ...rest } = omitThemingProps(props);
  return /* @__PURE__ */ jsx(
// ...
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

