### PR TITLE
fix(cli): remove documentation blocks filtering

### DIFF
--- a/.changeset/eight-plums-warn.md
+++ b/.changeset/eight-plums-warn.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/cli": patch
+---
+
+**Pro Blocks**: Allow CLI to read new documentation blocks filtering

--- a/packages/cli/src/commands/blocks.ts
+++ b/packages/cli/src/commands/blocks.ts
@@ -81,10 +81,7 @@ export const BlocksCommand = new Command("blocks")
         const apiKey = ensureApiKey()
 
         const blocksResponse = await fetchProBlocks()
-        const allBlocks = blocksResponse.data.filter(
-          (block: ChakraProBlock) =>
-            block.group.toLowerCase() !== "documentation",
-        )
+        const allBlocks = blocksResponse.data
 
         let blocksToDownload: string[] = []
 


### PR DESCRIPTION
## 📝 Description

Removed the filtering logic that excluded "documentation" blocks from the CLI blocks command, allowing users to access and download all blocks, including documentation blocks.

## ⛳️ Current behavior (updates)

Previously, the CLI filtered out blocks in the "documentation" group, preventing users from accessing documentation-related blocks via the `blocks` command.

## 🚀 New behavior

All blocks from the Chakra Pro API are now available through the CLI, including documentation blocks. Users can discover and download any block without arbitrary filtering.

## 💣 Is this a breaking change (Yes/No):

No - This is purely additive functionality. It removes a restriction rather than changing existing behavior.

## 📝 Additional Information

**Files changed:**
- `packages/cli/src/commands/blocks.ts` - Removed the filter that excluded documentation blocks

