### PR TITLE
feat: improve createOverlay types

### DIFF
--- a/.changeset/overlay-return-types.md
+++ b/.changeset/overlay-return-types.md
@@ -2,14 +2,22 @@
 "@chakra-ui/react": minor
 ---
 
-Improve `createOverlay` types. The overlay's return value is now typed through a
-`TReturn` generic, so awaiting `open()` gives you the value passed to `close()`
-instead of `any`. Pass it as the second type argument:
+**createOverlay**: Add a `TReturn` generic so awaiting `open()` returns the
+value passed to `close()` instead of `any`.
 
 ```ts
-createOverlay<DialogProps, DialogResult>(Component)
+interface DialogResult {
+  message: string
+}
+
+const dialog = createOverlay<DialogProps, DialogResult>(Component)
+
+const result = await dialog.open("id", props)
+if (result) {
+  console.log(result.message)
+}
 ```
 
-`open()`'s props argument is now optional, and its return type is
-`Promise<TReturn | undefined>` — code that relied on the previous `any` return
-may need to handle `undefined`.
+`TReturn` defaults to `unknown`, so untyped `open()` calls may need narrowing
+now. The result can also be `undefined`, since `close(id, value)` doesn't
+require a value.

--- a/.changeset/overlay-return-types.md
+++ b/.changeset/overlay-return-types.md
@@ -1,0 +1,15 @@
+---
+"@chakra-ui/react": minor
+---
+
+Improve `createOverlay` types. The overlay's return value is now typed through a
+`TReturn` generic, so awaiting `open()` gives you the value passed to `close()`
+instead of `any`. Pass it as the second type argument:
+
+```ts
+createOverlay<DialogProps, DialogResult>(Component)
+```
+
+`open()`'s props argument is now optional, and its return type is
+`Promise<TReturn | undefined>` — code that relied on the previous `any` return
+may need to handle `undefined`.

--- a/apps/compositions/src/examples/overlay-with-return-value.tsx
+++ b/apps/compositions/src/examples/overlay-with-return-value.tsx
@@ -9,7 +9,11 @@ interface DialogProps {
   content?: React.ReactNode
 }
 
