### PR TITLE
fix docs: NumberInput example in Migration guide

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -592,7 +592,7 @@ After
 
 ```tsx
 <NumberInput.Root>
-  <NumberInput.Field />
+  <NumberInput.Input />
   <NumberInput.Control>
     <NumberInput.IncrementTrigger />
     <NumberInput.DecrementTrigger />


### PR DESCRIPTION
The migration guide refers to `<NumberInput.Field />` which is not exported, which I believe should be `<NumberInput.Input />`

## 📝 Description

> Fix example of NumberInput usage, replacing NumberInput.Field with NumberInput.Input to match what's exported from package

## ⛳️ Current behavior (updates)

> Corrects mistake in documentation

## 🚀 New behavior

> None

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
