### PR TITLE
fix: reject invalid css unit decimals

### DIFF
--- a/packages/react/__tests__/unit.test.ts
+++ b/packages/react/__tests__/unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest"
+import { isCssUnit } from "../src/utils/unit"
+
+describe("isCssUnit", () => {
+  test("accepts valid CSS length values", () => {
+    expect(isCssUnit("12px")).toBe(true)
+    expect(isCssUnit("1.5rem")).toBe(true)
+    expect(isCssUnit("-.5em")).toBe(true)
+    expect(isCssUnit("1e3px")).toBe(true)
+    expect(isCssUnit("100%")).toBe(true)
+  })
+
+  test("rejects invalid decimal separators", () => {
+    expect(isCssUnit("1a5rem")).toBe(false)
+    expect(isCssUnit("1-5rem")).toBe(false)
+    expect(isCssUnit("12 px")).toBe(false)
+  })
+})

--- a/packages/react/src/utils/unit.ts
+++ b/packages/react/src/utils/unit.ts
@@ -2,7 +2,7 @@ const lengthUnits =
   "cm,mm,Q,in,pc,pt,px,em,ex,ch,rem,lh,rlh,vw,vh,vmin,vmax,vb,vi,svw,svh,lvw,lvh,dvw,dvh,cqw,cqh,cqi,cqb,cqmin,cqmax,%"
 const lengthUnitsPattern = `(?:${lengthUnits.split(",").join("|")})`
 const lengthRegExp = new RegExp(
-  `^[+-]?[0-9]*.?[0-9]+(?:[eE][+-]?[0-9]+)?${lengthUnitsPattern}$`,
+  `^[+-]?[0-9]*\\.?[0-9]+(?:[eE][+-]?[0-9]+)?${lengthUnitsPattern}$`,
 )
 
 export const isCssUnit = (v: unknown) =>


### PR DESCRIPTION

**Repo:** chakra-ui/chakra-ui (⭐ 38000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +19/-1

## What
This change fixes the `isCssUnit` helper in `packages/react/src/utils/unit.ts` so it only accepts a literal decimal point when parsing CSS length values. It also adds a focused Vitest regression test covering valid values like `1.5rem` and `100%`, plus invalid inputs such as `1a5rem`, `1-5rem`, and `12 px`.

## Why
The previous regex used `.?` instead of `\\.?`, which allowed any single character to act like a decimal separator. That meant malformed values such as `1a5rem` and `1-5rem` could be treated as valid CSS units and flow into spacing-related styling logic. Tightening the regex closes that gap with a minimal, low-risk fix and a test that prevents regressions.

## Testing
Attempted to run `pnpm vitest run packages/react/__tests__/unit.test.ts`, but `pnpm` could not execute in this sandbox because it tried to access blocked global/cache paths and then the network. As a lightweight local check, I verified the corrected regex behavior with `node`, confirming valid units pass and malformed separators are rejected.

## Risk
Low / The change narrows a utility regex to reject invalid input and adds direct regression coverage for the intended behavior.
