### PR TITLE
docs: correct toast position -> placement

### DIFF
--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -124,7 +124,7 @@ each other, set the `overlap` prop to `true` in the `createToaster` function.
 
 ```jsx title="@/components/ui/toaster.tsx"
 const toaster = createToaster({
-  position: "top-right",
+  placement: "top-end",
   overlap: true,
 })
 ```

--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -113,7 +113,7 @@ desired position and configure it in the `createToaster` function.
 
 ```jsx title="@/components/ui/toaster.tsx"
 const toaster = createToaster({
-  position: "top-right",
+  placement: "top-end",
 })
 ```
 


### PR DESCRIPTION
## 📝 Description

I found out that the docs for the Toaster are a bit outdated. A few propertynames have been renamed.

## ⛳️ Current behavior (updates)

Currently, under https://www.chakra-ui.com/docs/components/toast it says:
![image](https://github.com/user-attachments/assets/027e16b2-134c-4d76-a283-69feba1d61f6)

## 🚀 New behavior

But as you can see here, **postition** does not exist anymore, it has been renamed to **placement**.
Also, parameters like **bottom-right** do not exist anymore, you renamed it to **bottom-end**.
![image](https://github.com/user-attachments/assets/84d1447f-fde0-4bc1-a4d7-35813bbfe7ee)

## 📝 Additional Information

This is probably not a big problem because you should come across **placement** when searching for properties starting with **p** but the docs should still be correct 😃
