### PR TITLE
fix(cli): snippet not found response

### DIFF
--- a/packages/cli/src/commands/snippet.ts
+++ b/packages/cli/src/commands/snippet.ts
@@ -131,23 +131,29 @@ export const SnippetCommand = new Command("snippet")
                     return
                   }
 
-                  const item = await fetchComposition(id)
+                  try {
+                    const item = await fetchComposition(id)
+                    if (jsx) {
+                      item.file.name = item.file.name.replace(".tsx", ".jsx")
+                      await transformToJsx(item)
+                    }
 
-                  if (jsx) {
-                    item.file.name = item.file.name.replace(".tsx", ".jsx")
-                    await transformToJsx(item)
-                  }
+                    const outPath = join(outdir, item.file.name)
 
-                  const outPath = join(outdir, item.file.name)
-
-                  if (dryRun) {
-                    printFileSync(item)
-                  } else {
-                    await writeFile(
-                      outPath,
-                      item.file.content.replace("compositions/ui", "."),
-                      "utf-8",
-                    )
+                    if (dryRun) {
+                      printFileSync(item)
+                    } else {
+                      await writeFile(
+                        outPath,
+                        item.file.content.replace("compositions/ui", "."),
+                        "utf-8",
+                      )
+                    }
+                  } catch (error) {
+                    if (error instanceof Error) {
+                      p.log.error(error?.message)
+                      process.exit(0)
+                    }
                   }
                 }),
               )

--- a/packages/cli/src/utils/fetch.ts
+++ b/packages/cli/src/utils/fetch.ts
@@ -19,9 +19,15 @@ export async function fetchCompositions() {
 }
 
 export async function fetchComposition(id: string) {
-  const res = await fetch(`${env.REGISTRY_URL}/compositions/${id}.json`, {
-    agent,
-  })
-  const json = await res.json()
-  return compositionFileSchema.parse(json)
+  try {
+    const res = await fetch(`${env.REGISTRY_URL}/compositions/${id}.json`, {
+      agent,
+    })
+    const json = await res.json()
+    return compositionFileSchema.parse(json)
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch snippet "${id}". Make sure the id is correct or run @chakra-ui/cli snippet list to see available snippets.`,
+    )
+  }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

The CLI is able to generate snippets with `@chakra-ui/cli snippet add <ID>` by fetching a /compositions/<id>.json file, however today if the snippet couldn't be found it tries to parse the 404 page as json instead of cancelling.

## ⛳️ Current behavior (updates)

![cli-snippet-before](https://github.com/user-attachments/assets/530351b3-3cf2-4cf8-bfc1-55206f6690e5)

## 🚀 New behavior

![cli-snippet-after](https://github.com/user-attachments/assets/7eb34308-9a32-4fb3-9b80-740ef54f09b7)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A