### PR TITLE
update broken documentation link

### DIFF
--- a/packages/react/src/components/image/image.tsx
+++ b/packages/react/src/components/image/image.tsx
@@ -29,7 +29,7 @@ export interface ImageProps extends HTMLChakraProps<"img", ImageOptions> {}
  * React component that renders an image with support
  * for fallbacks
  *
- * @see Docs https://chakra-ui.com/image
+ * @see Docs https://www.chakra-ui.com/docs/components/image
  */
 export const Image = forwardRef<HTMLImageElement, ImageProps>(
   function Image(props, ref) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> replace broken link in JSDoc comment

## ⛳️ Current behavior (updates)

The JSDoc comment  in file `chakra-ui\packages\react\src\components\image\image.tsx` at **line 32** contained a broken link, leading to a 404 error page on the Chakra UI docs.

## 🚀 New behavior

The broken link `https://chakra-ui.com/image` was replaced by `https://www.chakra-ui.com/docs/components/image` which now leads to the correct documentation for the Image component.

## 💣 Is this a breaking change (Yes/No):

> No

## 📝 Additional Information
