### PR TITLE
chore(package): remove legacy `website` package and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "react": "pnpm --filter=@chakra-ui/react",
-    "website": "pnpm --filter=./website",
     "www": "pnpm --filter=./apps/www",
     "lint": "eslint packages --ext .ts,.tsx --config .eslintrc --cache",
     "format:check": "prettier --check packages --cache",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - "packages/**/**"
   - "sandbox/**"
-  - "website"
   - "apps/**"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Remove references to the legacy website folder and its related scripts, as it is no longer used in Chakra UI version 3.

## ⛳️ Current behavior (updates)

The` pnpm-workspace.yaml `file and` package.json` scripts currently include references to the website folder. However, the website folder is no longer in the repository, and running `pnpm --filter=./website build` returns: 'No projects matched the filters ~'.

## 🚀 New behavior

- Removed `website` from `pnpm-workspace.yaml`.
- Deleted the `website` script from `package.json`.
- These changes ensure that references to non-existent packages are cleaned up, reducing confusion and potential errors in the workspace.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- The website folder seems to have been deprecated and removed in Chakra UI version 3.
- If the website folder is still required or referenced externally, this PR can be reverted or adjusted as needed.
