### PR TITLE
fix: fix factory.tsx to avoid crash

### DIFF
--- a/packages/react/src/styled-system/factory.tsx
+++ b/packages/react/src/styled-system/factory.tsx
@@ -218,15 +218,19 @@ const createStyled = (tag: any, configOrCva: any = {}, options: any = {}) => {
       options.forwardAsChild || options.forwardProps?.includes("asChild")
 
     if (props.asChild && !forwardAsChild) {
-      const child = React.Children.only(props.children)
-      FinalTag = child.type
-
-      // clean props
-      finalProps.children = null
-      Reflect.deleteProperty(finalProps, "asChild")
-
-      finalProps = mergeProps(finalProps, child.props)
-      finalProps.ref = mergeRefs(ref, getElementRef(child))
+      if (React.isValidElement(props.children)) {
+        const child = React.Children.only(props.children)
+        FinalTag = child.type
+  
+        // clean props
+        finalProps.children = null
+        Reflect.deleteProperty(finalProps, "asChild")
+  
+        finalProps = mergeProps(finalProps, child.props as any)
+        finalProps.ref = mergeRefs(ref, getElementRef(child))
+      } else {
+        finalProps.children = props.children
+      }
     }
 
     if (finalProps.as && forwardAsChild) {


### PR DESCRIPTION
Closes #10205

## 📝 Description

This PR resolves the crash in `factory.tsx`. However, this fix introduces hydration errors and should be considered an incomplete solution that requires further improvement.

## ⛳️ Current behavior (updates)

The application crashes, as demonstrated in the linked repository: https://github.com/exKAZUu/chakra-v3-issue

## 🚀 New behavior

With this change, `factory.tsx` no longer crashes.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

@segunadebayo: Please note that this is not an ideal solution. It is intended as a starting point to help guide a more complete fix. Feel free to close / edit this PR.