### PR TITLE
fix(select): improve select placeholder styling

### DIFF
--- a/packages/react/src/theme/recipes/select.ts
+++ b/packages/react/src/theme/recipes/select.ts
@@ -23,7 +23,7 @@ export const selectSlotRecipe = defineSlotRecipe({
       textAlign: "start",
       focusVisibleRing: "inside",
       _placeholderShown: {
-        color: "fg.muted",
+        color: "fg.muted/80",
       },
       _disabled: {
         layerStyle: "disabled",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

I noticed a slight difference in normal and select inputs' placeholders.

![image](https://github.com/user-attachments/assets/59291255-8576-4c64-90b4-3b1a7f1b2f02)

![image](https://github.com/user-attachments/assets/6c5d04d6-409a-44c1-8f04-2f459e4dd8b7)

## ⛳️ Current behavior (updates)

Select input's span uses flat color styling without opacity, differing from the normal input's placeholder, which uses a color-mixing technique with 80% opacity.

## 🚀 New behavior

Implemented consistent color-mixing styling for the select input's placeholder, matching the styling of the normal input placeholders for consistency.


https://github.com/user-attachments/assets/06de736a-2661-4ab8-8ef9-d8ecb619b2ad


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A
