### PR TITLE
fix: JSX namespace

### DIFF
--- a/packages/components/src/highlight/highlight.tsx
+++ b/packages/components/src/highlight/highlight.tsx
@@ -1,5 +1,5 @@
 import { SystemStyleObject } from "@chakra-ui/styled-system"
-import { Fragment } from "react"
+import { Fragment, type JSX } from "react"
 import { Chunk } from "./highlight-words"
 import { Mark } from "./mark"
 import { useHighlight } from "./use-highlight"

--- a/packages/components/src/system/providers.tsx
+++ b/packages/components/src/system/providers.tsx
@@ -11,7 +11,7 @@ import {
   Global,
   Interpolation,
 } from "@emotion/react"
-import { useMemo } from "react"
+import { useMemo, type JSX } from "react"
 import { useColorMode } from "../color-mode"
 
 export interface ThemeProviderProps extends EmotionThemeProviderProps {

--- a/packages/components/src/system/system.types.tsx
+++ b/packages/components/src/system/system.types.tsx
@@ -4,7 +4,7 @@ import type {
   SystemStyleObject,
 } from "@chakra-ui/styled-system"
 import type { Interpolation } from "@emotion/react"
-import { ElementType } from "react"
+import { ElementType, type JSX } from "react"
 
 export interface ChakraProps extends SystemProps {
   /**

--- a/packages/components/src/system/system.utils.ts
+++ b/packages/components/src/system/system.utils.ts
@@ -1,4 +1,5 @@
 import { isString } from "@chakra-ui/utils"
+import { type JSX } from "react"
 
 /**
  * All html and svg elements for chakra components.

--- a/packages/components/src/toast/create-standalone-toast.tsx
+++ b/packages/components/src/toast/create-standalone-toast.tsx
@@ -1,4 +1,5 @@
 import { theme as defaultTheme } from "@chakra-ui/theme"
+import { type JSX } from "react"
 import { ColorModeContext, type ColorMode } from "../color-mode"
 import { ThemeProvider, useChakra } from "../system"
 import { CreateToastFnReturn, createToastFn } from "./create-toast-fn"

--- a/packages/components/src/toast/toast.tsx
+++ b/packages/components/src/toast/toast.tsx
@@ -1,3 +1,4 @@
+import { type JSX } from "react"
 import { chakra } from "../system"
 import {
   Alert,

--- a/packages/theme-tools/src/component.ts
+++ b/packages/theme-tools/src/component.ts
@@ -3,6 +3,7 @@ import type {
   StyleFunctionProps,
   SystemStyleInterpolation,
 } from "@chakra-ui/styled-system"
+import { type JSX } from "react"
 
 export type {
   StyleConfig,


### PR DESCRIPTION
## 📝 Description

Fix issue where `chakra.x` factory component props throws TS error in React 19. The same as https://github.com/chakra-ui/chakra-ui/commit/be8f80ad9e1a2c987ebb477944377ed72138e33c, but for v2.

## 💣 Is this a breaking change (Yes/No):

No
