### PR TITLE
feat: make label text selectable

### DIFF
--- a/packages/panda-preset/src/slot-recipes/field.ts
+++ b/packages/panda-preset/src/slot-recipes/field.ts
@@ -31,7 +31,6 @@ export const fieldSlotRecipe = defineSlotRecipe({
       textStyle: "sm",
       fontWeight: "medium",
       gap: "1",
-      userSelect: "none",
       _disabled: {
         opacity: "0.5",
       },


### PR DESCRIPTION
- Remove userSelect: 'none' from field label recipe
- Allows users to select and copy label text for better accessibility

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Remove `userSelect: 'none'` from the field label recipe to improve accessibility by allowing users to select and copy label text.

## ⛳️ Current behavior (updates)

Field labels currently have `userSelect: 'none'` which prevents users from selecting the label text, making it impossible to copy or select the text for accessibility purposes.

## 🚀 New behavior

Field labels no longer have the `userSelect: 'none'` property, allowing users to select and copy label text. This improves accessibility for users who need to copy form labels or interact with them in ways that require text selection.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This change improves accessibility compliance by allowing users to select and copy label text, which is important for screen readers and other assistive technologies. The change is minimal and only affects the CSS `user-select` property on field labels.
