### PR TITLE
fix(cli): output the real version

### DIFF
--- a/.changeset/calm-days-yawn.md
+++ b/.changeset/calm-days-yawn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Output the real version from `package.json`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts"
 import { Command } from "commander"
+import { resolve } from "path/posix"
 import { EjectCommand } from "./commands/eject.js"
 import { SnippetCommand } from "./commands/snippet.js"
 import { TypegenCommand } from "./commands/typegen.js"
@@ -8,11 +9,11 @@ process.setMaxListeners(Infinity)
 
 export async function run() {
   p.intro("Chakra CLI ⚡️")
-
+  const packageJson = await import(resolve("package.json"))
   const program = new Command()
     .name("chakra-ui")
     .description("The official CLI for Chakra UI projects")
-    .version("3.0.0")
+    .version(packageJson.version)
 
   program
     .addCommand(TypegenCommand)


### PR DESCRIPTION
Closes # N/A

## 📝 Description

Update CLI to display the actual package version instead of a hardcoded version number.

## ⛳️ Current behavior (updates)

Currently, the CLI version is hardcoded as "3.0.0", which may not reflect the actual package version.

## 🚀 New behavior

- CLI now reads the actual version from package.json file
- Running `npx @chakra-ui/cli--version` will display the real package version

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This change improves version accuracy by ensuring the CLI displays the version that matches the installed package version.