### PR TITLE
fix(v2 / modal): Allow overriding lockFocusAcrossFrames prop

### DIFF
--- a/packages/components/src/modal/modal.tsx
+++ b/packages/components/src/modal/modal.tsx
@@ -155,7 +155,7 @@ export const Modal: React.FC<ModalProps> = (props) => {
     preserveScrollBarGap: true,
     motionPreset: "scale",
     ...props,
-    lockFocusAcrossFrames: props.lockFocusAcrossFrames || true,
+    lockFocusAcrossFrames: props.lockFocusAcrossFrames ?? true,
   }
 
   const {

--- a/packages/props-docs/generated/modal.json
+++ b/packages/props-docs/generated/modal.json
@@ -338,7 +338,7 @@
     },
     "lockFocusAcrossFrames": {
       "type": "boolean",
-      "defaultValue": false,
+      "defaultValue": true,
       "required": false,
       "description": "Enables aggressive focus capturing within iframes.\n- If `true`: keep focus in the lock, no matter where lock is active\n- If `false`:  allows focus to move outside of iframe"
     },


### PR DESCRIPTION
## 📝 Description

We observed we're unable to set the `<Modal lockFocusAcrossFrames={false} />`. Further checking the [v2](https://github.com/chakra-ui/chakra-ui/blob/v2/packages/components/src/modal/modal.tsx#L158) [code](https://github.com/chakra-ui/chakra-ui/blob/0511f22/packages/components/src/modal/modal.tsx#L158) stated that it was unable to override due to the logical OR operator

## ⛳️ Current behavior (updates)

The `lockFocusAcrossFrames` prop of `<Modal />` is always `true` and is unable to override. This is also inconsistent with the v2 doc. https://v2.chakra-ui.com/docs/components/modal/props

![5f9ce68d0390d175b56369524b1e189fa515ee5f](https://github.com/user-attachments/assets/5dda24d5-4c6f-402e-8a05-e211e27b729d)

## 🚀 New behavior

1. Allow overriding the `lockFocusAcrossFrames` prop of `<Modal />`
2. Update the document of it to show the matching default value

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
