### PR TITLE
fix(www): prevent infinite re-render in table of contents

### DIFF
--- a/apps/www/lib/use-scroll-spy.tsx
+++ b/apps/www/lib/use-scroll-spy.tsx
@@ -1,10 +1,23 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
+
+const useStableSelectors = (selectors: string[]): string[] => {
+  const ref = useRef<string[]>(selectors)
+  const prev = ref.current
+
+  if (
+    prev.length !== selectors.length ||
+    prev.some((value, index) => value !== selectors[index])
+  ) {
+    ref.current = selectors
+  }
+
+  return ref.current
+}
 
 export const useScrollSpy = (selectors: string[]) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableSelectors = useMemo(() => selectors, [JSON.stringify(selectors)])
+  const stableSelectors = useStableSelectors(selectors)
 
   const [activeIds, setActiveIds] = useState<Set<string>>(
     () => new Set(stableSelectors[0] ? [stableSelectors[0]] : []),


### PR DESCRIPTION
## 📝 Description

The selectors array passed to useScrollSpy created a new reference on every render, causing an infinite loop: useEffect re-runs → IntersectionObserver re-created → state update → re-render. Fixed by stabilizing the array reference with
useMemo.

## ⛳ Current behavior (updates)

The "On This Page" (ToC) sidebar triggers infinite re-renders on every documentation page due to unstable array reference in useScrollSpy's useEffect dependency.

<img width="475" height="373" alt="Screenshot from 2026-03-04 22-06-54" src="https://github.com/user-attachments/assets/850af6e1-8055-49ee-b5df-2a2addf25e8a" />


## 🚀 New behavior

useScrollSpy memoizes the selectors array so the effect only re-runs when the array contents actually change, eliminating the infinite loop.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information