### PR TITLE
fix(pagination): add locale-aware page text formatting

### DIFF
--- a/apps/compositions/src/ui/pagination.tsx
+++ b/apps/compositions/src/ui/pagination.tsx
@@ -1,12 +1,17 @@
 "use client"
 
-import type { ButtonProps, TextProps } from "@chakra-ui/react"
+import type {
+  ButtonProps,
+  PaginationPageTextDetails,
+  TextProps,
+} from "@chakra-ui/react"
 import {
   Button,
   Pagination as ChakraPagination,
   IconButton,
   Text,
   createContext,
+  useLocaleContext,
   usePaginationContext,
 } from "@chakra-ui/react"
 import * as React from "react"
@@ -35,8 +40,10 @@ const [RootPropsProvider, useRootProps] = createContext<ButtonVariantContext>({
   name: "RootPropsProvider",
 })
 
-export interface PaginationRootProps
-  extends Omit<ChakraPagination.RootProps, "type"> {
+export interface PaginationRootProps extends Omit<
+  ChakraPagination.RootProps,
+  "type"
+> {
   size?: ButtonProps["size"]
   variant?: PaginationVariant
   getHref?: (page: number) => string
@@ -186,19 +193,39 @@ export const PaginationItems = (props: React.HTMLAttributes<HTMLElement>) => {
 
 interface PageTextProps extends TextProps {
   format?: "short" | "compact" | "long"
+  formatText?: ((details: PaginationPageTextDetails) => string) | undefined
 }
 
 export const PaginationPageText = React.forwardRef<
   HTMLParagraphElement,
   PageTextProps
 >(function PaginationPageText(props, ref) {
-  const { format = "compact", ...rest } = props
+  const { format = "compact", formatText, ...rest } = props
   const { page, totalPages, pageRange, count } = usePaginationContext()
+  const { locale } = useLocaleContext()
   const content = React.useMemo(() => {
-    if (format === "short") return `${page} / ${totalPages}`
-    if (format === "compact") return `${page} of ${totalPages}`
-    return `${pageRange.start + 1} - ${Math.min(pageRange.end, count)} of ${count}`
-  }, [format, page, totalPages, pageRange, count])
+    const nf = new Intl.NumberFormat(locale)
+    const details = {
+      format,
+      page,
+      totalPages,
+      pageRange,
+      count,
+      locale,
+      formattedPage: nf.format(page),
+      formattedTotalPages: nf.format(totalPages),
+      formattedRangeStart: nf.format(pageRange.start + 1),
+      formattedRangeEnd: nf.format(Math.min(pageRange.end, count)),
+      formattedCount: nf.format(count),
+    }
+
+    if (formatText) return formatText(details)
+    if (format === "short")
+      return `${details.formattedPage} / ${details.formattedTotalPages}`
+    if (format === "compact")
+      return `${details.formattedPage} of ${details.formattedTotalPages}`
+    return `${details.formattedRangeStart} - ${details.formattedRangeEnd} of ${details.formattedCount}`
+  }, [count, format, formatText, locale, page, pageRange, totalPages])
 
   return (
     <Text fontWeight="medium" ref={ref} {...rest}>

--- a/packages/react/__tests__/pagination.test.tsx
+++ b/packages/react/__tests__/pagination.test.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom/vitest"
+import { render, screen } from "@testing-library/react"
+import { LocaleProvider } from "../src/components/locale"
+import {
+  PaginationPageText,
+  PaginationRoot,
+} from "../src/components/pagination"
+import { defaultSystem } from "../src/preset"
+import { ChakraProvider } from "../src/styled-system/provider"
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+)
+
+describe("Pagination.PageText", () => {
+  test("uses the current default English text", () => {
+    render(
+      <PaginationRoot count={100} pageSize={10} defaultPage={2}>
+        <PaginationPageText />
+      </PaginationRoot>,
+      { wrapper },
+    )
+
+    expect(screen.getByText("2 of 10")).toBeInTheDocument()
+  })
+
+  test("supports a custom formatter", () => {
+    render(
+      <LocaleProvider locale="de-DE">
+        <PaginationRoot count={12345} pageSize={10} defaultPage={124}>
+          <PaginationPageText
+            format="long"
+            formatText={(details) =>
+              `${details.formattedRangeStart} - ${details.formattedRangeEnd} von ${details.formattedCount}`
+            }
+          />
+        </PaginationRoot>
+      </LocaleProvider>,
+      { wrapper },
+    )
+
+    expect(screen.getByText("1.231 - 1.240 von 12.345")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/pagination/index.ts
+++ b/packages/react/src/components/pagination/index.ts
@@ -21,6 +21,7 @@ export type {
   PaginationItemProps,
   PaginationPageChangeDetails,
   PaginationPageSizeChangeDetails,
+  PaginationPageTextDetails,
   PaginationPageTextProps,
   PaginationItemsProps,
 } from "./pagination"

--- a/packages/react/src/components/pagination/namespace.ts
+++ b/packages/react/src/components/pagination/namespace.ts
@@ -20,6 +20,7 @@ export type {
   PaginationRootProviderProps as RootProviderProps,
   PaginationPageChangeDetails as PageChangeDetails,
   PaginationPageSizeChangeDetails as PageSizeChangeDetails,
+  PaginationPageTextDetails as PageTextDetails,
   PaginationPageTextProps as PageTextProps,
   PaginationItemsProps as ItemsProps,
 } from "./pagination"

--- a/packages/react/src/components/pagination/pagination.tsx
+++ b/packages/react/src/components/pagination/pagination.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type { Assign } from "@ark-ui/react"
+import { useLocaleContext } from "@ark-ui/react/locale"
 import {
   Pagination as ArkPagination,
   usePaginationContext,
@@ -131,21 +132,58 @@ export interface PaginationPageSizeChangeDetails
 
 ////////////////////////////////////////////////////////////////////////////////////
 
+export interface PaginationPageTextDetails {
+  format: "short" | "compact" | "long"
+  page: number
+  totalPages: number
+  pageRange: { start: number; end: number }
+  count: number
+  locale: string
+  formattedPage: string
+  formattedTotalPages: string
+  formattedRangeStart: string
+  formattedRangeEnd: string
+  formattedCount: string
+}
+
 export interface PaginationPageTextProps extends BoxProps {
   format?: "short" | "compact" | "long" | undefined
+  formatText?: ((details: PaginationPageTextDetails) => string) | undefined
 }
 
 export const PaginationPageText = forwardRef<
   HTMLParagraphElement,
   PaginationPageTextProps
 >(function PaginationPageText(props, ref) {
-  const { format = "compact", ...rest } = props
+  const { format = "compact", formatText, ...rest } = props
   const { page, totalPages, pageRange, count } = usePaginationContext()
+  const { locale } = useLocaleContext()
   const content = useMemo(() => {
-    if (format === "short") return `${page} / ${totalPages}`
-    if (format === "compact") return `${page} of ${totalPages}`
-    return `${pageRange.start + 1} - ${Math.min(pageRange.end, count)} of ${count}`
-  }, [format, page, totalPages, pageRange, count])
+    const nf = new Intl.NumberFormat(locale)
+    const details = {
+      format,
+      page,
+      totalPages,
+      pageRange,
+      count,
+      locale,
+      formattedPage: nf.format(page),
+      formattedTotalPages: nf.format(totalPages),
+      formattedRangeStart: nf.format(pageRange.start + 1),
+      formattedRangeEnd: nf.format(Math.min(pageRange.end, count)),
+      formattedCount: nf.format(count),
+    } satisfies PaginationPageTextDetails
+
+    if (formatText) return formatText(details)
+    if (format === "short") {
+      return `${details.formattedPage} / ${details.formattedTotalPages}`
+    }
+    if (format === "compact") {
+      return `${details.formattedPage} of ${details.formattedTotalPages}`
+    }
+
+    return `${details.formattedRangeStart} - ${details.formattedRangeEnd} of ${details.formattedCount}`
+  }, [count, format, formatText, locale, page, pageRange, totalPages])
 
   return (
     <Box fontWeight="medium" ref={ref} {...rest}>


### PR DESCRIPTION
Closes #10654                                                                                                         
                                                                                                                      
## Description                                                                                                        
This PR removes hardcoded English text assumptions from `PaginationPageText` by adding a formatter API that supports  
locale-aware custom output.                                                                                           
                                                                                                                      
## Current behavior (updates)                                                                                         
`PaginationPageText` output uses fixed English phrasing (`"of"`) and fixed sentence structure.                        
                                                                                                                      
## New behavior                                                                                                       
- Added `formatText` prop to `PaginationPageText`.                                                                    
- Added exported `PaginationPageTextDetails` type for strongly typed formatter callbacks.                             
- Kept existing default text output unchanged when `formatText` is not provided.                                      
- Applied the same formatter support in compositions pagination wrapper.                                              
                                                                                                                      
## Tests                                                                                                              
- Added `packages/react/__tests__/pagination.test.tsx`                                                                
- Verified:                                                                                                           
  - default behavior remains `"2 of 10"`                                                                              
  - custom formatter works with locale-formatted numbers (example: `de-DE` -> `"1.231 - 1.240 von 12.345"`)           
                                                                                                                      
## Breaking change                                                                                                    
No                                                                                    

## Breaking change
No