### PR TITLE
✏️ Fix typo in migration.mdx —  `typigns` -> `typings`

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -135,7 +135,7 @@ The Provider component compose the `ChakraProvider` from Chakra and
 - **TypeScript:** Improved IntelliSense and type inference for style props and
   tokens.
 
-- **Polymorphism:** Loosened the `as` prop typigns in favor of using the
+- **Polymorphism:** Loosened the `as` prop typings in favor of using the
   `asChild` prop. This pattern was inspired by Radix Primitives and Ark UI.
 
 ## Removed Features


### PR DESCRIPTION
## 📝 Description

Typo: `typigns` -> `typings`