### PR TITLE
docs: update dark-mode

### DIFF
--- a/apps/www/content/docs/styling/dark-mode.mdx
+++ b/apps/www/content/docs/styling/dark-mode.mdx
@@ -35,7 +35,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <ChakraProvider theme={defaultSystem}>
+    <ChakraProvider value={defaultSystem}>
       <ColorModeProvider>{children}</ColorModeProvider>
     </ChakraProvider>
   )


### PR DESCRIPTION
## 📝 Description
The attribute "theme" does not exist, the correct property is "value".
![image](https://github.com/user-attachments/assets/afa8c7e4-fd24-47a1-8f46-f5e3508524b0)
![image](https://github.com/user-attachments/assets/ed9cf42b-fbaa-4c97-9940-d093f38c1bce)

## ⛳️ Current behavior (updates)

This [demo](https://github.com/chakra-ui/chakra-ui/blob/main/sandbox/vite-ts/src/main.tsx) also use "value" instead of "theme"
![image](https://github.com/user-attachments/assets/fd028f41-3344-4cb7-b4cf-bc2b4d000be5)


## 🚀 New behavior

> Please describe the behavior or changes this PR adds
theme -> value

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
