### PR TITLE
Update dark-mode.mdx to fix semantic tokens link

### DIFF
--- a/apps/www/content/docs/styling/dark-mode.mdx
+++ b/apps/www/content/docs/styling/dark-mode.mdx
@@ -85,7 +85,7 @@ applied automatically and consistently.
 
 Chakra provides a set of semantic tokens that you can use to style components
 for dark mode. Learn more about
-[semantic tokens](/docs/design-tokens/colors#semantic-tokens).
+[semantic tokens](/docs/theming/semantic-tokens).
 
 ```tsx
 <Box bg="bg.subtle">


### PR DESCRIPTION
Updates semantic tokens link to point to `/docs/theming/semantic-tokens`
