### PR TITLE
fix: wrong anatomy exportation

### DIFF
--- a/packages/react/src/anatomy.ts
+++ b/packages/react/src/anatomy.ts
@@ -220,6 +220,7 @@ export const timelineAnatomy = createAnatomy("timeline").parts(
 export { avatarAnatomy } from "@ark-ui/react/avatar"
 export { checkboxAnatomy } from "@ark-ui/react/checkbox"
 export { collapsibleAnatomy } from "@ark-ui/react/collapsible"
+export { colorPickerAnatomy } from "@ark-ui/react/color-picker"
 export { fieldsetAnatomy } from "@ark-ui/react/fieldset"
 export { hoverCardAnatomy } from "@ark-ui/react/hover-card"
 export { numberInputAnatomy } from "@ark-ui/react/number-input"

--- a/packages/react/src/anatomy.ts
+++ b/packages/react/src/anatomy.ts
@@ -3,6 +3,7 @@ import { createAnatomy } from "@ark-ui/react/anatomy"
 import { dialogAnatomy as arkDialogAnatomy } from "@ark-ui/react/dialog"
 import { editableAnatomy as arkEditableAnatomy } from "@ark-ui/react/editable"
 import { fieldAnatomy as arkFieldAnatomy } from "@ark-ui/react/field"
+import { fieldsetAnatomy as arkFieldsetAnatomy } from "@ark-ui/react/fieldset"
 import { fileUploadAnatomy as arkFileUploadAnatomy } from "@ark-ui/react/file-upload"
 import { menuAnatomy as arkMenuAnatomy } from "@ark-ui/react/menu"
 import { popoverAnatomy as arkPopoverAnatomy } from "@ark-ui/react/popover"
@@ -98,6 +99,8 @@ export const emptyStateAnatomy = createAnatomy("empty-state", [
 ])
 
 export const fieldAnatomy = arkFieldAnatomy.extendWith("requiredIndicator")
+
+export const fieldsetAnatomy = arkFieldsetAnatomy.extendWith("content")
 
 export const fileUploadAnatomy = arkFileUploadAnatomy.extendWith(
   "itemContent",
@@ -221,7 +224,6 @@ export { avatarAnatomy } from "@ark-ui/react/avatar"
 export { checkboxAnatomy } from "@ark-ui/react/checkbox"
 export { collapsibleAnatomy } from "@ark-ui/react/collapsible"
 export { colorPickerAnatomy } from "@ark-ui/react/color-picker"
-export { fieldsetAnatomy } from "@ark-ui/react/fieldset"
 export { hoverCardAnatomy } from "@ark-ui/react/hover-card"
 export { numberInputAnatomy } from "@ark-ui/react/number-input"
 export { pinInputAnatomy } from "@ark-ui/react/pin-input"

--- a/packages/react/src/theme/recipes/color-picker.ts
+++ b/packages/react/src/theme/recipes/color-picker.ts
@@ -1,4 +1,4 @@
-import { colorPickerAnatomy } from "@ark-ui/react/color-picker"
+import { colorPickerAnatomy } from "../../anatomy"
 import { defineSlotRecipe } from "../../styled-system"
 import { colorSwatchRecipe } from "./color-swatch"
 import { inputRecipe } from "./input"

--- a/packages/react/src/theme/recipes/fieldset.ts
+++ b/packages/react/src/theme/recipes/fieldset.ts
@@ -1,9 +1,9 @@
-import { fieldsetAnatomy } from "@ark-ui/react/fieldset"
+import { fieldsetAnatomy } from "../../anatomy"
 import { defineSlotRecipe } from "../../styled-system"
 
 export const fieldsetSlotRecipe = defineSlotRecipe({
   className: "fieldset",
-  slots: [...fieldsetAnatomy.keys(), "content"],
+  slots: fieldsetAnatomy.keys(),
   base: {
     root: {
       display: "flex",


### PR DESCRIPTION
## 📝 Description

- The color picker anatomy is not exported as other anatomies
- The fieldset anatomy doesn't contain all the keys

## ⛳️ Current behavior (updates)

- You can not import the anatomy like `import { colorPickerAnatomy } from "@chakra-ui/react/anatomy";`
- If you import the fieldset anatomy the content key is missing

## 🚀 New behavior

- Exporting the color picker anatomy like other components
- Extending the fieldset anatomy with the content key

## 💣 Is this a breaking change (Yes/No):

No
