### PR TITLE
fix(utils): prevent infinite loop in objectToArrayNotation with trailing nulls

### DIFF
--- a/packages/utils/src/responsive.ts
+++ b/packages/utils/src/responsive.ts
@@ -33,8 +33,9 @@ export function objectToArrayNotation(
   bps = breakpoints,
 ) {
   const result = bps.map((br) => obj[br] ?? null)
-  const lastItem = result[result.length - 1]
-  while (lastItem === null) result.pop()
+  while (result.length > 0 && result[result.length - 1] === null) {
+    result.pop()
+  }
   return result
 }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

There is no corresponding issue to this PR

## 📝 Description

v2 - Fixed infinite loop in `objectToArrayNotation` function that occurs when the last value in the result array is null.

## ⛳️ Current behavior (updates)

The function uses `while (lastItem === null)` but `lastItem` is assigned once before the loop and never updated, causing an infinite loop when the last array element is null.

## 🚀 New behavior

The function now checks the array length and re-evaluates the last item on each iteration: `while (result.length > 0 && result[result.length - 1] === null)`
## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
This bug was introduced during a refactor and affects responsive props handling when trailing breakpoint values are null.