### PR TITLE
docs: Update cli.mdx (node.js version reminder)

### DIFF
--- a/apps/www/content/docs/get-started/cli.mdx
+++ b/apps/www/content/docs/get-started/cli.mdx
@@ -28,6 +28,9 @@ bun add -d @chakra-ui/cli
 
 :::
 
+> [!NOTE]    
+> To use the CLI tool, please ensure that the version of Node.js is `>= 20.6.0`.
+
 ## Usage
 
 Use the Chakra CLI to run any of the commands listed below with your preferred

--- a/apps/www/content/docs/get-started/cli.mdx
+++ b/apps/www/content/docs/get-started/cli.mdx
@@ -28,8 +28,11 @@ bun add -d @chakra-ui/cli
 
 :::
 
-> [!NOTE]    
-> To use the CLI tool, please ensure that the version of Node.js is `>= 20.6.0`.
+:::warning
+
+To use the CLI tool, please ensure that the version of Node.js is `>= 20.6.0`.
+
+:::
 
 ## Usage
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here --> none

## 📝 Description

When I tried to migrate Chakra UI from v2 to v3, I initially used `pnpx @chakra-ui/cli snippet add`, but it only displayed an error saying "Can't find package."

Later, I switched to npx and discovered that it was due to the `import.meta.resolve` feature, which requires Node.js version to be `>= v20.6.0`.

I spent about 1 hours debugging this, so I think it would be helpful to include this in the documentation as a reminder.

## ⛳️ Current behavior (updates)

- none

## 🚀 New behavior

- none

## 💣 Is this a breaking change (Yes/No):

- No

## 📝 Additional Information

- Screenshots
![螢幕擷取畫面 2024-11-06 180123](https://github.com/user-attachments/assets/b99db6a1-6071-417e-93f3-4a000f8a8274)

![螢幕擷取畫面 2024-11-06 180219](https://github.com/user-attachments/assets/5f699764-4173-48d2-8e24-8b32a1128f40)

