### PR TITLE
fix(cva): normalize base styles

### DIFF
--- a/.changeset/fix-cva-normalize-base.md
+++ b/.changeset/fix-cva-normalize-base.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+**cva**: Normalize base styles to prevent shorthand properties from overwriting
+variant styles

--- a/packages/react/__tests__/recipe.test.ts
+++ b/packages/react/__tests__/recipe.test.ts
@@ -1,4 +1,4 @@
-import { createSystem } from "../src"
+import { createSystem, defaultConfig } from "../src"
 
 describe("Recipe bracket syntax fix", () => {
   const system = createSystem({
@@ -248,6 +248,88 @@ describe("Recipe bracket syntax fix", () => {
         "@media screen and (min-width: 40rem)": {
           color: "darkblue",
         },
+      },
+    })
+  })
+
+  it("should normalize base shorthand so variant longhand wins", () => {
+    const fullSystem = createSystem(defaultConfig)
+    const recipe = fullSystem.cva({
+      base: {
+        rounded: "1rem",
+      },
+      variants: {
+        size: {
+          md: {
+            rounded: "100px",
+          },
+        },
+      },
+      defaultVariants: {
+        size: "md",
+      },
+    })
+
+    const result = recipe({ size: "md" })
+
+    expect(result).toMatchObject({
+      "@layer recipes": {
+        borderRadius: "100px",
+      },
+    })
+    expect(result["@layer recipes"]).not.toHaveProperty("rounded")
+  })
+
+  it("should normalize base shorthand - variant should override base", () => {
+    const fullSystem = createSystem(defaultConfig)
+    const recipe = fullSystem.cva({
+      base: {
+        borderRadius: "8px",
+      },
+      variants: {
+        size: {
+          md: {
+            rounded: "100px",
+          },
+        },
+      },
+      defaultVariants: {
+        size: "md",
+      },
+    })
+
+    const result = recipe({ size: "md" })
+
+    expect(result).toMatchObject({
+      "@layer recipes": {
+        borderRadius: "100px",
+      },
+    })
+  })
+
+  it("should normalize base shorthand - variant longhand should override", () => {
+    const fullSystem = createSystem(defaultConfig)
+    const recipe = fullSystem.cva({
+      base: {
+        rounded: "8px",
+      },
+      variants: {
+        size: {
+          md: {
+            borderRadius: "100px",
+          },
+        },
+      },
+      defaultVariants: {
+        size: "md",
+      },
+    })
+
+    const result = recipe({ size: "md" })
+
+    expect(result).toMatchObject({
+      "@layer recipes": {
+        borderRadius: "100px",
       },
     })
   })

--- a/packages/react/src/styled-system/cva.ts
+++ b/packages/react/src/styled-system/cva.ts
@@ -54,7 +54,7 @@ export function createRecipeFn(options: Options): RecipeCreatorFn {
         ...compact(props),
       })
 
-      let variantCss = { ...base }
+      let variantCss = { ...normalize(base) }
 
       mergeWith(variantCss, getVariantCss(variantSelections))
 


### PR DESCRIPTION
## 📝 Description
Closes #10513

Normalize base styles in recipes to prevent shorthand properties from overwriting variant styles.

## ⛳️ Current behavior (updates)

When using shorthand properties like `rounded` in both `base` and `variants`, the base value can overwrite the variant value during CSS generation because base styles are not normalized.

## 🚀 New behavior

Base styles are now normalized the same way as variant styles, ensuring proper merge behavior.

## 💣 Is this a breaking change (Yes/No):

No