### PR TITLE
fix(docs): update Next.js dev script to use --webpack flag instead of…

### DIFF
--- a/apps/www/content/docs/get-started/frameworks/next-app.mdx
+++ b/apps/www/content/docs/get-started/frameworks/next-app.mdx
@@ -125,12 +125,15 @@ rendered HTML did not match the client**, and the error looks similar to:
 -<style data-emotion="css-global xxx" data-s="">
 ```
 
-This is caused by how Next.js hydrates Emotion CSS in `--turbo` mode. Please
-remove the `--turbo` flag from your `dev` script in your `package.json` file.
+This is caused by how Next.js hydrates Emotion CSS when running with Turbopack.
+Please add the `--webpack` flag to your `dev` and `build` scripts in your
+`package.json` file instead.
 
 ```diff
-- "dev": "next dev --turbo"
-+ "dev": "next dev"
+- "dev": "next dev"
+- "build": "next build"
++ "dev": "next dev --webpack"
++ "build": "next build --webpack"
 ```
 
 When this is fixed by the `Next.js` team, we'll update this guide.

--- a/apps/www/content/docs/get-started/frameworks/next-pages.mdx
+++ b/apps/www/content/docs/get-started/frameworks/next-pages.mdx
@@ -138,12 +138,15 @@ rendered HTML did not match the client**, and the error looks similar to:
 -<style data-emotion="css-global xxx" data-s="">
 ```
 
-This is caused by how Next.js hydrates Emotion CSS in `--turbo` mode. Please
-remove the `--turbo` flag from your `dev` script in your `package.json` file.
+This is caused by how Next.js hydrates Emotion CSS when running with Turbopack.
+Please add the `--webpack` flag to your `dev` and `build` scripts in your
+`package.json` file instead.
 
 ```diff
-- "dev": "next dev --turbo"
-+ "dev": "next dev"
+- "dev": "next dev"
+- "build": "next build"
++ "dev": "next dev --webpack"
++ "build": "next build --webpack"
 ```
 
 When this is fixed by the `Next.js` team, we'll update this guide.


### PR DESCRIPTION
## 📝 Description

With the Next.js 16 update, Turbopack is now enabled by default. This change removed the `--turbo` flag and introduced the `--webpack` flag. This PR updates the documentation to reflect these changes.

## 💣 Is this a breaking change (Yes/No):

No



