### PR TITLE
feat(hooks): useMediaQuery migrate to syncExternalStore

### DIFF
--- a/.changeset/migrate-use-media-query-sync-external-store.md
+++ b/.changeset/migrate-use-media-query-sync-external-store.md
@@ -1,0 +1,12 @@
+---
+"@chakra-ui/react": minor
+---
+
+Migrate `useMediaQuery` hook from `useState + useEffect` to
+`useSyncExternalStore`
+
+- Eliminates hydration flicker (SSR fallback → real value transition is now
+  synchronous)
+- Prevents tearing in React concurrent mode
+- The `ssr` option is now a no-op (kept for backward compatibility)
+- Dropped legacy `addListener`/`removeListener` fallback (Safari <14)

--- a/packages/react/__tests__/use-media-query.test.tsx
+++ b/packages/react/__tests__/use-media-query.test.tsx
@@ -1,0 +1,151 @@
+import { act, renderHook } from "@testing-library/react"
+import { useMediaQuery } from "../src"
+
+function mockMatchMedia(matches: Record<string, boolean>) {
+  const listeners = new Map<string, Set<() => void>>()
+
+  const impl = vi.fn().mockImplementation((query: string) => ({
+    matches: matches[query] ?? false,
+    media: query,
+    addEventListener: (_: string, cb: () => void) => {
+      if (!listeners.has(query)) listeners.set(query, new Set())
+      listeners.get(query)!.add(cb)
+    },
+    removeEventListener: (_: string, cb: () => void) => {
+      listeners.get(query)?.delete(cb)
+    },
+  }))
+
+  const fire = (query: string, newMatches: boolean) => {
+    matches[query] = newMatches
+    listeners.get(query)?.forEach((cb) => cb())
+  }
+
+  return { impl, fire }
+}
+
+describe("useMediaQuery", () => {
+  test("returns correct matches for multiple queries", () => {
+    const { impl } = mockMatchMedia({
+      "(min-width: 0px)": true,
+      "(min-width: 768px)": false,
+    })
+    const original = window.matchMedia
+    window.matchMedia = impl
+
+    try {
+      const { result } = renderHook(() =>
+        useMediaQuery(["(min-width: 0px)", "(min-width: 768px)"]),
+      )
+      expect(result.current).toEqual([true, false])
+    } finally {
+      window.matchMedia = original
+    }
+  })
+
+  test("fallback option does not override client matchMedia values", () => {
+    const { impl } = mockMatchMedia({
+      "(min-width: 0px)": false,
+      "(min-width: 768px)": false,
+    })
+    const original = window.matchMedia
+    window.matchMedia = impl
+
+    try {
+      const { result } = renderHook(() =>
+        useMediaQuery(["(min-width: 0px)", "(min-width: 768px)"], {
+          fallback: [true, true],
+        }),
+      )
+      expect(result.current).toEqual([false, false])
+    } finally {
+      window.matchMedia = original
+    }
+  })
+
+  test("updates when a media query match changes", async () => {
+    const { impl, fire } = mockMatchMedia({ "(min-width: 768px)": false })
+    const original = window.matchMedia
+    window.matchMedia = impl
+
+    try {
+      const { result } = renderHook(() => useMediaQuery(["(min-width: 768px)"]))
+      expect(result.current).toEqual([false])
+
+      act(() => fire("(min-width: 768px)", true))
+      expect(result.current).toEqual([true])
+    } finally {
+      window.matchMedia = original
+    }
+  })
+
+  test("returns same array reference when values unchanged", () => {
+    const { impl, fire } = mockMatchMedia({ "(min-width: 768px)": true })
+    const original = window.matchMedia
+    window.matchMedia = impl
+
+    try {
+      const { result, rerender } = renderHook(() =>
+        useMediaQuery(["(min-width: 768px)"]),
+      )
+      const first = result.current
+
+      rerender()
+      expect(result.current).toBe(first)
+
+      act(() => fire("(min-width: 768px)", true))
+      expect(result.current).toBe(first)
+    } finally {
+      window.matchMedia = original
+    }
+  })
+
+  test("resubscribes to new queries when query array changes", () => {
+    const { impl, fire } = mockMatchMedia({
+      "(min-width: 768px)": false,
+      "(min-width: 1024px)": true,
+    })
+    const original = window.matchMedia
+    window.matchMedia = impl
+
+    try {
+      const { result, rerender } = renderHook(
+        ({ queries }: { queries: string[] }) => useMediaQuery(queries),
+        { initialProps: { queries: ["(min-width: 768px)"] } },
+      )
+      expect(result.current).toEqual([false])
+
+      rerender({ queries: ["(min-width: 1024px)"] })
+      expect(result.current).toEqual([true])
+
+      act(() => fire("(min-width: 1024px)", false))
+      expect(result.current).toEqual([false])
+
+      act(() => fire("(min-width: 768px)", true))
+      expect(result.current).toEqual([false])
+    } finally {
+      window.matchMedia = original
+    }
+  })
+
+  test("works with custom getWindow", () => {
+    const customWindow = {
+      matchMedia: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(min-width: 0px)",
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    } as unknown as typeof window
+
+    const { result } = renderHook(() =>
+      useMediaQuery(["(min-width: 0px)", "(min-width: 768px)"], {
+        getWindow: () => customWindow,
+      }),
+    )
+
+    expect(customWindow.matchMedia).toHaveBeenCalledWith("(min-width: 0px)")
+    expect(customWindow.matchMedia).toHaveBeenCalledWith("(min-width: 768px)")
+    expect(result.current).toEqual([true, false])
+  })
+})

