### PR TITLE
fix(react): normalize font token array values

### DIFF
--- a/packages/react/__tests__/system.test.ts
+++ b/packages/react/__tests__/system.test.ts
@@ -217,4 +217,25 @@ describe("system", () => {
       }
     `)
   })
+
+  test("should generate font token css from array values", () => {
+    const sys = createSystem({
+      theme: {
+        tokens: {
+          fonts: {
+            heading: { value: ["Roboto Mono", "monospace"] as any },
+          },
+        },
+      },
+    })
+
+    expect(sys.token("fonts.heading")).toBe("Roboto Mono, monospace")
+    expect(sys.getTokenCss()).toEqual({
+      "@layer tokens": {
+        "&:where(:root, :host)": {
+          "--chakra-fonts-heading": "Roboto Mono, monospace",
+        },
+      },
+    })
+  })
 })

--- a/packages/react/__tests__/token-dictionary.test.ts
+++ b/packages/react/__tests__/token-dictionary.test.ts
@@ -222,4 +222,16 @@ describe("token dictionary", () => {
       ]
     `)
   })
+
+  test("font tokens normalize array values", () => {
+    const dict = createTokenDictionary({
+      tokens: {
+        fonts: {
+          heading: { value: ["Roboto Mono", "monospace"] as any },
+        },
+      },
+    })
+
+    expect(dict.getByName("fonts.heading")?.value).toBe("Roboto Mono, monospace")
+  })
 })

--- a/packages/react/src/styled-system/token-dictionary.ts
+++ b/packages/react/src/styled-system/token-dictionary.ts
@@ -44,6 +44,14 @@ const isToken = (value: any) => {
   return isObject(value) && Object.prototype.hasOwnProperty.call(value, "value")
 }
 
+function normalizeTokenValue(category: string, value: any) {
+  if (category === "fonts" && Array.isArray(value)) {
+    return value.join(", ")
+  }
+
+  return value
+}
+
 function expandBreakpoints(breakpoints?: Record<string, string>) {
   if (!breakpoints) return { breakpoints: {}, sizes: {} }
   return {
@@ -113,9 +121,10 @@ export function createTokenDictionary(options: Options): TokenDictionary {
         const name = formatTokenName(path)
 
         const t = isString(entry) ? { value: entry } : entry
+        const value = normalizeTokenValue(category, t.value)
 
         const token: Token = {
-          value: t.value,
+          value,
           originalValue: t.value,
           name,
           path,
@@ -148,9 +157,10 @@ export function createTokenDictionary(options: Options): TokenDictionary {
         const t = isString(entry.value)
           ? { value: { base: entry.value } }
           : entry
+        const value = normalizeTokenValue(category, t.value.base || "")
 
         const token: Token = {
-          value: t.value.base || "",
+          value,
           originalValue: t.value.base || "",
           name,
           path,
@@ -506,7 +516,7 @@ function getConditionalTokens(token: Token) {
     // Efficient shallow clone - only copy what we need to modify
     const nextToken: Token = {
       ...token,
-      value,
+      value: normalizeTokenValue(token.extensions.category, value),
       extensions: {
         ...token.extensions,
         condition: nextPath.join(":"),


### PR DESCRIPTION
## Summary
- normalize font token array values to comma-separated strings before storing them in the token dictionary
- ensure conditional token expansion applies the same normalization
- add regression coverage for token dictionary normalization and generated CSS/token resolution

## Testing
- Added focused regression coverage in:
  - `packages/react/__tests__/system.test.ts`
  - `packages/react/__tests__/token-dictionary.test.ts`

Closes #10763