### PR TITLE
fix(combobox overflow): add paddingRight to prevent overflow onto tri…

### DIFF
--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -117,8 +117,13 @@ export interface ComboboxInputProps
 export const ComboboxInput = withContext<HTMLInputElement, ComboboxInputProps>(
   ArkCombobox.Input,
   "input",
-  { forwardAsChild: true },
+  { forwardAsChild: true,
+    defaultProps:{
+      paddingRight:"3rem"
+    }
+  },
 )
+
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -178,7 +183,9 @@ export interface ComboboxItemProps
 export const ComboboxItem = withContext<HTMLDivElement, ComboboxItemProps>(
   ArkCombobox.Item,
   "item",
-  { forwardAsChild: true },
+  { forwardAsChild: true, 
+    
+  },
 )
 
 ////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
…gger

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # Combobox input text overflows onto triggers #10414


## 📝 Description

Fixes an issue where the text inside "ComboboxInput" could overflow onto the trigger button when the input value is long. Added a default "paddingRight: 3rem" to prevent overflow and ensure proper spacing.

## ⛳️ Current behavior (updates)

When typing a long value in ComboboxInput, the text can extend over the trigger button, making the input look broken and harder to read.

## 🚀 New behavior

The input now has a default right padding of 3rem, preventing text from overlapping the trigger button. The fix ensures proper spacing between the input text and the trigger, without affecting other functionality.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Tested in Storybook with various input lengths.

Compatible with Chakra’s forwardAsChild and theming system.

Closes GitHub issue [#10414](https://github.com/chakra-ui/chakra-ui/issues/10414)
.