### PR TITLE
fix: normalize nested token overrides when merging default theme

### DIFF
--- a/.changeset/large-dancers-bet.md
+++ b/.changeset/large-dancers-bet.md
@@ -1,0 +1,13 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix: normalize nested token overrides when merging default theme
+
+When merging a custom token into the default theme, token normalization could
+stop at the category level (for example `colors`) and prevent promoting flat
+tokens to `DEFAULT`. This change updates the merge logic so adding nested
+overrides like `colors.black.100` correctly moves the original `colors.black`
+value to `DEFAULT` and resolves nested tokens.
+
+Fixes: #10800

--- a/packages/react/__tests__/merge-config.test.ts
+++ b/packages/react/__tests__/merge-config.test.ts
@@ -139,6 +139,59 @@ describe("mergeConfig", () => {
     `)
   })
 
+  test("should handle nested token overrides with mixed-case sibling keys", () => {
+    const baseConfig = {
+      theme: {
+        tokens: {
+          colors: {
+            black: { value: "#09090B" },
+            whiteAlpha: {
+              100: { value: "rgba(255, 255, 255, 0.06)" },
+            },
+          },
+        },
+      },
+    }
+
+    const customConfig = defineConfig({
+      theme: {
+        tokens: {
+          colors: {
+            black: {
+              100: { value: "#EE0F0F" },
+            },
+          },
+        },
+      },
+    })
+
+    const mergedConfig = mergeConfigs(baseConfig, customConfig)
+    const system = createSystem(mergedConfig)
+
+    expect(system.token("colors.black")).toBe("#09090B")
+    expect(system.token("colors.black.100")).toBe("#EE0F0F")
+
+    expect(mergedConfig.theme?.tokens).toMatchInlineSnapshot(`
+      {
+        "colors": {
+          "black": {
+            "100": {
+              "value": "#EE0F0F",
+            },
+            "DEFAULT": {
+              "value": "#09090B",
+            },
+          },
+          "whiteAlpha": {
+            "100": {
+              "value": "rgba(255, 255, 255, 0.06)",
+            },
+          },
+        },
+      }
+    `)
+  })
+
   test("override functions should be merged", () => {
     const baseConfig = defineConfig({
       utilities: {

--- a/packages/react/src/styled-system/merge-config.ts
+++ b/packages/react/src/styled-system/merge-config.ts
@@ -37,14 +37,11 @@ export const mergeConfigs = (...configs: SystemConfig[]): SystemConfig => {
       },
       {
         stop(value) {
-          // Stop traversal when we encounter a token-like object
+          // Stop traversal only for actual token entries.
+          // Mixed-case token names like `whiteAlpha` live at the category level
+          // and should not prevent us from reaching sibling tokens like `black`.
           return (
-            isValidToken(value) &&
-            Object.keys(value).some(
-              (k) =>
-                tokenKeys.includes(k) ||
-                (k !== k.toLowerCase() && k !== k.toUpperCase()),
-            )
+            isValidToken(value) && tokenKeys.some((key) => value[key] != null)
           )
         },
       },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #10800 <!-- Github issue # here -->

## 📝 Description

Fix token normalization when merging custom tokens into the default theme so nested overrides are correctly promoted and resolved.

## ⛳️ Current behavior (updates)

When merging a custom theme, flat tokens can be left unpromoted and nested overrides like colors.black.100 may be undefined.

## 🚀 New behavior

Merge logic now promotes existing flat tokens to DEFAULT when nested overrides are added, ensuring system.token("colors.black.100") resolves.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->
No

## 📝 Additional Information

Includes a regression test and an updated changeset; fixes issue #10800.