### PR TITLE
fix: backgroundClip text transform

### DIFF
--- a/.changeset/short-lions-jog.md
+++ b/.changeset/short-lions-jog.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Added transform function to backgroundClip to appropriately handle 'text' value

--- a/apps/compositions/src/examples/heading-with-gradient.tsx
+++ b/apps/compositions/src/examples/heading-with-gradient.tsx
@@ -1,0 +1,14 @@
+import { Heading } from "@chakra-ui/react"
+
+export const HeadingWithGradient = () => {
+  return (
+    <Heading
+      bgGradient="to-l"
+      gradientFrom="red.500"
+      gradientTo="blue.500"
+      bgClip="text"
+    >
+      The quick brown fox jumps over the lazy dog
+    </Heading>
+  )
+}

--- a/packages/react/__stories__/heading.stories.tsx
+++ b/packages/react/__stories__/heading.stories.tsx
@@ -18,3 +18,4 @@ export { HeadingWithAsProp as AsProps } from "compositions/examples/heading-with
 export { HeadingWithWeights as Weights } from "compositions/examples/heading-with-weights"
 export { HeadingWithHighlight as Highlight } from "compositions/examples/heading-with-highlight"
 export { HeadingWithComposition as Composition } from "compositions/examples/heading-with-composition"
+export { HeadingWithGradient as Gradient } from "compositions/examples/heading-with-gradient"

--- a/packages/react/src/preset-base.ts
+++ b/packages/react/src/preset-base.ts
@@ -221,7 +221,14 @@ export const defaultBaseConfig = defineConfig({
     backgroundPosition: { shorthand: ["bgPos"] },
     backgroundRepeat: { shorthand: ["bgRepeat"] },
     backgroundAttachment: { shorthand: ["bgAttachment"] },
-    backgroundClip: { shorthand: ["bgClip"] },
+    backgroundClip: {
+      shorthand: ["bgClip"],
+      transform(value) {
+        return value === "text"
+          ? { color: "transparent", backgroundClip: "text" }
+          : { backgroundClip: value }
+      },
+    },
     backgroundGradient: {
       shorthand: ["bgGradient"],
       values(theme) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #8904 

## 📝 Description

Added transform function to `backgroundClip` property to appropriately handle `text` value by setting `color` to `transparent`

## ⛳️ Current behavior (updates)

`bgGradient` property did not work on typography components since color was not set to transparent when `bgClip` was set to `text`

## 🚀 New behavior

Transform function added to `backgroundClip` property to appropriately set color to transparent when backgroundClip is set to `text`

## 💣 Is this a breaking change (Yes/No):

No. All tests still pass. This just resolves a bug related to setting gradient on typography components and preserves backwards compatibility.

## 📝 Additional Information

New `Heading` story created showcasing gradient on heading.