### PR TITLE
omit valid element for button props

### DIFF
--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -4,8 +4,8 @@ import {
   SystemStyleObject,
   ThemingProps,
 } from "@chakra-ui/styled-system"
-import { cx, dataAttr } from "@chakra-ui/utils"
-import { useMemo } from "react"
+import { cx, dataAttr, objectFilter } from "@chakra-ui/utils"
+import { isValidElement, useMemo } from "react"
 import { chakra, forwardRef, HTMLChakraProps, useStyleConfig } from "../system"
 import { useButtonGroup } from "./button-context"
 import { ButtonIcon } from "./button-icon"
@@ -13,10 +13,18 @@ import { ButtonSpinner } from "./button-spinner"
 import { ButtonOptions } from "./button-types"
 import { useButtonType } from "./use-button-type"
 
+
 export interface ButtonProps
   extends HTMLChakraProps<"button">,
     ButtonOptions,
     ThemingProps<"Button"> {}
+
+/**
+ * This function will filter out all props that are valid React elements, e.g., `leftIcon`, `rightIcon`, `children`, ...
+ */
+const function omitValidElementProps(props: ButtonProps) {
+  return objectFilter(props, (value) => !isValidElement(value))
+}
 
 /**
  * Button component is used to trigger an action or event, such as submitting a form, opening a Dialog, canceling an action, or performing a delete operation.
@@ -26,7 +34,8 @@ export interface ButtonProps
  */
 export const Button = forwardRef<ButtonProps, "button">((props, ref) => {
   const group = useButtonGroup()
-  const styles = useStyleConfig("Button", { ...group, ...props })
+  const styleProps = omitValidElementProps(props)
+  const styles = useStyleConfig("Button", { ...group, ...styleProps })
 
   const {
     isDisabled = group?.isDisabled,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

> No issue for this one

## 📝 Description

In the latest Next.js `15.0.2` when a react element prop is passed to `useStyleConfig` the `mergeWith` function on https://github.com/chakra-ui/chakra-ui/blob/v2/packages/components/src/system/use-style-config.ts#L33 enters an infinite loop and VDOM is never finished therefore the response is never returned. As a result, your request will never finish.

This was not the case on Next.js `v14`.

## ⛳️ Current behavior (updates)

With the latest Next.js `15.0.2` the Button from v2 **does not work** when a react element is passed as a prop (e.g. for `leftIcon`).

## 🚀 New behavior

With the latest Next.js `15.0.2` the Button from v2 **does work** when a react element is passed as a prop (e.g. for `leftIcon`).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Let me know if this should be applied to any other component.

cc: @isbatak
