### PR TITLE
fix(input): flushed input variant error focus style 

### DIFF
--- a/apps/compositions/src/examples/input-with-focus-error-color.tsx
+++ b/apps/compositions/src/examples/input-with-focus-error-color.tsx
@@ -15,6 +15,19 @@ export const InputWithFocusErrorColor = () => {
         <Field.Label>errorColor=blue</Field.Label>
         <Input placeholder="Password" css={{ "--error-color": "blue" }} />
       </Field.Root>
+
+      <Field.Root invalid>
+        <Field.Label>variant=outline,focusColor=error</Field.Label>
+        <Input placeholder="Focus me" variant="outline" />
+      </Field.Root>
+      <Field.Root invalid>
+        <Field.Label>variant=subtle,focusColor=error</Field.Label>
+        <Input placeholder="Focus me" variant="subtle" />
+      </Field.Root>
+      <Field.Root invalid>
+        <Field.Label>variant=flushed,focusColor=error</Field.Label>
+        <Input placeholder="Focus me" variant="flushed" />
+      </Field.Root>
     </Stack>
   )
 }

--- a/packages/react/src/theme/recipes/input.ts
+++ b/packages/react/src/theme/recipes/input.ts
@@ -86,6 +86,10 @@ export const inputRecipe = defineRecipe({
         _focusVisible: {
           borderColor: "var(--focus-color)",
           boxShadow: "0px 1px 0px 0px var(--focus-color)",
+          _invalid: {
+            borderColor: "var(--error-color)",
+            boxShadow: "0px 1px 0px 0px var(--error-color)",
+          },
         },
       },
     },


### PR DESCRIPTION
Fix the focus state of the flushed variant when the input is in an error state.

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

https://github.com/user-attachments/assets/648d69ca-a980-4659-a21a-52f221206d07

## 🚀 New behavior


https://github.com/user-attachments/assets/02108cc7-9f59-4afe-bb57-d52c60678501

## 💣 Is this a breaking change (Yes/No):

No
