### PR TITLE
bugfix: remove id attribute from SkipNavLink

### DIFF
--- a/packages/react/src/components/skip-nav/skip-nav-link.tsx
+++ b/packages/react/src/components/skip-nav/skip-nav-link.tsx
@@ -22,16 +22,16 @@ export const fallbackId = "chakra-skip-nav"
 export const SkipNavLink = forwardRef<HTMLAnchorElement, SkipNavLinkProps>(
   function SkipNavLink(props, ref) {
     const recipe = useRecipe({ key: "skipNavLink", recipe: props.recipe })
-    const [variantProps, localProps] = recipe.splitVariantProps(props)
+    const [variantProps, { id, ...localProps }] = recipe.splitVariantProps(props)
     const styles = recipe(variantProps)
 
-    localProps.id ||= fallbackId
+    const targetId = id ?? fallbackId
 
     return (
       <chakra.a
         {...localProps}
         ref={ref}
-        href={`#${localProps.id}`}
+        href={`#${targetId}`}
         css={[styles, props.css]}
       />
     )


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

SkipNavContent and SkipNavLink were broken because both of them were elements having the same `id` and the browser would always focus on SkipNavLink since it appears earlier in the DOM. This fix removes the `id` attribute from SkipNavLink so that it always focuses on SkipNavContent.

This Issue can be reproduced from the [docs page](https://chakra-ui.com/docs/components/skip-nav)

## ⛳️ Current behavior (updates)

 - Press <kbd>tab</kbd> to focus on SkipNavLink
 - Press <kbd>enter</kbd> to trigger skip navigation
 - URL now includes `#chakra-skip-nav` at the end but focus does not change

## 🚀 New behavior

 - Press <kbd>tab</kbd> to focus on SkipNavLink
 - Press <kbd>enter</kbd> to trigger skip navigation
 - URL now includes `#chakra-skip-nav` at the end and **the focus is on SkipNavContent**

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
