### PR TITLE
[README] Add proper links to npm and github badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@
   <a href="https://github.com/chakra-ui/chakra-ui/blob/main/LICENSE">
     <img alt="MIT License" src="https://img.shields.io/github/license/chakra-ui/chakra-ui"/>
   </a>
-  <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@chakra-ui/react.svg?style=flat"/>
-  <img alt="Github Stars" src="https://badgen.net/github/stars/chakra-ui/chakra-ui" />
+  <a href="https://www.npmjs.com/package/@chakra-ui/react">
+    <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@chakra-ui/react.svg?style=flat"/>
+  </a>
+  <a href="https://github.com/chakra-ui/chakra-ui">
+    <img alt="Github Stars" src="https://badgen.net/github/stars/chakra-ui/chakra-ui" />
+  </a>
   <a href="https://discord.gg/chakra-ui">
     <img alt="Discord" src="https://img.shields.io/discord/660863154703695893.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2" />
   </a>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

It's expected that when an NPM badge is clicked on a README, we should go to its NPM page. Doesn't hurt if the GitHub badge has a link as well.

## ⛳️ Current behavior (updates)

Both link to their images

## 🚀 New behavior

Both link to their corresponding pages (NPM and GitHub repo pages). We can now click them to navigate!

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
