### PR TITLE
fix(dialog): use dvh and dvw units

### DIFF
--- a/packages/react/src/theme/recipes/dialog.ts
+++ b/packages/react/src/theme/recipes/dialog.ts
@@ -10,7 +10,7 @@ export const dialogSlotRecipe = defineSlotRecipe({
       pos: "fixed",
       left: 0,
       top: 0,
-      w: "100vw",
+      w: "100dvw",
       h: "100dvh",
       zIndex: "overlay",
       _open: {
@@ -24,7 +24,7 @@ export const dialogSlotRecipe = defineSlotRecipe({
     },
     positioner: {
       display: "flex",
-      width: "100vw",
+      width: "100dvw",
       height: "100dvh",
       position: "fixed",
       left: 0,
@@ -180,8 +180,8 @@ export const dialogSlotRecipe = defineSlotRecipe({
       },
       full: {
         content: {
-          maxW: "100vw",
-          minH: "100vh",
+          maxW: "100dvw",
+          minH: "100dvh",
           "--dialog-margin": "0",
           borderRadius: "0",
         },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #10170

## 📝 Description

Use `dvh` and `dvw` units instead of `vh` and `vw` to dynamically adjust to viewport size changes.

## ⛳️ Current behavior (updates)

Dialogs with size set to `"full"` might overflow on certain mobile devices.

## 🚀 New behavior

Dialogs with size set to `"full"` adjust dynamically to viewport size changes.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
