### PR TITLE
fix(docs): update TagsInput editable description

### DIFF
--- a/apps/www/content/docs/components/tags-input.mdx
+++ b/apps/www/content/docs/components/tags-input.mdx
@@ -108,8 +108,9 @@ tags that can be added.
 
 ### Editable Tags
 
-Use the `editable` prop to enable inline editing of existing tags by clicking on
-them, allowing users to quickly update tag values.
+Use the `editable` prop to enable inline editing of existing tags by double
+clicking or pressing `Enter` when highlighted, allowing users to quickly update
+tag values.
 
 <ExampleTabs name="tags-input-editable" />
 


### PR DESCRIPTION
## 📝 Description

Minor thing I noticed when looking at `TagsInput` docs: the description for `editable` doesn't reflect the actual behaviour - it should say double click. I also included that Enter can be used to edit.

## 💣 Is this a breaking change:
No; docs only

