### PR TITLE
fix(compositions): make date picker presets responsive on mobile

### DIFF
--- a/apps/compositions/src/examples/date-picker-presets.tsx
+++ b/apps/compositions/src/examples/date-picker-presets.tsx
@@ -18,9 +18,19 @@ export const DatePickerPresets = () => {
       </DatePicker.Control>
       <Portal>
         <DatePicker.Positioner>
-          <DatePicker.Content>
-            <Flex px="4" py="4" gap="6">
-              <VStack align="stretch" gap="2" minW="140px" height="100%">
+          <DatePicker.Content maxW="100dvw" w="fit-content" overflow="auto">
+            <Flex
+              px={{ base: "3", sm: "4" }}
+              py={{ base: "3", sm: "4" }}
+              gap={{ base: "3", sm: "6" }}
+              flexDirection={{ base: "column", sm: "row" }}
+            >
+              <VStack
+                align="stretch"
+                gap={{ base: "1.5", sm: "2" }}
+                minW={{ base: "full", sm: "140px" }}
+                height="100%"
+              >
                 <DatePicker.PresetTrigger value="last7Days" asChild>
                   <Button variant="surface" size="sm" width="100%">
                     Last 7 days

--- a/apps/compositions/src/examples/date-picker-with-presets-sidebar.tsx
+++ b/apps/compositions/src/examples/date-picker-with-presets-sidebar.tsx
@@ -13,8 +13,14 @@ import {
 export const DatePickerWithPresetsSidebar = () => {
   return (
     <DatePicker.Root inline fixedWeeks width="fit-content" borderWidth="1px">
-      <Flex>
-        <Stack gap="0" minW="2xs" borderEndWidth="1px" py="2">
+      <Flex flexDirection={{ base: "column", sm: "row" }}>
+        <Stack
+          gap="0"
+          minW={{ base: "full", sm: "2xs" }}
+          borderBottomWidth={{ base: "1px", sm: "0" }}
+          borderEndWidth={{ base: "0", sm: "1px" }}
+          py="2"
+        >
           {presets.map((preset) => (
             <DatePicker.Context key={preset.label}>
               {(ctx) => (


### PR DESCRIPTION
Closes #10690

## 📝 Description

The date picker presets were breaking on mobile — the calendar 
was getting cut off on the right side with no way to see the 
full week. Opened it on a phone and half the calendar was just... gone.

## ⛳️ Current behavior

The layout is always horizontal, so on small screens the preset 
buttons and the calendar try to sit side by side and end up 
overflowing the viewport.

## 🚀 New behavior

Made it stack vertically on mobile and switch back to the 
side-by-side layout on wider screens using Chakra's responsive 
syntax. Also stopped the popup from ever going wider than the 
screen with maxW="100dvw".

## 💣 Is this a breaking change: No
