### PR TITLE
fix: include missing `TimelineTitle` in exports

### DIFF
--- a/.changeset/hip-apes-learn.md
+++ b/.changeset/hip-apes-learn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Export missing `TimelineTitle`

--- a/packages/react/src/components/timeline/index.ts
+++ b/packages/react/src/components/timeline/index.ts
@@ -7,6 +7,7 @@ export {
   TimelineRoot,
   TimelineRootPropsProvider,
   TimelineSeparator,
+  TimelineTitle,
   useTimelineStyles,
 } from "./timeline"
 


### PR DESCRIPTION
Without this change unable to import TimelineTitle component in react.
