### PR TITLE
fix: combobox dropdown appears above dialog modals

### DIFF
--- a/.changeset/fix-combobox-zindex-dialog.md
+++ b/.changeset/fix-combobox-zindex-dialog.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react": patch
+---
+
+fix: combobox dropdown appears above dialog modals
+
+Updated combobox content z-index from 'dropdown' (1000) to 'popover' (1500) to ensure dropdown options are visible when used inside dialog components (z-index 1400).

--- a/apps/compositions/src/examples/combobox-in-dialog.tsx
+++ b/apps/compositions/src/examples/combobox-in-dialog.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import {
+  Button,
+  Combobox,
+  Dialog,
+  Portal,
+  useFilter,
+  useListCollection,
+} from "@chakra-ui/react"
+
+export const ComboboxInDialog = () => {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <Button>Open Dialog</Button>
+      </Dialog.Trigger>
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Select Framework</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <ComboboxDemo />
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.ActionTrigger>
+              <Dialog.ActionTrigger asChild>
+                <Button>Save</Button>
+              </Dialog.ActionTrigger>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  )
+}
+
+const ComboboxDemo = () => {
+  const { contains } = useFilter({ sensitivity: "base" })
+
+  const { collection, filter } = useListCollection({
+    initialItems: frameworks,
+    filter: contains,
+  })
+
+  return (
+    <Combobox.Root
+      collection={collection}
+      onInputValueChange={(e) => filter(e.inputValue)}
+    >
+      <Combobox.Control>
+        <Combobox.Input placeholder="Type to search" />
+        <Combobox.IndicatorGroup>
+          <Combobox.ClearTrigger />
+          <Combobox.Trigger />
+        </Combobox.IndicatorGroup>
+      </Combobox.Control>
+      <Combobox.Positioner>
+        <Combobox.Content>
+          <Combobox.Empty>No items found</Combobox.Empty>
+          {collection.items.map((item) => (
+            <Combobox.Item item={item} key={item.value}>
+              {item.label}
+              <Combobox.ItemIndicator />
+            </Combobox.Item>
+          ))}
+        </Combobox.Content>
+      </Combobox.Positioner>
+    </Combobox.Root>
+  )
+}
+
+const frameworks = [
+  { label: "React", value: "react" },
+  { label: "Vue", value: "vue" },
+  { label: "Angular", value: "angular" },
+  { label: "Svelte", value: "svelte" },
+  { label: "Next.js", value: "nextjs" },
+]

--- a/packages/react/src/theme/recipes/combobox.ts
+++ b/packages/react/src/theme/recipes/combobox.ts
@@ -89,7 +89,7 @@ export const comboboxSlotRecipe = defineSlotRecipe({
       background: "bg.panel",
       display: "flex",
       flexDirection: "column",
-      zIndex: "dropdown",
+      zIndex: "popover",
       borderRadius: "l2",
       outline: 0,
       maxH: "96",


### PR DESCRIPTION
 Closes #10342

## 📝 Description

Fixed z-index issue where combobox dropdown options were not visible when used inside dialog components. Updated combobox content z-index from 'dropdown' (1000) to 'popover' (1500) to ensure proper layering above dialog modals (1400).

## ⛳️ Current behavior (updates)

When a Combobox is used inside a Dialog component, clicking the dropdown trigger or typing in the input does not show the dropdown options because they appear behind the dialog due to z-index layering (dropdown: 1000 < modal: 1400).

## 🚀 New behavior

Combobox dropdown options now appear above dialog modals. Users can interact with the combobox normally when it's placed inside dialog components.

## 💣 Is this a breaking change (Yes/No): No

This is a visual fix that doesn't change any APIs or component behavior, only improves the z-index stacking order.

## 📝 Additional Information

- Added test example `combobox-in-dialog.tsx` to demonstrate the fix
- Z-index hierarchy: dropdown (1000) → modal (1400) → popover (1500) ✅
- Minimal change: only 1 line modified in the combobox theme recipe
