### PR TITLE
fix(react): preserve semantic token condition metadata

### DIFF
--- a/.changeset/fix-token-dictionary-conditions.md
+++ b/.changeset/fix-token-dictionary-conditions.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix token dictionary lookups to preserve semantic token condition metadata when
+using `getByName`.

--- a/packages/react/__tests__/token-dictionary.test.ts
+++ b/packages/react/__tests__/token-dictionary.test.ts
@@ -122,6 +122,55 @@ describe("token dictionary", () => {
     `)
   })
 
+  test("getByName returns semantic token metadata with conditions", () => {
+    const dict = createTokenDictionary({
+      semanticTokens: {
+        colors: {
+          accent: { value: { base: "red", _dark: "blue" } },
+        },
+      },
+    })
+
+    const token = dict.getByName("colors.accent")
+
+    expect(token?.value).toBe("red")
+    expect(token?.extensions.condition).toBe("base")
+    expect(token?.extensions.conditions).toEqual({ base: "red", _dark: "blue" })
+  })
+
+  test("semantic token references preserve conditional token references", () => {
+    const dict = createTokenDictionary({
+      prefix: "chakra",
+      tokens: {
+        colors: {
+          blue: {
+            100: { value: "#dbeafe" },
+            900: { value: "#14204a" },
+          },
+        },
+      },
+      semanticTokens: {
+        colors: {
+          primary: {
+            value: {
+              base: "{colors.blue.900}",
+              _dark: "{colors.blue.100}",
+            },
+          },
+          fg: {
+            DEFAULT: {
+              value: "{colors.primary}",
+            },
+          },
+        },
+      },
+    })
+
+    expect(dict.getByName("colors.fg")?.value).toBe(
+      "var(--chakra-colors-primary)",
+    )
+  })
+
   test("comma-list token categories: array value is joined (fonts, shadows, …) — issue #10763", () => {
     const dict = createTokenDictionary({
       tokens: {

--- a/packages/react/src/styled-system/token-dictionary.ts
+++ b/packages/react/src/styled-system/token-dictionary.ts
@@ -87,7 +87,13 @@ export function createTokenDictionary(options: Options): TokenDictionary {
 
   function registerToken(token: Token, phase?: TokenEnforcePhase) {
     allTokens.push(token)
-    tokenNameMap.set(token.name, token)
+
+    if (
+      token.extensions.condition === "base" ||
+      !tokenNameMap.has(token.name)
+    ) {
+      tokenNameMap.set(token.name, token)
+    }
 
     if (phase) {
       transforms.forEach((fn) => {


### PR DESCRIPTION
Closes #10797
Closes #10798

## 📝 Description

Preserves the base semantic token entry in `tokenNameMap` so `TokenDictionary.getByName()` returns the token that carries `extensions.conditions`, rather than a later generated conditional branch.

## ⛳️ Current behavior (updates)

Generated conditional semantic token branches reuse the same token name and overwrite the dictionary's name lookup. That makes `getByName("colors.primary")` return the last conditional branch without `extensions.conditions`, and can cause semantic token references to resolve to a branch value instead of the referenced CSS variable.

## 🚀 New behavior

Base token entries continue to back `getByName()`, preserving condition metadata and allowing semantic-token references to remain CSS variable references. Added regression tests for both direct `getByName()` metadata and references to conditional semantic tokens.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Verification:

- `pnpm exec vitest run packages/react/__tests__/token-dictionary.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter=@chakra-ui/react typecheck`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint --no-cache` (passes with existing warnings in `packages/cli/src/utils/io.ts` and `packages/react/src/styled-system/generated/prop-types.gen.ts`)
- `pnpm exec prettier --check packages/react/src/styled-system/token-dictionary.ts packages/react/__tests__/token-dictionary.test.ts .changeset/fix-token-dictionary-conditions.md`
- `pnpm --filter=@chakra-ui/react build:fast`
