### PR TITLE
Fix drawer close animation

### DIFF
--- a/.changeset/sweet-impalas-return.md
+++ b/.changeset/sweet-impalas-return.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix drawer close animation in RTL

--- a/packages/react/src/theme/recipes/drawer.ts
+++ b/packages/react/src/theme/recipes/drawer.ts
@@ -162,7 +162,7 @@ export const drawerSlotRecipe = defineSlotRecipe({
           _closed: {
             animationName: {
               base: "slide-to-right-full, fade-out",
-              _rtl: "slide-to-right-full, fade-out",
+              _rtl: "slide-to-left-full, fade-out",
             },
           },
         },


### PR DESCRIPTION

## 📝 Description

Fix drawer close animation for RTL pages when placement is end

## ⛳️ Current behavior (updates)

Currently, on RTL pages, when the placement is set to `end` (the default), the close animation is incorrect. The drawer appears from the left side but doesn’t move to the left side when closed.

## 🚀 New behavior

This PR fixes the animation name for said conditions.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
