### PR TITLE
docs: update minor version of v2 in version menu

### DIFF
--- a/apps/www/components/docs/header.tsx
+++ b/apps/www/components/docs/header.tsx
@@ -145,7 +145,7 @@ const HeaderVersionMenu = ({ containerRef }: HeaderVersionMenuProps) => (
   <VersionMenu
     items={[
       { title: "v3", value: "3.0.0", url: "#" },
-      { title: "v2", value: "2.8.x", url: "https://v2.chakra-ui.com" },
+      { title: "v2", value: "2.10.x", url: "https://v2.chakra-ui.com" },
       { title: "v1", value: "1.5.x", url: "https://v1.chakra-ui.com" },
     ]}
     portalRef={containerRef}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

The docs page still contained 2.8.x as version option in the version menu. As there was currently a release for v2 with minor version 10, this is updated.

## ⛳️ Current behavior (updates)

Displaying 2.8.x as version option in version menu.

## 🚀 New behavior

Displaying 2.10.x as version option in version menu.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
