### PR TITLE
docs: fix typo in migration docs

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -25,7 +25,7 @@ packages are no longer required in Chakra UI.
 npm uninstall @emotion/styled framer-motion
 ```
 
-Next, install component snippets using the CLI snippets. Snippets that provide
+Next, install component snippets using the CLI snippets. Snippets provide
 pre-built compositions of Chakra components to save you time and put you in
 charge.
 


### PR DESCRIPTION
## 📝 Description

Fixes a grammatical error in the v3 migration docs page

## 💣 Is this a breaking change (Yes/No):

No