### PR TITLE
docs: add custom font guides

### DIFF
--- a/apps/www/content/guides/theming-add-custom-font-to-nextjs.mdx
+++ b/apps/www/content/guides/theming-add-custom-font-to-nextjs.mdx
@@ -2,13 +2,13 @@
 title: Add custom fonts to a Next.js project
 description:
   Learn how to add a custom font when using Chakra UI in a Next.js project
-publishedAt: "2024-11-19"
+publishedAt: "2024-11-18"
 collection: theming
 ---
 
 ## Loading the custom fonts
 
-In Next.js, Google Fonts are available by default. At the top of your
+Google Fonts are available in Next.js by default. At the top of your
 `layout.tsx` file, import the font from `next/font/google`:
 
 ```tsx title="layout.tsx"
@@ -19,13 +19,13 @@ Configure the font by defining the variable and subsets to include:
 
 ```tsx title="layout.tsx"
 const bricolage = Bricolage_Grotesque({
-  variable: "--font-bricolage", // Define the CSS variable for the font
-  subsets: ["latin"], // Specify subsets (e.g., Latin)
+  variable: "--font-bricolage",
+  subsets: ["latin"],
 })
 ```
 
 Now, attach the font to the `<html>` element in your application. This ensures
-that the font is loaded globally.
+that the font is available to be used in Chakra UI.
 
 ```tsx /className={bricolage.variable}/
 <html className={bricolage.variable} lang="en" suppressHydrationWarning>
@@ -35,9 +35,9 @@ that the font is loaded globally.
 </html>
 ```
 
-## Using the custom font
+## Configure the custom font
 
-With the `createSystem` method, define the custom font in Chakra UI's theme
+Use the `createSystem` method to define the custom font in Chakra UI's theme
 configuration:
 
 ```tsx title="components/ui/provider.tsx"
