### PR TITLE
fix(docs): Title on theming/layer-styles page

### DIFF
--- a/apps/www/content/docs/theming/layer-styles.mdx
+++ b/apps/www/content/docs/theming/layer-styles.mdx
@@ -1,5 +1,5 @@
 ---
-title: Slot Recipes
+title: Layer Styles
 description: The built-in layer styles in Chakra UI
 ---
 


### PR DESCRIPTION
## 📝 Description

On the documentation page for Theming / Layer Styles, the title was incorrectly set to "Slot Recipes".

The page itself shows the incorrect title, very easy to check. On top of that, when searching for "Layer Styles" you would just find the **Styling** page, but not the **Theming** page for Layer Styles, because it had a different/wrong title.

## ⛳️ Current behavior (updates)

It's set as the wrong title of "Slot Recipes", and not as the correct "Layer Styles" title.

![image](https://github.com/user-attachments/assets/e0936856-8425-4251-acb7-6ca1c0d8d199)

## 🚀 New behavior

It's now fixed to "Layer Styles" which is the correct name for this page 🫡

![image](https://github.com/user-attachments/assets/2aff3f1a-2429-48fe-a3ca-fcd386eb834c)

## 💣 Is this a breaking change (Yes/No):

Not a breaking change, but it's better to have well written docs ✨
