### PR TITLE
fix(docs): Fixed error in migration guide when using snippet Provider

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -103,10 +103,25 @@ import { Provider } from "@/components/ui/provider"
 import { defaultSystem } from "@chakra-ui/react"
 
 export const App = ({ Component }) => (
-  <Provider value={defaultSystem}>
+  <Provider>
     <Component />
   </Provider>
 )
+```
+
+
+```tsx {1,3}
+import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+
+import { ColorModeProvider } from '@/components/ui/color-mode';
+
+export function Provider(props) {
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <ColorModeProvider {...props} />
+    </ChakraProvider>
+  );
+}
 ```
 
 > If you have a custom theme, replace `defaultSystem` with the custom `system`


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #9503 

## 📝 Description
Fixed wrong code in migration guide that leads to errors with next-themes when "attribute" is set to "class" in next-themes ThemeProvider

## ⛳️ Current behavior (updates)

Migration guide change. The proposed code in it causes errors in specific scenario. 

## 🚀 New behavior

The migration guide provides correct code for how Chakra is working now when using the snippets.

## 💣 Is this a breaking change (Yes/No):

No

