### PR TITLE
Removed team link from footer of documentation website

### DIFF
--- a/apps/www/components/site/footer.section.tsx
+++ b/apps/www/components/site/footer.section.tsx
@@ -31,7 +31,6 @@ const linkTree = [
   {
     title: "Community",
     items: [
-      { label: "Team", href: "/team" },
       { label: "Discord", href: "https://discord.gg/chakra-ui" },
       { label: "Twitter", href: "https://x.com/chakra_ui" },
       { label: "GitHub", href: "https://github.com/chakra-ui/chakra-ui" },


### PR DESCRIPTION
Closes #9892

## 📝 Description

Removed the "Team" link from the documentation website footer component for a cleaner and more relevant footer experience.

## ⛳️ Current behavior (updates)

The footer previously included a "Team" link, which is currently unused or not routed in the documentation site.

## 🚀 New behavior

The "Team" link has been removed from the footer (`apps/www/components/Footer.tsx`). Other footer links remain unchanged.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This is a minor UI update scoped only to the documentation website. It does not affect the core Chakra UI components or API.
