### PR TITLE
docs: fix typo 'when' to 'with'

### DIFF
--- a/apps/www/content/docs/get-started/installation.mdx
+++ b/apps/www/content/docs/get-started/installation.mdx
@@ -95,7 +95,7 @@ tsconfig file to include the following options:
 
 ### Enjoy!
 
-When the power of the snippets and the primitive components from Chakra UI, you
+With the power of the snippets and the primitive components from Chakra UI, you
 can build your UI faster.
 
 ```tsx


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

Corrected a typo in the documentation, changing "when" to "with" for improved clarity.

## ⛳️ Current behavior (updates)

The documentation currently contains a typo where "when" is used instead of "with," which could lead to minor confusion when reading.

## 🚀 New behavior

The typo has been corrected to "with," improving the readability and accuracy of the documentation.

## 💣 Is this a breaking change (Yes/No):

> No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

> This is a small, non-functional update to the documentation with no impact on code or user functionality.