-const dialog = createOverlay<DialogProps>((props) => {
+interface DialogResult {
+  message: string
+}
+
+const dialog = createOverlay<DialogProps, DialogResult>((props) => {
   const { title, description, content, ...rest } = props
   return (
     <Dialog.Root {...rest}>
@@ -46,8 +50,7 @@ export const OverlayWithReturnValue = () => {
             content: (
               <Button
                 onClick={() => {
-                  const returnValue = { message: "Welcome" }
-                  dialog.close("a", returnValue)
+                  dialog.close("a", { message: "Welcome" })
                 }}
               >
                 Close
@@ -56,6 +59,8 @@ export const OverlayWithReturnValue = () => {
           })
 
           await dialog.waitForExit("a")
+
+          if (!returnValue) return
 
           dialog.open("b", {
             title: returnValue.message,

--- a/packages/react/src/hooks/use-overlay.tsx
+++ b/packages/react/src/hooks/use-overlay.tsx
@@ -9,12 +9,15 @@ const shallowEqualEntries = <T extends Dict>(
 ) => {
   if (a.length !== b.length) return false
   for (let i = 0; i < a.length; i++) {
-    if (a[i].id !== b[i].id) return false
-    const aKeys = Object.keys(a[i].props)
-    const bKeys = Object.keys(b[i].props)
+    const aEntry = a[i]
+    const bEntry = b[i]
+    if (!aEntry || !bEntry) return false
+    if (aEntry.id !== bEntry.id) return false
+    const aKeys = Object.keys(aEntry.props)
+    const bKeys = Object.keys(bEntry.props)
     if (aKeys.length !== bKeys.length) return false
     for (const key of aKeys) {
-      if (!Object.is(a[i].props[key], b[i].props[key])) return false
+      if (!Object.is(aEntry.props[key], bEntry.props[key])) return false
     }
   }
   return true
@@ -24,7 +27,7 @@ const shallowEqualEntries = <T extends Dict>(
  * Props that are injected into the overlay component by the `createOverlay` function.
  * These props are used to control the overlay's state and lifecycle.
  */
-export interface CreateOverlayProps {
+export interface CreateOverlayProps<TReturn = unknown> {
   /** Whether the overlay is currently open */
   open?: boolean
   /** Callback fired when the overlay's open state changes */
@@ -32,47 +35,50 @@ export interface CreateOverlayProps {
   /** Callback fired when the overlay's exit animation completes */
   onExitComplete?: () => void
   /** Internal callback used to set the return value when the overlay closes */
-  setReturnValue?: ((value: unknown) => void) | undefined
+  setReturnValue?: ((value: TReturn) => void) | undefined
   /** Internal callback used to signal when the exit animation is complete */
   setExitComplete?: (() => void) | undefined
 }
 
-export interface OverlayOptions<T extends CreateOverlayProps> {
-  props?: T
+export interface OverlayOptions<TProps extends CreateOverlayProps> {
+  props?: TProps
 }
 
-export interface CreateOverlayReturn<T extends CreateOverlayProps> {
+export interface CreateOverlayReturn<
+  TProps extends CreateOverlayProps,
+  TReturn = unknown,
+> {
   /** The root component for the overlay */
   Viewport: React.ElementType
   /** Opens a new overlay with the given id and props */
-  open: (id: string, props: T) => Promise<any>
+  open: (id: string, props?: TProps | undefined) => Promise<TReturn | undefined>
   /** Closes the overlay with the given id and returns the value */
-  close: (id: string, value?: any) => Promise<void>
+  close: (id: string, value?: TReturn | undefined) => Promise<void>
   /** Updates the props of the overlay with the given id */
-  update: (id: string, props: T) => void
+  update: (id: string, props: TProps) => void
   /** Removes the overlay with the given id */
   remove: (id: string) => void
   /** Removes all overlays */
   removeAll: () => void
   /** Gets the props of the overlay with the given id */
-  get: (id: string) => T
+  get: (id: string) => TProps
   /** Checks if the overlay with the given id exists */
   has: (id: string) => boolean
   /** Gets the current snapshot of the overlays */
-  getSnapshot: () => T[]
+  getSnapshot: () => TProps[]
   /** Waits for the exit animation to complete for the overlay with the given id */
   waitForExit: (id: string) => Promise<void>
 }
 
-export function createOverlay<T extends Dict>(
-  Component: React.ComponentType<T & CreateOverlayProps>,
-  options?: OverlayOptions<T>,
-): CreateOverlayReturn<T> {
-  const map = new Map<string, T>()
+export function createOverlay<TProps extends Dict, TReturn = unknown>(
+  Component: React.ComponentType<CreateOverlayProps<TReturn> & TProps>,
+  options?: OverlayOptions<TProps>,
+): CreateOverlayReturn<TProps, TReturn> {
+  const map = new Map<string, TProps>()
   const exitPromises = new Map<string, Promise<void>>()
 
-  const subscribers = new Set<(nextOverlayProps: T[]) => void>()
-  const subscribe = (callback: (nextOverlayProps: T[]) => void) => {
+  const subscribers = new Set<(nextOverlayProps: TProps[]) => void>()
+  const subscribe = (callback: (nextOverlayProps: TProps[]) => void) => {
     subscribers.add(callback)
     return () => subscribers.delete(callback)
   }
@@ -82,11 +88,11 @@ export function createOverlay<T extends Dict>(
     }
   }
 
-  let lastSnapshotWithIds: OverlaySnapshotEntry<T>[] = []
-  let lastSnapshotProps: T[] = []
+  let lastSnapshotWithIds: OverlaySnapshotEntry<TProps>[] = []
+  let lastSnapshotProps: TProps[] = []
 
   const getSnapshotForStore = () => {
-    const nextSnapshot: OverlaySnapshotEntry<T>[] = Array.from(
+    const nextSnapshot: OverlaySnapshotEntry<TProps>[] = Array.from(
       map.entries(),
     ).map(([id, props]) => ({ id, props }))
     if (shallowEqualEntries(lastSnapshotWithIds, nextSnapshot)) {
@@ -97,7 +103,7 @@ export function createOverlay<T extends Dict>(
     return lastSnapshotWithIds
   }
 
-  const getSnapshot = (): T[] => {
+  const getSnapshot = (): TProps[] => {
     getSnapshotForStore()
     return lastSnapshotProps
   }
@@ -106,7 +112,7 @@ export function createOverlay<T extends Dict>(
     return exitPromises.get(id) || Promise.resolve()
   }
 
-  const open = (id: string, props: T) => {
+  const open = (id: string, props?: TProps) => {
     const overlayProps = {
       ...options?.props,
       ...props,
@@ -115,7 +121,7 @@ export function createOverlay<T extends Dict>(
         if (!e.open) close(id)
       },
       onExitComplete: () => {
-        const overlay = get(id) as T & CreateOverlayProps
+        const overlay = get(id) as CreateOverlayProps<TReturn> & TProps
         if (overlay.setExitComplete) {
           overlay.setExitComplete()
           overlay.setExitComplete = undefined
@@ -124,15 +130,15 @@ export function createOverlay<T extends Dict>(
       },
       setReturnValue: undefined,
       setExitComplete: undefined,
-    }
+    } as unknown as TProps
 
-    map.set(id, overlayProps as T)
+    map.set(id, overlayProps)
 
-    const prom = new Promise<any>((resolve) => {
+    const prom = new Promise<TReturn>((resolve) => {
       map.set(id, {
         ...overlayProps,
         setReturnValue: resolve,
-      } as T)
+      } as unknown as TProps)
     })
 
     publish()
@@ -140,23 +146,23 @@ export function createOverlay<T extends Dict>(
     return prom
   }
 
-  const close = (id: string, value?: any) => {
-    const prevProps = get(id) as T & CreateOverlayProps
+  const close = (id: string, value?: TReturn) => {
+    const prevProps = get(id) as CreateOverlayProps<TReturn> & TProps
     map.set(id, { ...prevProps, open: false })
 
     if (prevProps.setReturnValue) {
-      prevProps.setReturnValue(value)
+      prevProps.setReturnValue(value as TReturn)
       prevProps.setReturnValue = undefined
     }
 
     publish()
 
     const exitPromise = new Promise<void>((resolve) => {
-      const overlay = get(id) as T & CreateOverlayProps
+      const overlay = get(id) as CreateOverlayProps<TReturn> & TProps
       map.set(id, {
         ...overlay,
         setExitComplete: resolve,
-      } as T)
+      } as TProps)
     })
 
     exitPromises.set(id, exitPromise)
@@ -169,7 +175,7 @@ export function createOverlay<T extends Dict>(
     publish()
   }
 
-  const update = (id: string, props: T) => {
+  const update = (id: string, props: TProps) => {
     const prevProps = get(id)
     map.set(id, {
       ...prevProps,
@@ -196,7 +202,7 @@ export function createOverlay<T extends Dict>(
     publish()
   }
 
-  function OverlayViewportItem(props: T & CreateOverlayProps) {
+  function OverlayViewportItem(props: CreateOverlayProps<TReturn> & TProps) {
     const [mounted, setMounted] = React.useState(false)
 
     React.useEffect(() => {

--- a/packages/react/src/hooks/use-overlay.tsx
+++ b/packages/react/src/hooks/use-overlay.tsx
@@ -51,7 +51,7 @@ export interface CreateOverlayReturn<
   /** The root component for the overlay */
   Viewport: React.ElementType
   /** Opens a new overlay with the given id and props */
-  open: (id: string, props?: TProps | undefined) => Promise<TReturn | undefined>
+  open: (id: string, props: TProps) => Promise<TReturn | undefined>
   /** Closes the overlay with the given id and returns the value */
   close: (id: string, value?: TReturn | undefined) => Promise<void>
   /** Updates the props of the overlay with the given id */
@@ -112,7 +112,7 @@ export function createOverlay<TProps extends Dict, TReturn = unknown>(
     return exitPromises.get(id) || Promise.resolve()
   }
 
-  const open = (id: string, props?: TProps) => {
+  const open = (id: string, props: TProps) => {
     const overlayProps = {
       ...options?.props,
       ...props,


### PR DESCRIPTION
## 📝 Description

The key improvement is type-safe return values from overlays.

Before, when you awaited `overlay.open()`, TypeScript had no idea what value would come back, it was typed as `Promise<any>,` so you got no autocomplete and no type errors if you used the result incorrectly.

After this change, the return type flows through the entire chain:

```
// You define what the dialog returns
const confirmDialog = createOverlay<ConfirmProps, boolean>(ConfirmDialog)

// Now TypeScript knows this is `Promise<boolean | undefined>`
const confirmed = await confirmDialog.open("confirm")

if (confirmed) { ... } // ✅ properly typed, no casting needed
```

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