--- a/packages/react/src/hooks/use-media-query.ts
+++ b/packages/react/src/hooks/use-media-query.ts
@@ -1,19 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { useCallbackRef } from "./use-callback-ref"
-
-type MediaQueryCallback = (event: MediaQueryListEvent) => void
-
-function listen(query: MediaQueryList, callback: MediaQueryCallback) {
-  try {
-    query.addEventListener("change", callback)
-    return () => query.removeEventListener("change", callback)
-  } catch (e) {
-    query.addListener(callback)
-    return () => query.removeListener(callback)
-  }
-}
+import { useState, useSyncExternalStore } from "react"
 
 export interface UseMediaQueryOptions {
   fallback?: boolean[] | undefined
@@ -21,59 +8,83 @@ export interface UseMediaQueryOptions {
   getWindow?(): typeof window
 }
 
+class MediaQueryStore {
+  private queries: string[]
+  private getWindow?: () => typeof window
+  private cache: boolean[]
+  private listeners = new Set<() => void>()
+
+  constructor(
+    queries: string[],
+    fallback: boolean[],
+    getWindow?: () => typeof window,
+  ) {
+    this.queries = queries
+    this.getWindow = getWindow
+    this.cache = queries.map((_, i) => !!fallback[i])
+  }
+
+  private getWin = () => {
+    return this.getWindow?.() ?? window
+  }
+
+  private notify = () => {
+    for (const cb of this.listeners) cb()
+  }
+
+  subscribe = (callback: () => void) => {
+    this.listeners.add(callback)
+    const win = this.getWin()
+    const mqls = this.queries.map((q) => win.matchMedia(q))
+    mqls.forEach((mql) => mql.addEventListener("change", this.notify))
+    return () => {
+      this.listeners.delete(callback)
+      mqls.forEach((mql) => mql.removeEventListener("change", this.notify))
+    }
+  }
+
+  getSnapshot = (): boolean[] => {
+    if (typeof document === "undefined") return this.cache
+    const win = this.getWin()
+    const next = this.queries.map((q) => win.matchMedia(q).matches)
+    const prev = this.cache
+    if (prev.length === next.length && prev.every((v, i) => v === next[i])) {
+      return prev
+    }
+    this.cache = next
+    return next
+  }
+
+  getServerSnapshot = (): boolean[] => {
+    return this.cache
+  }
+}
+
 export function useMediaQuery(
   query: string[],
   options: UseMediaQueryOptions = {},
 ): boolean[] {
-  const { fallback: _fallback = [], ssr = true, getWindow } = options
-  const getWin = useCallbackRef(getWindow)
+  const { fallback: _fallback = [], getWindow } = options
 
   const queries = Array.isArray(query) ? query : [query]
-
   const fallback = _fallback?.filter((v) => v != null) as boolean[]
 
-  const [value, setValue] = useState(() => {
-    return queries.map((query, index) => {
-      if (!ssr) {
-        const { media, matches } = (getWindow?.() ?? window).matchMedia(query)
-        return { media, matches }
-      }
-      return { media: query, matches: !!fallback[index] }
-    })
-  })
+  const queryKey = queries.join("\0")
 
-  useEffect(() => {
-    const win = getWin() ?? window
-    setValue((prev) => {
-      const current = queries.map((query) => {
-        const { media, matches } = win.matchMedia(query)
-        return { media, matches }
-      })
+  const [store, setStore] = useState(
+    () => new MediaQueryStore(queries, fallback, getWindow),
+  )
 
-      return prev.every(
-        (v, i) =>
-          v.matches === current[i].matches && v.media === current[i].media,
-      )
-        ? prev
-        : current
-    })
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey)
 
-    const mql = queries.map((query) => win.matchMedia(query))
+  if (queryKey !== prevQueryKey) {
+    setStore(new MediaQueryStore(queries, fallback, getWindow))
+    setPrevQueryKey(queryKey)
+  }
 
-    const handler = (evt: MediaQueryListEvent) => {
-      setValue((prev) => {
-        return prev.slice().map((item) => {
-          if (item.media === evt.media) return { ...item, matches: evt.matches }
-          return item
-        })
-      })
-    }
-
-    const cleanups = mql.map((v) => listen(v, handler))
-    return () => cleanups.forEach((fn) => fn())
-
-    // eslint-disable-next-line
-  }, [getWin])
-
-  return value.map((item) => item.matches)
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot,
+  )
 }

