### PR TITLE
fix(useDisclosure): Memoize returned object value

### DIFF
--- a/packages/hooks/src/use-disclosure.ts
+++ b/packages/hooks/src/use-disclosure.ts
@@ -59,7 +59,7 @@ export function useDisclosure(props: UseDisclosureProps = {}) {
     }
   }, [isOpen, onOpen, onClose])
 
-  function getButtonProps(props: HTMLProps = {}): HTMLProps {
+  const getButtonProps = useCallback((props: HTMLProps = {}): HTMLProps => {
     return {
       ...props,
       "aria-expanded": isOpen,
@@ -69,25 +69,36 @@ export function useDisclosure(props: UseDisclosureProps = {}) {
         onToggle()
       },
     }
-  }
+  }, [isOpen, id, onToggle])
 
-  function getDisclosureProps(props: HTMLProps = {}): HTMLProps {
+  const getDisclosureProps = useCallback((props: HTMLProps = {}): HTMLProps => {
     return {
       ...props,
       hidden: !isOpen,
       id,
     }
-  }
+  }, [id, isOpen])
 
-  return {
-    isOpen,
-    onOpen,
-    onClose,
-    onToggle,
-    isControlled,
-    getButtonProps,
-    getDisclosureProps,
-  }
+  return useMemo(
+    () => ({
+      isOpen,
+      onOpen,
+      onClose,
+      onToggle,
+      isControlled,
+      getButtonProps,
+      getDisclosureProps,
+    }),
+    [
+      isOpen,
+      onOpen,
+      onClose,
+      onToggle,
+      isControlled,
+      getButtonProps,
+      getDisclosureProps,
+    ]
+  )
 }
 
 export type UseDisclosureReturn = ReturnType<typeof useDisclosure>


### PR DESCRIPTION
Prevents unnecessary re-renders triggered by the disclosure object always changing when consuming the whole object.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

Prevents unnecessary re-renders triggered by the disclosure object always changing when consuming the whole object somewhere downstream.

## ⛳️ Current behavior (updates)

The object is currently always re-created on renders, so when the disclosure is passed down into a memoized (i.e. [memo](https://react.dev/reference/react/memo), [useMemo](https://react.dev/reference/react/useMemo) or [useCallback](https://react.dev/reference/react/useCallback)), the disclosure value will always trigger a re-renders of said component.

The current way to avoid this is to do one of either:
- deconstruct the useDisclosure return value (and put them into a new, memoized object if you need to pass them all down)
- put the value from useDisclosure into a ref and pass along the ref

## 🚀 New behavior

Now it will "just work". The object and everything inside it is memoized by default. Yay!

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

To elaborate on the issue: The object returned by `useDisclosure` is unstable, so if you pass it down to memoized components, you will will see undesired re-renders.

```
import { Box, Modal, useDisclosure } from '@chakra-ui/react';
import React, { memo } from 'react';

function MyParentComponent({ longListOfItems }) {
  const disclosure = useDisclosure();
  return (
    <Box>
      {longListOfItems.map((item) => (
        <SomeItemChildComponent
          key={item.id}
          item={item}
          disclosure={disclosure}
        />
      ))}

      <Modal isOpen={disclosure.isOpen} onClose={disclosure.onClose}>
        {/* Modal Content */}
      </Modal>
    </Box>
  );
}

const SomeItemChildComponent = memo(function SomeItemChildComponentFunction({ item, disclosure }) {
  return (
    <Box
      style={disclosure.isOpen ? { color: 'purple' } : {}}
      onClick={() => disclosure.onOpen()}
    >
      Hello from {item.name}!
    </Box>
  );
});
```

Since useDisclosure returns a new object on each render, the disclosure prop being passed to SomeItemChildComponent is always different. This leads to unnecessary re-renders of every SomeItemChildComponent whenever MyParentComponent re-renders (despite the component being memoized), even though the disclosure state might not have changed.

While it’s technically possible to destructure isOpen and onOpen from the disclosure object and pass only the needed values, this results in fragmented code:

```
{longListOfItems.map((item) => (
  <SomeItemChildComponent
    key={item.id}
    item={item}
    isOpen={disclosure.isOpen}
    onOpen={disclosure.onOpen}
  />
))}
```

This workaround is inconvenient, as it forces the developer to pick and pass individual properties instead of passing the whole disclosure object.

We could also put the properties into a memoized disclosure ourselves:

```
  // Create a memoized version of the relevant properties
  const memoizedDisclosure = useMemo(() => ({
    isOpen: disclosure.isOpen,
    onOpen: disclosure.onOpen,
    onClose: disclosure.onClose,
  }), [disclosure.isOpen, disclosure.onOpen, disclosure.onClose]);
```

Additionally, if the structure or API of useDisclosure changes (e.g., new properties are added), every component consuming individual properties would need to be updated. This introduces potential bugs during refactoring, especially in large codebases.

Imo @segunadebayo, he current behavior shifts the burden of memoization onto the user. Ideally, hooks like useDisclosure should return stable references by default to minimize the cognitive load on developers and prevent subtle performance issues.



