### PR TITLE
fix(docs): submit button in checkbox-with-form example

### DIFF
--- a/apps/compositions/src/examples/checkbox-with-form.tsx
+++ b/apps/compositions/src/examples/checkbox-with-form.tsx
@@ -26,7 +26,7 @@ export const CheckboxWithForm = () => {
           <Checkbox.Label>Remember me</Checkbox.Label>
         </Checkbox.Root>
 
-        <Button variant="solid" mt="3">
+        <Button type="submit" variant="solid" mt="3">
           Submit
         </Button>
       </Stack>


### PR DESCRIPTION
## 📝 Description

Fix to the composition example of the checkbox documentation: https://www.chakra-ui.com/docs/components/checkbox#composition

`<form>` has `onSubmit` event defined but the submit button was missing the `type="submit"`.

## ⛳️ Current behavior (updates)

Submit button did nothing when clicked (onSubmit was dead code)

## 🚀 New behavior

Submit button now shows the form elements in the console.
