### PR TITLE
Fix:: Update the Github Starts link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <img alt="MIT License" src="https://img.shields.io/github/license/chakra-ui/chakra-ui"/>
   </a>
   <a href="https://www.npmjs.com/package/@chakra-ui/react">
-    <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@chakra-ui/react.svg?style=flat"/>]
+    <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@chakra-ui/react.svg?style=flat"/>
   </a>
   <a href="https://github.com/chakra-ui/chakra-ui">
     <img alt="Github Stars" src="https://img.shields.io/github/stars/chakra-ui/chakra-ui?style=social" />


### PR DESCRIPTION
## 📝 Description

> Update the GitHub stars link.

## ⛳️ Current Behavior (updates)

> GitHub stars are broken.

## 🚀 New Behavior

> Updated the correct link that displays the chakra-ui GitHub stars.

## 💣 This is a compatibility-breaking change (Yes/No):

No


