### PR TITLE
fix(styleconfig): omit react elements from props used in useStyleConfig

### DIFF
--- a/packages/components/src/system/style-config.test.tsx
+++ b/packages/components/src/system/style-config.test.tsx
@@ -1,123 +1,206 @@
 import { render } from "@chakra-ui/test-utils"
 import { ThemeProvider, useStyleConfig } from "."
 import { createTheme } from "./theme"
+import { Icon } from "../icon"
+import { FaReact } from "react-icons/fa"
+import type * as StyledSystem from "@chakra-ui/styled-system"
 
-test("should resolve styles in theme", async () => {
-  const Component = () => {
-    const styles = useStyleConfig("Button", { size: "sm" })
-    return <>{JSON.stringify(styles, null, 2)}</>
-  }
+const mockResolveStyleConfig = vi.fn().mockReturnValue(() => ({}))
+let mockResolveStyleConfigEnabled = false
 
-  const { asFragment } = render(
-    <ThemeProvider
-      theme={createTheme({
-        components: {
-          Button: {
-            baseStyle: {
-              px: 4,
-              py: 8,
-            },
-            sizes: {
-              sm: {
-                fontSize: 4,
-              },
-              md: {
-                fontSize: 8,
-              },
-            },
-          },
-        },
-      })}
-    >
-      <Component />
-    </ThemeProvider>,
-    {
-      withChakraProvider: false,
+vi.mock("@chakra-ui/styled-system", async (importOriginal) => {
+  const actual = await importOriginal<typeof StyledSystem>()
+  return {
+    ...actual,
+    resolveStyleConfig: (config: any) => {
+      if (mockResolveStyleConfigEnabled) {
+        return (props: any) => mockResolveStyleConfig(props)
+      }
+      return actual.resolveStyleConfig(config)
     },
-  )
-
-  expect(asFragment()).toMatchInlineSnapshot(`
-    <DocumentFragment>
-      {
-      "px": 4,
-      "py": 8,
-      "fontSize": 4
-    }
-    </DocumentFragment>
-  `)
+  }
 })
 
-test("should resolve multipart styles in theme", async () => {
-  const Component = () => {
-    const props = {
-      size: "sm",
-      variant: "outline",
-    }
-    const styles = useStyleConfig("Tabs", props)
-    return <>{JSON.stringify(styles, null, 2)}</>
-  }
+describe("useStyleConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResolveStyleConfigEnabled = false
+  })
 
-  const { asFragment } = render(
-    <ThemeProvider
-      theme={createTheme({
-        components: {
-          Tabs: {
-            parts: ["tablist", "tabpanel", "tab"],
-            defaultProps: { variant: "solid" },
-            baseStyle: {
-              tab: {
+  test("should resolve styles in theme", async () => {
+    const Component = () => {
+      const styles = useStyleConfig("Button", { size: "sm" })
+      return <>{JSON.stringify(styles, null, 2)}</>
+    }
+
+    const { asFragment } = render(
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            Button: {
+              baseStyle: {
                 px: 4,
-                py: 3,
-                color: "red.500",
+                py: 8,
               },
-            },
-            sizes: {
-              sm: {
-                tab: {
-                  fontSize: 5,
+              sizes: {
+                sm: {
+                  fontSize: 4,
                 },
-                tablist: {
-                  p: 4,
-                },
-              },
-            },
-            variants: {
-              outline: {
-                tablist: {
-                  border: "1px solid",
-                },
-              },
-              solid: {
-                tab: {
-                  bg: "red.300",
+                md: {
+                  fontSize: 8,
                 },
               },
             },
           },
-        },
-      })}
-    >
-      <Component />
-    </ThemeProvider>,
-    {
-      withChakraProvider: false,
-    },
-  )
-
-  expect(asFragment()).toMatchInlineSnapshot(`
-    <DocumentFragment>
+        })}
+      >
+        <Component />
+      </ThemeProvider>,
       {
-      "tab": {
-        "px": 4,
-        "py": 3,
-        "color": "red.500",
-        "fontSize": 5
+        withChakraProvider: false,
       },
-      "tablist": {
-        "p": 4,
-        "border": "1px solid"
+    )
+
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        {
+        "px": 4,
+        "py": 8,
+        "fontSize": 4
       }
+      </DocumentFragment>
+    `)
+  })
+
+  test("should omit react element props", async () => {
+    mockResolveStyleConfigEnabled = true
+    const Component = () => {
+      const props = {
+        size: "sm",
+        children: <div>Hello</div>,
+        leftIcon: <Icon as={FaReact} />,
+      }
+      const styles = useStyleConfig("Button", props)
+      return <>{JSON.stringify(styles, null, 2)}</>
     }
-    </DocumentFragment>
-  `)
+
+    render(
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            Button: {
+              baseStyle: {
+                px: 4,
+                py: 8,
+              },
+              sizes: {
+                sm: {
+                  fontSize: 4,
+                },
+                md: {
+                  fontSize: 8,
+                },
+              },
+            },
+          },
+        })}
+      >
+        <Component />
+      </ThemeProvider>,
+      {
+        withChakraProvider: false,
+      },
+    )
+
+    expect(mockResolveStyleConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: "sm",
+      }),
+    )
+    expect(mockResolveStyleConfig).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        children: expect.anything(),
+      }),
+    )
+    expect(mockResolveStyleConfig).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        leftIcon: expect.anything(),
+      }),
+    )
+  })
+
+  test("should resolve multipart styles in theme", async () => {
+    const Component = () => {
+      const props = {
+        size: "sm",
+        variant: "outline",
+      }
+      const styles = useStyleConfig("Tabs", props)
+      return <>{JSON.stringify(styles, null, 2)}</>
+    }
+
+    const { asFragment } = render(
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            Tabs: {
+              parts: ["tablist", "tabpanel", "tab"],
+              defaultProps: { variant: "solid" },
+              baseStyle: {
+                tab: {
+                  px: 4,
+                  py: 3,
+                  color: "red.500",
+                },
+              },
+              sizes: {
+                sm: {
+                  tab: {
+                    fontSize: 5,
+                  },
+                  tablist: {
+                    p: 4,
+                  },
+                },
+              },
+              variants: {
+                outline: {
+                  tablist: {
+                    border: "1px solid",
+                  },
+                },
+                solid: {
+                  tab: {
+                    bg: "red.300",
+                  },
+                },
+              },
+            },
+          },
+        })}
+      >
+        <Component />
+      </ThemeProvider>,
+      {
+        withChakraProvider: false,
+      },
+    )
+
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        {
+        "tab": {
+          "px": 4,
+          "py": 3,
+          "color": "red.500",
+          "fontSize": 5
+        },
+        "tablist": {
+          "p": 4,
+          "border": "1px solid"
+        }
+      }
+      </DocumentFragment>
+    `)
+  })
 })

--- a/packages/components/src/system/use-style-config.ts
+++ b/packages/components/src/system/use-style-config.ts
@@ -3,18 +3,25 @@ import {
   SystemStyleObject,
   ThemingProps,
 } from "@chakra-ui/styled-system"
-import {
-  compact,
-  Dict,
-  memoizedGet as get,
-  mergeWith,
-  omit,
-} from "@chakra-ui/utils"
-import { useRef } from "react"
+import { compact, Dict, memoizedGet as get, mergeWith } from "@chakra-ui/utils"
+import { isValidElement, useRef } from "react"
 import isEqual from "react-fast-compare"
 import { useChakra } from "./hooks"
 
 type StylesRef = SystemStyleObject | Record<string, SystemStyleObject>
+
+function omitReactElements(props: Dict) {
+  return Object.fromEntries(
+    Object.entries(props).filter(([key, value]) => {
+      return (
+        value !== null &&
+        value !== undefined &&
+        key !== "children" &&
+        !isValidElement(value)
+      )
+    }),
+  )
+}
 
 function useStyleConfigImpl(
   themeKey: string | null,
@@ -33,7 +40,7 @@ function useStyleConfigImpl(
   const mergedProps = mergeWith(
     { theme, colorMode },
     styleConfig?.defaultProps ?? {},
-    compact(omit(rest, ["children"])),
+    compact(omitReactElements(rest)),
     (obj, src) => (!obj ? src : undefined),
   )
 


### PR DESCRIPTION
Closes #9984 

## 📝 Description

Omit react elements from `mergedProps` in `useStyleConfigImpl`

## ⛳️ Current behavior (updates)

SSR rendered components freeze in dev mode when non-memoized react components are passed to `useStyleConfigImpl`

## 🚀 New behavior

This PR omits those props from being uses as they are not needed anyway.

## 💣 Is this a breaking change (Yes/No): NO


## 📝 Additional Information
