### PR TITLE
feat: Unplug Chakra UI

### DIFF
--- a/.changeset/few-geese-matter.md
+++ b/.changeset/few-geese-matter.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+Unplug @chakra-ui/react to facilitate type generation in Yarn PnP mode

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,6 +68,7 @@
     "typedocs": "tsx scripts/typedocs.ts",
     "typecheck": "tsc --noEmit"
   },
+  "preferUnplugged": true,
   "exports": {
     ".": {
       "source": "./src/index.ts",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #9757 

## 📝 Description

> Let Package Managers (Yarn PnP specifically) know to unplug the package for the type generation

## ⛳️ Current behavior (updates)

> Chakra UI Package is stored as a .zip file in yarn pnp mode making it non-writable

## 🚀 New behavior

> Yarn PnP will by default unplug the `@chakra-ui/react` package till the time the package implements module augmentation

## 💣 Is this a breaking change (Yes/No):

This may be a breaking change for users using zero-install feature of Yarn PnP. [Check the note on unplugged folder](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored). The user will need to run yarn install on every system after every upgrade to unplug and make sure that the unplugged chakra-ui is upgraded. There's a [pending issue](https://github.com/yarnpkg/berry/issues/5379) on yarn regarding this

TLDR; this will cause zero install to break in yarn pnp repo's.

## 📝 Additional Information
