### PR TITLE
feat(theme): Refactor slide animations to use CSS variables

### DIFF
--- a/packages/react/src/theme/tokens/keyframes.ts
+++ b/packages/react/src/theme/tokens/keyframes.ts
@@ -124,40 +124,40 @@ export const keyframes = defineKeyframes({
   },
 
   // slide from
-  "slide-from-top": {
-    "0%": { translate: "0 -0.5rem" },
-    to: { translate: "0" },
-  },
-  "slide-from-bottom": {
-    "0%": { translate: "0 0.5rem" },
-    to: { translate: "0" },
-  },
-  "slide-from-left": {
-    "0%": { translate: "-0.5rem 0" },
-    to: { translate: "0" },
-  },
-  "slide-from-right": {
-    "0%": { translate: "0.5rem 0" },
-    to: { translate: "0" },
-  },
+	'slide-from-top': {
+		'0%': { translate: '0 calc(var(--slide-from-top-distance, 0.5rem) * -1)' },
+		to: { translate: '0' },
+	},
+	'slide-from-bottom': {
+		'0%': { translate: '0 var(--slide-from-bottom-distance, 0.5rem)' },
+		to: { translate: '0' },
+	},
+	'slide-from-left': {
+		'0%': { translate: 'calc(var(--slide-from-left-distance, 0.5rem) * -1) 0' },
+		to: { translate: '0' },
+	},
+	'slide-from-right': {
+		'0%': { translate: 'var(--slide-from-right-distance, 0.5rem) 0' },
+		to: { translate: '0' },
+	},
 
-  // slide to
-  "slide-to-top": {
-    "0%": { translate: "0" },
-    to: { translate: "0 -0.5rem" },
-  },
-  "slide-to-bottom": {
-    "0%": { translate: "0" },
-    to: { translate: "0 0.5rem" },
-  },
-  "slide-to-left": {
-    "0%": { translate: "0" },
-    to: { translate: "-0.5rem 0" },
-  },
-  "slide-to-right": {
-    "0%": { translate: "0" },
-    to: { translate: "0.5rem 0" },
-  },
+	// slide to
+	'slide-to-top': {
+		'0%': { translate: '0' },
+		to: { translate: '0 calc(var(--slide-to-top-distance, 0.5rem) * -1)' },
+	},
+	'slide-to-bottom': {
+		'0%': { translate: '0' },
+		to: { translate: '0 var(--slide-to-bottom-distance, 0.5rem)' },
+	},
+	'slide-to-left': {
+		'0%': { translate: '0' },
+		to: { translate: 'calc(var(--slide-to-left-distance, 0.5rem) * -1) 0' },
+	},
+	'slide-to-right': {
+		'0%': { translate: '0' },
+		to: { translate: '0 var(--slide-to-right-distance, 0.5rem)' },
+	},
 
   // scale
   "scale-in": {


### PR DESCRIPTION
## 📝 Description

Changed the slide animations to use CSS variables so you can control how far things slide from outside the component.

Added CSS variables for all the slide animations:

```css
--slide-from-top-distance
--slide-from-bottom-distance
--slide-from-left-distance
--slide-from-right-distance
--slide-to-top-distance
--slide-to-bottom-distance
--slide-to-left-distance
--slide-to-right-distance
```

Still defaults to 0.5rem if you don't set anything.

Example:
```tsx
<Float placement="top-end" offsetY="0.5" offsetX="-1">
    <Presence
        present={showCounter}
        css={{
            '--slide-from-bottom-distance': '0.1rem',
            '--slide-to-bottom-distance': '0.1rem',
        }}
        animationName={{
            _open: 'slide-from-bottom, fade-in',
            _closed: 'slide-to-bottom, fade-out',
        }}
        animationDuration="fast"
    >
        <Badge size="2xs" variant="solid">
            {count}
        </Badge>
    </Presence>
</Float>
```

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
