### PR TITLE
fix docs: update docs of get started

### DIFF
--- a/apps/www/content/docs/get-started/environments/shadow-dom.mdx
+++ b/apps/www/content/docs/get-started/environments/shadow-dom.mdx
@@ -172,8 +172,7 @@ With the power of the snippets and the primitive components from Chakra UI, you
 can build your UI faster.
 
 ```tsx
-import { Button } from "@/components/ui/button"
-import { HStack } from "@chakra-ui/react"
+import { Button, HStack } from "@chakra-ui/react"
 
 export default function App() {
   return (

--- a/apps/www/content/docs/get-started/frameworks/next-app.mdx
+++ b/apps/www/content/docs/get-started/frameworks/next-app.mdx
@@ -121,8 +121,7 @@ With the power of the snippets and the primitive components from Chakra UI, you
 can build your UI faster.
 
 ```tsx
-import { Button } from "@/components/ui/button"
-import { HStack } from "@chakra-ui/react"
+import { Button, HStack } from "@chakra-ui/react"
 
 const Demo = () => {
   return (

--- a/apps/www/content/docs/get-started/frameworks/next-pages.mdx
+++ b/apps/www/content/docs/get-started/frameworks/next-pages.mdx
@@ -134,8 +134,7 @@ With the power of the snippets and the primitive components from Chakra UI, you
 can build your UI faster.
 
 ```tsx
-import { Button } from "@/components/ui/button"
-import { HStack } from "@chakra-ui/react"
+import { Button, HStack } from "@chakra-ui/react"
 
 const Demo = () => {
   return (

--- a/apps/www/content/docs/get-started/frameworks/remix.mdx
+++ b/apps/www/content/docs/get-started/frameworks/remix.mdx
@@ -93,8 +93,7 @@ When the power of the snippets and the primitive components from Chakra UI, you
 can build your UI faster.
 
 ```tsx
-import { Button } from "@/components/ui/button"
-import { HStack } from "@chakra-ui/react"
+import { Button, HStack } from "@chakra-ui/react"
 
 const Demo = () => {
   return (

--- a/apps/www/content/docs/get-started/frameworks/vite.mdx
+++ b/apps/www/content/docs/get-started/frameworks/vite.mdx
@@ -113,8 +113,7 @@ With the power of the snippets and the primitive components from Chakra UI, you
 can build your UI faster.
 
 ```tsx
-import { Button } from "@/components/ui/button"
-import { HStack } from "@chakra-ui/react"
+import { Button, HStack } from "@chakra-ui/react"
 
 const Demo = () => {
   return (

--- a/apps/www/content/docs/get-started/installation.mdx
+++ b/apps/www/content/docs/get-started/installation.mdx
@@ -102,8 +102,7 @@ With the power of the snippets and the primitive components from Chakra UI, you
 can build your UI faster.
 
 ```tsx
-import { Button } from "@/components/ui/button"
-import { HStack } from "@chakra-ui/react"
+import { Button, HStack } from "@chakra-ui/react"
 
 const Demo = () => {
   return (


### PR DESCRIPTION
Closes #

## 📝 Description

When I used the sample code listed in the documentation, an error occurs in the import statement.

## ⛳️ Current behavior (updates)

In the following section of source code, an error message is displayed indicating that the module does not exist and the button is not displayed.

```
import { Button } from "@/components/ui/button"
```

## 🚀 New behavior

The button is displayed.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
