### PR TITLE
fix: add missing menu --arrow-size and --arrow-background

### DIFF
--- a/packages/panda-preset/src/slot-recipes/menu.ts
+++ b/packages/panda-preset/src/slot-recipes/menu.ts
@@ -22,7 +22,8 @@ export const menuSlotRecipe = defineSlotRecipe({
   base: {
     content: {
       outline: 0,
-      bg: "bg.panel",
+      "--menu-bg": "bg.panel",
+      bg: "var(--menu-bg)",
       boxShadow: "lg",
       color: "fg",
       maxHeight: "var(--available-height)",
@@ -94,6 +95,14 @@ export const menuSlotRecipe = defineSlotRecipe({
       bg: "bg.muted",
       my: "1",
       mx: "-1",
+    },
+    arrow: {
+      "--arrow-size": "sizes.3",
+      "--arrow-background": "var(--menu-bg)",
+    },
+    arrowTip: {
+      borderTopWidth: "1px",
+      borderLeftWidth: "1px",
     },
   },
   variants: {

--- a/packages/react/src/theme/recipes/menu.ts
+++ b/packages/react/src/theme/recipes/menu.ts
@@ -7,7 +7,8 @@ export const menuSlotRecipe = defineSlotRecipe({
   base: {
     content: {
       outline: 0,
-      bg: "bg.panel",
+      "--menu-bg": "bg.panel",
+      bg: "var(--menu-bg)",
       boxShadow: "lg",
       color: "fg",
       maxHeight: "var(--available-height)",
@@ -79,6 +80,14 @@ export const menuSlotRecipe = defineSlotRecipe({
       bg: "bg.muted",
       my: "1",
       mx: "-1",
+    },
+    arrow: {
+      "--arrow-size": "sizes.3",
+      "--arrow-background": "var(--menu-bg)",
+    },
+    arrowTip: {
+      borderTopWidth: "1px",
+      borderLeftWidth: "1px",
     },
   },
 


### PR DESCRIPTION
## 📝 Description

I noticed that `<Menu.Arrow />` was not visible. After a quick look at the chrome devtool, it looks like `--arrow-size` and `--arrow-background` are missing

<img width="576" height="548" alt="image" src="https://github.com/user-attachments/assets/c6d41e9b-c343-40e9-bc4b-0f1b19e8db21" />

You can see by yourself using this [playground](https://stackblitz.com/edit/chakra-ui-v3-kuakhdpq?file=src%2FApp.tsx,src%2Fmain.tsx,src%2Fcomponents%2Fui%2Fprovider.tsx)

You can replace `defaultSystem` by `system` in `provider.tsx` to see the result with the fix. I'm not sure if the fix is correct, it's heavily inspired by what's done in `popover`


## ⛳️ Current behavior (updates)

Arrow is not visible

## 🚀 New behavior

Arrow is visible

## 💣 Is this a breaking change (Yes/No):

No


