### PR TITLE
fix(useDisclosure): Memoize returned object value

### DIFF
--- a/packages/hooks/src/use-disclosure.ts
+++ b/packages/hooks/src/use-disclosure.ts
@@ -59,7 +59,7 @@ export function useDisclosure(props: UseDisclosureProps = {}) {
     }
   }, [isOpen, onOpen, onClose])
 
-  function getButtonProps(props: HTMLProps = {}): HTMLProps {
+  const getButtonProps = useCallback((props: HTMLProps = {}): HTMLProps => {
     return {
       ...props,
       "aria-expanded": isOpen,
@@ -69,25 +69,36 @@ export function useDisclosure(props: UseDisclosureProps = {}) {
         onToggle()
       },
     }
-  }
+  }, [isOpen, id, onToggle])
 
-  function getDisclosureProps(props: HTMLProps = {}): HTMLProps {
+  const getDisclosureProps = useCallback((props: HTMLProps = {}): HTMLProps => {
     return {
       ...props,
       hidden: !isOpen,
       id,
     }
-  }
+  }, [id, isOpen])
 
-  return {
-    isOpen,
-    onOpen,
-    onClose,
-    onToggle,
-    isControlled,
-    getButtonProps,
-    getDisclosureProps,
-  }
+  return useMemo(
+    () => ({
+      isOpen,
+      onOpen,
+      onClose,
+      onToggle,
+      isControlled,
+      getButtonProps,
+      getDisclosureProps,
+    }),
+    [
+      isOpen,
+      onOpen,
+      onClose,
+      onToggle,
+      isControlled,
+      getButtonProps,
+      getDisclosureProps,
+    ]
+  )
 }
 
 export type UseDisclosureReturn = ReturnType<typeof useDisclosure>


### PR DESCRIPTION
Prevents unnecessary re-renders triggered by the disclosure object always changing when consuming the whole object.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

Prevents unnecessary re-renders triggered by the disclosure object always changing when consuming the whole object somewhere downstream.

## ⛳️ Current behavior (updates)

The object is currently always re-created on renders, so when the disclosure is passed down into a memoized (i.e. [memo](https://react.dev/reference/react/memo), [useMemo](https://react.dev/reference/react/useMemo) or [useCallback](https://react.dev/reference/react/useCallback)), the disclosure value will always trigger a re-renders of said component.

The current way to avoid this is to do one of either:
- deconstruct the useDisclosure return value (and put them into a new, memoized object if you need to pass them all down)
- put the value from useDisclosure into a ref and pass along the ref

## 🚀 New behavior

Now it will "just work". The object and everything inside it is memoized by default. Yay!

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
