### PR TITLE
fix: improve rtl support for breadcrumb

### DIFF
--- a/.changeset/warm-spiders-do.md
+++ b/.changeset/warm-spiders-do.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix issue where breadcrumb arrow don't flip in RTL

--- a/packages/react/src/theme/recipes/breadcrumb.ts
+++ b/packages/react/src/theme/recipes/breadcrumb.ts
@@ -10,6 +10,7 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
       alignItems: "center",
       wordBreak: "break-word",
       color: "fg.muted",
+      listStyle: "none"
     },
     link: {
       outline: "0",
@@ -30,6 +31,9 @@ export const breadcrumbSlotRecipe = defineSlotRecipe({
       _icon: {
         boxSize: "1em",
       },
+      _rtl: {
+        rotate: "180deg",
+      }
     },
     ellipsis: {
       display: "inline-flex",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #9615

## 📝 Description

Hides list marker and Rotates separator in rtl parent/page.

## ⛳️ Current behavior (updates)

currently the chevron is in the wrong direction (facing right instead of left) and list marker from user set list-style property can be visible inside breadcrumb's UI.

## 🚀 New behavior

Now, chevron is rotated to face the correct direction for RTL breadcrumb and using `listStyle:none` property no marker is visilble for Items.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
