### PR TITLE
fix(code): add right padding to prevent text from touching border

### DIFF
--- a/packages/react/src/theme/recipes/code.ts
+++ b/packages/react/src/theme/recipes/code.ts
@@ -4,13 +4,11 @@ import { badgeRecipe } from "./badge"
 const { variants, defaultVariants } = badgeRecipe
 
 export const codeRecipe = defineRecipe({
-  className: "chakra-code",
   base: {
     fontFamily: "mono",
-    alignItems: "center",
-    display: "inline-flex",
-    borderRadius: "l2",
+    fontSize: "sm",
+    px: "0.2em",
+    pr: "0.6em",   // Fix: preventing from text touching border
+    borderRadius: "sm",
   },
-  variants,
-  defaultVariants,
 })


### PR DESCRIPTION
Closes #<i#10327>  https://github.com/chakra-ui/chakra-ui/issues/10327

## 📝 Description

This PR fixes a small UI issue in the `<Code>` component where long lines of code touch the right border without any spacing.  
I added a small right padding to the base style so the text always has a little breathing room.

## ⛳️ Current behavior (updates)

Right now, if a line of code is too long and scrolls horizontally, the last character touches the right border, which looks cramped.

## 🚀 New behavior

With this change, there’s always a small margin on the right side.  
Now even long lines scroll cleanly without sticking to the edge.

## 💣 Is this a breaking change (Yes/No):

No – this is just a minor styling fix, no breaking changes.

## 📝 Additional Information

Verified in Storybook with long code lines.  
This improves readability and keeps spacing consistent with the left side.