### PR TITLE
docs: fix capitalization error in highlight multiple docs

### DIFF
--- a/apps/compositions/src/examples/highlight-multiple.tsx
+++ b/apps/compositions/src/examples/highlight-multiple.tsx
@@ -4,7 +4,7 @@ export const HighlightMultiple = () => {
   return (
     <Heading lineHeight="tall">
       <Highlight
-        query={["spotlight", "emphasize", "Accentuate"]}
+        query={["spotlight", "emphasize", "accentuate"]}
         styles={{ px: "0.5", bg: "teal.muted" }}
       >
         With the Highlight component, you can spotlight, emphasize and


### PR DESCRIPTION
## 📝 Description

`Accentuate` in the array passed to query was capitalized, however `accentuate` in the content was lowercase.

This caused the accentuate in the content to not be highlighted.

## 💣 Is this a breaking change (Yes/No): No