### PR TITLE
docs(readme): replace expired tweet link with Ryan Florence's profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ We'll appreciate some support. Thank you to all our supporters! 🙏
 > the accessibility on the couple components I looked is complete.
 >
 > Great work @thesegunadebayo, really inspiring work. –
-> [Ryan Florence](https://twitter.com/ryanflorence/status/1169260008069947392)
+> [Ryan Florence](https://twitter.com/ryanflorence)
 
 > Awesome new open-source component library from @thesegunadebayo. Really
 > impressive stuff! –


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- If there's an issue number, reference it here; otherwise, leave this blank or remove it. -->

## 📝 Description

The link to Ryan Florence’s tweet in the "Testimonials" section no longer works because the tweet was removed. This PR updates the link to Ryan Florence’s main Twitter profile.

## ⛳️ Current behavior (updates)

A broken link points to a removed tweet, resulting in unavailable page.

## 🚀 New behavior

The link now directs to Ryan Florence’s profile, preserving proper attribution without leading users to a non-existent resource.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a minor documentation fix. If there’s a preferred link or format, I’m happy to adjust.