### PR TITLE
docs: update the link to composition page

### DIFF
--- a/apps/www/components/mdx/prop-table.tsx
+++ b/apps/www/components/mdx/prop-table.tsx
@@ -140,7 +140,9 @@ export const PropTable = async (props: PropTableProps) => {
                     <Text as="span">
                       For more details, read our{" "}
                       <Link asChild>
-                        <NextLink href={`/docs/guides/composition`}>
+                        <NextLink
+                          href={`/docs/components/concepts/composition`}
+                        >
                           Composition
                         </NextLink>
                       </Link>{" "}


### PR DESCRIPTION
## 📝 Description

The path of Composition within the `asChild` row of `Item` section leads to a "404 Page Not Found". It needed a minor fix by updating the path in `apps/www/components/mdx/prop-table.tsx` file.

## ⛳️ Current behavior (updates)

The link for Composition in the `asChild` row of `Item` section leads to a "404 Page Not Found". The older link led to [composition](https://www.chakra-ui.com/docs/guides/composition).

https://github.com/user-attachments/assets/1d1b5042-feef-4629-8671-e9ad445ba304

## 🚀 New behavior

I have fixed the path. Updated it to the actual one i.e. [Composition](https://www.chakra-ui.com/docs/components/concepts/composition)

https://github.com/user-attachments/assets/821a1533-3b95-4e52-9b79-df38eddf4716

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
