### PR TITLE
fix(cli): properly check for existing files when not run with --force

### DIFF
--- a/packages/cli/src/commands/snippet.ts
+++ b/packages/cli/src/commands/snippet.ts
@@ -8,7 +8,10 @@ import { join } from "node:path/posix"
 import { getProjectContext } from "../utils/context"
 import { convertTsxToJsx } from "../utils/convert-tsx-to-jsx"
 import { fetchComposition, fetchCompositions } from "../utils/fetch"
-import { getFileDependencies } from "../utils/get-file-dependencies"
+import {
+  findCompositionById,
+  getFileDependencies,
+} from "../utils/get-file-dependencies"
 import { ensureDir } from "../utils/io"
 import { installCommand } from "../utils/run-command"
 import {
@@ -117,7 +120,13 @@ export const SnippetCommand = new Command("snippet")
             task: async () => {
               await Promise.all(
                 components.map(async (id) => {
-                  if (existsSync(join(outdir, id)) && !force) {
+                  let filename =
+                    findCompositionById(items, id)?.file ?? id + ".tsx"
+                  if (jsx) {
+                    filename = filename.replace(".tsx", ".jsx")
+                  }
+
+                  if (existsSync(join(outdir, filename)) && !force) {
                     skippedFiles.push(id)
                     return
                   }

--- a/packages/cli/src/utils/get-file-dependencies.ts
+++ b/packages/cli/src/utils/get-file-dependencies.ts
@@ -1,6 +1,6 @@
 import type { Compositions } from "./schema"
 
-const findCompositionById = (compositions: Compositions, id: string) => {
+export const findCompositionById = (compositions: Compositions, id: string) => {
   return compositions.find((comp) => comp.id === id)
 }
 


### PR DESCRIPTION
## 📝 Description

Fix `chakra snippet add` overwriting existing files even without `--force` specified.

## ⛳️ Current behavior (updates)

`chakra snippet add` overwrites existing files even without specifying `--force`.

## 🚀 New behavior

`chakra snippet add` checks if the file for the snippet already exists and only overwrites with `--force`.

## 💣 Is this a breaking change (Yes/No):

No, but users might have relied on the automatic overwriting.

## 📝 Additional Information

The `chakra snippet add` command erroneously relied on the snippet `id` to detect whether it was already existing. This does not work, because the `id` comes without the file extensions and therefore `existsSync(id)` will always fail.

This is fixed by extracting the filename from the registry instead and falling back on the id, if no entry was found. The latter might be better handled by proper error messages and early returns but no such facility exists at the moment.