### PR TITLE
fix(www): update showcase navigation

### DIFF
--- a/apps/www/docs.config.ts
+++ b/apps/www/docs.config.ts
@@ -401,7 +401,7 @@ export const docsConfig: DocsConfig = {
   donationUrl: "https://opencollective.com/chakra-ui",
   navigation: [
     docsLinks,
-    { title: "Showcase", url: "/showcase" },
+    { title: "Showcase", url: "showcase" },
     { title: "Blog", url: "blog" },
     { title: "Guides", url: "guides" },
   ],


### PR DESCRIPTION
## 📝 Description

> Fixes navigation to Showcase page from /docs

## ⛳️ Current behavior (updates)

> When in /docs, navigating to the Showcase page was broken

![Screen Recording 2025-09-28 at 13 45 57 (1)](https://github.com/user-attachments/assets/f0c53292-0829-45d2-bf67-afa095546e8d)

## 🚀 New behavior

> User can now navigate to the Showcase page from /docs




