### PR TITLE
fix(chart-tooltip): apply formatter prop to display formatted values

### DIFF
--- a/packages/charts/src/chart/chart.tsx
+++ b/packages/charts/src/chart/chart.tsx
@@ -197,6 +197,7 @@ export interface ChartTooltipProps extends TooltipProps<string, string> {
   fitContent?: boolean
   nameKey?: string
   indicator?: "line" | "dot" | "dashed"
+  formatter?: (value: any) => React.ReactNode
   render?: (item: Payload<string, string>) => React.ReactNode
 }
 
@@ -211,6 +212,7 @@ export function ChartTooltip(props: ChartTooltipProps) {
     showTotal,
     fitContent,
     nameKey,
+    formatter,
     render,
   } = props
 
@@ -273,7 +275,9 @@ export function ChartTooltip(props: ChartTooltipProps) {
                     fontWeight="medium"
                     fontVariantNumeric="tabular-nums"
                   >
-                    {item.value.toLocaleString()}
+                    {formatter
+                      ? formatter(item.value)
+                      : item.value.toLocaleString()}
                   </Text>
                 )}
               </HStack>
@@ -292,7 +296,7 @@ export function ChartTooltip(props: ChartTooltipProps) {
               fontWeight="medium"
               fontVariantNumeric="tabular-nums"
             >
-              {total.toLocaleString()}
+              {formatter ? formatter(total) : total.toLocaleString()}
             </Text>
           </HStack>
         </>


### PR DESCRIPTION
Sure! Here's a filled-out version of your PR template based on your recent change (`formatter` prop in `ChartTooltip`):

---

<!---  
Thanks for creating a Pull Request 💖!

Please read the following before submitting:  
- PRs that add new external dependencies might take a while to review.  
- Keep your PR as small as possible.  
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.  
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> This PR adds support for a `formatter` prop in the `ChartTooltip` component to allow formatting values using custom logic (e.g., number formatting, currency, percentage).

## ⛳️ Current behavior (updates)

> Currently, `ChartTooltip` displays raw values without formatting, making it difficult to localize or display them with consistent precision or styles.

## 🚀 New behavior

> With this update, users can pass a `formatter` function as a prop to `ChartTooltip`, which will be used to format the values shown in the tooltip.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This is a non-breaking enhancement and does not introduce new dependencies. Useful for displaying values in a user-friendly or localized format inside charts.

---

