### PR TITLE
docs(migration): move form error before sample heading underneath the list

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -306,8 +306,10 @@ export default preview
 - **StackItem**: You don't need this anymore. Use `Box` instead.
 - **FocusLock**: We no longer ship a focus lock component. Install and use
   `react-focus-lock` directly.
-- **FormControl**: Replace with the `Field` component
-- **FormErrorMessage**: Replace with the `Field.ErrorText` component Before:
+- **FormControl**: Replace with the `Field` component.
+- **FormErrorMessage**: Replace with the `Field.ErrorText` component.
+
+Before:
 
 ```tsx
 <FormControl>


### PR DESCRIPTION
Closes # - not an existing issue I believe.

## 📝 Description

> The "before" heading was shown inline with the last bullet point for the Form Error section.

## ⛳️ Current behavior (updates)

> Shown inline:

<img width="824" alt="image" src="https://github.com/user-attachments/assets/5edabbbc-183e-452c-ae23-71d3f4211027" />

## 🚀 New behavior

> This PR moves it to just after said list:

<img width="826" alt="image" src="https://github.com/user-attachments/assets/3e15951e-dc5d-4ca1-946b-1bd84515bed5" />

## 💣 Is this a breaking change (Yes/No):

No, document text update only in a mdx file.

## 📝 Additional Information

-