### PR TITLE
docs: fix /docs endpoint

### DIFF
--- a/apps/www/components/site/accessibility.section.tsx
+++ b/apps/www/components/site/accessibility.section.tsx
@@ -44,7 +44,7 @@ const Intro = () => (
       w="fit-content"
       px="8"
     >
-      <Link href="/docs/get-started/overview/installation">Start Building</Link>
+      <Link href="/docs/get-started/installation">Start Building</Link>
     </Button>
   </Stack>
 )

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -16,7 +16,7 @@ const nextConfig = {
   redirects: async () => [
     {
       source: "/docs",
-      destination: "/docs/get-started/overview/installation",
+      destination: "/docs/get-started/installation",
       permanent: true,
     },
   ],


### PR DESCRIPTION
Closes #9365 

## 📝 Description

This change updates the `/docs` route to lead to its intended destination.

## ⛳️ Current behavior (updates)

The current `/docs` route leads to a 404 at https://www.chakra-ui.com/docs/get-started/overview/installation

## 🚀 New behavior

The new `/docs` route will lead to its intended destination at https://www.chakra-ui.com/docs/get-started/installation

## 💣 Is this a breaking change (Yes/No):

No