### PR TITLE
fix(DatePicker): correct border radius for selected dates in range

### DIFF
--- a/packages/react/src/theme/recipes/date-picker.ts
+++ b/packages/react/src/theme/recipes/date-picker.ts
@@ -277,9 +277,6 @@ export const datePickerSlotRecipe = defineSlotRecipe({
       "&[data-selected][data-in-range]": {
         bg: "colorPalette.solid",
         color: "colorPalette.contrast",
-        borderRadius: "0",
-        borderStartRadius: "l2",
-        borderEndRadius: "l2",
         _hover: { bg: "colorPalette.solid" },
       },
       _disabled: {


### PR DESCRIPTION
Selected dates within a date range now have square corners on the sides adjacent to other selected dates, maintaining a continuous rectangular range highlight instead of having rounded corners that break the visual continuity.

Fixes #10710