@@ -57,9 +57,13 @@ const system = createSystem(defaultConfig, {
 })
 ```
 
-> You can customize which text elements use the font by specifying it for
-> `heading`, `body`, or both. In this case, we are setting both the body and
-> heading fonts to Bricolage Grotesque.
+:::info
+
+You can customize which text elements use the font by specifying it for
+`heading`, `body`, or both. In this case, we are setting both the body and
+heading fonts to "Bricolage Grotesque".
+
+:::
 
 Finally, pass the `system` into the `ChakraProvider`
 

--- a/apps/www/content/guides/theming-add-custom-font-to-nextjs.mdx
+++ b/apps/www/content/guides/theming-add-custom-font-to-nextjs.mdx
@@ -1,0 +1,79 @@
+---
+title: Add custom fonts to a Next.js project
+description:
+  Learn how to add a custom font when using Chakra UI in a Next.js project
+publishedAt: "2024-11-19"
+collection: theming
+---
+
+## Loading the custom fonts
+
+In Next.js, Google Fonts are available by default. At the top of your
+`layout.tsx` file, import the font from `next/font/google`:
+
+```tsx title="layout.tsx"
+import { Bricolage_Grotesque } from "next/font/google"
+```
+
+Configure the font by defining the variable and subsets to include:
+
+```tsx title="layout.tsx"
+const bricolage = Bricolage_Grotesque({
+  variable: "--font-bricolage", // Define the CSS variable for the font
+  subsets: ["latin"], // Specify subsets (e.g., Latin)
+})
+```
+
+Now, attach the font to the `<html>` element in your application. This ensures
+that the font is loaded globally.
+
+```tsx /className={bricolage.variable}/
+<html className={bricolage.variable} lang="en" suppressHydrationWarning>
+  <body>
+    <Provider>{children}</Provider>
+  </body>
+</html>
+```
+
+## Using the custom font
+
+With the `createSystem` method, define the custom font in Chakra UI's theme
+configuration:
+
+```tsx title="components/ui/provider.tsx"
+"use client"
+
+import { createSystem, defaultConfig } from "@chakra-ui/react"
+
+const system = createSystem(defaultConfig, {
+  theme: {
+    tokens: {
+      fonts: {
+        heading: { value: "var(--font-bricolage)" },
+        body: { value: "var(--font-bricolage)" },
+      },
+    },
+  },
+})
+```
+
+> You can customize which text elements use the font by specifying it for
+> `heading`, `body`, or both. In this case, we are setting both the body and
+> heading fonts to Bricolage Grotesque.
+
+Finally, pass the `system` into the `ChakraProvider`
+
+```tsx title="components/ui/provider.tsx" /value={system}/
+export function Provider(props: ColorModeProviderProps) {
+  return (
+    <ChakraProvider value={system}>
+      <ColorModeProvider {...props} />
+    </ChakraProvider>
+  )
+}
+```
+
+This ensures that the custom font is applied across your entire app.
+
+> Remember to remove any unused styles from your `global.css` and
+> `page.module.css` files to prevent your custom font from being overridden.

--- a/apps/www/content/guides/theming-add-custom-font-to-vite.mdx
+++ b/apps/www/content/guides/theming-add-custom-font-to-vite.mdx
@@ -1,0 +1,63 @@
+---
+title: Add custom fonts to a Vite project
+description:
+  Learn how to add a custom font when using Chakra UI in a Vite project
+publishedAt: "2024-11-19"
+collection: theming
+---
+
+## Loading the custom fonts
+
+To add a custom font in your project, you need to install the specific font you
+want to use from [Fontsource](https://fontsource.org/). In this case, we'll use
+the "Bricolage Grotesque" font as an example.
+
+```bash
+pnpm add @fontsource-variable/bricolage-grotesque
+```
+
+Next, import the font at the root of your project, referencing the `css` path:
+
+```tsx title="main.tsx"
+import "@fontsource-variable/bricolage-grotesque/index.css"
+```
+
+## Using the custom font
+
+With the `createSystem` method, define the custom font in Chakra UI's theme
+configuration:
+
+```tsx title="components/ui/provider.tsx"
+"use client"
+
+import { createSystem, defaultConfig } from "@chakra-ui/react"
+
+const system = createSystem(defaultConfig, {
+  theme: {
+    tokens: {
+      fonts: {
+        heading: { value: "Bricolage Grotesque Variable" },
+        body: { value: "Bricolage Grotesque Variable" },
+      },
+    },
+  },
+})
+```
+
+> You can customize which text elements use the font by specifying it for
+> `heading`, `body`, or both. In this case, we are setting both the body and
+> heading fonts to Bricolage Grotesque.
+
+Finally, pass the `system` into the `ChakraProvider`
+
+```tsx title="components/ui/provider.tsx" /value={system}/
+export function Provider(props: ColorModeProviderProps) {
+  return (
+    <ChakraProvider value={system}>
+      <ColorModeProvider {...props} />
+    </ChakraProvider>
+  )
+}
+```
+
+This ensures that the custom font is applied across your entire app.

--- a/apps/www/content/guides/theming-add-custom-font-to-vite.mdx
+++ b/apps/www/content/guides/theming-add-custom-font-to-vite.mdx
@@ -2,15 +2,16 @@
 title: Add custom fonts to a Vite project
 description:
   Learn how to add a custom font when using Chakra UI in a Vite project
-publishedAt: "2024-11-19"
+publishedAt: "2024-11-18"
 collection: theming
 ---
 
 ## Loading the custom fonts
 
-To add a custom font in your project, you need to install the specific font you
-want to use from [Fontsource](https://fontsource.org/). In this case, we'll use
-the "Bricolage Grotesque" font as an example.
+To add a custom font in your project, install the Google font you want to use
+from [Fontsource](https://fontsource.org/). For this guide, we'll use the
+["Bricolage Grotesque"](https://fontsource.org/fonts/bricolage-grotesque) font
+as an example.
 
 ```bash
 pnpm add @fontsource-variable/bricolage-grotesque
@@ -22,9 +23,9 @@ Next, import the font at the root of your project, referencing the `css` path:
 import "@fontsource-variable/bricolage-grotesque/index.css"
 ```
 
-## Using the custom font
+## Configure the custom font
 
-With the `createSystem` method, define the custom font in Chakra UI's theme
+Use the `createSystem` method to define the custom font in Chakra UI's theme
 configuration:
 
 ```tsx title="components/ui/provider.tsx"
@@ -44,9 +45,13 @@ const system = createSystem(defaultConfig, {
 })
 ```
 
-> You can customize which text elements use the font by specifying it for
-> `heading`, `body`, or both. In this case, we are setting both the body and
-> heading fonts to Bricolage Grotesque.
+:::info
+
+You can customize which text elements use the font by specifying it for
+`heading`, `body`, or both. In this case, we are setting both the body and
+heading fonts to "Bricolage Grotesque".
+
+:::
 
 Finally, pass the `system` into the `ChakraProvider`
 


### PR DESCRIPTION
## 📝 Description

This PR adds guides for custom fonts in a nextjs and vite app.

## 💣 Is this a breaking change (Yes/No):

No
