### PR TITLE
Amend install command so that v2 docs don't install v3

### DIFF
--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -9,10 +9,10 @@ terminal:
 
 <PackageManagers
   command={{
-    npm: 'npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion',
-    yarn: 'yarn add @chakra-ui/react @emotion/react @emotion/styled framer-motion',
-    pnpm: 'pnpm add @chakra-ui/react @emotion/react @emotion/styled framer-motion',
-    bun: 'bun add @chakra-ui/react @emotion/react @emotion/styled framer-motion',
+    npm: 'npm i @chakra-ui/react@^2 @emotion/react @emotion/styled framer-motion',
+    yarn: 'yarn add @chakra-ui/react@^2 @emotion/react @emotion/styled framer-motion',
+    pnpm: 'pnpm add @chakra-ui/react@^2 @emotion/react @emotion/styled framer-motion',
+    bun: 'bun add @chakra-ui/react@^2 @emotion/react @emotion/styled framer-motion',
   }}
 />
 


### PR DESCRIPTION
This updates the v2 docs. I just ran the command to check what version of framer motion would be resolved and ended up with chakra ui 3 being installed.

## ⛳️ Current behavior (updates)

Running the install command at https://v2.chakra-ui.com/getting-started will actually install chakra ui v3.

Arguably that is what everybody should migrate to asap and it's definitely the cooler kid in town now – however if someone specifically looks at the v2 docs, they would propably expect to get v2 from the install instructions :smile: 

## 🚀 New behavior

Running the install command at https://v2.chakra-ui.com/getting-started will now install chakra ui v2.


## 💣 Is this a breaking change (Yes/No):

No

