### PR TITLE
fix: align input radius

### DIFF
--- a/packages/react/src/theme/recipes/number-input.ts
+++ b/packages/react/src/theme/recipes/number-input.ts
@@ -12,7 +12,7 @@ const triggerStyle = defineStyle({
   cursor: "button",
   lineHeight: "1",
   color: "fg.muted",
-  "--stepper-base-radius": "radii.xs",
+  "--stepper-base-radius": "radii.l1",
   "--stepper-radius": "calc(var(--stepper-base-radius) + 1px)",
   _icon: {
     boxSize: "1em",


### PR DESCRIPTION
## 📝 Description

The input is using the semantic token radii of l2. But the number input triggers are using the token radii.xs

## ⛳️ Current behavior (updates)

If I decide to increase/decrease the radii semantic tokens, the input triggers will not be adjusted as they are not using the semantic token

## 🚀 New behavior

Using the semantic token on the number input triggers 

## 💣 Is this a breaking change (Yes/No):

No