### PR TITLE
fix(compositions): add aria-label to icon-only carousel and pagination buttons

### DIFF
--- a/apps/compositions/src/examples/carousel-basic.tsx
+++ b/apps/compositions/src/examples/carousel-basic.tsx
@@ -19,7 +19,7 @@ export const CarouselBasic = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -27,7 +27,7 @@ export const CarouselBasic = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-composition.tsx
+++ b/apps/compositions/src/examples/carousel-composition.tsx
@@ -19,12 +19,12 @@ export const CarouselComposition = () => {
         <Span fontWeight="medium">Popular homes in Cape Town</Span>
         <HStack>
           <Carousel.PrevTrigger asChild>
-            <IconButton size="xs" variant="subtle">
+            <IconButton size="xs" variant="subtle" aria-label="Previous slide">
               <LuChevronLeft />
             </IconButton>
           </Carousel.PrevTrigger>
           <Carousel.NextTrigger asChild>
-            <IconButton size="xs" variant="subtle">
+            <IconButton size="xs" variant="subtle" aria-label="Next slide">
               <LuChevronRight />
             </IconButton>
           </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-controlled.tsx
+++ b/apps/compositions/src/examples/carousel-controlled.tsx
@@ -30,7 +30,7 @@ export const CarouselControlled = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -38,7 +38,7 @@ export const CarouselControlled = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-explorer-demo.tsx
+++ b/apps/compositions/src/examples/carousel-explorer-demo.tsx
@@ -21,7 +21,7 @@ export const CarouselExplorerDemo = () => {
         <Carousel.ProgressText textStyle="sm" minW="8" />
 
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -38,7 +38,7 @@ export const CarouselExplorerDemo = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-slides-per-move.tsx
+++ b/apps/compositions/src/examples/carousel-slides-per-move.tsx
@@ -28,7 +28,7 @@ export const CarouselSlidesPerMove = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -36,7 +36,7 @@ export const CarouselSlidesPerMove = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-slides-per-page.tsx
+++ b/apps/compositions/src/examples/carousel-slides-per-page.tsx
@@ -27,7 +27,7 @@ export const CarouselSlidesPerPage = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -35,7 +35,7 @@ export const CarouselSlidesPerPage = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-spacing.tsx
+++ b/apps/compositions/src/examples/carousel-spacing.tsx
@@ -28,7 +28,7 @@ export const CarouselSpacing = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -36,7 +36,7 @@ export const CarouselSpacing = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-variable-size.tsx
+++ b/apps/compositions/src/examples/carousel-variable-size.tsx
@@ -20,13 +20,13 @@ export const CarouselVariableSize = () => {
     >
       <Carousel.Control gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-vertical.tsx
+++ b/apps/compositions/src/examples/carousel-vertical.tsx
@@ -22,7 +22,7 @@ export const CarouselVertical = () => {
       </Carousel.ItemGroup>
       <Carousel.Control h="100%" justifyContent="space-between" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronUp />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -30,7 +30,7 @@ export const CarouselVertical = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronDown />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-autoplay.tsx
+++ b/apps/compositions/src/examples/carousel-with-autoplay.tsx
@@ -33,7 +33,7 @@ export const CarouselWithAutoplay = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -47,7 +47,7 @@ export const CarouselWithAutoplay = () => {
           </IconButton>
         </Carousel.AutoplayTrigger>
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-dialog.tsx
+++ b/apps/compositions/src/examples/carousel-with-dialog.tsx
@@ -41,7 +41,7 @@ export const CarouselWithDialog = () => {
               <Carousel.Root slideCount={items.length} w="full" h="full">
                 <Carousel.Control justifyContent="center" px="4" gap="4">
                   <Carousel.PrevTrigger asChild>
-                    <IconButton size="xs" variant="ghost">
+                    <IconButton size="xs" variant="ghost" aria-label="Previous slide">
                       <LuChevronLeft />
                     </IconButton>
                   </Carousel.PrevTrigger>
@@ -61,7 +61,7 @@ export const CarouselWithDialog = () => {
                   </Carousel.ItemGroup>
 
                   <Carousel.NextTrigger asChild>
-                    <IconButton size="xs" variant="ghost">
+                    <IconButton size="xs" variant="ghost" aria-label="Next slide">
                       <LuChevronRight />
                     </IconButton>
                   </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-floating-arrow.tsx
+++ b/apps/compositions/src/examples/carousel-with-floating-arrow.tsx
@@ -9,7 +9,7 @@ export const CarouselWithFloatingArrow = () => {
     <Carousel.Root slideCount={items.length} maxW="xl" mx="auto" gap="4">
       <Carousel.Control justifyContent="center" gap="4" width="full">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="outline">
+          <IconButton size="xs" variant="outline" aria-label="Previous slide">
             <LuArrowLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -25,7 +25,7 @@ export const CarouselWithFloatingArrow = () => {
         </Carousel.ItemGroup>
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="outline">
+          <IconButton size="xs" variant="outline" aria-label="Next slide">
             <LuArrowRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-images.tsx
+++ b/apps/compositions/src/examples/carousel-with-images.tsx
@@ -15,7 +15,7 @@ export const CarouselWithImages = () => {
     >
       <Carousel.Control gap="4" width="full" position="relative">
         <Carousel.PrevTrigger asChild>
-          <ActionButton insetStart="4">
+          <ActionButton insetStart="4" aria-label="Previous slide">
             <LuArrowLeft />
           </ActionButton>
         </Carousel.PrevTrigger>
@@ -35,7 +35,7 @@ export const CarouselWithImages = () => {
         </Carousel.ItemGroup>
 
         <Carousel.NextTrigger asChild>
-          <ActionButton insetEnd="4">
+          <ActionButton insetEnd="4" aria-label="Next slide">
             <LuArrowRight />
           </ActionButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-mouse-drag.tsx
+++ b/apps/compositions/src/examples/carousel-with-mouse-drag.tsx
@@ -27,7 +27,7 @@ export const CarouselWithMouseDrag = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -35,7 +35,7 @@ export const CarouselWithMouseDrag = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-progress-text.tsx
+++ b/apps/compositions/src/examples/carousel-with-progress-text.tsx
@@ -19,13 +19,13 @@ export const CarouselWithProgressText = () => {
 
       <Carousel.Control gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuArrowLeft />
           </IconButton>
         </Carousel.PrevTrigger>
         <Carousel.ProgressText />
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuArrowRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-store.tsx
+++ b/apps/compositions/src/examples/carousel-with-store.tsx
@@ -26,7 +26,7 @@ export const CarouselWithStore = () => {
 
       <Carousel.Control justifyContent="center" gap="4">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -34,7 +34,7 @@ export const CarouselWithStore = () => {
         <Carousel.Indicators />
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="ghost">
+          <IconButton size="xs" variant="ghost" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/carousel-with-thumbnails.tsx
+++ b/apps/compositions/src/examples/carousel-with-thumbnails.tsx
@@ -6,7 +6,7 @@ export const CarouselWithThumbnails = () => {
     <Carousel.Root slideCount={items.length} maxW="2xl" gap="4">
       <Carousel.Control justifyContent="center" gap="4" width="full">
         <Carousel.PrevTrigger asChild>
-          <IconButton size="xs" variant="outline">
+          <IconButton size="xs" variant="outline" aria-label="Previous slide">
             <LuChevronLeft />
           </IconButton>
         </Carousel.PrevTrigger>
@@ -27,7 +27,7 @@ export const CarouselWithThumbnails = () => {
         </Carousel.ItemGroup>
 
         <Carousel.NextTrigger asChild>
-          <IconButton size="xs" variant="outline">
+          <IconButton size="xs" variant="outline" aria-label="Next slide">
             <LuChevronRight />
           </IconButton>
         </Carousel.NextTrigger>

--- a/apps/compositions/src/examples/pagination-with-count-text.tsx
+++ b/apps/compositions/src/examples/pagination-with-count-text.tsx
@@ -7,12 +7,12 @@ export const PaginationWithCountText = () => {
       <ButtonGroup variant="ghost" size="sm" w="full">
         <Pagination.PageText format="long" flex="1" />
         <Pagination.PrevTrigger asChild>
-          <IconButton>
+          <IconButton aria-label="Previous page">
             <LuChevronLeft />
           </IconButton>
         </Pagination.PrevTrigger>
         <Pagination.NextTrigger asChild>
-          <IconButton>
+          <IconButton aria-label="Next page">
             <LuChevronRight />
           </IconButton>
         </Pagination.NextTrigger>


### PR DESCRIPTION
## Summary

All `Carousel.PrevTrigger` / `Carousel.NextTrigger` examples across the compositions library were rendering icon-only `IconButton` components **without an accessible name**. Screen readers would announce these as generic "button" elements, giving keyboard/AT users no indication of their purpose.

The same issue existed in `pagination-with-count-text.tsx`.

### Changes

- **17 carousel example files**: Added `aria-label="Previous slide"` and `aria-label="Next slide"` to every icon-only prev/next `IconButton` (including the vertical carousel which uses up/down chevrons)
- **`pagination-with-count-text.tsx`**: Added `aria-label="Previous page"` and `aria-label="Next page"` to the pagination icon buttons

### Why not fix this in the component defaults?

`Carousel.PrevTrigger` and `Carousel.NextTrigger` intentionally accept `asChild` for custom rendering. Adding a default `aria-label` in `defaultProps` would be overridden by users who pass their own, and the correct label text is context-dependent (e.g., could be "Previous image" or "Previous item"). Fixing the examples is the right layer — it sets a clear pattern for consumers.

### WCAG reference

WCAG 2.1 SC 4.1.2 — Name, Role, Value: interactive controls must have a programmatically determinable name.

## Test plan

- [ ] Review the diff — every modified `IconButton` that wraps a chevron/arrow icon now has `aria-label`
- [ ] Open any carousel example in a browser with VoiceOver or NVDA — prev/next buttons are now announced with their purpose