### PR TITLE
docs(hover-card): fix typo import from popover

### DIFF
--- a/apps/www/content/docs/components/hover-card.mdx
+++ b/apps/www/content/docs/components/hover-card.mdx
@@ -29,7 +29,7 @@ import {
   HoverCardContent,
   HoverCardRoot,
   HoverCardTrigger,
-} from "@/components/ui/popover"
+} from "@/components/ui/hover-card"
 ```
 
 ```jsx


### PR DESCRIPTION
## 📝 Description

> The purpose of this PR is to fix typo on `hover-card`. The `import` statement should be from `hover-card` (`@/components/ui/hover-card`) instead of `popover` (`@/components/ui/popover`)

```jsx
import {
  HoverCardArrow,
  HoverCardContent,
  HoverCardRoot,
  HoverCardTrigger,
} from "@/components/ui/hover-card"
```

## ⛳️ Current behavior (updates)

> When you import some parts of Hover Card (example: `HoverCardArrow`) from `@/components/ui/popover` , you will get warning because `Module '"@/components/ui/popover"' has no exported member 'HoverCardArrow'.` and you can't run the app.

## 🚀 New behavior

> The changes should fix the docs so that you can follow it and import `hover-card` properly.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
