### PR TITLE
Fix link focus outline visibility -  by showing link outline only for keyboard focus

### DIFF
--- a/packages/react/src/theme/recipes/link.ts
+++ b/packages/react/src/theme/recipes/link.ts
@@ -9,7 +9,8 @@ export const linkRecipe = defineRecipe({
     gap: "1.5",
     cursor: "pointer",
     borderRadius: "l1",
-    focusRing: "outside",
+    focusRing: "none",
+    focusVisibleRing: "outside",
   },
 
   variants: {


### PR DESCRIPTION
Closes #10812

## 📝 Description

Updated the Link recipe so focus outlines appear only during keyboard navigation using `focusVisibleRing`.

## ⛳️ Current behavior (updates)

Currently, the Link component shows a focus outline even when clicked using the mouse, which can feel visually distracting.

## 🚀 New behavior

The Link component now:

- hides the focus outline on mouse click
- shows the outline only during keyboard navigation (`Tab` focus)

This aligns the behavior with other Chakra UI components and improves accessibility UX consistency.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Replaced:

```ts
focusRing: "outside"