### PR TITLE
fix(input-group): add proper typing for children prop

### DIFF
--- a/apps/compositions/src/ui/input-group.tsx
+++ b/apps/compositions/src/ui/input-group.tsx
@@ -7,7 +7,7 @@ export interface InputGroupProps extends BoxProps {
   endElementProps?: InputElementProps
   startElement?: React.ReactNode
   endElement?: React.ReactNode
-  children: React.ReactElement
+  children: React.ReactElement<InputElementProps>
   startOffset?: InputElementProps["paddingStart"]
   endOffset?: InputElementProps["paddingEnd"]
 }


### PR DESCRIPTION
## 📝 Description

Closes #9420

Adds the correct typing for the `children` prop in the `InputGroup` component to resolve compatibility issues with TypeScript and prevent build errors in projects using Chakra UI.

## ⛳️ Current behavior (updates)

Currently, the `children` prop in `InputGroup` is typed generically (`React.ReactElement<unknown>`), which may cause build errors in TypeScript projects when using incorrectly typed child elements.

## 🚀 New behavior

The updated typing expects a child of type `React.ReactElement<InputElementProps>`. This ensures TypeScript can correctly validate the children of `InputGroup` and prevents compilation errors.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Without the correct typing, build errors can occur in TypeScript projects that utilize the `InputGroup` component. This is because TypeScript cannot properly infer the expected types when using custom child components. 

This PR resolves the issue by providing accurate typings, improving compatibility and predictability when using the `InputGroup` component. If needed, I can suggest additional tests to avoid similar issues in the future.