### PR TITLE
fix: checkbox / radio perf

### DIFF
--- a/.changeset/rare-bugs-clap.md
+++ b/.changeset/rare-bugs-clap.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix performance issue where all checkboxes and radios would rerender whenever
+trackFocusVisible modality changed, e.g. click into an input then type

--- a/packages/components/src/checkbox/use-checkbox.ts
+++ b/packages/components/src/checkbox/use-checkbox.ts
@@ -62,13 +62,15 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   const onBlurProp = useCallbackRef(onBlur)
   const onFocusProp = useCallbackRef(onFocus)
 
-  const [isFocusVisible, setIsFocusVisible] = useState(false)
   const [isFocused, setFocused] = useState(false)
   const [isHovered, setHovered] = useState(false)
   const [isActive, setActive] = useState(false)
 
+  const isFocusVisibleRef = useRef(false)
   useEffect(() => {
-    return trackFocusVisible(setIsFocusVisible)
+    return trackFocusVisible((state) => {
+      isFocusVisibleRef.current = state
+    })
   }, [])
 
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -188,7 +190,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
         "data-hover": dataAttr(isHovered),
         "data-checked": dataAttr(isChecked),
         "data-focus": dataAttr(isFocused),
-        "data-focus-visible": dataAttr(isFocused && isFocusVisible),
+        "data-focus-visible": dataAttr(isFocused && isFocusVisibleRef.current),
         "data-indeterminate": dataAttr(isIndeterminate),
         "data-disabled": dataAttr(isDisabled),
         "data-invalid": dataAttr(isInvalid),
@@ -209,7 +211,6 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       isChecked,
       isDisabled,
       isFocused,
-      isFocusVisible,
       isHovered,
       isIndeterminate,
       isInvalid,
@@ -225,7 +226,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       "data-hover": dataAttr(isHovered),
       "data-checked": dataAttr(isChecked),
       "data-focus": dataAttr(isFocused),
-      "data-focus-visible": dataAttr(isFocused && isFocusVisible),
+      "data-focus-visible": dataAttr(isFocused && isFocusVisibleRef.current),
       "data-indeterminate": dataAttr(isIndeterminate),
       "data-disabled": dataAttr(isDisabled),
       "data-invalid": dataAttr(isInvalid),
@@ -236,7 +237,6 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       isChecked,
       isDisabled,
       isFocused,
-      isFocusVisible,
       isHovered,
       isIndeterminate,
       isInvalid,

--- a/packages/components/src/radio/use-radio.ts
+++ b/packages/components/src/radio/use-radio.ts
@@ -6,7 +6,7 @@ import {
   PropGetter,
 } from "@chakra-ui/utils"
 import { trackFocusVisible } from "@zag-js/focus-visible"
-import { useCallback, useEffect, useId, useState } from "react"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
 import { useFormControlContext } from "../form-control"
 import { visuallyHiddenStyle } from "../visually-hidden"
 import { useRadioGroupContext } from "./radio-group"
@@ -138,7 +138,6 @@ export function useRadio(props: UseRadioProps = {}) {
   const isRequired = isRequiredProp ?? formControl?.isRequired
   const isInvalid = isInvalidProp ?? formControl?.isInvalid
 
-  const [isFocusVisible, setIsFocusVisible] = useState(false)
   const [isFocused, setFocused] = useState(false)
   const [isHovered, setHovering] = useState(false)
   const [isActive, setActive] = useState(false)
@@ -148,8 +147,11 @@ export function useRadio(props: UseRadioProps = {}) {
   const isControlled = typeof isCheckedProp !== "undefined"
   const isChecked = isControlled ? isCheckedProp : isCheckedState
 
+  const isFocusVisibleRef = useRef(false)
   useEffect(() => {
-    return trackFocusVisible(setIsFocusVisible)
+    return trackFocusVisible((state) => {
+      isFocusVisibleRef.current = state
+    })
   }, [])
 
   const handleChange = useCallback(
@@ -196,7 +198,7 @@ export function useRadio(props: UseRadioProps = {}) {
       "data-invalid": dataAttr(isInvalid),
       "data-checked": dataAttr(isChecked),
       "data-focus": dataAttr(isFocused),
-      "data-focus-visible": dataAttr(isFocused && isFocusVisible),
+      "data-focus-visible": dataAttr(isFocused && isFocusVisibleRef.current),
       "data-readonly": dataAttr(isReadOnly),
       "aria-hidden": true,
       onMouseDown: callAllHandlers(props.onMouseDown, () => setActive(true)),
@@ -216,7 +218,6 @@ export function useRadio(props: UseRadioProps = {}) {
       isChecked,
       isFocused,
       isReadOnly,
-      isFocusVisible,
     ],
   )
 


### PR DESCRIPTION
Avoid re-rendering when focus visible tracker emits a value. Greatly improves performance on pages with lots of checkboxes and/or radios.

Fixes #9771
