### PR TITLE
fix(strong): correct props type and font weight for Strong component

### DIFF
--- a/packages/react/src/components/strong/index.tsx
+++ b/packages/react/src/components/strong/index.tsx
@@ -5,7 +5,7 @@ import { type HTMLChakraProps, chakra } from "../../styled-system"
 export interface StrongProps extends HTMLChakraProps<"strong"> {}
 
 export const Strong = chakra("strong", {
-  base: { fontWeight: "bold" },
+  base: { fontWeight: "semibold" },
 })
 
 Strong.displayName = "Strong"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixes the `Strong` component by correcting its props type and updating the font-weight to match semantic HTML.  
Previously, `StrongProps` incorrectly extended `HTMLChakraProps<"em">` and the font-weight was `semibold`.  
This change ensures:

- The component uses `<strong>` element props correctly.
- The font-weight is set to `bold` to match semantic emphasis.

> Add a brief description

## ⛳️ Current behavior (updates)

- `StrongProps` extends `HTMLChakraProps<"em">` (wrong type)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

- `StrongProps` extends `HTMLChakraProps<"strong">`
- `fontWeight` is `"bold"`

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):


<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
