### PR TITLE
fix: dialog drawer backdrop

### DIFF
--- a/packages/react/src/theme/recipes/dialog.ts
+++ b/packages/react/src/theme/recipes/dialog.ts
@@ -12,7 +12,7 @@ export const dialogSlotRecipe = defineSlotRecipe({
       top: 0,
       w: "100vw",
       h: "100dvh",
-      zIndex: "calc(var(--z-index) - 2) ",
+      zIndex: "calc(var(--z-index) - 2)",
       _open: {
         animationName: "fade-in",
         animationDuration: "slow",

--- a/packages/react/src/theme/recipes/dialog.ts
+++ b/packages/react/src/theme/recipes/dialog.ts
@@ -12,7 +12,7 @@ export const dialogSlotRecipe = defineSlotRecipe({
       top: 0,
       w: "100vw",
       h: "100dvh",
-      zIndex: "calc(var(--z-index) - 1) ",
+      zIndex: "calc(var(--z-index) - 2) ",
       _open: {
         animationName: "fade-in",
         animationDuration: "slow",

--- a/packages/react/src/theme/recipes/dialog.ts
+++ b/packages/react/src/theme/recipes/dialog.ts
@@ -12,7 +12,7 @@ export const dialogSlotRecipe = defineSlotRecipe({
       top: 0,
       w: "100vw",
       h: "100dvh",
-      zIndex: "calc(var(--z-index) - 2)",
+      zIndex: "calc(var(--dialog-z-index) - 1)",
       _open: {
         animationName: "fade-in",
         animationDuration: "slow",

--- a/packages/react/src/theme/recipes/drawer.ts
+++ b/packages/react/src/theme/recipes/drawer.ts
@@ -12,7 +12,7 @@ export const drawerSlotRecipe = defineSlotRecipe({
       top: 0,
       w: "100vw",
       h: "100dvh",
-      zIndex: "calc(var(--chakra-z-index-modal) - 1)",
+      zIndex: "calc({zIndex.modal} - 1)",
       _open: {
         animationName: "fade-in",
         animationDuration: "slow",

--- a/packages/react/src/theme/recipes/drawer.ts
+++ b/packages/react/src/theme/recipes/drawer.ts
@@ -12,7 +12,7 @@ export const drawerSlotRecipe = defineSlotRecipe({
       top: 0,
       w: "100vw",
       h: "100dvh",
-      zIndex: "calc(var(--z-index) - 1) ",
+      zIndex: "calc(var(--z-index) - 2)",
       _open: {
         animationName: "fade-in",
         animationDuration: "slow",

--- a/packages/react/src/theme/recipes/drawer.ts
+++ b/packages/react/src/theme/recipes/drawer.ts
@@ -12,7 +12,7 @@ export const drawerSlotRecipe = defineSlotRecipe({
       top: 0,
       w: "100vw",
       h: "100dvh",
-      zIndex: "calc(var(--z-index) - 2)",
+      zIndex: "calc(var(--chakra-z-index-modal) - 1)",
       _open: {
         animationName: "fade-in",
         animationDuration: "slow",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

 
 




The zIndex: `-1` introduced an issue where the backdrop appears in front of the positioner when the dialog is opened, even though it fixed the drawer issue. This happens because `--z-index` is set to `1400` for the drawer, but `1402` for the dialog.

By default, the positioner uses the modal z-index `(var(--chakra-z-index-modal))`, which equals `1400`. Previously, it was using a zIndex of `1402`, which caused it to appear in front of the positioner. The earlier fix ([commit e3d7db7#r154974953](https://github.com/chakra-ui/chakra-ui/pull/9903#)) adjusted it from `1402` to `1401`.

Now, since it's added to the layer styles, the value is more explicit, ensuring the overlay consistently appears above the positioner.

This fix ensures it's always -1 from the positioner zIndex, which solves the problem. 
 
 
## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information

Environment used is nextJs dev environment
Browser: Chrome latest version
