### PR TITLE
feat(compositions): add contentProps to ToggleTip

### DIFF
--- a/apps/compositions/src/ui/toggle-tip.tsx
+++ b/apps/compositions/src/ui/toggle-tip.tsx
@@ -12,6 +12,7 @@ export interface ToggleTipProps extends ChakraPopover.RootProps {
   portalled?: boolean
   portalRef?: React.RefObject<HTMLElement>
   content?: React.ReactNode
+  contentProps?: ChakraPopover.ContentProps
 }
 
 export const ToggleTip = React.forwardRef<HTMLDivElement, ToggleTipProps>(
@@ -21,6 +22,7 @@ export const ToggleTip = React.forwardRef<HTMLDivElement, ToggleTipProps>(
       children,
       portalled = true,
       content,
+      contentProps,
       portalRef,
       ...rest
     } = props
@@ -40,6 +42,7 @@ export const ToggleTip = React.forwardRef<HTMLDivElement, ToggleTipProps>(
               textStyle="xs"
               rounded="sm"
               ref={ref}
+              {...contentProps}
             >
               {showArrow && (
                 <ChakraPopover.Arrow>


### PR DESCRIPTION
## Current behavior

The ToggleTip composition was missing contentProps, resulting in lack of customizability

## New behavior

Added contentProps to ToggleTip

## Additional Information

Matches Tooltip's implementation: https://github.com/chakra-ui/chakra-ui/blob/a8ae90cb02044b54a2bb221d619b997793697244/apps/compositions/src/ui/tooltip.tsx#L9-L33