### PR TITLE
docs: [v3.8] Update radii.mdx

### DIFF
--- a/apps/www/content/docs/theming/radii.mdx
+++ b/apps/www/content/docs/theming/radii.mdx
@@ -9,3 +9,19 @@ hideToc: true
 Chakra UI supports the following border radius tokens out of the box.
 
 <BorderRadiusTokenDoc />
+
+Here’s the conversion of the given rem values to px, assuming the root font size is 16px (which is the default in most browsers)
+
+| Size  | rem Value  | px Equivalent  |
+|-------|-----------|---------------|
+| none  | 0         | 0px           |
+| 2xs   | 0.0625rem | 1px           |
+| xs    | 0.125rem  | 2px           |
+| sm    | 0.25rem   | 4px           |
+| md    | 0.375rem  | 6px           |
+| lg    | 0.5rem    | 8px           |
+| xl    | 0.75rem   | 12px          |
+| 2xl   | 1rem      | 16px          |
+| 3xl   | 1.5rem    | 24px          |
+| 4xl   | 2rem      | 32px          |
+| full  | 9999px    | 9999px        |


### PR DESCRIPTION
📝 Description
This PR adds a reference table for converting between px and rem, making it easier for developers to switch seamlessly between units.

⛳️ Current behavior (updates)
Currently, there is no clear reference for px to rem conversions in the documentation, which may require developers to calculate values manually.

🚀 New behavior
Adds a table listing common rem values and their px equivalents, improving accessibility and consistency in UI design.

💣 Is this a breaking change (Yes/No):
No

📝 Additional Information
Using rem ensures better scalability, accessibility, and maintainability. This update helps developers quickly find the correct unit conversions without extra effort. 🚀