### PR TITLE
docs: add LightMode and DarkMode migration instructions

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -144,7 +144,8 @@ The Provider component compose the `ChakraProvider` from Chakra and
 
 - `ColorModeProvider` and `useColorMode` have been removed in favor of
   `next-themes`
-- `LightMode`, `DarkMode` and `ColorModeScript` components have been removed
+- `LightMode`, `DarkMode` and `ColorModeScript` components have been removed.
+  You now have to use `className="light"` or `className="dark"` to force themes.
 - `useColorModeValue` has been removed in favor of `useTheme` from `next-themes`
 
 :::note


### PR DESCRIPTION
Was a little confused on how I could replace `LightMode` and `DarkMode` component behavior before reading the docs that states that we can add `dark` and `light` class.

This PR add this to the migration instructions