### PR TITLE
docs/FormControl-import-statement

### DIFF
--- a/website/content/docs/components/form-control/usage.mdx
+++ b/website/content/docs/components/form-control/usage.mdx
@@ -27,7 +27,7 @@ import {
   FormLabel,
   FormErrorMessage,
   FormHelperText,
-} from '@chakra-ui/react'
+} from '@chakra-ui/form-control'
 ```
 
 ## Usage


### PR DESCRIPTION
## 📝 Description

This pull request makes a small update to the import path for form control components in the documentation. 

## ⛳️ Current behavior (updates)

The code snippet mentioned importing from `@chakra-ui/react`, however FormControl, FormLabel, FormErrorMessage and FormHelperText are not available in that package.

## 🚀 New behavior

The code snippet now mentions to import from `@chakra-ui/form-control` instead of `@chakra-ui/react`.

## 💣 Is this a breaking change (Yes/No):

Nope.

## 📝 Additional Information

N/A.