### PR TITLE
fix(www): move virtual content props to Box in scroll-area example

### DIFF
--- a/apps/compositions/src/examples/scroll-area-virtualization.tsx
+++ b/apps/compositions/src/examples/scroll-area-virtualization.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ScrollArea } from "@chakra-ui/react"
+import { Box, ScrollArea } from "@chakra-ui/react"
 import { type VirtualItem, useVirtualizer } from "@tanstack/react-virtual"
 import { DecorativeBox } from "compositions/lib/decorative-box"
 import React, { useCallback, useMemo, useRef } from "react"
@@ -53,15 +53,17 @@ export const ScrollAreaVirtualization = () => {
   return (
     <ScrollArea.Root height="20rem" maxWidth="xl">
       <ScrollArea.Viewport ref={scrollRef}>
-        <ScrollArea.Content {...contentProps}>
-          {virtualizer.getVirtualItems().map((virtualItem) => {
-            const item = items[virtualItem.index]
-            return (
-              <div key={virtualItem.key} {...getItemProps(virtualItem)}>
-                <DecorativeBox w="full">{item.name}</DecorativeBox>
-              </div>
-            )
-          })}
+        <ScrollArea.Content>
+          <Box {...contentProps}>
+            {virtualizer.getVirtualItems().map((virtualItem) => {
+              const item = items[virtualItem.index]
+              return (
+                <div key={virtualItem.key} {...getItemProps(virtualItem)}>
+                  <DecorativeBox w="full">{item.name}</DecorativeBox>
+                </div>
+              )
+            })}
+          </Box>
         </ScrollArea.Content>
       </ScrollArea.Viewport>
       <ScrollArea.Scrollbar bg="transparent" />

--- a/apps/compositions/src/examples/scroll-area-virtualization.tsx
+++ b/apps/compositions/src/examples/scroll-area-virtualization.tsx
@@ -28,7 +28,7 @@ export const ScrollAreaVirtualization = () => {
     (): React.ComponentProps<"div"> => ({
       style: {
         height: `${virtualizer.getTotalSize()}px`,
-        width: "full",
+        width: "100%",
         position: "relative",
       },
     }),


### PR DESCRIPTION
Closes [#10771](https://github.com/chakra-ui/chakra-ui/issues/10771)

## 📝 Description

Fix `ScrollArea` virtualization example by wrapping virtual content in a `Box` instead of spreading container styles directly on `ScrollArea.Content`.

## ⛳️ Current behavior (updates)

The `scroll-area-virtualization` composition spreads virtualizer container props (`position: relative`, dynamic `height`) directly on `ScrollArea.Content`. This causes the virtual list to not render or scroll correctly because `ScrollArea.Content` does not forward arbitrary style props to the underlying DOM element.

https://github.com/user-attachments/assets/13ead9c5-56aa-49c3-8565-f1036853daf6

## 🚀 New behavior

Virtual container props are now applied to a `Box` element nested inside `ScrollArea.Content`, ensuring the virtualizer's absolute positioning and dynamic height work correctly. The scroll area now properly virtualizes 1000 items.

https://github.com/user-attachments/assets/faffa3c2-436c-4e03-82cc-0be5c3331a7e

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Only affects the `scroll-area-virtualization` composition example. No changes to the core `ScrollArea` component.