### PR TITLE
fix: make Tooltip work when `react.lazy` is given as a child

### DIFF
--- a/.changeset/brave-bananas-hunt.md
+++ b/.changeset/brave-bananas-hunt.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+fix: make Tooltip work when `react.lazy` is given as child

--- a/packages/components/src/tooltip/tooltip.tsx
+++ b/packages/components/src/tooltip/tooltip.tsx
@@ -101,7 +101,10 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
   }
   const tooltip = useTooltip({ ...rest, direction: theme.direction })
 
-  const shouldWrap = typeof children === "string" || shouldWrapChildren
+  const shouldWrap =
+    typeof children === 'string' ||
+    shouldWrapChildren ||
+    (children as any)?.type?.$$typeof === Symbol.for('react.lazy')
 
   let trigger: React.ReactElement
 

--- a/packages/components/src/tooltip/tooltip.tsx
+++ b/packages/components/src/tooltip/tooltip.tsx
@@ -104,7 +104,7 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
   const shouldWrap =
     typeof children === 'string' ||
     shouldWrapChildren ||
-    (children as any)?.type?.$$typeof === Symbol.for('react.lazy')
+    (children as any)?.$$typeof === Symbol.for('react.lazy')
 
   let trigger: React.ReactElement
 


### PR DESCRIPTION
## 📝 Description

After upgrading Next.js to v15.0.x, we are encoutering the error that `children` is not a single element in the following code.
The root cause is that `children` could be `react.lazy` and `Children.only(children)` causes the error.

```ts
    /**
     * Ensure tooltip has only one child node
     */
    const child = Children.only(children) as React.ReactElement & {
      ref?: React.Ref<unknown>;
    };
    trigger = cloneElement(child, tooltip.getTriggerProps(child.props, child.ref));
```

## ⛳️ Current behavior (updates)

`Children.only(children)` throws the error when `children` is `react.layze`.

## 🚀 New behavior

`shouldWrap` is `true` and `Children.only(children)` doesn't be called when `children` is `react.layze`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

We are using the modified `Tooltip` in our production.
