### PR TITLE
docs(migration): fix typos in Theme Tools and IconButton sections

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -247,7 +247,7 @@ We now use CSS color-mix
 ```jsx
 defineStyle({
   bg: "blue.200/16",
-  // -> color-mix(in srgb, var(--chakra-colors-200), transparent 16%)
+  // -> color-mix(in srgb, var(--chakra-colors-blue-200), transparent 16%)
 })
 ```
 
@@ -1548,7 +1548,7 @@ After:
 ### IconButton
 
 - `icon` → render as `children` directly
-- `isRounded` → `borderRadius="full"`
+- `isRound` → `borderRadius="full"`
 - `isDisabled` → `disabled`
 
 Before:

--- a/packages/codemod/docs/ICON_BUTTON_MIGRATION.md
+++ b/packages/codemod/docs/ICON_BUTTON_MIGRATION.md
@@ -11,7 +11,7 @@ React patterns. The codemod automatically handles these transformations.
 ## Key Changes
 
 1. **`icon` prop removed**: Icons are now passed as direct children
-2. **`isRounded` → `borderRadius="full"`**: Updated prop name for clarity
+2. **`isRound` → `borderRadius="full"`**: Updated prop name for clarity
 
 ## Transformation Examples
 


### PR DESCRIPTION
 ## 📝 Description

Fixes two documentation errors in the v3 migration guide (`apps/www/content/docs/get started/migration.mdx`).

## ⛳️ Current behavior (updates)

1. **Theme Tools section** — Comment shows `var(--chakra-colors-200)` (missing color name `blue`). Should be `var(--chakra-colors-blue-200)` per the naming convention `--chakra-colors-{colorName}{shade}` documented in [theming/overview](https://chakra-ui.com/docs/theming/overview).

2. **IconButton section** — Before-example uses `isRounded` prop, but v2 API was `isRound` (no "d"). See [v2 IconButton docs](https://v2.chakra-ui.com/docs/components/icon-button).

Both errors can mislead developers migrating from v2 — wrong CSS variable name in manual usage, or failed search for `isRounded` that doesn't exist in their codebase.

## 🚀 New behavior

- Comment corrected: `var(--chakra-colors-200)` → `var(--chakra-colors-blue-200)`
- Prop name corrected: `isRounded` → `isRound`

## 💣 Is this a breaking change (Yes/No):

No — documentation-only change.

## 📝 Additional Information

The runtime code is correct in both cases — only comments and examples are wrong.