### PR TITLE
refactoring(breadcrumb.tsx): prevent screen reader from reading the separator

### DIFF
--- a/.changeset/polite-boxes-thank.md
+++ b/.changeset/polite-boxes-thank.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Prevent screen reader from reading the separator

--- a/packages/react/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb/breadcrumb.tsx
@@ -89,6 +89,7 @@ export const BreadcrumbSeparator = withContext<
   BreadcrumbSeparatorProps
 >("li", "separator", {
   defaultProps: {
+    "aria-hidden": true,
     children: <ChevronRightIcon />,
   },
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

- Added `aria-hidden="true"` attribute to the separator component of the breadcrumb.
- The separator in a breadcrumb should not be read by screen readers. ([Refer to W3C documentation](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/#accessibilityfeatures))

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

No

## 📝 Additional Information
