### PR TITLE
docs: matchMedia mock implementation to testing docs

### DIFF
--- a/apps/www/content/docs/components/concepts/testing.mdx
+++ b/apps/www/content/docs/components/concepts/testing.mdx
@@ -62,6 +62,21 @@ const { window } = new JSDOM()
 vi.stubGlobal("ResizeObserver", ResizeObserver)
 window["ResizeObserver"] = ResizeObserver
 
+// matchMedia mock
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 // IntersectionObserver mock
 const IntersectionObserverMock = vi.fn(() => ({
   disconnect: vi.fn(),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description
Added a mock implementation for matchMedia to the testing documentation. matchmedia is needed to make the unit test work.

## ⛳️ Current behavior (updates)
I am currently modifying the testing documentation to support unit tests with testing-library and jsdom

## 🚀 New behavior
Based on the tutorial, it somehow returns `TypeError: window.matchMedia is not a function`, so I decided to add matchmedia function to the setup test file