### PR TITLE
docs(examples): Add DatePicker variant for input compositions

### DIFF
--- a/apps/compositions/src/examples/calender-example.tsx
+++ b/apps/compositions/src/examples/calender-example.tsx
@@ -1,0 +1,156 @@
+import {
+  Box,
+  Button,
+  Card,
+  Grid,
+  HStack,
+  IconButton,
+  Input,
+  Text,
+  VStack,
+  useDisclosure,
+} from "@chakra-ui/react"
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  format,
+  getDay,
+  isSameDay,
+  startOfMonth,
+  subMonths,
+} from "date-fns"
+import * as React from "react"
+import { LuChevronLeft, LuChevronRight } from "react-icons/lu"
+
+export function DatePickerExample() {
+  const [selected, setSelected] = React.useState<Date | null>(new Date())
+  const [currentMonth, setCurrentMonth] = React.useState<Date>(new Date())
+  const { open, onOpen, onClose } = useDisclosure()
+  const inputRef = React.useRef<HTMLDivElement>(null)
+
+  const monthStart = startOfMonth(currentMonth)
+  const monthEnd = endOfMonth(currentMonth)
+  const daysInMonth = eachDayOfInterval({ start: monthStart, end: monthEnd })
+  const blanks = Array.from({ length: getDay(monthStart) })
+
+  const handlePrev = () => setCurrentMonth((m) => subMonths(m, 1))
+  const handleNext = () => setCurrentMonth((m) => addMonths(m, 1))
+  const handleSelect = (day: Date) => {
+    setSelected(day)
+    onClose()
+  }
+
+  // Detect click outside to close
+  React.useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (inputRef.current && !inputRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener("mousedown", handleClick)
+    return () => document.removeEventListener("mousedown", handleClick)
+  }, [onClose])
+
+  return (
+    <Box ref={inputRef} position="relative" maxW="sm">
+      <Input
+        readOnly
+        onClick={open ? onClose : onOpen}
+        value={selected ? format(selected, "PPP") : ""}
+        placeholder="Select a date"
+        cursor="pointer"
+      />
+
+      {open && (
+        <Card.Root
+          position="absolute"
+          top="100%"
+          left={0}
+          mt={2}
+          zIndex={1}
+          boxShadow="md"
+          width="100%"
+        >
+          <Card.Body>
+            <VStack gap={2} align="stretch">
+              <HStack justify="space-between" align="center" mb={2}>
+                <IconButton
+                  aria-label="Previous month"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handlePrev}
+                >
+                  <LuChevronLeft />
+                </IconButton>
+
+                <Text fontWeight="bold">
+                  {format(currentMonth, "MMMM yyyy")}
+                </Text>
+
+                <IconButton
+                  aria-label="Next month"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleNext}
+                >
+                  <LuChevronRight />
+                </IconButton>
+              </HStack>
+
+              <Grid templateColumns="repeat(7, 1fr)" gap={1} textAlign="center">
+                {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
+                  <Text key={d} fontSize="xs" color="gray.500">
+                    {d}
+                  </Text>
+                ))}
+
+                {blanks.map((_, i) => (
+                  <Box key={`b-${i}`} height="36px" />
+                ))}
+
+                {daysInMonth.map((day) => {
+                  const isSelected = selected ? isSameDay(day, selected) : false
+                  return (
+                    <Button
+                      key={day.toISOString()}
+                      size="sm"
+                      variant={isSelected ? "solid" : "ghost"}
+                      colorScheme={isSelected ? "blue" : undefined}
+                      onClick={() => handleSelect(day)}
+                      height="36px"
+                      minW="0"
+                    >
+                      {format(day, "d")}
+                    </Button>
+                  )
+                })}
+              </Grid>
+
+              <HStack gap={2} pt={2}>
+                <Button size="sm" onClick={() => handleSelect(new Date())}>
+                  Today
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setSelected(null)}
+                >
+                  Clear
+                </Button>
+              </HStack>
+            </VStack>
+          </Card.Body>
+        </Card.Root>
+      )}
+    </Box>
+  )
+}
+
+export default function DatePickerExampleWrapper() {
+  return (
+    <Box p={6}>
+      <DatePickerExample />
+    </Box>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@typescript-eslint/parser": "8.46.1",
     "consola": "^3.4.2",
     "cross-env": "7.0.3",
+    "date-fns": "^4.1.0",
     "dotenv": "16.6.0",
     "eslint": "9.37.0",
     "eslint-config-prettier": "10.1.8",

--- a/packages/react/__stories__/input.stories.tsx
+++ b/packages/react/__stories__/input.stories.tsx
@@ -38,3 +38,4 @@ export { InputWithStartAndEndText as StartAndEndText } from "compositions/exampl
 export { InputWithStartElementEndAddon as StartElementEndAddon } from "compositions/examples/input-with-start-element-end-addon"
 export { InputWithStartIcon as StartIcon } from "compositions/examples/input-with-start-icon"
 export { InputWithStartText as StartText } from "compositions/examples/input-with-start-text"
+export { DatePickerExample as DatePicker } from "compositions/examples/calender-example"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       dotenv:
         specifier: 16.6.0
         version: 16.6.0


### PR DESCRIPTION
PR for: Add DatePicker variant example for different input field compositions

## 📝 Description
Added a new DatePickerExample component under apps/compositions/src/examples/calender-example.tsx and registered it in Storybook under the Input section. This component demonstrates a simple, dependency-light DatePicker implementation using Chakra UI primitives and date-fns utilities.

## ⛳️ Current behavior (updates)
Chakra UI currently showcases several input field compositions like InputWithErrorText, InputWithFloatingLabel, InputWithStartAddon, etc., but lacks a basic DatePicker that integrates calendar-style date selection with an input field. This example shows a date picker using existing Chakra components. Currently, Chakra Does not have such component which is crucial in deadline based applications.

## 🚀 New behavior
**What's New**
- If this example PR is approved, the next logical step would be to extract this functionality into a reusable component within the Chakra UI library itself — for example: Calendar.tsx or DatePicker.tsx under apps/compositions/src/ui/
- This would allow developers to import and use a ready-made date selection component directly, just like other existing primitives (e.g., Rating, Accordion, etc.).

The extracted version could:
- Support controlled and uncontrolled modes (accepting value and onChange)
- Offer customization via Chakra props for theme, variant, and size
- Optionally expose both Calendar and DatePicker variants (inline vs. input-dropdown)
- Serve as a base for integrating more advanced date-range or time-picker demos later

Starting with this example helps validate design, behavior, and accessibility before promoting it into a reusable, documented component under ui/.

## 💣 Is this a breaking change (Yes/No):
No.

## Check Out Demo Here:

https://github.com/user-attachments/assets/67de212f-2361-49b0-84ca-5833b8a0a575





