### PR TITLE
fix: avoid to overrride aspect ratio css prop when css prop is provided

### DIFF
--- a/.changeset/weak-turtles-check.md
+++ b/.changeset/weak-turtles-check.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+AspectRatio: Fix issue where `css` prop was not respected

--- a/packages/react/src/components/aspect-ratio/aspect-ratio.tsx
+++ b/packages/react/src/components/aspect-ratio/aspect-ratio.tsx
@@ -26,7 +26,7 @@ export interface AspectRatioProps
  */
 export const AspectRatio = forwardRef<HTMLDivElement, AspectRatioProps>(
   function AspectRatio(props, ref) {
-    const { ratio = 4 / 3, children, className, ...rest } = props
+    const { ratio = 4 / 3, children, className, css, ...rest } = props
     const child = Children.only(children)
 
     return (
@@ -57,7 +57,7 @@ export const AspectRatio = forwardRef<HTMLDivElement, AspectRatioProps>(
           "& > img, & > video": {
             objectFit: "cover",
           },
-          ...props.css,
+          ...css,
         }}
         {...rest}
       >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #9711

## 📝 Description

CSS prop value now is merging config.

## ⛳️ Current behavior (updates)

Before fix, CSS prop on AspectRatio component is overriding the default CSS value.

## 🚀 New behavior

After fix, provided CSS prop value will merge (as it was intended).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
