### PR TITLE
docs: add TypeScript typing information for slot recipes

### DIFF
--- a/apps/www/content/docs/theming/slot-recipes.mdx
+++ b/apps/www/content/docs/theming/slot-recipes.mdx
@@ -135,6 +135,15 @@ recipe context.
 Then, use the `withProvider` and `withContext` functions to create the compound
 components that share the same context.
 
+:::info
+
+You will need to manually type the generics for `withProvider` and
+`withContext`. This approach is designed to optimize TypeScript performance.
+Auto-inference, while convenient, would slow down TypeScript compilation due to
+the complexity of the types involved.
+
+:::
+
 ```tsx title="checkbox.tsx"
 "use client"
 
@@ -145,9 +154,27 @@ const { withProvider, withContext } = createSlotRecipeContext({
   recipe: checkboxSlotRecipe,
 })
 
-export const CheckboxRoot = withProvider("label", "root")
-export const CheckboxControl = withContext("input", "control")
-export const CheckboxLabel = withContext("span", "label")
+interface CheckboxRootProps
+  extends HTMLChakraProps<
+    "div",
+    RecipeVariantProps<typeof checkboxSlotRecipe>
+  > {}
+export const CheckboxRoot = withProvider<HTMLLabelElement, CheckboxRootProps>(
+  "label",
+  "root",
+)
+
+interface CheckboxControlProps extends HTMLChakraProps<"input"> {}
+export const CheckboxControl = withContext<
+  HTMLInputElement,
+  CheckboxControlProps
+>("input", "control")
+
+interface CheckboxLabelProps extends HTMLChakraProps<"span"> {}
+export const CheckboxLabel = withContext<HTMLSpanElement, CheckboxLabelProps>(
+  "span",
+  "label",
+)
 ```
 
 Pass the variant props to the "root" component that to apply the styles.

--- a/apps/www/content/docs/theming/slot-recipes.mdx
+++ b/apps/www/content/docs/theming/slot-recipes.mdx
@@ -156,7 +156,7 @@ const { withProvider, withContext } = createSlotRecipeContext({
 
 interface CheckboxRootProps
   extends HTMLChakraProps<
-    "div",
+    "label",
     RecipeVariantProps<typeof checkboxSlotRecipe>
   > {}
 export const CheckboxRoot = withProvider<HTMLLabelElement, CheckboxRootProps>(


### PR DESCRIPTION
Related https://github.com/chakra-ui/chakra-ui/issues/9023

## 📝 Description

Updated the usage of slot recipes.

## ⛳️ Current behavior (updates)

Currently the docs does not mention the need for manually typing `withProvider` and `withContext`, resulting in many typescript errors (see in original issue) 

## 🚀 New behavior

The docs are now showing the manual typing with a small note.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

While I understand the trade-off, I think that manually typing the generics adds too much clutter and impacts development velocity.