### PR TITLE
refactor(recipe): use the same semantic token for Select _highlighted regardless of theme

### DIFF
--- a/.changeset/orange-shrimps-exercise.md
+++ b/.changeset/orange-shrimps-exercise.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Use the same semantic token for select `_highlighted` state

--- a/packages/react/src/theme/recipes/select.ts
+++ b/packages/react/src/theme/recipes/select.ts
@@ -80,7 +80,7 @@ export const selectSlotRecipe = defineSlotRecipe({
       textAlign: "start",
       borderRadius: "l1",
       _highlighted: {
-        bg: { _light: "bg.muted", _dark: "bg.emphasized" },
+        bg: "bg.emphasized",
       },
       _disabled: {
         pointerEvents: "none",


### PR DESCRIPTION
Visually, the background of the highlighted Select option is much more emphasized in dark mode than in light mode:

![image](https://github.com/user-attachments/assets/06ae6981-930b-4d49-863a-3dd93512f3c1)
![image](https://github.com/user-attachments/assets/fc27499c-0b43-496c-9602-b0673ec523f9)

To my understanding, the same semantic token should be used for light mode and dark mode in this case, as the highlighted option should have the same emphasis in light and dark mode.

But if we feel that using the semantic token in both light and dark mode leads to a bad contrast, then it means the colors of the semantic tokens are not optimal, and should be changed.