### PR TITLE
docs: Remove Wrap from Component Changes in migration guide

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -429,17 +429,6 @@ This was done for two reasons:
 - Move fallback icon to `Avatar.Fallback` component
 - Move `name` prop to `Avatar.Fallback` component
 
-### Wrap
-
-We changed the props for the `Wrap` component to be more explicit and easier to
-understand.
-
-- Changed `spacing` to `gap`
-- Changed `spacingX` to `rowGap`
-- Changed `spacingY` to `columnGap`
-- Removed `shouldWrapChildren` in favor of using the `WrapItem` component
-  explicitly
-
 ### Portal
 
 - Remove `appendToParentPortal` prop in favor of using the `containerRef`


### PR DESCRIPTION
## 📝 Description

I just noticed that the `Wrap` component is removed, but in the migration guide it's mentioned like a changed component.

## ⛳️ Current behavior (updates)

Confusing Wrap mention because that removed.

## 🚀 New behavior

I just removed Wrap from Component Changes section.

## 💣 Is this a breaking change (Yes/No):

No.
