### PR TITLE
style: readme logo based on color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <p align="center">
   <a href="https://github.com/chakra-ui/chakra-ui">
-    <img src="https://raw.githubusercontent.com/chakra-ui/chakra-ui/main/media/logo-colored@2x.png?raw=true" alt="Chakra logo" width="300" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/chakra-ui/chakra-ui/main/media/logo-colored-white@2x.png?raw=true">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/chakra-ui/chakra-ui/main/media/logo-colored@2x.png?raw=true">
+      <img src="https://raw.githubusercontent.com/chakra-ui/chakra-ui/main/media/logo-colored@2x.png?raw=true" alt="Chakra logo" width="300" />
+    </picture>
   </a>
 </p>
 


### PR DESCRIPTION

## 📝 Description

Chakra logo wasn't displaying properly for me on dark mode, this PR fixes that

## ⛳️ Current behavior (updates)

<img width="936" height="261" alt="2025-12-09 at 09 25 58@2x" src="https://github.com/user-attachments/assets/44797ebc-0b80-4fb8-b32b-62f63382c14d" />
<img width="918" height="283" alt="2025-12-09 at 09 26 11@2x" src="https://github.com/user-attachments/assets/e255a1a9-864c-494e-8dfd-aa0a47067c48" />

## 🚀 New behavior

<img width="933" height="273" alt="2025-12-09 at 09 25 46@2x" src="https://github.com/user-attachments/assets/d933adba-592b-4b6b-ae26-a4f3c34b69ac" />
<img width="931" height="344" alt="2025-12-09 at 09 24 57@2x" src="https://github.com/user-attachments/assets/6ba49a7f-6cf0-4c2b-954f-8fe5f4f2f94a" />

