### PR TITLE
docs(client-only): add line examples and wire ExampleTabs

### DIFF
--- a/apps/compositions/src/examples/client-only-basic.tsx
+++ b/apps/compositions/src/examples/client-only-basic.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { ClientOnly, Text } from "@chakra-ui/react"
+
+export const ClientOnlyBasic = () => {
+  return (
+    <ClientOnly>
+      <Text>This content is rendered only on the client.</Text>
+    </ClientOnly>
+  )
+}

--- a/apps/compositions/src/examples/client-only-render-prop.tsx
+++ b/apps/compositions/src/examples/client-only-render-prop.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { ClientOnly, Code, Skeleton, Stack, Text } from "@chakra-ui/react"
+
+export const ClientOnlyRenderProp = () => {
+  return (
+    <ClientOnly fallback={<Skeleton height="12" width="full" maxW="sm" />}>
+      {() => (
+        <Stack align="flex-start" gap="1" textStyle="sm">
+          <Text>
+            Current URL: <Code>{window.location.href}</Code>
+          </Text>
+          <Text>
+            Screen width: <Code>{window.innerWidth}px</Code>
+          </Text>
+        </Stack>
+      )}
+    </ClientOnly>
+  )
+}

--- a/apps/compositions/src/examples/client-only-with-fallback.tsx
+++ b/apps/compositions/src/examples/client-only-with-fallback.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { ClientOnly, Skeleton, Stack, Text } from "@chakra-ui/react"
+import { useEffect, useState } from "react"
+
+function Clock() {
+  const [time, setTime] = useState(() => new Date().toLocaleTimeString())
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setTime(new Date().toLocaleTimeString())
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [])
+
+  return <Text>Current time: {time}</Text>
+}
+
+export const ClientOnlyWithFallback = () => {
+  return (
+    <ClientOnly fallback={<Skeleton height="5" width="32" />}>
+      <Stack gap="1">
+        <Text fontWeight="medium">Client clock</Text>
+        <Clock />
+      </Stack>
+    </ClientOnly>
+  )
+}

--- a/apps/www/content/docs/components/client-only.mdx
+++ b/apps/www/content/docs/components/client-only.mdx
@@ -5,6 +5,8 @@ links:
   source: components/client-only
 ---
 
+<ExampleTabs name="client-only-basic" />
+
 ## Usage
 
 ```jsx
@@ -24,11 +26,7 @@ import { ClientOnly, Skeleton } from "@chakra-ui/react"
 Use the `fallback` prop to render a loading state while the client-side content
 is being prepared.
 
-```jsx
-<ClientOnly fallback={<Skeleton boxSize="8" />}>
-  <ColorModeButton />
-</ClientOnly>
-```
+<ExampleTabs name="client-only-with-fallback" />
 
 ### Render Prop (Recommended)
 
@@ -36,16 +34,7 @@ When your component accesses browser-only APIs (like `window`, `document`, or
 `localStorage`), use the render prop pattern to prevent server-side rendering
 issues:
 
-```jsx
-<ClientOnly fallback={<Skeleton />}>
-  {() => (
-    <div>
-      Current URL: {window.location.href}
-      Screen width: {window.innerWidth}px
-    </div>
-  )}
-</ClientOnly>
-```
+<ExampleTabs name="client-only-render-prop" />
 
 This pattern ensures that components accessing browser APIs are only evaluated
 on the client side, preventing hydration mismatches and server-side errors.


### PR DESCRIPTION
  ## 📝 Description

  Add live `ClientOnly` docs examples and wire them with `ExampleTabs`.

  ##  Current behavior (updates)

  The `ClientOnly` docs page mostly used static code snippets and did not show runnable
  examples via `ExampleTabs`.

  ## 🚀 New behavior

  Added three runnable examples in `apps/compositions/src/examples`:

  - `client-only-basic.tsx`
  - `client-only-with-fallback.tsx`
  - `client-only-render-prop.tsx`

  Updated `apps/www/content/docs/components/client-only.mdx` to render these examples
  with:

  - `<ExampleTabs name="client-only-basic" />`
  - `<ExampleTabs name="client-only-with-fallback" />`
  - `<ExampleTabs name="client-only-render-prop" />`

  ## 💣 Is this a breaking change (Yes/No):

  No

  ## 📝 Additional Information

  Scope is docs/examples only. No new dependencies were added.