### PR TITLE
Fix collapse width animation to use width instead of height

### DIFF
--- a/packages/panda-preset/src/keyframes.ts
+++ b/packages/panda-preset/src/keyframes.ts
@@ -86,10 +86,10 @@ export const keyframes = {
   },
   "collapse-width": {
     from: {
-      height: "var(--width)",
+      width: "var(--width)",
     },
     to: {
-      height: "0",
+      width: "0",
     },
   },
   "fade-in": {


### PR DESCRIPTION
## 📝 Description

Collapse width animation is using the height property, but it should be height instead.

