### PR TITLE
fix(docs): typo CheckboxCardGroup component on Checkbox Card/Group section

### DIFF
--- a/apps/www/content/docs/components/checkbox-card.mdx
+++ b/apps/www/content/docs/components/checkbox-card.mdx
@@ -47,7 +47,7 @@ checkbox card.
 
 ### Group
 
-Use the `CheckboxCardGroup` component to group multiple checkbox cards.
+Use the `CheckboxGroup` component to group multiple checkbox cards.
 
 <ExampleTabs name="checkbox-card-with-group" />
 


### PR DESCRIPTION
Closes #10307 

## 📝 Description

For grouping CheckboxCard components documentation mentions a non-existent component called CheckboxCardGroup. 
The example correctly shows <CheckboxGroup /> instead

## ⛳️ Current behavior (updates)

Documentation description is:
Use the CheckboxCardGroup component to group multiple checkbox cards.

## 🚀 New behavior

Documentation description is:
Use the CheckboxGroup component to group multiple checkbox cards.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
