### PR TITLE
docs: remove unused import of Radio component

### DIFF
--- a/apps/www/content/docs/components/radio.mdx
+++ b/apps/www/content/docs/components/radio.mdx
@@ -12,7 +12,7 @@ links:
 ## Usage
 
 ```tsx
-import { Radio, RadioGroup } from "@chakra-ui/react"
+import { RadioGroup } from "@chakra-ui/react"
 ```
 
 ```tsx


### PR DESCRIPTION
## 📝 Description

Remove unused import of `Radio` component from the radio documentation page to keep the docs accurate.

## ⛳️ Current behavior (updates)

The radio component documentation currently shows an import statement that includes the `Radio` component which causes a TypeScript error:

```
Module "@chakra-ui/react" has no exported member Radio.
```

This indicates that the import statement is incorrect and needs to be updated.

## 🚀 New behavior

- Remove the non-existent `Radio` import from the documentation.
- Keep only the necessary `RadioGroup` import.
- Fix the TypeScript error for developers who copy the code.
- Ensure documentation accuracy.

## 💣 Is this a breaking change (Yes/No):

No.
