### PR TITLE
fix: checkmark indicator svg is not visible on safari

### DIFF
--- a/.changeset/many-moose-fix.md
+++ b/.changeset/many-moose-fix.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+fix: checkmark indicator svg is not visible on safari

--- a/packages/react/src/theme/recipes/checkmark.ts
+++ b/packages/react/src/theme/recipes/checkmark.ts
@@ -12,6 +12,9 @@ export const checkmarkRecipe = defineRecipe({
     borderColor: "transparent",
     borderRadius: "l1",
     focusVisibleRing: "outside",
+    "& > svg": {
+      width: "fit-content",
+    },
     _invalid: {
       colorPalette: "red",
       borderColor: "border.error",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/9097

## 📝 Description

Fixes an issue where the `svg` inside the checkmark control was not visible in Safari.

## ⛳️ Current behavior (updates)

<img width="474" alt="image" src="https://github.com/user-attachments/assets/adf4af99-34d0-4260-9093-89382c444a97">

## 🚀 New behavior

<img width="474" alt="image" src="https://github.com/user-attachments/assets/c738366c-5169-46ff-926f-5bb3b8b08c07">

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A
