### PR TITLE
docs: update breakpoint unit faq

### DIFF
--- a/apps/www/content/docs/styling/responsive-design.mdx
+++ b/apps/www/content/docs/styling/responsive-design.mdx
@@ -111,9 +111,9 @@ To learn how to customize breakpoints, please refer to the
 
 ## FAQs
 
-### Why are breakpoints converted to `rem`?
+### Why are breakpoints converted to `em`?
 
-The conversion to `rem` is intentional and beneficial for accessibility reasons:
+The conversion to `em` is intentional and beneficial for accessibility reasons:
 
 - User Changed Their Browser's Font Setting
 - User Zooms In


### PR DESCRIPTION
## 📝 Description

breakpoints' unit is "em", and the article below is recommending "em", too. But the FAQ is "rem". I'm missing something or it should be "em"?

<img width="663" alt="image" src="https://github.com/user-attachments/assets/63227f4d-50d5-4c9b-80ba-89c0a91f05a9" />

