### PR TITLE
fix: correct variant inference in RecipeSelection for defaultVariants

### DIFF
--- a/packages/react/src/styled-system/recipe.types.ts
+++ b/packages/react/src/styled-system/recipe.types.ts
@@ -4,7 +4,7 @@ import type { ColorPalette } from "./generated/token.gen"
 
 type StringToBoolean<T> = T extends "true" | "false" ? boolean : T
 
-export type RecipeVariantRecord = Record<any, Record<any, SystemStyleObject>>
+export type RecipeVariantRecord = Record<string, Record<string, SystemStyleObject>>
 
 export type RecipeSelection<
   T extends RecipeVariantRecord | SlotRecipeVariantRecord<string>,


### PR DESCRIPTION
## Fix: `defaultVariants` does not accept valid variant keys (TypeScript)

### Summary

This PR fixes a TypeScript typing issue where valid keys such as `variant` are rejected inside `defaultVariants`, even though they work correctly at runtime.

---

### Problem

When defining a recipe:

```ts
defaultVariants: {
  variant: "subtle", //  TypeScript error
}
```

TypeScript reports that `variant` is not a valid property, despite the component rendering correctly.

---

### Root Cause

The issue originates from the definition of:

```ts
type RecipeVariantRecord = Record<any, Record<any, SystemStyleObject>>
```

Using `Record<any, ...>` causes TypeScript to widen all keys to:

```
string | number | symbol
```

This breaks type inference and triggers the fallback condition in:

```ts
type RecipeSelection<T> =
  keyof any extends keyof T ? {} : { ... }
```

Since `keyof T` becomes too broad, the condition evaluates to `true`, and `RecipeSelection<T>` resolves to `{}`.

As a result, no keys (like `variant`, `size`) are available in `defaultVariants`.

---

### Solution

Update `RecipeVariantRecord` to preserve key types:

```ts
type RecipeVariantRecord = Record<string, Record<string, SystemStyleObject>>
```

This ensures:

* Literal keys (e.g. `variant`, `size`) are preserved
* `RecipeSelection<T>` correctly infers valid keys
* The fallback `{}` case is no longer incorrectly triggered

---

### Result

After this change:

```ts
defaultVariants: {
  variant: "subtle", //  correctly typed
}
```

Invalid values are still rejected:

```ts
defaultVariants: {
  variant: "invalid", // type error (expected)
}
```

---

### Scope of Change

* Type-level fix only (no runtime impact)
* Minimal and targeted change
* Improves developer experience without loosening type safety

---

### Notes

* The fallback logic in `RecipeSelection<T>` is preserved
* This PR ensures that valid recipe definitions do not lose type information prematurely
* Tested with button and other recipe components


