### PR TITLE
Docs: update Icon "custom svg" example to use 'asChild' prop

### DIFF
--- a/apps/compositions/src/examples/icon-with-custom-svg.tsx
+++ b/apps/compositions/src/examples/icon-with-custom-svg.tsx
@@ -2,7 +2,7 @@ import { Icon } from "@chakra-ui/react"
 
 export const IconWithCustomSvg = () => {
   return (
-    <Icon size="lg" color="red.500">
+    <Icon size="lg" color="red.500" asChild>
       <svg viewBox="0 0 32 32">
         <g fill="currentColor">
           <path d="M16,11.5a3,3,0,1,0-3-3A3,3,0,0,0,16,11.5Z" />


### PR DESCRIPTION
Closes #

## 📝 Description

Update Icon with custom SVG example to use 'asChild' as suggested in documentation:

https://chakra-ui.com/docs/components/icon#custom-svg

## ⛳️ Current behavior (updates)

Example renders double svg's

## 🚀 New behavior

Example renders a single svg, as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
