### PR TITLE
docs: add 'surface' variant option to alert component explanations

### DIFF
--- a/apps/www/content/docs/components/alert.mdx
+++ b/apps/www/content/docs/components/alert.mdx
@@ -52,7 +52,7 @@ color scheme and icon used. Alert supports `error`, `success`, `warning`, and
 ### Variants
 
 Use the `variant` prop to change the visual style of the alert. Values can be
-either `subtle`, `solid`, `outline`
+either `subtle`, `solid`, `outline`, `surface`
 
 <ExampleTabs name="alert-with-variants" />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> this commit will add 'surface' to Alert variants explanations

## ⛳️ Current behavior (updates)

> right now 'surface' is used in the code examples but is not mentioned in the explanation above the example.

## 🚀 New behavior

> 'surface' is mentioned next to the subtle, solid, outline variants

## 💣 Is this a breaking change (Yes/No):

No, it's not a breaking change

## 📝 Additional Information

![LXcSNPudDm](https://github.com/user-attachments/assets/0cbcba1b-645f-46f8-a35b-b62bb5a74a7d)

