### PR TITLE
fix(www): account for banner height in docs sidebars

### DIFF
--- a/apps/www/app/docs/sidebar.tsx
+++ b/apps/www/app/docs/sidebar.tsx
@@ -42,7 +42,7 @@ export const SidebarStart = (props: BoxProps) => {
       py="8"
       flexShrink="0"
       ref={containerRef}
-      height="var(--content-height)"
+      height="var(--sidebar-height)"
       overflowY="auto"
       overscrollBehavior="contain"
       width="16rem"
@@ -77,7 +77,7 @@ export const SidebarEnd = (props: BoxProps) => {
       pb="8"
       px="2"
       flexShrink="0"
-      height="var(--content-height)"
+      height="var(--sidebar-height)"
       overflowY="auto"
       overscrollBehavior="contain"
       width="16rem"

--- a/apps/www/app/theme.ts
+++ b/apps/www/app/theme.ts
@@ -11,8 +11,10 @@ export const system = createSystem(defaultConfig, {
   },
   globalCss: {
     ":root": {
+      "--banner-height": "44px",
       "--header-height": { base: "64px", md: "104px" },
       "--content-height": "calc(100dvh - var(--header-height))",
+      "--sidebar-height": "calc(var(--content-height) - var(--banner-height))",
     },
   },
 })


### PR DESCRIPTION
## 📝 Description
Fixes the docs sidebar height calculation when the top promo banner is visible.

## ⛳️ Current behavior (updates)
The docs sidebars use `--content-height`, which subtracts only the sticky header height from
the viewport height.

When the promo banner is visible, it also takes up vertical space. On shorter desktop
viewports, this can make the sidebar scroll container extend past the visible viewport,
causing the bottom of the sidebar content to appear clipped.

## 🚀 New behavior
Adds a sidebar-specific height variable that accounts for the promo banner height, and applies
it only to the docs sidebars.

This keeps the existing docs content height unchanged while preventing the sidebar scroll area
from extending below the viewport when the banner is visible.

## 📸 Screenshots

### Before
<img width="1722" height="964" alt="image" src="https://github.com/user-attachments/assets/740b72e7-a42b-44d7-956a-ef2278f8c74a" />

The sidebar scroll area extends past the visible viewport when the promo banner is visible.

### After
<img width="1725" height="966" alt="image" src="https://github.com/user-attachments/assets/f88b9574-6ac8-4679-8b12-2f3c9be4b040" />

The sidebar scroll area accounts for the promo banner height.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
Tested with:
- `pnpm --dir apps/www exec eslint app/theme.ts app/docs/sidebar.tsx`
- Manually checked `/docs/get-started/installation`