--- a/packages/react/src/hooks/use-media-query.ts
+++ b/packages/react/src/hooks/use-media-query.ts
@@ -8,56 +8,45 @@ export interface UseMediaQueryOptions {
   getWindow?(): typeof window
 }
 
-class MediaQueryStore {
-  private queries: string[]
-  private getWindow?: () => typeof window
-  private cache: boolean[]
-  private listeners = new Set<() => void>()
+function createMediaQueryStore(
+  queries: string[],
+  fallback: boolean[],
+  getWindow?: () => typeof window,
+) {
+  const getWin = () => getWindow?.() ?? window
+  const listeners = new Set<() => void>()
+  let cache: boolean[] = queries.map((_, i) => !!fallback[i])
 
-  constructor(
-    queries: string[],
-    fallback: boolean[],
-    getWindow?: () => typeof window,
-  ) {
-    this.queries = queries
-    this.getWindow = getWindow
-    this.cache = queries.map((_, i) => !!fallback[i])
+  const notify = () => {
+    for (const cb of listeners) cb()
   }
 
-  private getWin = () => {
-    return this.getWindow?.() ?? window
-  }
-
-  private notify = () => {
-    for (const cb of this.listeners) cb()
-  }
-
-  subscribe = (callback: () => void) => {
-    this.listeners.add(callback)
-    const win = this.getWin()
-    const mqls = this.queries.map((q) => win.matchMedia(q))
-    mqls.forEach((mql) => mql.addEventListener("change", this.notify))
+  const subscribe = (callback: () => void) => {
+    listeners.add(callback)
+    const win = getWin()
+    const mqls = queries.map((q) => win.matchMedia(q))
+    mqls.forEach((mql) => mql.addEventListener("change", notify))
     return () => {
-      this.listeners.delete(callback)
-      mqls.forEach((mql) => mql.removeEventListener("change", this.notify))
+      listeners.delete(callback)
+      mqls.forEach((mql) => mql.removeEventListener("change", notify))
     }
   }
 
-  getSnapshot = (): boolean[] => {
-    if (typeof document === "undefined") return this.cache
-    const win = this.getWin()
-    const next = this.queries.map((q) => win.matchMedia(q).matches)
-    const prev = this.cache
+  const getSnapshot = (): boolean[] => {
+    if (typeof document === "undefined") return cache
+    const win = getWin()
+    const next = queries.map((q) => win.matchMedia(q).matches)
+    const prev = cache
     if (prev.length === next.length && prev.every((v, i) => v === next[i])) {
       return prev
     }
-    this.cache = next
+    cache = next
     return next
   }
 
-  getServerSnapshot = (): boolean[] => {
-    return this.cache
-  }
+  const getServerSnapshot = (): boolean[] => cache
+
+  return { subscribe, getSnapshot, getServerSnapshot }
 }
 
 export function useMediaQuery(
@@ -71,14 +60,14 @@ export function useMediaQuery(
 
   const queryKey = queries.join("\0")
 
-  const [store, setStore] = useState(
-    () => new MediaQueryStore(queries, fallback, getWindow),
+  const [store, setStore] = useState(() =>
+    createMediaQueryStore(queries, fallback, getWindow),
   )
 
   const [prevQueryKey, setPrevQueryKey] = useState(queryKey)
 
   if (queryKey !== prevQueryKey) {
-    setStore(new MediaQueryStore(queries, fallback, getWindow))
+    setStore(createMediaQueryStore(queries, fallback, getWindow))
     setPrevQueryKey(queryKey)
   }
 


### PR DESCRIPTION
## 📝 Description

Migrate `useMediaQuery` from `useState` + `useEffect` to `useSyncExternalStore`.

## ⛳️ Current behavior (updates)

Media query values are set via `useEffect`, causing a hydration flicker (SSR fallback → real value) and potential tearing in concurrent mode.

## 🚀 New behavior
No hydration flicker — `useSyncExternalStore` provides the correct value synchronously on the client
No tearing in concurrent mode
`ssr` option kept for backward compatibility but is now a no-op
Dropped legacy `addListener`/`removeListener` fallback (Safari <14)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A

TODO:
- [ ] Test on a large real-world project to validate hydration behavior end-to-end