### PR TITLE
feat: expose utils

### DIFF
--- a/.changeset/sour-mice-chew.md
+++ b/.changeset/sour-mice-chew.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Added /utils export

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -124,6 +124,17 @@
         "default": "./dist/cjs/styled-system/index.cjs"
       }
     },
+    "./utils": {
+      "source": "./src/utils/index.ts",
+      "import": {
+        "types": "./dist/types/utils/index.d.ts",
+        "default": "./dist/esm/utils/index.js"
+      },
+      "require": {
+        "types": "./dist/types/utils/index.d.ts",
+        "default": "./dist/cjs/utils/index.cjs"
+      }
+    },
     "./collection": {
       "source": "./src/collection.ts",
       "import": {


### PR DESCRIPTION
Since the @chakra-ui/utils package is deprecated it's no longer possible to use utilities like `cx` in v3.

This exposes the utils at `@chakra-ui/react/utils` so design system builders can use the utils to build on top of chakra.