### PR TITLE
refactor: fix duplicated ref

### DIFF
--- a/apps/compositions/src/ui/password-input.tsx
+++ b/apps/compositions/src/ui/password-input.tsx
@@ -125,7 +125,7 @@ export const PasswordStrengthMeter = React.forwardRef<
 
   return (
     <Stack align="flex-end" gap="1" ref={ref} {...rest}>
-      <HStack width="full" ref={ref} {...rest}>
+      <HStack width="full" {...rest}>
         {Array.from({ length: max }).map((_, index) => (
           <Box
             key={index}


### PR DESCRIPTION
## 📝 Description

Because `ref` prop is used twice, remove one of them.

## ⛳️ Current behavior (updates)

No change.

## 🚀 New behavior

No change.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
