### PR TITLE
Fix/avatar root as prop

### DIFF
--- a/.changeset/fast-snails-travel.md
+++ b/.changeset/fast-snails-travel.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": major
+---
+
+Adds support for the 'as' prop in the Avatar component to allow root element
+customization.

--- a/apps/compositions/src/ui/avatar.tsx
+++ b/apps/compositions/src/ui/avatar.tsx
@@ -7,6 +7,7 @@ import { forwardRef } from "react"
 type ImageProps = React.ImgHTMLAttributes<HTMLImageElement>
 
 export interface AvatarProps extends ChakraAvatar.RootProps {
+  as?: React.ElementType // Add `as` prop type here
   name?: string
   src?: string
   srcSet?: string
@@ -17,10 +18,19 @@ export interface AvatarProps extends ChakraAvatar.RootProps {
 
 export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
   function Avatar(props, ref) {
-    const { name, src, srcSet, loading, icon, fallback, children, ...rest } =
-      props
+    const {
+      as = "div",
+      name,
+      src,
+      srcSet,
+      loading,
+      icon,
+      fallback,
+      children,
+      ...rest
+    } = props
     return (
-      <ChakraAvatar.Root ref={ref} {...rest}>
+      <ChakraAvatar.Root as={as} ref={ref} {...rest}>
         <AvatarFallback name={name} icon={icon}>
           {fallback}
         </AvatarFallback>
@@ -32,15 +42,16 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
 )
 
 interface AvatarFallbackProps extends ChakraAvatar.FallbackProps {
+  as?: React.ElementType // Add `as` prop type here
   name?: string
   icon?: React.ReactElement
 }
 
 const AvatarFallback = forwardRef<HTMLDivElement, AvatarFallbackProps>(
   function AvatarFallback(props, ref) {
-    const { name, icon, children, ...rest } = props
+    const { as = "div", name, icon, children, ...rest } = props
     return (
-      <ChakraAvatar.Fallback ref={ref} {...rest}>
+      <ChakraAvatar.Fallback as={as} ref={ref} {...rest}>
         {children}
         {name != null && children == null && <>{getInitials(name)}</>}
         {name == null && children == null && (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2-related PRs against the `v2` branch.
-->

Closes #9046

## 📝 Description

This pull request addresses Issue #9046 by adding support for the `as` prop in the `Avatar.Root` component, enabling users to specify the HTML element for the root (e.g., `span`, `section`, etc.). Previously, the `Avatar.Root` component defaulted to rendering as a `<div>` even when the `as` prop was set.

## ⛳️ Current behavior (updates)

Currently, setting `<Avatar.Root as="span">` or any other element type does not affect the rendered HTML. The `Avatar` component always defaults to a `<div>` for the root element, regardless of the `as` prop value.

## 🚀 New behavior

With this change:
- The `Avatar.Root` component now respects the `as` prop, rendering the specified HTML element (e.g., `<span>`).
- This enhancement provides more flexibility in markup and alignment for various use cases, particularly when specific elements are required for styling or accessibility.

## 💣 Is this a breaking change (Yes/No):

No, this change is backward-compatible.

## 📝 Additional Information

- Verified the update using Storybook to confirm that the `as` prop renders the specified element.
- Link to reproduction provided in the original issue for verification: [Reproduction on Stackblitz](https://stackblitz.com/edit/vitejs-vite-ntrqra?file=src%2Fcomponents%2Fui%2Favatar.tsx)

---

By supporting the `as` prop, Chakra UI's `Avatar` component can now better adapt to various semantic and layout needs.

