### PR TITLE
docs(aspect-ratio): improve documentation clarity

### DIFF
--- a/apps/compositions/src/examples/aspect-ratio-basic.tsx
+++ b/apps/compositions/src/examples/aspect-ratio-basic.tsx
@@ -2,8 +2,8 @@ import { AspectRatio, Center } from "@chakra-ui/react"
 
 export const AspectRatioBasic = () => {
   return (
-    <AspectRatio bg="bg.muted" ratio={2 / 1}>
-      <Center fontSize="xl">2 / 1</Center>
+    <AspectRatio bg="bg.muted" ratio={16 / 9}>
+      <Center fontSize="xl">16 / 9</Center>
     </AspectRatio>
   )
 }

--- a/apps/www/content/docs/components/aspect-ratio.mdx
+++ b/apps/www/content/docs/components/aspect-ratio.mdx
@@ -1,6 +1,7 @@
 ---
 title: Aspect Ratio
-description: Used to embed responsive videos and maps, etc
+description:
+  Maintain a consistent aspect ratio for embedding videos, images, maps, etc.
 links:
   source: components/aspect-ratio
   storybook: layout-aspectratio--responsive
@@ -10,12 +11,15 @@ links:
 
 ## Usage
 
+The `ratio` prop overrides the original aspect ratios of `AspectRatio`'s child
+content, accepting only numeric values, not strings.
+
 ```jsx
 import { AspectRatio } from "@chakra-ui/react"
 ```
 
 ```jsx
-<AspectRatio>
+<AspectRatio ratio={16 / 9}>
   <iframe
     title="naruto"
     src="https://www.youtube.com/embed/QhBnZ6NPOY0"
@@ -34,8 +38,8 @@ Here's how to embed an image that has a 4 by 3 aspect ratio.
 
 ### Video
 
-To embed a video with a specific aspect ratio, use an iframe with `src` pointing
-to the link of the video.
+Embed a video using an iframe, and use the `ratio` prop to override the video's
+original aspect ratio.
 
 <ExampleTabs name="aspect-ratio-with-video" />
 
@@ -56,3 +60,8 @@ Here's an example of applying a responsive aspect ratio to a box.
 These props can be passed to the `AspectRatio` component.
 
 <PropTable component="AspectRatio" part="AspectRatio" />
+Chakra UI also provides [predefined aspect ratio
+tokens](/docs/theming/aspect-ratios) out of the box, including `square`,
+`landscape`, `portrait`, `wide`, `ultrawide`, and `golden` that can be used with
+components that support the `aspectRatio` CSS prop. They cannot currently be
+used with the `ratio` prop that `AspectRatio` accepts.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #10444

## 📝 Description

Improves `AspectRatio` component documentation for clarity on how the `ratio` prop works and how aspect ratio tokens are used. 

## ⛳️ Current behavior (updates)

- Documentation didn't clearly explain that the ratio prop overrides the child's aspect ratio
- Unclear distinction between using tokens with the aspectRatio CSS prop vs the ratio prop on the AspectRatio component

## 🚀 New behavior

- Clarified `ratio` prop behavior: Added explanation that the ratio prop overrides the original aspect ratios of AspectRatio's child content and accepts only numeric values
- Token usage clarification: Added note that predefined aspect ratio tokens (square, landscape, portrait, wide, ultrawide, golden) can be used with components that support the aspectRatio CSS prop, but cannot be used with the ratio prop on the AspectRatio component
Updated basic example: Changed to (ratio={16 / 9}) to demonstrate standard slide/ screen aspect ratios 
Improved video section: Enhanced documentation to clearly explain using the ratio prop to override a video's original aspect ratio

## 💣 Is this a breaking change (Yes/No): 
**No** - Documentation-only changes; no API or behavior changes.


## 📝 Additional Information
