### PR TITLE
fix(docs): set the aria-label for the extra options menu of the copy page widget

### DIFF
--- a/apps/www/components/llms-copy-widget.tsx
+++ b/apps/www/components/llms-copy-widget.tsx
@@ -30,7 +30,11 @@ export const LLMSCopyWidget = (props: { data: Docs }) => {
         mx="-1px"
         zIndex="1"
       />
-      <ActionMenu data={data} borderStartRadius="0">
+      <ActionMenu
+        data={data}
+        borderStartRadius="0"
+        aria-label="More Markdown options"
+      >
         <LuChevronDown />
       </ActionMenu>
     </ButtonGroup>


### PR DESCRIPTION
Related to https://github.com/chakra-ui/ark/issues/3835

## 📝 Description

This PR sets the `aria-label` for the extra options menu next to the "Copy Page" (as Markdown) button. This way, screen reader users can learn more about the menu without having to open and navigate through it. 

The PR was tested using VoiceOver + Safari and VoiceOver + Chrome.

## ⛳️ Current behavior (updates)

The extra options menu next to the "Copy Page" button on the documentation pages is announced only as a generic menu.

## 🚀 New behavior

The menu is now introduced as "More Markdown options":

https://github.com/user-attachments/assets/b3841bf7-a59d-4717-a5ad-1c975e61c5c8

## 💣 Is this a breaking change (Yes/No):

No