### PR TITLE
fix: add special handling for top-level selectors

### DIFF
--- a/packages/react/src/styled-system/serialize.ts
+++ b/packages/react/src/styled-system/serialize.ts
@@ -13,7 +13,7 @@ export function createSerializeFn(
 
         if (!conditions.has(prop) && !isValidProperty(prop)) {
           return parseSelectors(prop)
-            .map((s) => "&" + s)
+            .map((s) => (isTopLevelSelector(s) ? `${s} &` : `&${s}`))
             .join(", ")
         }
 
@@ -21,6 +21,10 @@ export function createSerializeFn(
       },
     })
   }
+}
+
+function isTopLevelSelector(s: string): boolean {
+  return s.startsWith(":host") || s.startsWith(":host-context")
 }
 
 function parseSelectors(selector: string): string[] {


### PR DESCRIPTION
## Description

This PR adjusts how selector strings are transformed during serialization by improving support for top-level selectors like `:host` and `:host-context`. This avoids incorrect nesting or formatting when dealing with Web Components and Shadow DOM contexts.

## Current behavior

Currently, selectors that begin with `:host` or `:host-context` are treated like any other nested selector, which can result in incorrect CSS output. For example, `:host(.foo)` might become `&:host(.foo)` or similar, which breaks the intended semantics.

## New behavior

Selectors that begin with `:host` or `:host-context` are now recognized as top-level and are serialized accordingly with `:host &` formatting, preserving proper structure and specificity when used inside Shadow DOM or custom elements.

## Is this a breaking change?

No

## Additional Information

The logic was added in the `createSerializeFn` helper. A new helper function `isTopLevelSelector()` checks for `:host` and `:host-context` prefixes and adjusts selector composition accordingly during serialization.
