### PR TITLE
fix doc: moved textStyles from extend

### DIFF
--- a/apps/www/content/docs/styling/text-styles.mdx
+++ b/apps/www/content/docs/styling/text-styles.mdx
@@ -55,9 +55,7 @@ import { textStyles } from "./text-styles"
 
 const config = defineConfig({
   theme: {
-    extend: {
-      textStyles,
-    },
+    textStyles,
   },
 })
 


### PR DESCRIPTION
📝 Description
Fixed an incorrect description in the Chakra UI documentation for the textStyles configuration.

⛳️ Current behavior (updates)
In the file `chakra-ui/apps/www/content/docs/styling/text-styles.mdx` in line 57 there is an inconsistency in the description of textStyles. That field should be next to the extend field, not inside it

🚀 New behavior
An edit was made with the correct description

💣 Is this a breaking change (Yes/No):
No

📝 Additional Information