### PR TITLE
fix: resolve CLS in color mode button (#10292)

### DIFF
--- a/apps/compositions/src/ui/color-mode.tsx
+++ b/apps/compositions/src/ui/color-mode.tsx
@@ -54,7 +54,7 @@ export const ColorModeButton = React.forwardRef<
 >(function ColorModeButton(props, ref) {
   const { toggleColorMode } = useColorMode()
   return (
-    <ClientOnly fallback={<Skeleton boxSize="8" />}>
+    <ClientOnly fallback={<Skeleton boxSize="9" />}>
       <IconButton
         onClick={toggleColorMode}
         variant="ghost"


### PR DESCRIPTION
Closes #10292 


## 📝 Description

> Fixes the Cumulative Layout Shift (CLS) on the color mode button by ensuring the Skeleton fallback matches the IconButton's boxSize. This resolves a minor UI jump during hydration.

## ⛳️ Current behavior (updates)

> Currently, the color mode button, when initially rendered, has a Skeleton fallback with `boxSize="8"`, while the `IconButton` itself uses `boxSize="9"`. This mismatch causes a slight layout shift (CLS) as the component hydrates.

## 🚀 New behavior

> The `Skeleton` fallback for the color mode button now uses `boxSize="9"`, matching the `IconButton`. This eliminates the layout shift, providing a smoother user experience during the initial render.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

> N/A