### PR TITLE
fix(docs): update default values for lazyMount and unmountOnExit in Menu

### DIFF
--- a/apps/www/public/types/ark/menu.json
+++ b/apps/www/public/types/ark/menu.json
@@ -269,7 +269,7 @@
       "lazyMount": {
         "type": "boolean",
         "isRequired": false,
-        "defaultValue": "false",
+        "defaultValue": "true",
         "description": "Whether to enable lazy mounting"
       },
       "loopFocus": {
@@ -347,7 +347,7 @@
       "unmountOnExit": {
         "type": "boolean",
         "isRequired": false,
-        "defaultValue": "false",
+        "defaultValue": "true",
         "description": "Whether to unmount on exit."
       }
     }


### PR DESCRIPTION
Closes #9884  

## 📝 Description

This PR updates the documentation for the `Menu` component, correcting the default values for `lazyMount` and `unmountOnExit`. 

The previous values in the documentation were outdated and incorrect based on the latest changes in Chakra UI.

## ⛳️ Current behavior (updates)

- `lazyMount` was documented as `false`, but the correct default is `true`.
- `unmountOnExit` was documented as `false`, but the correct default is `true`.

## 🚀 New behavior

- Updated `lazyMount` to correctly reflect `true` as the default value.
- Updated `unmountOnExit` to correctly reflect `true` as the default value.

## 💣 Is this a breaking change (Yes/No):

No
