### PR TITLE
Added --all flag to cli docs

### DIFF
--- a/apps/www/content/docs/get-started/cli.mdx
+++ b/apps/www/content/docs/get-started/cli.mdx
@@ -77,7 +77,7 @@ Generates useful component compositions that boost your development speed.
 
 ```bash
 # Add all snippets
-chakra snippet add
+chakra snippet add --all
 
 # Add a specific snippet
 chakra snippet add button


### PR DESCRIPTION
Closes #

## 📝 Description

Since the way to add all snippets was changed to need a flag in the cli i thought the docs should showcase this, because its a bit misleading right now how to add all the snippets

## ⛳️ Current behavior (updates)
## 🚀 New behavior


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
