### PR TITLE
fix: export missing slot recipe context types

### DIFF
--- a/.changeset/large-queens-cover.md
+++ b/.changeset/large-queens-cover.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fixed issue where exporting withProvider and withContext would result in type
+error

--- a/packages/react/src/styled-system/create-slot-recipe-context.tsx
+++ b/packages/react/src/styled-system/create-slot-recipe-context.tsx
@@ -23,11 +23,11 @@ interface WithRootProviderOptions<P> extends WrapElementProps<P> {
   defaultProps?: Partial<P>
 }
 
-interface WithProviderOptions<P>
+export interface WithProviderOptions<P>
   extends JsxFactoryOptions<P>,
     WrapElementProps<P> {}
 
-interface WithContextOptions<P> extends JsxFactoryOptions<P> {}
+export interface WithContextOptions<P> extends JsxFactoryOptions<P> {}
 
 const upperFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 

--- a/packages/react/src/styled-system/index.ts
+++ b/packages/react/src/styled-system/index.ts
@@ -2,6 +2,10 @@ export * from "./config"
 export { createRecipeContext } from "./create-recipe-context"
 export { createSlotRecipeContext } from "./create-slot-recipe-context"
 export type {
+  WithProviderOptions,
+  WithContextOptions,
+} from "./create-slot-recipe-context"
+export type {
   ConditionalValue,
   GlobalStyleObject,
   SystemStyleObject,

--- a/packages/react/src/styled-system/index.ts
+++ b/packages/react/src/styled-system/index.ts
@@ -43,6 +43,7 @@ export type {
   RecipeProps,
   SlotRecipeProps,
   SlotRecipeRecord,
+  ConfigRecipeSlots,
 } from "./generated/recipes.gen"
 export type { ColorPalette, Token, Tokens } from "./generated/token.gen"
 export * from "./provider"


### PR DESCRIPTION
When exporting withProvider / withContext from a module it results in type cannot be named error because the used types are not exported from the package.

Code:
```
import { createSlotRecipeContext } from '@chakra-ui/react'

export const {
  withProvider,
  withContext,
  useStyles: useNavbarStyles,
} = createSlotRecipeContext({
  key: 'navbar',
})
```

Error:
```
src/components/navbar/navbar.context.ts(4,3): error TS4023: Exported variable 'withProvider' has or is using name 'WithProviderOptions' from external module "/Users/eelco/Development/appulse/saas-ui-v3/node_modules/@chakra-ui/react/dist/types/styled-system/create-slot-recipe-context" but cannot be named.
src/components/navbar/navbar.context.ts(5,3): error TS4023: Exported variable 'withContext' has or is using name 'WithContextOptions' from external module "/Users/eelco/Development/appulse/saas-ui-v3/node_modules/@chakra-ui/react/dist/types/styled-system/create-slot-recipe-context" but cannot be named.
```