### PR TITLE
fix(table): ensure stickyHeader works with outline variant

### DIFF
--- a/.changeset/thirty-eels-battle.md
+++ b/.changeset/thirty-eels-battle.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+fix(table): ensure stickyHeader works with outline variant

--- a/packages/react/src/theme/recipes/table.ts
+++ b/packages/react/src/theme/recipes/table.ts
@@ -101,7 +101,6 @@ export const tableSlotRecipe = defineSlotRecipe({
       outline: {
         root: {
           boxShadow: "0 0 0 1px {colors.border}",
-          overflow: "hidden",
         },
         columnHeader: {
           borderBottomWidth: "1px",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->


## 📝 Description

This PR fixes an issue where the `stickyHeader` prop does not work on the `Table` component when `variant="outline"` is set.

## ⛳️ Current behavior (updates)

When using the `stickyHeader` prop along with `variant="outline"`, the table header does not remain sticky at the top of the viewport upon scrolling.

Example: https://stackblitz.com/edit/fmajukce?file=src%2FApp.tsx

## 🚀 New behavior

The table header correctly sticks to the top of the viewport when scrolling, even when the `outline` variant is set.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
I don't know why `overflow: hidden` is set.
