### PR TITLE
docs: fix disabled button state in Toast Pause and Play example

### DIFF
--- a/apps/compositions/src/examples/toaster-pause-and-play.tsx
+++ b/apps/compositions/src/examples/toaster-pause-and-play.tsx
@@ -8,9 +8,20 @@ import { HiPause, HiPlay } from "react-icons/hi"
 export const ToasterPauseAndPlay = () => {
   const id = useId()
   const [paused, setPaused] = useState(false)
+  const [shown, setShown] = useState(false)
 
   const show = () => {
-    toaster.success({ id, title: "This is a success toast" })
+    toaster.success({
+      id,
+      title: "This is a success toast",
+      onStatusChange: (details) => {
+        if (details.status === "visible") {
+          setShown(true)
+        } else if (details.status === "dismissing") {
+          setShown(false)
+        }
+      },
+    })
   }
 
   const pause = () => {
@@ -25,14 +36,24 @@ export const ToasterPauseAndPlay = () => {
 
   return (
     <HStack>
-      <Button variant="outline" size="sm" onClick={show}>
+      <Button variant="outline" size="sm" onClick={show} disabled={shown}>
         Show Toast
       </Button>
-      <Button variant="outline" size="sm" onClick={pause} disabled={!paused}>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={pause}
+        disabled={!shown || paused}
+      >
         <HiPause />
         Pause Toast
       </Button>
-      <Button variant="outline" size="sm" onClick={play} disabled={paused}>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={play}
+        disabled={!shown || !paused}
+      >
         <HiPlay />
         Play Toast
       </Button>

--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -85,6 +85,9 @@ Use the `duration` prop to set the duration of the toast.
 Use the `pause` and `resume` methods on the `toaster` object to pause and play
 the toast.
 
+Pausing a toast prevents it from timing out, while resuming it will reenable the
+timeout using the remaining duration.
+
 <ExampleTabs name="toaster-pause-and-play" />
 
 ### Lifecycle


### PR DESCRIPTION
I noticed that the [Pause and Play](https://www.chakra-ui.com/docs/components/toast#pause-and-play) example for the Toast component didn't seem to work. 

It turns out that the `disabled` properties were inverted causing the buttons to be disabled when they should have been enabled, and vice versa.

Also: 
- Updates the example to disable the _Show Toast_ button while the toast is visible, and re-enable it once the toast is dismissed.
- Adds clarification to the documentation on what pause/resume actually does, because I found that a little unclear when I was reading this. 