### PR TITLE
Fix AbsoluteCenter when parent is RTL

### DIFF
--- a/packages/react/src/components/center/absolute-center.tsx
+++ b/packages/react/src/components/center/absolute-center.tsx
@@ -25,16 +25,22 @@ export const AbsoluteCenter = chakra("div", {
     axis: {
       horizontal: {
         insetStart: "50%",
-        transform: "translateX(-50%)",
+        translate: "-50%",
+        _rtl: {
+          translate: "50%",
+        },
       },
       vertical: {
         top: "50%",
-        transform: "translateY(-50%)",
+        translate: "0 -50%",
       },
       both: {
         insetStart: "50%",
         top: "50%",
-        transform: "translate(-50%, -50%)",
+        translate: "-50% -50%",
+        _rtl: {
+          translate: "50% -50%",
+        },
       },
     },
   },


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #9526 

## 📝 Description

Fix centering when parent is RTL

## ⛳️ Current behavior (updates)

Currently the child is not placed at the center using `AbsoluteCenter` when the parent or page is set to RTL direction

## 🚀 New behavior

This PR will fix this and also uses `translate` css property instead of `transform: translate` which would have less conflict with other user provided styles.

## 💣 Is this a breaking change (Yes/No):

No this would not effect anything else and no change is required.

## 📝 Additional Information
