### PR TITLE
fix: next.js dev server inifinite loop

### DIFF
--- a/.changeset/honest-mugs-tease.md
+++ b/.changeset/honest-mugs-tease.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix next.js dev server infinite loop when passing a react element to a styled
+component

--- a/packages/components/src/system/use-style-config.ts
+++ b/packages/components/src/system/use-style-config.ts
@@ -34,6 +34,7 @@ function useStyleConfigImpl(
     { theme, colorMode },
     styleConfig?.defaultProps ?? {},
     compact(omit(rest, ["children"])),
+    (obj, src) => (!obj ? src : undefined),
   )
 
   /**


### PR DESCRIPTION
Closes #8911.

## 📝 Description

With the latest versions of Next.js canary and/or React canary, the dev server goes in an infinite loop while rendering pages in which a React element is passed as a prop to any chakra-ui styled components. There is a reproduction repo in the linked issue.

## ⛳️ Current behavior (updates)

Dev server goes in a infinite loop.

## 🚀 New behavior

Everything works as expected.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The issue seem to be in some internals of React only when server side rendering. In the browser it works fine.
