### PR TITLE
fix(popper): add transparent borders to improve popper arrow border alignment

### DIFF
--- a/packages/components/src/popper/modifiers.ts
+++ b/packages/components/src/popper/modifiers.ts
@@ -1,5 +1,5 @@
 import { Placement, Modifier, State } from "@popperjs/core"
-import { getBoxShadow, toTransformOrigin, cssVars } from "./utils"
+import { getBorder, toTransformOrigin, cssVars } from "./utils"
 
 /* -------------------------------------------------------------------------------------------------
  The match width modifier sets the popper width to match the reference.
@@ -77,8 +77,7 @@ const setArrowStyles = (state: Partial<State>) => {
     })
 
     const vars = {
-      [cssVars.arrowSizeHalf
-        .var]: `calc(${cssVars.arrowSize.varRef} / 2 - 1px)`,
+      [cssVars.arrowSizeHalf.var]: `calc(${cssVars.arrowSize.varRef} / 2)`,
       [cssVars.arrowOffset.var]: `calc(${cssVars.arrowSizeHalf.varRef} * -1)`,
     }
 
@@ -131,10 +130,8 @@ const setInnerArrowStyles = (state: State) => {
   ) as HTMLElement | null
 
   if (!inner) return
-  const boxShadow = getBoxShadow(state.placement)
-  if (boxShadow) {
-    inner.style.setProperty("--popper-arrow-default-shadow", boxShadow)
-  }
+
+  const border = getBorder(state.placement)
 
   Object.assign(inner.style, {
     transform: "rotate(45deg)",
@@ -145,6 +142,6 @@ const setInnerArrowStyles = (state: State) => {
     height: "100%",
     position: "absolute",
     zIndex: "inherit",
-    boxShadow: `var(--popper-arrow-shadow, var(--popper-arrow-default-shadow))`,
+    ...border,
   })
 }

--- a/packages/components/src/popper/utils.ts
+++ b/packages/components/src/popper/utils.ts
@@ -14,15 +14,39 @@ export const cssVars = {
   arrowOffset: toVar("--popper-arrow-offset"),
 } as const
 
-export function getBoxShadow(placement: Placement) {
-  if (placement.includes("top"))
-    return `1px 1px 0px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("bottom"))
-    return `-1px -1px 0px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("right"))
-    return `-1px 1px 0px 0 var(--popper-arrow-shadow-color)`
-  if (placement.includes("left"))
-    return `1px -1px 0px 0 var(--popper-arrow-shadow-color)`
+export function getBorder(placement: Placement) {
+  const borderDefinition = `1px solid ${cssVars.arrowShadowColor.varRef}`
+  const transparentBorderDefinition = `1px solid transparent`
+
+  if (placement.includes("top")) {
+    return {
+      borderBottom: borderDefinition,
+      borderRight: borderDefinition,
+      borderLeft: transparentBorderDefinition,
+      borderTop: transparentBorderDefinition,
+    }
+  } else if (placement.includes("bottom")) {
+    return {
+      borderTop: borderDefinition,
+      borderLeft: borderDefinition,
+      borderRight: transparentBorderDefinition,
+      borderBottom: transparentBorderDefinition,
+    }
+  } else if (placement.includes("right")) {
+    return {
+      borderBottom: borderDefinition,
+      borderLeft: borderDefinition,
+      borderTop: transparentBorderDefinition,
+      borderRight: transparentBorderDefinition,
+    }
+  } else if (placement.includes("left")) {
+    return {
+      borderTop: borderDefinition,
+      borderRight: borderDefinition,
+      borderBottom: transparentBorderDefinition,
+      borderLeft: transparentBorderDefinition,
+    }
+  }
 }
 
 const transforms: Record<string, string> = {


### PR DESCRIPTION
Closes #5934 

## 📝 Description

Popover arrow had a border defined with boxShadow, it is now a border. This change fixes small triangles that are left behind as shown in current and new behaviors. Popover arrow now has smooth edges that flow with the rest of the popover border.

I am not sure how to handle the `--popper-arrow-shadow` and `--popper-arrow-shadow-color` vars. They are referenced  in `use-popover`, `use-tooltip` and `popover-arrow`. This will break custom popover shadows. 

It is not a problem to handle these cases, I am looking for feedback on how to handle them.

## ⛳️ Current behavior (updates)

Taken from `Popover - Click => Arrow` story

<img width="369" alt="image" src="https://github.com/user-attachments/assets/5153ac4a-970a-4f3b-9496-0b15d77be404">

Taken from `Popover - Hover => With Custom Animation` story

<img width="341" alt="image" src="https://github.com/user-attachments/assets/6dcd29b8-1629-4dde-94f2-6a9764f586f5">


## 🚀 New behavior

<img width="338" alt="image" src="https://github.com/user-attachments/assets/82a55efc-0d5a-47a5-a5a0-8d8de4028668">

Taken from `Popover - Hover => With Custom Animation` story

<img width="337" alt="image" src="https://github.com/user-attachments/assets/2f4978b0-74b9-471d-88d9-ab7c2bd90fdb">


## 💣 Is this a breaking change (Yes/No):

Yes, any users that had `--popper-arrow-shadow` set, it will stop working. 

## 📝 Additional Information

This is a copy of https://github.com/chakra-ui/chakra-ui/pull/6412 that targets the v2 branch.
