### PR TITLE
Fix/checkbox types export

### DIFF
--- a/.changeset/ninety-owls-sit.md
+++ b/.changeset/ninety-owls-sit.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+- export `CheckboxRootProviderProps` type

--- a/packages/react/src/components/checkbox/index.ts
+++ b/packages/react/src/components/checkbox/index.ts
@@ -16,6 +16,7 @@ export type {
   CheckboxIndicatorProps,
   CheckboxLabelProps,
   CheckboxRootProps,
+  CheckboxRootProviderProps,
   CheckboxGroupProps,
   CheckboxCheckedChangeDetails,
 } from "./checkbox"


### PR DESCRIPTION
## 📝 Description

 export `CheckboxRootProviderProps` type. It's exported in namespace but not in the index.