### PR TITLE
docs: Fix Horizontal and Vertical margin CSS properties in spacing documentation

### DIFF
--- a/apps/www/content/docs/styling/style-props/spacing.mdx
+++ b/apps/www/content/docs/styling/style-props/spacing.mdx
@@ -143,10 +143,10 @@ axis of an element
 <Box my="8" /> // shorthand
 ```
 
-| Prop            | CSS Property  | Token Category |
-| --------------- | ------------- | -------------- |
-| `mx`, `marginX` | `margin-left` | `spacing`      |
-| `my`, `marginY` | `margin-top`  | `spacing`      |
+| Prop            | CSS Property     | Token Category |
+| --------------- | ---------------- | -------------- |
+| `mx`, `marginX` | `margin-inline`  | `spacing`      |
+| `my`, `marginY` | `margin-blolck`  | `spacing`      |
 
 ## Spacing Between
 


### PR DESCRIPTION
## 📝 Description
Updates the documentation for `mx`/`marginX` and `my`/`marginY` style props to accurately reflect the CSS logical properties

An example to confirm that `mx`/`marginX`  is reflected as `margin-inline` and `my`/`marginY` is reflected as `margin-block`.
https://stackblitz.com/edit/chakra-ui-v3-jqwkt19c?file=src%2FApp.tsx

## ⛳️ Current behavior (updates)
- The CSS Properties for `mx` and `marginX` are listed as `margin-left`
- The CSS Properties for `my` and `marginY` are listed as `margin-top`

## 🚀 New behavior
- The CSS Properties for `mx` and `marginX` are listed as `margin-inline`
- The CSS Properties for `my` and `marginY` are listed as `margin-block`

## 💣 Is this a breaking change (Yes/No):No

## 📝 Additional Information
