### PR TITLE
fix: pre-compute the isStyleProp function

### DIFF
--- a/.changeset/hip-clocks-exercise.md
+++ b/.changeset/hip-clocks-exercise.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/styled-system": minor
+"@chakra-ui/react": minor
+---
+
+pre-compute the isStyleProp function

--- a/packages/components/src/system/system.ts
+++ b/packages/components/src/system/system.ts
@@ -53,8 +53,7 @@ export const toCSSObject: GetStyleObject =
   ({ baseStyle }) =>
   (props) => {
     const { theme, css: cssProp, __css, sx, ...restProps } = props
-    const isStyleProp = isStylePropFn(theme)
-    const [styleProps] = splitProps(restProps, isStyleProp)
+    const [styleProps] = splitProps(restProps, theme.__isStyleProp)
 
     const finalBaseStyle = runIfFn(baseStyle, props)
     const finalStyles = assignAfter(

--- a/packages/styled-system/src/create-theme-vars/to-css-var.ts
+++ b/packages/styled-system/src/create-theme-vars/to-css-var.ts
@@ -2,6 +2,7 @@ import { analyzeBreakpoints } from "@chakra-ui/utils"
 import type { WithCSSVar } from "../utils"
 import { createThemeVars } from "./create-theme-vars"
 import { omitVars } from "./theme-tokens"
+import { isStylePropFn } from "../system"
 
 export function toCSSVar<T extends Record<string, any>>(rawTheme: T) {
   /**
@@ -34,10 +35,13 @@ export function toCSSVar<T extends Record<string, any>>(rawTheme: T) {
     "--chakra-space-y-reverse": "0",
   }
 
+  const isStyleProp = isStylePropFn(theme)
+
   Object.assign(theme, {
     __cssVars: { ...defaultCssVars, ...cssVars },
     __cssMap: cssMap,
     __breakpoints: analyzeBreakpoints(theme.breakpoints),
+    __isStyleProp: isStyleProp,
   })
 
   return theme as WithCSSVar<T>

--- a/packages/styled-system/src/system.ts
+++ b/packages/styled-system/src/system.ts
@@ -57,8 +57,8 @@ export const getPropNames = (theme: any) => [
 
 export const isStylePropFn = (theme: any) => {
   const pseudoSelectors = getPseudoSelectors(theme)
+  const styleProps = { ...systemProps, ...pseudoSelectors }
   return (prop: string) => {
-    const styleProps = { ...systemProps, ...pseudoSelectors }
     return Object.hasOwnProperty.call(styleProps, prop)
   }
 }

--- a/packages/styled-system/src/utils/types.ts
+++ b/packages/styled-system/src/utils/types.ts
@@ -35,6 +35,7 @@ export type WithCSSVar<T> = T & {
   __cssVars: Record<string, any>
   __cssMap: CSSMap
   __breakpoints: AnalyzeBreakpointsReturn
+  __isStyleProp: (prop: string) => boolean
 }
 
 export type CssTheme = WithCSSVar<{


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #8933.

## 📝 Description

The latest changes to enable custom theme conditions added a lot of overhead in the rendering of styled components.

## ⛳️ Current behavior (updates)

The rendering of styled components is 5 times slower.

## 🚀 New behavior

The rendering of styled components is as fast as it was before the implementation of custom theme condition.

## 💣 Is this a breaking change (Yes/No):

I don't think so.

## 📝 Additional Information

I don't know how to author changeset, hopefully it's correct, otherwise let me know what to change.
