### PR TITLE
fix(docs): update default values for lazyMount and unmountOnExit in Tooltip

### DIFF
--- a/apps/www/public/types/ark/tooltip.json
+++ b/apps/www/public/types/ark/tooltip.json
@@ -110,7 +110,7 @@
       "lazyMount": {
         "type": "boolean",
         "isRequired": false,
-        "defaultValue": "false",
+        "defaultValue": "true",
         "description": "Whether to enable lazy mounting"
       },
       "onExitComplete": {
@@ -147,7 +147,7 @@
       "unmountOnExit": {
         "type": "boolean",
         "isRequired": false,
-        "defaultValue": "false",
+        "defaultValue": "true",
         "description": "Whether to unmount on exit."
       }
     }


### PR DESCRIPTION
## 📝 Description

Like #9888, but for the `Tooltip` component.
`lazyMount` and `unmountOnExit` are true by default since [3.6.0](https://github.com/chakra-ui/chakra-ui/blob/main/.changelog/v3.mdx#360---2025-02-02).

## ⛳️ Current behavior (updates)

- `lazyMount` was documented as `false`, but the correct default is `true`.
- `unmountOnExit` was documented as `false`, but the correct default is `true`.


## 🚀 New behavior

- Updated `lazyMount` to correctly reflect `true` as the default value.
- Updated `unmountOnExit` to correctly reflect `true` as the default value.

## 💣 Is this a breaking change (Yes/No):

No
