### PR TITLE
fix(segmentGroup): use segment-radius var for borderRadius

### DIFF
--- a/packages/panda-preset/src/slot-recipes/segment-group.ts
+++ b/packages/panda-preset/src/slot-recipes/segment-group.ts
@@ -6,7 +6,7 @@ export const segmentGroupSlotRecipe = defineSlotRecipe({
   base: {
     root: {
       "--segment-radius": "radii.l2",
-      borderRadius: "l2",
+      borderRadius: "var(--segment-radius)",
       display: "inline-flex",
       boxShadow: "inset",
       minW: "max-content",

--- a/packages/react/src/theme/recipes/segment-group.ts
+++ b/packages/react/src/theme/recipes/segment-group.ts
@@ -7,7 +7,7 @@ export const segmentGroupSlotRecipe = defineSlotRecipe({
   base: {
     root: {
       "--segment-radius": "radii.l2",
-      borderRadius: "l2",
+      borderRadius: "var(--segment-radius)",
       display: "inline-flex",
       boxShadow: "inset",
       minW: "max-content",


### PR DESCRIPTION
## 📝 Description

Fixes segmentGroup root slot not using its `segment-radius` var for `borderRadius`

## 💣 Is this a breaking change:

Affects projects that previously set the `segment-radius` var and not the `borderRadius` prop