### PR TITLE
Fix Accordion render props migration docs

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -2684,7 +2684,7 @@ const Demo = () => (
 
 The `AccordionItem` render prop pattern (`{({ isExpanded }) => ...}`) has been
 replaced. Use the `Accordion.ItemContext` component or the
-`useAccordionItemContext` hook instead. The `isExpanded` property is now `open`.
+`useAccordionItemContext` hook instead. The `isExpanded` property is now `expanded`.
 
 Before:
 
@@ -2709,13 +2709,13 @@ After:
 ```tsx
 <Accordion.Item value="section-1">
   <Accordion.ItemContext>
-    {({ open }) => (
+    {({ expanded }) => (
       <>
         <Accordion.ItemTrigger>
           <Box flex="1" textAlign="left">
             Section title
           </Box>
-          {open ? <LuMinus /> : <LuPlus />}
+          {expanded ? <LuMinus /> : <LuPlus />}
         </Accordion.ItemTrigger>
         <Accordion.ItemContent>
           <Accordion.ItemBody>Content</Accordion.ItemBody>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

## 📝 Description

Changes the docs to be correct, `open` does not exist in `UseAccordionItemContext`, but `expanded` does.

## ⛳️ Current behavior (updates)

It's wrong

## 🚀 New behavior

It's correct

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
