### PR TITLE
Remove mention of image fallback from docs

### DIFF
--- a/packages/react/src/components/image/image.tsx
+++ b/packages/react/src/components/image/image.tsx
@@ -26,8 +26,7 @@ interface ImageOptions {
 export interface ImageProps extends HTMLChakraProps<"img", ImageOptions> {}
 
 /**
- * React component that renders an image with support
- * for fallbacks
+ * React component that renders an image
  *
  * @see Docs https://www.chakra-ui.com/docs/components/image
  */


### PR DESCRIPTION
## 📝 Description

The Image component, as of v3, doesn't support a fallback, yet it is still mentioned in the doc comment.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
https://github.com/chakra-ui/chakra-ui/issues/8988
https://www.chakra-ui.com/docs/get-started/migration