### PR TITLE
fix: select color palette support

### DIFF
--- a/.changeset/fix-select-color-palette.md
+++ b/.changeset/fix-select-color-palette.md
@@ -1,0 +1,12 @@
+---
+"@chakra-ui/react": patch
+"@chakra-ui/panda-preset": patch
+---
+
+Fix `Select` component not reflecting `colorPalette` prop
+
+- Add `colorPalette.focusRing` support for focus ring styling
+- Add `colorPalette.border` for expanded state border color
+- Add `colorPalette.subtle` for subtle variant trigger background
+- Add `colorPalette.muted/60` for highlighted item background
+- Update error state to use CSS variables for consistency

--- a/apps/compositions/src/examples/select-with-color-palettes.tsx
+++ b/apps/compositions/src/examples/select-with-color-palettes.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import {
+  For,
+  Portal,
+  Select,
+  Stack,
+  createListCollection,
+} from "@chakra-ui/react"
+
+export const SelectWithColorPalettes = () => {
+  return (
+    <Stack gap="5" width="320px">
+      <For each={["red", "blue", "green", "purple"]}>
+        {(color) => (
+          <Select.Root
+            key={color}
+            colorPalette={color}
+            variant="outline"
+            collection={frameworks}
+          >
+            <Select.HiddenSelect />
+            <Select.Label>colorPalette="{color}"</Select.Label>
+            <Select.Control>
+              <Select.Trigger>
+                <Select.ValueText placeholder="Select framework" />
+              </Select.Trigger>
+              <Select.IndicatorGroup>
+                <Select.Indicator />
+              </Select.IndicatorGroup>
+            </Select.Control>
+            <Portal>
+              <Select.Positioner>
+                <Select.Content>
+                  {frameworks.items.map((framework) => (
+                    <Select.Item item={framework} key={framework.value}>
+                      {framework.label}
+                      <Select.ItemIndicator />
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Positioner>
+            </Portal>
+          </Select.Root>
+        )}
+      </For>
+    </Stack>
+  )
+}
+
+const frameworks = createListCollection({
+  items: [
+    { label: "React.js", value: "react" },
+    { label: "Vue.js", value: "vue" },
+    { label: "Angular", value: "angular" },
+    { label: "Svelte", value: "svelte" },
+  ],
+})

--- a/packages/panda-preset/src/slot-recipes/select.ts
+++ b/packages/panda-preset/src/slot-recipes/select.ts
@@ -38,6 +38,8 @@ export const selectSlotRecipe = defineSlotRecipe({
       borderRadius: "l2",
       userSelect: "none",
       textAlign: "start",
+      "--focus-color": "colors.colorPalette.focusRing",
+      "--error-color": "colors.border.error",
       focusVisibleRing: "inside",
       _placeholderShown: {
         color: "fg.muted/80",
@@ -46,7 +48,8 @@ export const selectSlotRecipe = defineSlotRecipe({
         layerStyle: "disabled",
       },
       _invalid: {
-        borderColor: "border.error",
+        focusRingColor: "var(--error-color)",
+        borderColor: "var(--error-color)",
       },
     },
     indicatorGroup: {
@@ -100,9 +103,6 @@ export const selectSlotRecipe = defineSlotRecipe({
       flex: "1",
       textAlign: "start",
       borderRadius: "l1",
-      _highlighted: {
-        bg: "bg.emphasized/60",
-      },
       _disabled: {
         pointerEvents: "none",
         opacity: "0.5",
@@ -154,8 +154,14 @@ export const selectSlotRecipe = defineSlotRecipe({
           bg: "transparent",
           borderWidth: "1px",
           borderColor: "border",
+          focusRingColor: "var(--focus-color)",
           _expanded: {
-            borderColor: "border.emphasized",
+            borderColor: "colorPalette.border",
+          },
+        },
+        item: {
+          _highlighted: {
+            bg: "colorPalette.muted/60",
           },
         },
       },
@@ -163,7 +169,13 @@ export const selectSlotRecipe = defineSlotRecipe({
         trigger: {
           borderWidth: "1px",
           borderColor: "transparent",
-          bg: "bg.muted",
+          bg: "colorPalette.subtle",
+          focusRingColor: "var(--focus-color)",
+        },
+        item: {
+          _highlighted: {
+            bg: "colorPalette.muted/60",
+          },
         },
       },
     },

--- a/packages/react/__stories__/select.stories.tsx
+++ b/packages/react/__stories__/select.stories.tsx
@@ -34,3 +34,4 @@ export { SelectWithPositioning as Positioning } from "compositions/examples/sele
 export { SelectWithSizes as Sizes } from "compositions/examples/select-with-sizes"
 export { SelectWithVariants as Variants } from "compositions/examples/select-with-variants"
 export { SelectVirtualized as Virtualized } from "compositions/examples/select-virtualized"
+export { SelectWithColorPalettes as ColorPalettes } from "compositions/examples/select-with-color-palettes"

--- a/packages/react/src/theme/recipes/select.ts
+++ b/packages/react/src/theme/recipes/select.ts
@@ -22,6 +22,8 @@ export const selectSlotRecipe = defineSlotRecipe({
       borderRadius: "l2",
       userSelect: "none",
       textAlign: "start",
+      "--focus-color": "colors.colorPalette.focusRing",
+      "--error-color": "colors.border.error",
       focusVisibleRing: "inside",
       _placeholderShown: {
         color: "fg.muted/80",
@@ -30,7 +32,8 @@ export const selectSlotRecipe = defineSlotRecipe({
         layerStyle: "disabled",
       },
       _invalid: {
-        borderColor: "border.error",
+        focusRingColor: "var(--error-color)",
+        borderColor: "var(--error-color)",
       },
     },
     indicatorGroup: {
@@ -81,9 +84,6 @@ export const selectSlotRecipe = defineSlotRecipe({
       flex: "1",
       textAlign: "start",
       borderRadius: "l1",
-      _highlighted: {
-        bg: "bg.emphasized/60",
-      },
       _disabled: {
         pointerEvents: "none",
         opacity: "0.5",
@@ -134,8 +134,14 @@ export const selectSlotRecipe = defineSlotRecipe({
           bg: "transparent",
           borderWidth: "1px",
           borderColor: "border",
+          focusRingColor: "var(--focus-color)",
           _expanded: {
-            borderColor: "border.emphasized",
+            borderColor: "colorPalette.border",
+          },
+        },
+        item: {
+          _highlighted: {
+            bg: "colorPalette.muted/60",
           },
         },
       },
@@ -144,15 +150,27 @@ export const selectSlotRecipe = defineSlotRecipe({
         trigger: {
           borderWidth: "1px",
           borderColor: "transparent",
-          bg: "bg.muted",
+          bg: "colorPalette.subtle",
+          focusRingColor: "var(--focus-color)",
+        },
+        item: {
+          _highlighted: {
+            bg: "colorPalette.muted/60",
+          },
         },
       },
 
       ghost: {
         trigger: {
           bg: "transparent",
+          focusRingColor: "var(--focus-color)",
           _expanded: {
-            bg: "bg.muted",
+            bg: "colorPalette.subtle",
+          },
+        },
+        item: {
+          _highlighted: {
+            bg: "colorPalette.muted/60",
           },
         },
       },


### PR DESCRIPTION
Closes #10581

## 📝 Description

Fixes the `colorPalette` prop not being reflected on the Select component. The Select recipe was using hardcoded semantic tokens like `bg.muted` and `bg.emphasized/60` instead of `colorPalette.*` tokens, which meant the component could not respond to the `colorPalette` prop.

## ⛳️ Current behavior (updates)

When setting `colorPalette="red"` on a Select component, the component remains gray because the recipe does not use any `colorPalette.*` tokens.

## 🚀 New behavior

The Select component now reflects the `colorPalette` prop:
- Focus ring uses `colorPalette.focusRing`
- Expanded border (outline variant) uses `colorPalette.border`
- Highlighted items use `colorPalette.muted/60`
- Subtle variant trigger uses `colorPalette.subtle` for background

## 💣 Is this a breaking change (Yes/No):

No - the default `colorPalette` is `gray`, and `colorPalette.subtle`/`colorPalette.muted` resolve to the same values that were previously hardcoded.


<img width="507" height="458" alt="image" src="https://github.com/user-attachments/assets/a84327de-3108-446a-905e-74c7f6f2eb9c" />
