### PR TITLE
docs: add outline variant to alert code example

### DIFF
--- a/apps/compositions/src/examples/alert-with-variants.tsx
+++ b/apps/compositions/src/examples/alert-with-variants.tsx
@@ -13,6 +13,11 @@ export const AlertWithVariants = () => {
         <Alert.Title>Data uploaded to the server. Fire on!</Alert.Title>
       </Alert.Root>
 
+      <Alert.Root status="success" variant="outline">
+        <Alert.Indicator />
+        <Alert.Title>Data uploaded to the server. Fire on!</Alert.Title>
+      </Alert.Root>
+
       <Alert.Root status="success" variant="surface">
         <Alert.Indicator />
         <Alert.Title>Data uploaded to the server. Fire on!</Alert.Title>


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> variant='outline' is available in the explanations but not in the example code. this commit will add an Alert example with variant='outline' to the examples/

## ⛳️ Current behavior (updates)

> variant='outline' is available in the explanations but not in the example code.

## 🚀 New behavior

> we can see an Alert with variant='outline' in the examples.

## 💣 Is this a breaking change (Yes/No):

No; it's not a breaking change.

## 📝 Additional Information

![brave_FN1llHCSly](https://github.com/user-attachments/assets/1fcdf6f0-2d79-42c0-b34a-d486db47e1c6)

