### PR TITLE
[v2] fix checkbox indeterminate state accessiblity

### DIFF
--- a/packages/components/src/checkbox/use-checkbox.ts
+++ b/packages/components/src/checkbox/use-checkbox.ts
@@ -305,6 +305,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
         "aria-invalid": ariaInvalid ? Boolean(ariaInvalid) : isInvalid,
         "aria-describedby": ariaDescribedBy,
         "aria-disabled": isDisabled,
+        "aria-checked": isIndeterminate ? 'mixed' : isChecked,
         style: visuallyHiddenStyle,
       }
     },


### PR DESCRIPTION
Closes #9647

## 📝 Description

This updates the v2 Checkbox component to handle `isIndeterminate` accessibility according to the W3C specifications:
https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/examples/checkbox-mixed/

## ⛳️ Current behavior (updates)

Currently, there is no ARIA support for indeterminate checkboxes.

## 🚀 New behavior

This changes `aria-checked` based on the value of `isIndeterminate`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
