### PR TITLE
[fix] Tooltip: Avoid React 19 deprecation warning when accessing `element.ref`

### DIFF
--- a/packages/components/src/tooltip/tooltip.tsx
+++ b/packages/components/src/tooltip/tooltip.tsx
@@ -124,7 +124,10 @@ export const Tooltip = forwardRef<TooltipProps, "div">((props, ref) => {
     }
     trigger = cloneElement(
       child,
-      tooltip.getTriggerProps(child.props, child.ref),
+      tooltip.getTriggerProps(
+        child.props, 
+        Object.getOwnPropertyDescriptor(child, 'ref').value
+      ),
     )
   }
 


### PR DESCRIPTION
Closes #9329

Closes # <!-- Github issue # here -->

## 📝 Description

Accessing `element.ref` [will trigger a deprecation warning in React 19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#deprecated-element-ref) which this PR will avoid.

## ⛳️ Current behavior (updates)

Using the Tooltip component with React 19 will give:

> Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.

… decorated with a long an ugly stack trace in the console.

## 🚀 New behavior

This change ensures `element.ref` is still picked from the child when using React <19, but picked from the child props when using React >=19.

## 💣 Is this a breaking change (Yes/No):

No

