### PR TITLE
fix: add max available height to menu content

### DIFF
--- a/.changeset/friendly-ligers-arrive.md
+++ b/.changeset/friendly-ligers-arrive.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Add max available height to menu recipe

--- a/packages/react/src/theme/recipes/menu.ts
+++ b/packages/react/src/theme/recipes/menu.ts
@@ -10,10 +10,12 @@ export const menuSlotRecipe = defineSlotRecipe({
       bg: "bg.panel",
       boxShadow: "lg",
       color: "fg",
+      maxHeight: "var(--available-height)",
       "--menu-z-index": "zIndex.dropdown",
       zIndex: "calc(var(--menu-z-index) + var(--layer-index, 0))",
       borderRadius: "l2",
       overflow: "hidden",
+      overflowY: "auto",
       _open: {
         animationStyle: "slide-fade-in",
         animationDuration: "fast",


### PR DESCRIPTION
The menu recipe didn't utilize --available-height.

Same applies to select, @segunadebayo do you want to implement this?