### PR TITLE
docs: add instructions for Figma kit, typegen reminder for theme changes

### DIFF
--- a/apps/www/content/docs/get-started/figma.mdx
+++ b/apps/www/content/docs/get-started/figma.mdx
@@ -29,3 +29,18 @@ You can access the kit for free on Figma Community:
 
 > Everything in the kit is designed to reflect how Chakra UI works, so your
 > design decisions translate directly into production components.
+
+## [Light and Dark Mode](#light-and-dark-mode)
+
+The Figma kit includes both light and dark mode token sets out of the box.
+
+To switch to dark mode tokens:
+
+1. Open the Chakra UI Figma Kit file
+2. Click on "Apply Variable Mode" from the Appearance panel (right sidebar)
+3. Navigate to "Color/Semantic Tokens"
+4. Select "Chakra/dark" to switch to the dark token set
+
+> **Tip:** You can swap between `Chakra/Light` and `Chakra/Dark` at any time
+> without rebuilding your designs — the semantic token layer handles the switch
+> automatically.

--- a/apps/www/content/docs/theming/customization/recipes.mdx
+++ b/apps/www/content/docs/theming/customization/recipes.mdx
@@ -123,6 +123,33 @@ const Title = (props) => {
 }
 ```
 
+## Run Typegen After Theme Changes
+
+> ⚠️ **Important:** Whenever you update `theme.recipes` (or any theme config),
+> you must re-run `typegen` to keep your TypeScript types in sync. If you skip
+> this step, TypeScript will show errors on valid variant properties — errors
+> that look like broken config but are actually just stale generated types.
+
+After any change to your theme, run:
+
+```bash
+npx @chakra-ui/cli typegen
+```
+
+Or, if you have it set up as a script:
+
+```bash
+npm run typegen
+```
+
+When to run typegen:
+
+- After adding or modifying `theme.recipes`
+- After adding or modifying `theme.tokens` or `theme.semanticTokens`
+- After adding or modifying `theme.textStyles` or `theme.layerStyles`
+
+See the [CLI docs](/docs/get-started/cli) for full typegen usage and options.
+
 ## Slot Recipes
 
 To effectively override an existing slot recipe, we recommend connecting to its


### PR DESCRIPTION
## 📝 Description

- Add light and dark mode instructions for the Figma kit.

- Add reminder for typegen command after theme changes.
