### PR TITLE
fix(checkbox): cursor token

### DIFF
--- a/packages/react/src/theme/recipes/checkmark.ts
+++ b/packages/react/src/theme/recipes/checkmark.ts
@@ -11,6 +11,7 @@ export const checkmarkRecipe = defineRecipe({
     borderWidth: "1px",
     borderColor: "transparent",
     borderRadius: "l1",
+    cursor: "checkbox",
     focusVisibleRing: "outside",
     _icon: {
       boxSize: "full",
@@ -21,6 +22,7 @@ export const checkmarkRecipe = defineRecipe({
     },
     _disabled: {
       opacity: "0.5",
+      cursor: "disabled",
     },
   },
   variants: {


### PR DESCRIPTION
## 📝 Description

Semantic token `cursor.checkbox` is not being used by the `<Checkbox />` component. This PR fixes this by mimicking the same implementation as in the `< RadioGroup />` component. 

## ⛳️ Current behavior (updates)

Semantic token `cursor.checkbox` not taken into account.

## 🚀 New behavior

Semantic token `cursor.checkbox` consumed by the `<Checkbox />` component.

## 💣 Is this a breaking change

No

## 📝 Additional Information

N/A