### PR TITLE
fix: the logic for external routes

### DIFF
--- a/apps/www/components/pagination.tsx
+++ b/apps/www/components/pagination.tsx
@@ -4,10 +4,12 @@ import { LuChevronLeft, LuChevronRight } from "react-icons/lu"
 
 interface PaginationItemProps extends StackProps {
   href: LinkProps["href"]
+  external?: boolean | undefined
 }
 
 const PaginationItem = (props: PaginationItemProps) => {
-  const { children, href, ...rest } = props
+  const { children, href, external, ...rest } = props
+
   return (
     <Box
       flex="1"
@@ -19,22 +21,37 @@ const PaginationItem = (props: PaginationItemProps) => {
       {...rest}
       asChild
     >
-      <Link href={href}>{children}</Link>
+      {external ? (
+        <a href={href as string} target="_blank" rel="noopener noreferrer">
+          {children}
+        </a>
+      ) : (
+        <Link href={href}>{children}</Link>
+      )}
     </Box>
   )
 }
 
 interface PaginationProps extends StackProps {
-  previous?: { title: string; url?: LinkProps["href"] } | null
-  next?: { title: string; url?: LinkProps["href"] } | null
+  previous?: {
+    title: string
+    url?: LinkProps["href"]
+    external?: boolean | undefined
+  } | null
+  next?: {
+    title: string
+    url?: LinkProps["href"]
+    external?: boolean | undefined
+  } | null
 }
 
 export const Pagination = (props: PaginationProps) => {
   const { previous, next, ...rest } = props
+
   return (
     <HStack {...rest}>
       {previous ? (
-        <PaginationItem href={previous.url || "#"}>
+        <PaginationItem href={previous.url || "#"} external={previous.external}>
           <Stack gap="1" textAlign="start" textStyle="sm">
             <Text color="fg.muted">Previous</Text>
             <HStack
@@ -51,7 +68,7 @@ export const Pagination = (props: PaginationProps) => {
         <Box flex="1" />
       )}
       {next ? (
-        <PaginationItem href={next.url || "#"}>
+        <PaginationItem href={next.url || "#"} external={next.external}>
           <Stack gap="1" textAlign="end" textStyle="sm">
             <Text color="fg.muted">Next</Text>
             <HStack

--- a/apps/www/components/sidenav.tsx
+++ b/apps/www/components/sidenav.tsx
@@ -54,13 +54,25 @@ export const SideNav = (props: SideNavProps) => {
               layerStyle: "fill.subtle",
             }}
           >
-            <Link
-              href={item.url!}
-              aria-current={item.url === currentUrl ? "page" : undefined}
-            >
-              {item.title}
-              {item.status && <StatusBadge>{item.status}</StatusBadge>}
-            </Link>
+            {item.external ? (
+              <a
+                href={item.url as string}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-current={item.url === currentUrl ? "page" : undefined}
+              >
+                {item.title}
+                {item.status && <StatusBadge>{item.status}</StatusBadge>}
+              </a>
+            ) : (
+              <Link
+                href={item.url!}
+                aria-current={item.url === currentUrl ? "page" : undefined}
+              >
+                {item.title}
+                {item.status && <StatusBadge>{item.status}</StatusBadge>}
+              </Link>
+            )}
           </HStack>
         ))}
       </Stack>

--- a/apps/www/lib/use-route.ts
+++ b/apps/www/lib/use-route.ts
@@ -51,11 +51,20 @@ export function useRoute() {
   function getFlattenedNavItems(): FlattenNavItem[] {
     const result: FlattenNavItem[] = []
     const iterate = (item: NavItem, parentUrl = "") => {
-      const url = item.url ? `${parentUrl}/${item.url}` : parentUrl
+      const url = item.external
+        ? item.url
+        : item.url
+          ? `${parentUrl}/${item.url}`
+          : parentUrl
       if (item.items) {
         item.items.forEach((child) => iterate(child, url))
       } else {
-        result.push({ title: item.title, url, status: item.status })
+        result.push({
+          title: item.title,
+          url,
+          status: item.status,
+          external: item.external,
+        })
       }
     }
     docsConfig.navigation.forEach((item) => iterate(item))
@@ -95,6 +104,7 @@ export function useRoute() {
             current: currentUrl.startsWith(
               join(primaryNav.url, secondaryNav.url, group.url, item.url),
             ),
+            external: item.external,
           })) || [],
       })) || []
     )


### PR DESCRIPTION
## 📝 Description

The problem is a 404 error when going to the URL: `https://www.chakra-ui.com/docs/get-started//showcase` because the URL itself is incorrectly formed. The picture below shows where to click to reproduce the problem.

<img width="939" alt="image" src="https://github.com/user-attachments/assets/0ad2a8d7-ea69-4398-ab02-6f839bbe1b45" />

## ⛳️ Current behavior (updates)
This happens when you click on the pagination button, but also clicking on Showcase in the sidebar does not cause the error, but it also does not redirect the user to a new page, which contradicts the external parameter.

## 🚀 New behavior

After the changes made, the behavior is as expected: when clicking on a link (in the sidebar or in the pagination) if there is an external parameter - it redirects the user to another page

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
