### PR TITLE
docs: updated source links

### DIFF
--- a/apps/www/content/docs/components/close-button.mdx
+++ b/apps/www/content/docs/components/close-button.mdx
@@ -2,7 +2,6 @@
 title: Close Button
 description: Used to trigger close functionality
 links:
-  source: components/close-button
   storybook: components-close-button--basic
   recipe: close-button
 ---

--- a/apps/www/content/docs/components/environment-provider.mdx
+++ b/apps/www/content/docs/components/environment-provider.mdx
@@ -2,7 +2,6 @@
 title: Environment Provider
 description: Used to render components in iframes, Shadow DOM, or Electron.
 links:
-  source: components/environment-provider
   storybook: components-environment-provider--basic
   recipe: environment-provider
   ark: https://ark-ui.com/react/docs/utilities/environment-provider

--- a/apps/www/content/docs/components/format-byte.mdx
+++ b/apps/www/content/docs/components/format-byte.mdx
@@ -2,7 +2,6 @@
 title: Format Byte
 description: Used to format bytes to a human-readable format
 links:
-  source: components/format-byte
   storybook: components-format-byte--basic
   ark: https://ark-ui.com/react/docs/utilities/format-byte
 ---

--- a/apps/www/content/docs/components/format-number.mdx
+++ b/apps/www/content/docs/components/format-number.mdx
@@ -2,7 +2,6 @@
 title: Format Number
 description: Used to format numbers to a specific locale and options
 links:
-  source: components/format-number
   storybook: components-format-number--basic
   ark: https://ark-ui.com/react/docs/utilities/format-number
 ---

--- a/apps/www/content/docs/components/icon-button.mdx
+++ b/apps/www/content/docs/components/icon-button.mdx
@@ -2,7 +2,7 @@
 title: Icon Button
 description: Used to render an icon within a button
 links:
-  source: components/icon-button
+  source: components/button
   storybook: components-icon-button--basic
   recipe: button
 ---

--- a/apps/www/content/docs/components/radio.mdx
+++ b/apps/www/content/docs/components/radio.mdx
@@ -2,7 +2,6 @@
 title: Radio
 description: Used to select one option from several options
 links:
-  source: components/radio
   storybook: components-radio--basic
   recipe: radio-group
   ark: https://ark-ui.com/react/docs/components/radio

--- a/apps/www/content/docs/components/rating.mdx
+++ b/apps/www/content/docs/components/rating.mdx
@@ -2,7 +2,6 @@
 title: Rating
 description: Used to show reviews and ratings in a visual format.
 links:
-  source: components/rating
   storybook: components-rating--basic
   recipe: rating
   ark: https://ark-ui.com/react/docs/components/rating-group

--- a/apps/www/content/docs/components/segmented-control.mdx
+++ b/apps/www/content/docs/components/segmented-control.mdx
@@ -2,7 +2,6 @@
 title: Segmented Control
 description: Used to pick one choice from a linear set of options
 links:
-  source: components/segmented-control
   storybook: components-segmented-control--basic
   recipe: segmented-group
   ark: https://ark-ui.com/react/docs/components/segment-group

--- a/apps/www/content/docs/components/text.mdx
+++ b/apps/www/content/docs/components/text.mdx
@@ -2,7 +2,7 @@
 title: Text
 description: Used to render text and paragraphs within an interface.
 links:
-  source: components/text
+  source: components/typography
 ---
 
 <ExampleTabs name="text-basic" />


### PR DESCRIPTION
## 📝 Description

> Updates broken links in docs.

## ⛳️ Current behavior (updates)

> Accidentally came across the link to the `Text` component not working properly. I wanted to fix it, and I realized I might as well just go through all of the components and fix which have broken links & update them. `Text` and `Icon-Button` had broken links that I could update, for the others, their source was not under the components directory, and at first thought I removed the source links, but I can update this PR if need be. The `environment-provider.mdx` mentions that it's using Zag.js internally, and I couldn't find any source files for this so I also removed this link, but again, I can update the PR if need be.

## 🚀 New behavior

> The broken source links now either work and lead you to the correct source information, or they the source links are removed.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

None.
