### PR TITLE
bugfix: Update shadows.ts

### DIFF
--- a/packages/panda-preset/src/semantic-tokens/shadows.ts
+++ b/packages/panda-preset/src/semantic-tokens/shadows.ts
@@ -5,53 +5,53 @@ export const shadows = defineSemanticTokens.shadows({
     value: {
       _light:
         "0px 1px 2px {colors.gray.900/10}, 0px 0px 1px {colors.gray.900/20}",
-      _dark: "0px 1px 1px {black/64}, 0px 0px 1px inset {colors.gray.300/20}",
+      _dark: "0px 1px 1px {colors.black/64}, 0px 0px 1px inset {colors.gray.300/20}",
     },
   },
   sm: {
     value: {
       _light:
         "0px 2px 4px {colors.gray.900/10}, 0px 0px 1px {colors.gray.900/30}",
-      _dark: "0px 2px 4px {black/64}, 0px 0px 1px inset {colors.gray.300/30}",
+      _dark: "0px 2px 4px {colors.black/64}, 0px 0px 1px inset {colors.gray.300/30}",
     },
   },
   md: {
     value: {
       _light:
         "0px 4px 8px {colors.gray.900/10}, 0px 0px 1px {colors.gray.900/30}",
-      _dark: "0px 4px 8px {black/64}, 0px 0px 1px inset {colors.gray.300/30}",
+      _dark: "0px 4px 8px {colors.black/64}, 0px 0px 1px inset {colors.gray.300/30}",
     },
   },
   lg: {
     value: {
       _light:
         "0px 8px 16px {colors.gray.900/10}, 0px 0px 1px {colors.gray.900/30}",
-      _dark: "0px 8px 16px {black/64}, 0px 0px 1px inset {colors.gray.300/30}",
+      _dark: "0px 8px 16px {colors.black/64}, 0px 0px 1px inset {colors.gray.300/30}",
     },
   },
   xl: {
     value: {
       _light:
         "0px 16px 24px {colors.gray.900/10}, 0px 0px 1px {colors.gray.900/30}",
-      _dark: "0px 16px 24px {black/64}, 0px 0px 1px inset {colors.gray.300/30}",
+      _dark: "0px 16px 24px {colors.black/64}, 0px 0px 1px inset {colors.gray.300/30}",
     },
   },
   "2xl": {
     value: {
       _light:
         "0px 24px 40px {colors.gray.900/16}, 0px 0px 1px {colors.gray.900/30}",
-      _dark: "0px 24px 40px {black/64}, 0px 0px 1px inset {colors.gray.300/30}",
+      _dark: "0px 24px 40px {colors.black/64}, 0px 0px 1px inset {colors.gray.300/30}",
     },
   },
   inner: {
     value: {
-      _light: "inset 0 2px 4px 0 {black/5}",
-      _dark: "inset 0 2px 4px 0 black",
+      _light: "inset 0 2px 4px 0 {colors.black/5}",
+      _dark: "inset 0 2px 4px 0 {colors.black}",
     },
   },
   inset: {
     value: {
-      _light: "inset 0 0 0 1px {black/5}",
+      _light: "inset 0 0 0 1px {colors.black/5}",
       _dark: "inset 0 0 0 1px {colors.gray.300/5}",
     },
   },


### PR DESCRIPTION

## 📝 Description

Change values for `black` color token to `{colors.black}`

## ⛳️ Current behavior (updates)

After installing the preset from npm, it could not work in pandacss since `black` color token could not be found. I had to manually correct it and use `{colors.black}` instead.

## 🚀 New behavior

Update in `shadows.ts` semantic token and changed values `black` to `{colors.black}`

## 💣 Is this a breaking change (Yes/No):

No

