### PR TITLE
docs: update placeholders in select examples to reflect proper context

### DIFF
--- a/apps/compositions/src/examples/select-basic.tsx
+++ b/apps/compositions/src/examples/select-basic.tsx
@@ -15,12 +15,12 @@ export const SelectBasic = () => {
     <SelectRoot collection={frameworks} size="sm" width="320px">
       <SelectLabel>Select framework</SelectLabel>
       <SelectTrigger>
-        <SelectValueText placeholder="Select movie" />
+        <SelectValueText placeholder="Select framework" />
       </SelectTrigger>
       <SelectContent>
-        {frameworks.items.map((movie) => (
-          <SelectItem item={movie} key={movie.value}>
-            {movie.label}
+        {frameworks.items.map((item) => (
+          <SelectItem item={item} key={item.value}>
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/compositions/src/examples/select-controlled.tsx
+++ b/apps/compositions/src/examples/select-controlled.tsx
@@ -22,12 +22,12 @@ export const SelectControlled = () => {
     >
       <SelectLabel>Select framework</SelectLabel>
       <SelectTrigger>
-        <SelectValueText placeholder="Select movie" />
+        <SelectValueText placeholder="Select framework" />
       </SelectTrigger>
       <SelectContent>
-        {frameworks.items.map((movie) => (
-          <SelectItem item={movie} key={movie.value}>
-            {movie.label}
+        {frameworks.items.map((item) => (
+          <SelectItem item={item} key={item.value}>
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/compositions/src/examples/select-in-dialog.tsx
+++ b/apps/compositions/src/examples/select-in-dialog.tsx
@@ -38,7 +38,7 @@ export const SelectInDialog = () => {
               <SelectRoot collection={frameworks} size="sm">
                 <SelectLabel>Select framework</SelectLabel>
                 <SelectTrigger>
-                  <SelectValueText placeholder="Select movie" />
+                  <SelectValueText placeholder="Select framework" />
                 </SelectTrigger>
                 <SelectContent portalRef={contentRef}>
                   {frameworks.items.map((item) => (

--- a/apps/compositions/src/examples/select-in-popover.tsx
+++ b/apps/compositions/src/examples/select-in-popover.tsx
@@ -29,7 +29,7 @@ export const SelectInPopover = () => {
                 positioning={{ sameWidth: true, placement: "bottom" }}
               >
                 <SelectTrigger>
-                  <SelectValueText placeholder="Select" />
+                  <SelectValueText placeholder="Select framework" />
                 </SelectTrigger>
                 <SelectContent portalled={false} width="full">
                   {frameworks.items.map((item) => (

--- a/apps/compositions/src/examples/select-with-avatar.tsx
+++ b/apps/compositions/src/examples/select-with-avatar.tsx
@@ -11,7 +11,7 @@ import {
 } from "compositions/ui/select"
 
 const SelectValueItem = () => (
-  <SelectValueText placeholder="Select movie">
+  <SelectValueText placeholder="Select member">
     {(items: Array<{ name: string; avatar: string }>) => {
       const { name, avatar } = items[0]
       return (

--- a/apps/compositions/src/examples/select-with-clear.tsx
+++ b/apps/compositions/src/examples/select-with-clear.tsx
@@ -20,12 +20,12 @@ export const SelectWithClear = () => {
     >
       <SelectLabel>Select fav. anime</SelectLabel>
       <SelectTrigger clearable>
-        <SelectValueText placeholder="Select movie" />
+        <SelectValueText placeholder="Select anime" />
       </SelectTrigger>
       <SelectContent>
-        {animeMovies.items.map((movie) => (
-          <SelectItem item={movie} key={movie.value}>
-            {movie.label}
+        {animeMovies.items.map((item) => (
+          <SelectItem item={item} key={item.value}>
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/compositions/src/examples/select-with-disabled.tsx
+++ b/apps/compositions/src/examples/select-with-disabled.tsx
@@ -15,12 +15,12 @@ export const SelectWithDisabled = () => {
     <SelectRoot disabled collection={frameworks} size="sm" width="320px">
       <SelectLabel>Select framework</SelectLabel>
       <SelectTrigger>
-        <SelectValueText placeholder="Select movie" />
+        <SelectValueText placeholder="Select framework" />
       </SelectTrigger>
       <SelectContent>
-        {frameworks.items.map((movie) => (
-          <SelectItem item={movie} key={movie.value}>
-            {movie.label}
+        {frameworks.items.map((item) => (
+          <SelectItem item={item} key={item.value}>
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/compositions/src/examples/select-with-hook-form.tsx
+++ b/apps/compositions/src/examples/select-with-hook-form.tsx
@@ -33,7 +33,7 @@ export const SelectWithHookForm = () => {
     <form onSubmit={onSubmit}>
       <Stack gap="4" align="flex-start">
         <Field.Root invalid={!!errors.framework} width="320px">
-          <Field.Label>Rating</Field.Label>
+          <Field.Label>Select framework</Field.Label>
           <Controller
             control={control}
             name="framework"
@@ -46,12 +46,12 @@ export const SelectWithHookForm = () => {
                 collection={frameworks}
               >
                 <SelectTrigger>
-                  <SelectValueText placeholder="Select movie" />
+                  <SelectValueText placeholder="Select framework" />
                 </SelectTrigger>
                 <SelectContent>
-                  {frameworks.items.map((movie) => (
-                    <SelectItem item={movie} key={movie.value}>
-                      {movie.label}
+                  {frameworks.items.map((item) => (
+                    <SelectItem item={item} key={item.value}>
+                      {item.label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/apps/compositions/src/examples/select-with-invalid.tsx
+++ b/apps/compositions/src/examples/select-with-invalid.tsx
@@ -16,12 +16,12 @@ export const SelectWithInvalid = () => {
       <SelectRoot collection={frameworks} size="sm" width="320px">
         <SelectLabel>Select framework</SelectLabel>
         <SelectTrigger>
-          <SelectValueText placeholder="Select movie" />
+          <SelectValueText placeholder="Select framework" />
         </SelectTrigger>
         <SelectContent>
-          {frameworks.items.map((movie) => (
-            <SelectItem item={movie} key={movie.value}>
-              {movie.label}
+          {frameworks.items.map((item) => (
+            <SelectItem item={item} key={item.value}>
+              {item.label}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/compositions/src/examples/select-with-multiple.tsx
+++ b/apps/compositions/src/examples/select-with-multiple.tsx
@@ -15,12 +15,12 @@ export const SelectWithMultiple = () => {
     <SelectRoot multiple collection={frameworks} size="sm" width="320px">
       <SelectLabel>Select framework</SelectLabel>
       <SelectTrigger>
-        <SelectValueText placeholder="Movie" />
+        <SelectValueText placeholder="Select framework" />
       </SelectTrigger>
       <SelectContent>
-        {frameworks.items.map((movie) => (
-          <SelectItem item={movie} key={movie.value}>
-            {movie.label}
+        {frameworks.items.map((item) => (
+          <SelectItem item={item} key={item.value}>
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/compositions/src/examples/select-with-native-form.tsx
+++ b/apps/compositions/src/examples/select-with-native-form.tsx
@@ -23,12 +23,12 @@ export const SelectWithNativeForm = () => {
         <SelectRoot collection={frameworks} size="sm" name="framework">
           <SelectLabel>Select framework</SelectLabel>
           <SelectTrigger>
-            <SelectValueText placeholder="Select movie" />
+            <SelectValueText placeholder="Select framework" />
           </SelectTrigger>
           <SelectContent>
-            {frameworks.items.map((movie) => (
-              <SelectItem item={movie} key={movie.value}>
-                {movie.label}
+            {frameworks.items.map((item) => (
+              <SelectItem item={item} key={item.value}>
+                {item.label}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/compositions/src/examples/select-with-option-group.tsx
+++ b/apps/compositions/src/examples/select-with-option-group.tsx
@@ -13,10 +13,10 @@ import {
 
 export const SelectWithOptionGroup = () => {
   return (
-    <SelectRoot collection={frameworks} size="sm" width="320px">
-      <SelectLabel>Select framework</SelectLabel>
+    <SelectRoot collection={collection} size="sm" width="320px">
+      <SelectLabel>Select an option</SelectLabel>
       <SelectTrigger>
-        <SelectValueText placeholder="Select movie" />
+        <SelectValueText placeholder="Select an option" />
       </SelectTrigger>
       <SelectContent>
         {categories.map((category) => (
@@ -33,7 +33,7 @@ export const SelectWithOptionGroup = () => {
   )
 }
 
-const frameworks = createListCollection({
+const collection = createListCollection({
   items: [
     { label: "Naruto", value: "naruto", group: "Anime" },
     { label: "One Piece", value: "one-piece", group: "Anime" },
@@ -48,7 +48,7 @@ const frameworks = createListCollection({
   ],
 })
 
-const categories = frameworks.items.reduce(
+const categories = collection.items.reduce(
   (acc, item) => {
     const group = acc.find((group) => group.group === item.group)
     if (group) {
@@ -58,5 +58,5 @@ const categories = frameworks.items.reduce(
     }
     return acc
   },
-  [] as { group: string; items: (typeof frameworks)["items"] }[],
+  [] as { group: string; items: (typeof collection)["items"] }[],
 )

--- a/apps/compositions/src/examples/select-with-overflow.tsx
+++ b/apps/compositions/src/examples/select-with-overflow.tsx
@@ -15,12 +15,12 @@ export const SelectWithOverflow = () => {
     <SelectRoot collection={animeMovies} size="sm" width="240px">
       <SelectLabel>Select anime</SelectLabel>
       <SelectTrigger>
-        <SelectValueText placeholder="Select movie" />
+        <SelectValueText placeholder="Select anime" />
       </SelectTrigger>
       <SelectContent>
-        {animeMovies.items.map((movie) => (
-          <SelectItem item={movie} key={movie.value}>
-            {movie.label}
+        {animeMovies.items.map((item) => (
+          <SelectItem item={item} key={item.value}>
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/compositions/src/examples/select-with-positioning.tsx
+++ b/apps/compositions/src/examples/select-with-positioning.tsx
@@ -20,12 +20,12 @@ export const SelectWithPositioning = () => {
     >
       <SelectLabel>Select framework</SelectLabel>
       <SelectTrigger>
-        <SelectValueText placeholder="Select movie" />
+        <SelectValueText placeholder="Select framework" />
       </SelectTrigger>
       <SelectContent>
-        {frameworks.items.map((movie) => (
-          <SelectItem item={movie} key={movie.value}>
-            {movie.label}
+        {frameworks.items.map((item) => (
+          <SelectItem item={item} key={item.value}>
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/compositions/src/examples/select-with-sizes.tsx
+++ b/apps/compositions/src/examples/select-with-sizes.tsx
@@ -18,12 +18,12 @@ export const SelectWithSizes = () => {
           <SelectRoot key={size} size={size} collection={frameworks}>
             <SelectLabel>size = {size}</SelectLabel>
             <SelectTrigger>
-              <SelectValueText placeholder="Select movie" />
+              <SelectValueText placeholder="Select framework" />
             </SelectTrigger>
             <SelectContent>
-              {frameworks.items.map((movie) => (
-                <SelectItem item={movie} key={movie.value}>
-                  {movie.label}
+              {frameworks.items.map((item) => (
+                <SelectItem item={item} key={item.value}>
+                  {item.label}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/apps/compositions/src/examples/select-with-variants.tsx
+++ b/apps/compositions/src/examples/select-with-variants.tsx
@@ -18,12 +18,12 @@ export const SelectWithVariants = () => {
           <SelectRoot key={variant} variant={variant} collection={frameworks}>
             <SelectLabel>Select framework - {variant}</SelectLabel>
             <SelectTrigger>
-              <SelectValueText placeholder="Select movie" />
+              <SelectValueText placeholder="Select framework" />
             </SelectTrigger>
             <SelectContent>
-              {frameworks.items.map((movie) => (
-                <SelectItem item={movie} key={movie.value}>
-                  {movie.label}
+              {frameworks.items.map((item) => (
+                <SelectItem item={item} key={item.value}>
+                  {item.label}
                 </SelectItem>
               ))}
             </SelectContent>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

This PR improves the clarity and consistency of `Select` component examples by updating placeholder text and variable names to better match their contexts.

## ⛳️ Current behavior (updates)

The existing examples contain inconsistencies that may confuse developers:

- Placeholder texts (e.g., "Select movie") are used in contexts unrelated to movies, such as framework selection.
- Variable names (e.g., "movie") in mapping functions don’t align with the actual data being used (e.g., frameworks, members).

## 🚀 New behavior

This PR updates `Select` component examples to ensure clarity and correctness:

- Placeholder texts now accurately describe the content (e.g., "Select movie" → "Select framework").
- Variable names in mapping functions now reflect the actual data (e.g., "movie" → "item").

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No.
