### PR TITLE
fix(system): slot recipe TS issue `exactOptionalPropertyTypes`

### DIFF
--- a/packages/react/src/components/aspect-ratio/aspect-ratio.tsx
+++ b/packages/react/src/components/aspect-ratio/aspect-ratio.tsx
@@ -16,7 +16,7 @@ export interface AspectRatioProps
    *
    * `21/9`, `16/9`, `9/16`, `4/3`, `1.85/1`
    */
-  ratio?: ConditionalValue<number>
+  ratio?: ConditionalValue<number> | undefined
 }
 
 const baseStyle = defineStyle({

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -68,7 +68,7 @@ export interface AvatarFallbackProps
    * The name to derive the initials from.
    * If not provided, the fallback will display a generic icon.
    */
-  name?: string
+  name?: string | undefined
 }
 
 const StyledFallback = chakra(ArkAvatar.Fallback, {}, { forwardAsChild: true })

--- a/packages/react/src/components/bleed/bleed.tsx
+++ b/packages/react/src/components/bleed/bleed.tsx
@@ -12,27 +12,27 @@ export interface BleedProps extends HTMLChakraProps<"div"> {
   /**
    * The negative margin on the x-axis
    */
-  inline?: SystemStyleObject["marginInline"]
+  inline?: SystemStyleObject["marginInline"] | undefined
   /**
    * The negative margin on the y-axis
    */
-  block?: SystemStyleObject["marginBlock"]
+  block?: SystemStyleObject["marginBlock"] | undefined
   /**
    * The negative margin on the inline-start axis
    */
-  inlineStart?: SystemStyleObject["marginInlineStart"]
+  inlineStart?: SystemStyleObject["marginInlineStart"] | undefined
   /**
    * The negative margin on the inline-end axis
    */
-  inlineEnd?: SystemStyleObject["marginInlineEnd"]
+  inlineEnd?: SystemStyleObject["marginInlineEnd"] | undefined
   /**
    * The negative margin on the block-start axis
    */
-  blockStart?: SystemStyleObject["marginBlockStart"]
+  blockStart?: SystemStyleObject["marginBlockStart"] | undefined
   /**
    * The negative margin on the block-end axis
    */
-  blockEnd?: SystemStyleObject["marginBlockEnd"]
+  blockEnd?: SystemStyleObject["marginBlockEnd"] | undefined
 }
 
 const valueFn = (v: string) =>

--- a/packages/react/src/components/box/square.tsx
+++ b/packages/react/src/components/box/square.tsx
@@ -7,7 +7,7 @@ export interface SquareProps extends BoxProps {
   /**
    * The size (width and height) of the square
    */
-  size?: BoxProps["boxSize"]
+  size?: BoxProps["boxSize"] | undefined
 }
 
 export const Square = forwardRef<HTMLDivElement, SquareProps>(

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -21,20 +21,20 @@ export interface ButtonLoadingProps {
    * If `true`, the button will show a loading spinner.
    * @default false
    */
-  loading?: boolean
+  loading?: boolean | undefined
   /**
    * The text to show while loading.
    */
-  loadingText?: React.ReactNode
+  loadingText?: React.ReactNode | undefined
   /**
    * The spinner to show while loading.
    */
-  spinner?: React.ReactNode
+  spinner?: React.ReactNode | undefined
   /**
    * The placement of the spinner
    * @default "start"
    */
-  spinnerPlacement?: "start" | "end"
+  spinnerPlacement?: "start" | "end" | undefined
 }
 
 export interface ButtonBaseProps

--- a/packages/react/src/components/center/absolute-center.tsx
+++ b/packages/react/src/components/center/absolute-center.tsx
@@ -3,7 +3,7 @@
 import { type HTMLChakraProps, chakra } from "../../styled-system"
 
 export interface AbsoluteCenterProps extends HTMLChakraProps<"div"> {
-  axis?: "horizontal" | "vertical" | "both"
+  axis?: "horizontal" | "vertical" | "both" | undefined
 }
 
 /**

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -75,8 +75,8 @@ export const CheckboxLabel = withContext<HTMLElement, CheckboxLabelProps>(
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface CheckboxIndicatorProps extends HTMLChakraProps<"svg"> {
-  checked?: React.ReactElement
-  indeterminate?: React.ReactElement
+  checked?: React.ReactElement | undefined
+  indeterminate?: React.ReactElement | undefined
 }
 
 export const CheckboxIndicator = forwardRef<

--- a/packages/react/src/components/checkmark/checkmark.tsx
+++ b/packages/react/src/components/checkmark/checkmark.tsx
@@ -17,15 +17,15 @@ export interface CheckmarkProps
   /**
    * Whether the checkmark is checked
    */
-  checked?: boolean
+  checked?: boolean | undefined
   /**
    * Whether the checkmark is indeterminate
    */
-  indeterminate?: boolean
+  indeterminate?: boolean | undefined
   /**
    * Whether the checkmark is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export const Checkmark = forwardRef<SVGSVGElement, CheckmarkProps>(

--- a/packages/react/src/components/client-only/client-only.tsx
+++ b/packages/react/src/components/client-only/client-only.tsx
@@ -5,7 +5,7 @@ import { Show } from "../show"
 
 export interface ClientOnlyProps {
   children: React.ReactNode
-  fallback?: React.ReactNode
+  fallback?: React.ReactNode | undefined
 }
 
 export const ClientOnly = (props: ClientOnlyProps) => {

--- a/packages/react/src/components/field/field.tsx
+++ b/packages/react/src/components/field/field.tsx
@@ -88,7 +88,7 @@ export const FieldErrorIcon = createIcon({
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface FieldRequiredIndicatorProps extends HTMLChakraProps<"span"> {
-  fallback?: React.ReactNode
+  fallback?: React.ReactNode | undefined
 }
 
 export const FieldRequiredIndicator = forwardRef<

--- a/packages/react/src/components/file-upload/file-upload.tsx
+++ b/packages/react/src/components/file-upload/file-upload.tsx
@@ -207,9 +207,9 @@ export const FileUploadTrigger = withContext<
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface FileUploadItemsBaseProps {
-  showSize?: boolean
-  clearable?: boolean
-  files?: File[]
+  showSize?: boolean | undefined
+  clearable?: boolean | undefined
+  files?: File[] | undefined
 }
 
 export interface FileUploadItemsProps
@@ -262,7 +262,7 @@ export const FileUploadList = forwardRef<HTMLUListElement, FileUploadListProps>(
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface FileUploadFileTextProps extends HTMLChakraProps<"span"> {
-  fallback?: string
+  fallback?: string | undefined
 }
 
 export const FileUploadFileText = forwardRef<

--- a/packages/react/src/components/flex/flex.tsx
+++ b/packages/react/src/components/flex/flex.tsx
@@ -8,14 +8,14 @@ import {
 } from "../../styled-system"
 
 export interface FlexOptions {
-  align?: SystemStyleObject["alignItems"]
-  justify?: SystemStyleObject["justifyContent"]
-  wrap?: SystemStyleObject["flexWrap"]
-  direction?: SystemStyleObject["flexDirection"]
-  basis?: SystemStyleObject["flexBasis"]
-  grow?: SystemStyleObject["flexGrow"]
-  shrink?: SystemStyleObject["flexShrink"]
-  inline?: boolean
+  align?: SystemStyleObject["alignItems"] | undefined
+  justify?: SystemStyleObject["justifyContent"] | undefined
+  wrap?: SystemStyleObject["flexWrap"] | undefined
+  direction?: SystemStyleObject["flexDirection"] | undefined
+  basis?: SystemStyleObject["flexBasis"] | undefined
+  grow?: SystemStyleObject["flexGrow"] | undefined
+  shrink?: SystemStyleObject["flexShrink"] | undefined
+  inline?: boolean | undefined
 }
 
 export interface FlexProps extends HTMLChakraProps<"div", FlexOptions> {}

--- a/packages/react/src/components/float/float.tsx
+++ b/packages/react/src/components/float/float.tsx
@@ -15,30 +15,32 @@ export interface FloatOptions {
   /**
    * The x offset of the indicator
    */
-  offsetX?: SystemStyleObject["left"]
+  offsetX?: SystemStyleObject["left"] | undefined
   /**
    * The y offset of the indicator
    */
-  offsetY?: SystemStyleObject["top"]
+  offsetY?: SystemStyleObject["top"] | undefined
   /**
    * The x and y offset of the indicator
    */
-  offset?: SystemStyleObject["top"]
+  offset?: SystemStyleObject["top"] | undefined
   /**
    * The placement of the indicator
    * @default "top-end"
    */
-  placement?: ConditionalValue<
-    | "bottom-end"
-    | "bottom-start"
-    | "top-end"
-    | "top-start"
-    | "bottom-center"
-    | "top-center"
-    | "middle-center"
-    | "middle-end"
-    | "middle-start"
-  >
+  placement?:
+    | ConditionalValue<
+        | "bottom-end"
+        | "bottom-start"
+        | "top-end"
+        | "top-start"
+        | "bottom-center"
+        | "top-center"
+        | "middle-center"
+        | "middle-end"
+        | "middle-start"
+      >
+    | undefined
 }
 
 export interface FloatProps

--- a/packages/react/src/components/for/for.tsx
+++ b/packages/react/src/components/for/for.tsx
@@ -8,7 +8,7 @@ export interface ForProps<T> {
   /**
    * The fallback content to render when the array is empty
    */
-  fallback?: React.ReactNode
+  fallback?: React.ReactNode | undefined
   /**
    * The render function to render each item in the array
    */

--- a/packages/react/src/components/grid/grid-item.tsx
+++ b/packages/react/src/components/grid/grid-item.tsx
@@ -10,13 +10,13 @@ import { compact, mapObject } from "../../utils"
 import type { BoxProps } from "../box/box"
 
 export interface GridItemProps extends BoxProps {
-  area?: SystemStyleObject["gridArea"]
-  colSpan?: ConditionalValue<number | "auto">
-  colStart?: ConditionalValue<number | "auto">
-  colEnd?: ConditionalValue<number | "auto">
-  rowStart?: ConditionalValue<number | "auto">
-  rowEnd?: ConditionalValue<number | "auto">
-  rowSpan?: ConditionalValue<number | "auto">
+  area?: SystemStyleObject["gridArea"] | undefined
+  colSpan?: ConditionalValue<number | "auto"> | undefined
+  colStart?: ConditionalValue<number | "auto"> | undefined
+  colEnd?: ConditionalValue<number | "auto"> | undefined
+  rowStart?: ConditionalValue<number | "auto"> | undefined
+  rowEnd?: ConditionalValue<number | "auto"> | undefined
+  rowSpan?: ConditionalValue<number | "auto"> | undefined
 }
 
 function spanFn(span?: ConditionalValue<number | "auto">) {

--- a/packages/react/src/components/grid/grid.tsx
+++ b/packages/react/src/components/grid/grid.tsx
@@ -8,15 +8,15 @@ import {
 } from "../../styled-system"
 
 export interface GridOptions {
-  templateColumns?: SystemStyleObject["gridTemplateColumns"]
-  autoFlow?: SystemStyleObject["gridAutoFlow"]
-  autoRows?: SystemStyleObject["gridAutoRows"]
-  autoColumns?: SystemStyleObject["gridAutoColumns"]
-  templateRows?: SystemStyleObject["gridTemplateRows"]
-  templateAreas?: SystemStyleObject["gridTemplateAreas"]
-  column?: SystemStyleObject["gridColumn"]
-  row?: SystemStyleObject["gridRow"]
-  inline?: boolean
+  templateColumns?: SystemStyleObject["gridTemplateColumns"] | undefined
+  autoFlow?: SystemStyleObject["gridAutoFlow"] | undefined
+  autoRows?: SystemStyleObject["gridAutoRows"] | undefined
+  autoColumns?: SystemStyleObject["gridAutoColumns"] | undefined
+  templateRows?: SystemStyleObject["gridTemplateRows"] | undefined
+  templateAreas?: SystemStyleObject["gridTemplateAreas"] | undefined
+  column?: SystemStyleObject["gridColumn"] | undefined
+  row?: SystemStyleObject["gridRow"] | undefined
+  inline?: boolean | undefined
 }
 
 export interface GridProps

--- a/packages/react/src/components/grid/simple-grid.tsx
+++ b/packages/react/src/components/grid/simple-grid.tsx
@@ -13,11 +13,11 @@ interface SimpleGridOptions {
   /**
    * The width at which child elements will break into columns. Pass a number for pixel values or a string for any other valid CSS length.
    */
-  minChildWidth?: GridProps["minWidth"]
+  minChildWidth?: GridProps["minWidth"] | undefined
   /**
    * The number of columns
    */
-  columns?: ConditionalValue<number>
+  columns?: ConditionalValue<number> | undefined
 }
 
 export interface SimpleGridProps

--- a/packages/react/src/components/group/group.tsx
+++ b/packages/react/src/components/group/group.tsx
@@ -110,19 +110,19 @@ export interface GroupProps extends HTMLChakraProps<"div", VariantProps> {
   /**
    * The `alignItems` style property
    */
-  align?: JsxStyleProps["alignItems"]
+  align?: JsxStyleProps["alignItems"] | undefined
   /**
    * The `justifyContent` style property
    */
-  justify?: JsxStyleProps["justifyContent"]
+  justify?: JsxStyleProps["justifyContent"] | undefined
   /**
    * The `flexWrap` style property
    */
-  wrap?: JsxStyleProps["flexWrap"]
+  wrap?: JsxStyleProps["flexWrap"] | undefined
   /**
    * A function that determines if a child should be skipped
    */
-  skip?: (child: React.ReactElement) => boolean
+  skip?: (child: React.ReactElement) => boolean | undefined
 }
 
 export const Group = memo(

--- a/packages/react/src/components/highlight/highlight.tsx
+++ b/packages/react/src/components/highlight/highlight.tsx
@@ -9,9 +9,9 @@ import { Mark } from "../typography/mark"
 export interface HighlightProps {
   query: string | string[]
   children: string | ((props: HighlightChunk[]) => React.ReactNode)
-  styles?: SystemStyleObject
-  ignoreCase?: boolean
-  matchAll?: boolean
+  styles?: SystemStyleObject | undefined
+  ignoreCase?: boolean | undefined
+  matchAll?: boolean | undefined
 }
 
 /**

--- a/packages/react/src/components/icon/create-icon.tsx
+++ b/packages/react/src/components/icon/create-icon.tsx
@@ -8,24 +8,24 @@ interface CreateIconOptions {
    * The icon `svg` viewBox
    * @default "0 0 24 24"
    */
-  viewBox?: string
+  viewBox?: string | undefined
   /**
    * The `svg` path or group element
    * @type React.ReactElement | React.ReactElement[]
    */
-  path?: React.ReactElement | React.ReactElement[]
+  path?: React.ReactElement | React.ReactElement[] | undefined
   /**
    * If the `svg` has a single path, simply copy the path's `d` attribute
    */
-  d?: string
+  d?: string | undefined
   /**
    * The display name useful in the dev tools
    */
-  displayName?: string
+  displayName?: string | undefined
   /**
    * Default props automatically passed to the component; overwritable
    */
-  defaultProps?: IconProps
+  defaultProps?: IconProps | undefined
 }
 
 export function createIcon(options: CreateIconOptions) {

--- a/packages/react/src/components/image/image.tsx
+++ b/packages/react/src/components/image/image.tsx
@@ -14,13 +14,13 @@ interface ImageOptions {
    * It maps to css `object-fit` property.
    * @type SystemStyleObject["objectFit"]
    */
-  fit?: SystemStyleObject["objectFit"]
+  fit?: SystemStyleObject["objectFit"] | undefined
   /**
    * How to align the image within its bounds.
    * It maps to css `object-position` property.
    * @type SystemStyleObject["objectPosition"]
    */
-  align?: SystemStyleObject["objectPosition"]
+  align?: SystemStyleObject["objectPosition"] | undefined
 }
 
 export interface ImageProps extends HTMLChakraProps<"img", ImageOptions> {}

--- a/packages/react/src/components/input/input-group.tsx
+++ b/packages/react/src/components/input/input-group.tsx
@@ -7,17 +7,17 @@ import { InputAddon, type InputAddonProps } from "./input-addon"
 import { InputElement, type InputElementProps } from "./input-element"
 
 export interface InputGroupProps extends BoxProps {
-  startElementProps?: InputElementProps
-  endElementProps?: InputElementProps
-  startElement?: React.ReactNode
-  endElement?: React.ReactNode
-  startAddon?: React.ReactNode
-  startAddonProps?: InputAddonProps
-  endAddon?: React.ReactNode
-  endAddonProps?: InputAddonProps
+  startElementProps?: InputElementProps | undefined
+  endElementProps?: InputElementProps | undefined
+  startElement?: React.ReactNode | undefined
+  endElement?: React.ReactNode | undefined
+  startAddon?: React.ReactNode | undefined
+  startAddonProps?: InputAddonProps | undefined
+  endAddon?: React.ReactNode | undefined
+  endAddonProps?: InputAddonProps | undefined
   children: React.ReactElement<InputElementProps>
-  startOffset?: InputElementProps["paddingStart"]
-  endOffset?: InputElementProps["paddingEnd"]
+  startOffset?: InputElementProps["paddingStart"] | undefined
+  endOffset?: InputElementProps["paddingEnd"] | undefined
 }
 
 export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(

--- a/packages/react/src/components/loader/loader.tsx
+++ b/packages/react/src/components/loader/loader.tsx
@@ -9,20 +9,20 @@ export interface LoaderProps extends HTMLChakraProps<"span"> {
    * Whether the loader is visible
    * @default true
    */
-  visible?: boolean
+  visible?: boolean | undefined
   /**
    * The spinner to display when loading
    */
-  spinner?: React.ReactNode
+  spinner?: React.ReactNode | undefined
   /**
    * The placement of the spinner
    * @default "start"
    */
-  spinnerPlacement?: "start" | "end"
+  spinnerPlacement?: "start" | "end" | undefined
   /**
    * The text to display when loading
    */
-  text?: React.ReactNode
+  text?: React.ReactNode | undefined
 }
 
 export const Loader = React.forwardRef<HTMLSpanElement, LoaderProps>(

--- a/packages/react/src/components/native-select/native-select.tsx
+++ b/packages/react/src/components/native-select/native-select.tsx
@@ -14,8 +14,8 @@ import { cx, dataAttr } from "../../utils"
 import { ChevronDownIcon } from "../icons"
 
 interface NativeSelectBaseProps {
-  disabled?: boolean
-  invalid?: boolean
+  disabled?: boolean | undefined
+  invalid?: boolean | undefined
 }
 
 const [NativeSelectBasePropsProvider, useNativeSelectBaseProps] =
@@ -77,7 +77,7 @@ type Omitted = "disabled" | "required" | "readOnly" | "size"
 
 export interface NativeSelectFieldProps
   extends Omit<HTMLChakraProps<"select">, Omitted> {
-  placeholder?: string
+  placeholder?: string | undefined
 }
 
 const StyledSelect = chakra(ArkField.Select, {}, { forwardAsChild: true })

--- a/packages/react/src/components/pagination/pagination.tsx
+++ b/packages/react/src/components/pagination/pagination.tsx
@@ -121,7 +121,7 @@ export interface PaginationPageSizeChangeDetails
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface PaginationPageTextProps extends BoxProps {
-  format?: "short" | "compact" | "long"
+  format?: "short" | "compact" | "long" | undefined
 }
 
 export const PaginationPageText = forwardRef<
@@ -148,7 +148,7 @@ export const PaginationPageText = forwardRef<
 export interface PaginationItemsProps
   extends React.HTMLAttributes<HTMLElement> {
   render: (page: { type: "page"; value: number }) => React.ReactNode
-  ellipsis?: React.ReactElement
+  ellipsis?: React.ReactElement | undefined
 }
 
 export const PaginationItems = (props: PaginationItemsProps) => {

--- a/packages/react/src/components/radio-card/radio-card.tsx
+++ b/packages/react/src/components/radio-card/radio-card.tsx
@@ -155,7 +155,7 @@ export const RadioCardItemAddon = withContext<
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface RadioCardItemIndicatorProps extends HTMLChakraProps<"span"> {
-  checked?: React.ReactElement
+  checked?: React.ReactElement | undefined
 }
 
 export const RadioCardItemIndicator = forwardRef<

--- a/packages/react/src/components/radiomark/radiomark.tsx
+++ b/packages/react/src/components/radiomark/radiomark.tsx
@@ -17,11 +17,11 @@ export interface RadiomarkProps
   /**
    * Whether the checkmark is checked
    */
-  checked?: boolean
+  checked?: boolean | undefined
   /**
    * Whether the checkmark is disabled
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export const Radiomark = forwardRef<HTMLSpanElement, RadiomarkProps>(

--- a/packages/react/src/components/rating-group/rating-group.tsx
+++ b/packages/react/src/components/rating-group/rating-group.tsx
@@ -87,7 +87,7 @@ export const RatingGroupItem = withContext<
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface RatingGroupItemIndicatorProps extends HTMLChakraProps<"span"> {
-  icon?: React.ReactElement
+  icon?: React.ReactElement | undefined
 }
 
 function cloneIcon(icon: React.ReactElement | undefined, type: "bg" | "fg") {

--- a/packages/react/src/components/segment-group/segment-group.tsx
+++ b/packages/react/src/components/segment-group/segment-group.tsx
@@ -102,7 +102,7 @@ export const SegmentGroupIndicator = withContext<
 interface Item {
   value: string
   label: React.ReactNode
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface SegmentGroupItemsProps

--- a/packages/react/src/components/show/show.tsx
+++ b/packages/react/src/components/show/show.tsx
@@ -8,7 +8,7 @@ export interface ShowProps<T> {
   /**
    * The fallback content to render if `when` is `false`
    */
-  fallback?: React.ReactNode
+  fallback?: React.ReactNode | undefined
   /**
    * The children to render if `when` is `true`
    */

--- a/packages/react/src/components/skeleton/skeleton.tsx
+++ b/packages/react/src/components/skeleton/skeleton.tsx
@@ -29,7 +29,7 @@ export const SkeletonPropsProvider =
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface SkeletonCircleProps extends SkeletonProps {
-  size?: CircleProps["size"]
+  size?: CircleProps["size"] | undefined
 }
 
 export const SkeletonCircle = React.forwardRef<
@@ -47,8 +47,8 @@ export const SkeletonCircle = React.forwardRef<
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface SkeletonTextProps extends SkeletonProps {
-  noOfLines?: number
-  rootProps?: StackProps
+  noOfLines?: number | undefined
+  rootProps?: StackProps | undefined
 }
 
 export const SkeletonText = React.forwardRef<HTMLDivElement, SkeletonTextProps>(

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -168,7 +168,7 @@ export const SliderThumbs = (props: Omit<SliderThumbProps, "index">) => {
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface SliderMarksProps extends SliderMarkerGroupProps {
-  marks?: Array<number | { value: number; label: React.ReactNode }>
+  marks?: Array<number | { value: number; label: React.ReactNode }> | undefined
 }
 
 export const SliderMarks = forwardRef<HTMLDivElement, SliderMarksProps>(

--- a/packages/react/src/components/stack/stack.tsx
+++ b/packages/react/src/components/stack/stack.tsx
@@ -28,27 +28,27 @@ interface StackOptions {
    * Shorthand for `alignItems` style prop
    * @type SystemStyleObject["alignItems"]
    */
-  align?: SystemStyleObject["alignItems"]
+  align?: SystemStyleObject["alignItems"] | undefined
   /**
    * Shorthand for `justifyContent` style prop
    * @type SystemStyleObject["justifyContent"]
    */
-  justify?: SystemStyleObject["justifyContent"]
+  justify?: SystemStyleObject["justifyContent"] | undefined
   /**
    * Shorthand for `flexWrap` style prop
    * @type SystemStyleObject["flexWrap"]
    */
-  wrap?: SystemStyleObject["flexWrap"]
+  wrap?: SystemStyleObject["flexWrap"] | undefined
   /**
    * The direction to stack the items.
    * @default "column"
    */
-  direction?: StackDirection
+  direction?: StackDirection | undefined
   /**
    * If `true`, each stack item will show a separator
    * @type React.ReactElement
    */
-  separator?: React.ReactElement<any>
+  separator?: React.ReactElement<any> | undefined
 }
 
 export interface StackProps extends HTMLChakraProps<"div", StackOptions> {}

--- a/packages/react/src/components/steps/steps.tsx
+++ b/packages/react/src/components/steps/steps.tsx
@@ -160,7 +160,7 @@ export const StepsSeparator = withContext<HTMLDivElement, StepsSeparatorProps>(
 export interface StepsStatusProps {
   complete: React.ReactNode
   incomplete: React.ReactNode
-  current?: React.ReactNode
+  current?: React.ReactNode | undefined
 }
 
 export const StepsStatus = (props: StepsStatusProps) => {

--- a/packages/react/src/components/switch/switch.tsx
+++ b/packages/react/src/components/switch/switch.tsx
@@ -96,7 +96,7 @@ export const SwitchControl = withContext<HTMLSpanElement, SwitchControlProps>(
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface SwitchIndicatorProps extends HTMLChakraProps<"span"> {
-  fallback?: React.ReactNode
+  fallback?: React.ReactNode | undefined
 }
 
 export const SwitchIndicator = forwardRef<
@@ -121,7 +121,7 @@ export const SwitchIndicator = forwardRef<
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface SwitchThumbIndicatorProps extends HTMLChakraProps<"span"> {
-  fallback?: React.ReactNode
+  fallback?: React.ReactNode | undefined
 }
 
 export const SwitchThumbIndicator = forwardRef<

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -35,7 +35,7 @@ export interface TableRootProps
   /**
    * If `true`, the table will style its descendants with nested selectors
    */
-  native?: boolean
+  native?: boolean | undefined
 }
 
 export const TableRoot = forwardRef<HTMLTableElement, TableRootProps>(

--- a/packages/react/src/components/theme.tsx
+++ b/packages/react/src/components/theme.tsx
@@ -8,11 +8,11 @@ export interface ThemeProps extends HTMLChakraProps<"div"> {
   /**
    * The appearance of the theme.
    */
-  appearance?: "light" | "dark"
+  appearance?: "light" | "dark" | undefined
   /**
    * Whether to apply the theme background and color.
    */
-  hasBackground?: boolean
+  hasBackground?: boolean | undefined
 }
 
 export const Theme = forwardRef<HTMLDivElement, ThemeProps>(

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -27,7 +27,7 @@ export interface TooltipRootProviderBaseProps
     UnstyledProp {}
 
 export interface TooltipRootProviderProps extends TooltipRootProviderBaseProps {
-  children?: React.ReactNode
+  children?: React.ReactNode | undefined
 }
 
 export const TooltipRootProvider = withRootProvider<TooltipRootProviderProps>(
@@ -41,7 +41,7 @@ export interface TooltipRootBaseProps
     UnstyledProp {}
 
 export interface TooltipRootProps extends TooltipRootBaseProps {
-  children?: React.ReactNode
+  children?: React.ReactNode | undefined
 }
 
 export const TooltipRoot = withRootProvider<TooltipRootProps>(ArkTooltip.Root, {

--- a/packages/react/src/components/wrap/wrap.tsx
+++ b/packages/react/src/components/wrap/wrap.tsx
@@ -10,9 +10,9 @@ export interface WrapProps
   extends Assign<
     HTMLChakraProps<"div">,
     {
-      justify?: SystemStyleObject["justifyContent"]
-      align?: SystemStyleObject["alignItems"]
-      direction?: SystemStyleObject["flexDirection"]
+      justify?: SystemStyleObject["justifyContent"] | undefined
+      align?: SystemStyleObject["alignItems"] | undefined
+      direction?: SystemStyleObject["flexDirection"] | undefined
     }
   > {}
 

--- a/packages/react/src/create-context.ts
+++ b/packages/react/src/create-context.ts
@@ -6,12 +6,12 @@ import {
 } from "react"
 
 export interface CreateContextOptions<T> {
-  strict?: boolean
-  hookName?: string
-  providerName?: string
-  errorMessage?: string
-  name?: string
-  defaultValue?: T
+  strict?: boolean | undefined
+  hookName?: string | undefined
+  providerName?: string | undefined
+  errorMessage?: string | undefined
+  name?: string | undefined
+  defaultValue?: T | undefined
 }
 
 export type CreateContextReturn<T> = [

--- a/packages/react/src/hooks/use-breakpoint.ts
+++ b/packages/react/src/hooks/use-breakpoint.ts
@@ -9,10 +9,10 @@ import { useMediaQuery } from "./use-media-query"
  * -----------------------------------------------------------------------------*/
 
 export interface UseBreakpointOptions {
-  fallback?: string
-  ssr?: boolean
-  getWindow?: () => typeof window
-  breakpoints?: string[]
+  fallback?: string | undefined
+  ssr?: boolean | undefined
+  getWindow?: () => typeof window | undefined
+  breakpoints?: string[] | undefined
 }
 
 export function useBreakpoint(options: UseBreakpointOptions = {}) {

--- a/packages/react/src/hooks/use-controllable-state.ts
+++ b/packages/react/src/hooks/use-controllable-state.ts
@@ -15,10 +15,10 @@ export function useControllableProp<T>(prop: T | undefined, state: T) {
 }
 
 export interface UseControllableStateProps<T> {
-  value?: T
-  defaultValue?: T | (() => T)
-  onChange?: (value: T) => void
-  shouldUpdate?: (prev: T, next: T) => boolean
+  value?: T | undefined
+  defaultValue?: T | (() => T) | undefined
+  onChange?: (value: T) => void | undefined
+  shouldUpdate?: (prev: T, next: T) => boolean | undefined
 }
 
 /**

--- a/packages/react/src/hooks/use-disclosure.ts
+++ b/packages/react/src/hooks/use-disclosure.ts
@@ -4,8 +4,8 @@ import { useCallback, useState } from "react"
 import { useCallbackRef } from "./use-callback-ref"
 
 export interface UseDisclosureProps {
-  open?: boolean
-  defaultOpen?: boolean
+  open?: boolean | undefined
+  defaultOpen?: boolean | undefined
   onClose?(): void
   onOpen?(): void
 }

--- a/packages/react/src/hooks/use-list-collection.ts
+++ b/packages/react/src/hooks/use-list-collection.ts
@@ -16,12 +16,12 @@ export interface UseListCollectionProps<T> extends ListCollectionOptions<T> {
   /**
    * The filter function to use to filter the items.
    */
-  filter?: (itemText: string, filterText: string) => boolean
+  filter?: ((itemText: string, filterText: string) => boolean) | undefined
   /**
    * The maximum number of items to display in the collection.
    * Useful for performance when you have a large number of items.
    */
-  limit?: number
+  limit?: number | undefined
 }
 
 export function useListCollection<T>(props: UseListCollectionProps<T>) {

--- a/packages/react/src/hooks/use-media-query.ts
+++ b/packages/react/src/hooks/use-media-query.ts
@@ -16,8 +16,8 @@ function listen(query: MediaQueryList, callback: MediaQueryCallback) {
 }
 
 export interface UseMediaQueryOptions {
-  fallback?: boolean[]
-  ssr?: boolean
+  fallback?: boolean[] | undefined
+  ssr?: boolean | undefined
   getWindow?(): typeof window
 }
 

--- a/packages/react/src/styled-system/recipe.types.ts
+++ b/packages/react/src/styled-system/recipe.types.ts
@@ -100,7 +100,7 @@ export type RecipeIdentityFn = <T extends RecipeVariantRecord>(
  * Recipe / Slot
  * -----------------------------------------------------------------------------*/
 
-type SlotRecord<S extends string, T> = Partial<Record<S, T>>
+type SlotRecord<S extends string, T> = Partial<Record<S, T | undefined>>
 
 export type SlotRecipeVariantRecord<S extends string> = Record<
   any,

--- a/packages/react/src/utils/walk-object.ts
+++ b/packages/react/src/utils/walk-object.ts
@@ -13,7 +13,7 @@ export type MappedObject<T, K> = {
 export type WalkObjectStopFn = (value: any, path: string[]) => boolean
 
 export interface WalkObjectOptions {
-  stop?: WalkObjectStopFn
+  stop?: WalkObjectStopFn | undefined
   getKey?(prop: string, value: any): string
 }
 


### PR DESCRIPTION
## 📝 Description

Additional fixes to support TS exactOptionalPropertyTypes when combining two recipes. 
https://github.com/chakra-ui/chakra-ui/pull/10088/files#diff-9d26d449c503406e4c09906518cbb9671a7ac86fc67a43cd505f1b6d381ac261R103

I took a chance and update all the component, hook and create-context optional types too.

## ⛳️ Current behavior (updates)

![image](https://github.com/user-attachments/assets/76391cb1-87d7-4dc9-b4c9-7b64a992974c)

## 🚀 New behavior

no ts error

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
