### PR TITLE
docs: fix composition link

### DIFF
--- a/apps/www/content/docs/styling/chakra-factory.mdx
+++ b/apps/www/content/docs/styling/chakra-factory.mdx
@@ -176,4 +176,4 @@ or
 ```
 
 > Learn more about composition in Chakra UI
-> [here](/docs/components/overview/composition)
+> [here](/docs/components/concepts/composition)


### PR DESCRIPTION
## 📝 Description

> The current link is not valid

## ⛳️ Current behavior (updates)

> Goes to a 404 page

## 🚀 New behavior

> Goes to the composition page

## 💣 Is this a breaking change (Yes/No):

No
