### PR TITLE
fix: useBreakpointValue throws error if ssr is false

### DIFF
--- a/.changeset/eight-pots-judge.md
+++ b/.changeset/eight-pots-judge.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix issue where `useBreakpointValue` throws error if `ssr` is false

--- a/packages/react/src/hooks/use-media-query.ts
+++ b/packages/react/src/hooks/use-media-query.ts
@@ -36,7 +36,7 @@ export function useMediaQuery(
     return queries.map((query, index) => ({
       media: query,
       matches: !ssr
-        ? (getWin() ?? window).matchMedia?.(query)?.matches
+        ? (getWindow?.() ?? window).matchMedia?.(query)?.matches
         : !!fallback[index],
     }))
   })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes https://github.com/chakra-ui/chakra-ui/issues/9127

## 📝 Description

call useBreakpointValue() with ssr: false throws "Cannot call an event handler while rendering" error.

## ⛳️ Current behavior (updates)

calling `getWin()` immediately inner useMediaQuery:

## 🚀 New behavior

change it to `getWindow?.() ?? window`

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
