### PR TITLE
feat(cli): support React Router 7 framework detection

### DIFF
--- a/.changeset/nervous-points-attend.md
+++ b/.changeset/nervous-points-attend.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Support React Router 7 framework detection

--- a/packages/cli/src/utils/context.ts
+++ b/packages/cli/src/utils/context.ts
@@ -35,7 +35,9 @@ function getFramework(files: string[], cwd: string) {
       },
     )
     const viteConfig = readFileSync(viteConfigPath, "utf-8")
-    const isRemix = !!viteConfig?.includes("@remix-run/dev")
+    const isRemix =
+      !!viteConfig?.includes("@remix-run/dev") ||
+      !!viteConfig?.includes("@react-router/dev/vite")
     return isRemix ? "remix" : "vite"
   }
 


### PR DESCRIPTION
## 📝 Description

Add support for React Router 7 in the CLI's framework detection logic. Both React Router 7 and Remix projects follow similar project structures with code organized in the `app` directory, so we now detect projects using `@react-router/dev/vite` and treat them the same way as Remix projects.

## ⛳️ Current behavior (updates)

Currently, the CLI only detects Remix projects by checking for `@remix-run/dev` in the vite config file. However, React Router 7 projects also follow a similar project structure with code organized in the `app` directory, so they should follow the same directory structure conventions.

## 🚀 New behavior

The CLI now also checks for `@react-router/dev/vite` in the vite config file. If either `@remix-run/dev` or `@react-router/dev/vite` is found, the project will be treated as a Remix project, ensuring consistent component organization across both frameworks.

## 💣 Is this a breaking change (No):

No, this change only adds support for React Router 7 projects without affecting existing Remix or other projects.

## 📝 Additional Information

This change helps maintain consistency between Remix and React Router 7 projects, as they both organize their code in the `app` directory and should follow similar project organization patterns. The detection specifically looks for `@react-router/dev/vite` which is the correct package used in Vite projects with React Router 7.