### PR TITLE
docs: Fix the theme path for `cursor` in the docs

### DIFF
--- a/apps/compositions/src/lib/cursor-token-doc.tsx
+++ b/apps/compositions/src/lib/cursor-token-doc.tsx
@@ -6,7 +6,7 @@ import { TokenDoc } from "./token-doc"
 
 export const CursorTokenDoc = () => {
   return (
-    <TokenDoc title="theme.cursor" mt="8">
+    <TokenDoc title="theme.tokens.cursor" mt="8">
       <HStack wrap="wrap" gap="4">
         <Button size="sm">Button</Button>
         <Button size="sm" disabled>

--- a/apps/www/content/docs/theming/cursors.mdx
+++ b/apps/www/content/docs/theming/cursors.mdx
@@ -35,8 +35,10 @@ import { createSystem, defaultConfig } from "@chakra-ui/react"
 
 export const system = createSystem(defaultConfig, {
   theme: {
-    cursor: {
-      button: { value: "pointer" },
+    tokens: {
+      cursor: {
+        button: { value: "pointer" },
+      },
     },
   },
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

The docs for the `cursor` token are pointing at the wrong path. Currently they say to use `theme.cursor`, but in reality it should be `theme.tokens.cursor`. At least that's the only way I've made it work locally, but with proper typing, and functionally.

Current incorrect docs page: https://www.chakra-ui.com/docs/theming/cursors