### PR TITLE
Fixed CLI docs example that was incorrect and misleading.

### DIFF
--- a/apps/www/content/docs/get-started/cli.mdx
+++ b/apps/www/content/docs/get-started/cli.mdx
@@ -86,7 +86,7 @@ chakra snippet add button
 chakra snippet list
 
 # Specify a custom directory
-chakra snippet --outdir ./components/custom
+chakra snippet add dialog --outdir ./components/custom
 ```
 
 ## `chakra eject`


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR fixes a documentation error where the `--outdir` option was mistakenly shown with `chakra snippet` command instead of the correct `chakra snippet add` command. 
This update ensures users follow the proper usage (snippet add --outdir xxx) and helps prevent any potential confusion.

```
# Specify a custom directory
chakra snippet --outdir ./components/custom
```

## ⛳️ Current behavior (updates)
The documentation example incorrectly shows the `--outdir` option with the `snippet` command, which may mislead users into running `snippet --outdir xxx` and encountering errors.

## 🚀 New behavior
Updated the documentation to correctly demonstrate the usage of the `--outdir` option with the `snippet add` command. Users should now use `snippet add --outdir xxx` for the expected behavior.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

related discussion is here:
https://github.com/chakra-ui/chakra-ui/discussions/9459