### PR TITLE
fix(slider-v2): Correctly offset custom size slider thumb

### DIFF
--- a/.changeset/popular-queens-try.md
+++ b/.changeset/popular-queens-try.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix the incorrect offset of the custom size "SliderThumb" component relative to
+the "SliderTrack"

--- a/packages/components/src/slider/slider-utils.ts
+++ b/packages/components/src/slider/slider-utils.ts
@@ -39,7 +39,7 @@ export function getStyles(options: {
       ...orient({
         orientation,
         vertical: {
-          bottom: `calc(${thumbPercents[i]}%`,
+          bottom: `${thumbPercents[i]}%`,
           transform: "translate(-50%, 50%)",
         },
         horizontal: {

--- a/packages/components/src/slider/slider-utils.ts
+++ b/packages/components/src/slider/slider-utils.ts
@@ -43,7 +43,7 @@ export function getStyles(options: {
           transform: "translate(-50%, 50%)",
         },
         horizontal: {
-          left: `calc(${thumbPercents[i]}%`,
+          left: `${thumbPercents[i]}%`,
           transform: "translate(-50%, -50%)",
         },
       }),

--- a/packages/components/src/slider/slider-utils.ts
+++ b/packages/components/src/slider/slider-utils.ts
@@ -39,10 +39,12 @@ export function getStyles(options: {
       ...orient({
         orientation,
         vertical: {
-          bottom: `calc(${thumbPercents[i]}% - var(--slider-thumb-size) / 2)`,
+          bottom: `calc(${thumbPercents[i]}%`,
+          transform: "translate(-50%, 50%)",
         },
         horizontal: {
-          left: `calc(${thumbPercents[i]}% - var(--slider-thumb-size) / 2)`,
+          left: `calc(${thumbPercents[i]}%`,
+          transform: "translate(-50%, -50%)",
         },
       }),
     }


### PR DESCRIPTION
Closes #9151

## 📝 Description
The following pull request addresses an issue in V2 of Chakra UI, where the custom size `SliderThumb` component has an incorrect offset relative to the `SliderTrack`. 

## ⛳️ Current behavior (updates)
At the moment, the `SliderThumb` component gets rendered with a slight offset compared to the actual value. This appears to be the case for both keyboard and mouse interactions and appears to be caused by reliance on the hardcoded `--slider-thumb-size` variable, meaning that a custom-size slider thumb was incorrectly offset. As a side effect, this also meant that the `SliderThumb` component could be moved beyond the `SliderTrack`.

<video src="https://github.com/user-attachments/assets/f33fb3fa-5b11-4ffe-97d7-6da54223f8a1"></video>

You can find more details about this issue, along with steps to reproduce it, in the [following GitHub issue](https://github.com/chakra-ui/chakra-ui/issues/9151).

## 🚀 New behavior
Since the slider thumb offset is now dynamic and no longer reliant on the `--slider-thumb-size` variable, the `SliderThumb` component gets rendered as expected. 

<video src="https://github.com/user-attachments/assets/3f6ddccd-3150-422a-9184-b9955b2101cc"></video>

Please note that `SliderThumb` components using the standard size will continue to work as expected.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
Please do let me know if you think there is any way to improve the following PR!