### PR TITLE
docs: fix a small typo mistake in title for pseudo

### DIFF
--- a/.changeset/poor-sheep-study.md
+++ b/.changeset/poor-sheep-study.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": major
+"@chakra-ui/react": major
+---
+
+Fix a typography mistake in documentation (page Box)

--- a/apps/www/content/docs/components/box.mdx
+++ b/apps/www/content/docs/components/box.mdx
@@ -29,7 +29,7 @@ etc.
 
 <ExampleTabs name="box-with-shorthand" />
 
-### Psuedo Props
+### Pseudo Props
 
 Use pseudo props like `_hover` to apply styles on hover, `_focus` to apply
 styles on focus, etc.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->
 

## 📝 Description


I was reading the documentation and I came across a small typography mistake [on this page](https://www.chakra-ui.com/docs/components/box#psuedo-props).

## ⛳️ Current behavior (updates)

I'm removing the mistake in "Psuedo"

## 🚀 New behavior

This PR modifies the title "Psuedo" to "Pseudo" basically.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I'm not sure about how I created the changeset... It would be nice to have it in the next version but I'm not sure if all packages should be affected. 

Thank you in advance for your insights ! 