### PR TITLE
fix: import WithEscapeHatch type when strictTokens is enabled

### DIFF
--- a/.changeset/unlucky-seas-turn.md
+++ b/.changeset/unlucky-seas-turn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Fix issue where style props types show as `any` when using `strictTokens`

--- a/packages/cli/src/utils/generate-system-types.ts
+++ b/packages/cli/src/utils/generate-system-types.ts
@@ -8,9 +8,15 @@ export async function generateSystemTypes(sys: SystemContext) {
   )
   const propTypes = sys.utility.getTypes()
 
+  const shouldImportTypeWithEscapeHatch = sys._config.strictTokens
+
   const result = `
   import type { ConditionalValue, CssProperties } from "../css.types"
-  import type { UtilityValues } from "./prop-types.gen"
+  ${
+    shouldImportTypeWithEscapeHatch
+      ? `import type { UtilityValues, WithEscapeHatch } from "./prop-types.gen"`
+      : `import type { UtilityValues } from "./prop-types.gen"`
+  }
   import type { Token } from "./token.gen"
   type AnyString = (string & {})
   type AnyNumber = (number & {})


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

When trying to typegen with strict tokens, all properties are inferred as any due to a missing imported type. This PR fixes this issue by conditionally importing this type when `strictTokens` are set.

## ⛳️ Current behavior (updates)

Given the following config:

```ts
import { createSystem, mergeConfigs } from "@chakra-ui/react";
import { defaultConfig } from "@chakra-ui/react/preset";

const config = mergeConfigs(defaultConfig, {
  strictTokens: true,
});

export default createSystem(config);
```

When running `pnpm chakra typegen theme.ts`, all properties are inferred as `any`.

## 🚀 New behavior

When running the above-mentioned command, the properties will be inferred as expected and strict.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
