### PR TITLE
perf(react/styled-system): move isImportant to after null check

### DIFF
--- a/packages/react/src/styled-system/css.ts
+++ b/packages/react/src/styled-system/css.ts
@@ -38,13 +38,13 @@ export function createCssFn(context: CssFnOptions) {
     const result: Dict = createEmptyObject()
 
     walkObject(normalized, (value, paths) => {
-      const important = isImportant(value)
       if (value == null) return
 
       const [prop, ...selectors] = conditions
         .sort(paths)
         .map(conditions.resolve)
 
+      const important = isImportant(value)
       if (important) {
         value = withoutImportant(value)
       }


### PR DESCRIPTION
## 📝 Description

Title describes it, very minor perf improvement as it only prevents 2 func calls, unsure why isImportant was there to begin with 😆  

