### PR TITLE
docs: fix PropTable rendering

### DIFF
--- a/apps/www/content/docs/components/absolute-center.mdx
+++ b/apps/www/content/docs/components/absolute-center.mdx
@@ -59,4 +59,4 @@ the horizontal positioning and transforms appropriately.
 
 ## Props
 
-<PropTable component="AbsoluteCenter" />
+<PropTable component="AbsoluteCenter" part="AbsoluteCenter" />

--- a/apps/www/content/docs/components/checkmark.mdx
+++ b/apps/www/content/docs/components/checkmark.mdx
@@ -61,4 +61,4 @@ the checkmark.
 
 ## Props
 
-<PropTable component="Checkmark" />
+<PropTable component="Checkmark" part="Checkmark" />

--- a/apps/www/content/docs/components/download-trigger.mdx
+++ b/apps/www/content/docs/components/download-trigger.mdx
@@ -50,4 +50,4 @@ size of the file in a human-readable format.
 
 ## Props
 
-<PropTable component="DownloadTrigger" />
+<PropTable component="Button" part="Button" />

--- a/apps/www/content/docs/components/radiomark.mdx
+++ b/apps/www/content/docs/components/radiomark.mdx
@@ -55,4 +55,4 @@ the radiomark.
 
 ## Props
 
-<PropTable component="Radiomark" />
+<PropTable component="Radiomark" part="Radiomark" />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixes PropTable rendering by correcting the component reference in `download-trigger.mdx`, `absolute-center.mdx`, `checkmark.mdx` and `radiomark.mdx`


## ⛳️ Current behavior (updates)

PropTables not rendering for the components above 

## 🚀 New behavior

PropTables added 

## 💣 Is this a breaking change (Yes/No):
Not a breaking change, only documentation updates 

## 📝 Additional Information
