### PR TITLE
feat(slider): add markerLabel to anatomy

### DIFF
--- a/.changeset/polite-lemons-move.md
+++ b/.changeset/polite-lemons-move.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": minor
+---
+
+feat: add markerLabel to slider anatomy

--- a/packages/react/src/anatomy.ts
+++ b/packages/react/src/anatomy.ts
@@ -153,7 +153,10 @@ export const comboboxAnatomy = arkComboboxAnatomy.extendWith(
   "empty",
 )
 
-export const sliderAnatomy = arkSliderAnatomy.extendWith("markerIndicator")
+export const sliderAnatomy = arkSliderAnatomy.extendWith(
+  "markerIndicator",
+  "markerLabel",
+)
 
 export const statAnatomy = createAnatomy("stat").parts(
   "root",

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -195,7 +195,12 @@ export const SliderMarks = forwardRef<HTMLDivElement, SliderMarksProps>(
             <SliderMarker key={index} value={value}>
               <SliderMarkerIndicator />
               {label != null && (
-                <span className="chakra-slider__marker-label">{label}</span>
+                <chakra.span
+                  __css={styles.markerLabel}
+                  className="chakra-slider__marker-label"
+                >
+                  {label}
+                </chakra.span>
               )}
             </SliderMarker>
           )


### PR DESCRIPTION
Closes #10514

## Description

Added `markerLabel` to the `sliderAnatomy` and updated the Slider component to use `<chakra.span>` for the marker label. This allows the label to be styled via the theme system.

##  Current behavior (updates)

Currently, the slider marker label is a plain HTML `<span>` with a hardcoded class name (`chakra-slider__marker-label`). Because it is not part of the component anatomy or a chakra element, it ignores theme styles and cannot be customized via the theme config.

##  New behavior

* Added `markerLabel` to the `sliderAnatomy` definition.
* Updated the `Slider` component to render the label as a `<chakra.span>` instead of a plain `<span>`.
* Connected the label to the theme system using `__css={styles.markerLabel}`.

This allows users to style the marker label (e.g., adding `textOverflow`, changing colors, or adjusting font size) directly through the theme.

##  Is this a breaking change (Yes/No):

No

## Additional Information

Verified the changes in Storybook using the "With Marks" story. The existing class name `chakra-slider__marker-label` was preserved for backward compatibility.