### PR TITLE
chore(cli): migrate from deprecated tsconfck to get-tsconfig

### DIFF
--- a/.changeset/chore-cli-migrate-get-tsconfig.md
+++ b/.changeset/chore-cli-migrate-get-tsconfig.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Migrate from deprecated `tsconfck` to `get-tsconfig`. Enables installation next
+to TypeScript version 6 and up.

--- a/packages/cli/__tests__/resolve-tsconfig.test.ts
+++ b/packages/cli/__tests__/resolve-tsconfig.test.ts
@@ -85,7 +85,7 @@ describe("resolveTsconfig", () => {
     expect(result).toBe(appTsconfigPath)
   })
 
-  it("falls back to first reference when no paths found", async () => {
+  it("picks the reference that includes the source file when no paths exist", async () => {
     writeFileSync(
       join(testDir, "tsconfig.json"),
       JSON.stringify({
@@ -157,7 +157,7 @@ describe("resolveTsconfig", () => {
     expect(result).toBe(tsconfigPath)
   })
 
-  it("picks the reference with paths when it is not the first one", async () => {
+  it("picks the matching reference regardless of reference order", async () => {
     writeFileSync(
       join(testDir, "tsconfig.json"),
       JSON.stringify({
@@ -234,9 +234,9 @@ describe("resolveTsconfig", () => {
   })
 
   it("picks non-first reference with inherited paths over first reference without", async () => {
-    // This test disambiguates: does get-tsconfig merge `extends` in referenced
-    // configs so our `paths` check finds inherited paths? If not, the fallback
-    // would wrongly pick tsconfig.node.json (listed first).
+    // The matched config inherits its `paths` via `extends`. parseTsconfig
+    // resolves the extends chain, so the returned config still exposes the
+    // inherited paths to downstream consumers (e.g. esbuild).
     writeFileSync(
       join(testDir, "tsconfig.json"),
       JSON.stringify({
@@ -274,6 +274,97 @@ describe("resolveTsconfig", () => {
       appTsconfigPath,
       JSON.stringify({
         extends: "./tsconfig.base.json",
+        include: ["src"],
+      }),
+    )
+
+    writeFileSync(join(testDir, "src/index.ts"), "export default {}")
+
+    const result = await resolveTsconfig(join(testDir, "src/index.ts"))
+    expect(result).toBe(appTsconfigPath)
+  })
+
+  it("falls back to the root config when no reference includes the source file", async () => {
+    const rootTsconfigPath = join(testDir, "tsconfig.json")
+    writeFileSync(
+      rootTsconfigPath,
+      JSON.stringify({
+        files: [],
+        references: [{ path: "./tsconfig.node.json" }],
+      }),
+    )
+
+    writeFileSync(
+      join(testDir, "tsconfig.node.json"),
+      JSON.stringify({
+        compilerOptions: {},
+        include: ["vite.config.ts"],
+      }),
+    )
+
+    writeFileSync(join(testDir, "src/index.ts"), "export default {}")
+
+    const result = await resolveTsconfig(join(testDir, "src/index.ts"))
+    expect(result).toBe(rootTsconfigPath)
+  })
+
+  it("resolves nested project references", async () => {
+    writeFileSync(
+      join(testDir, "tsconfig.json"),
+      JSON.stringify({
+        files: [],
+        references: [{ path: "./tsconfig.solution.json" }],
+      }),
+    )
+
+    // intermediate solution-style config referencing the app config
+    writeFileSync(
+      join(testDir, "tsconfig.solution.json"),
+      JSON.stringify({
+        files: [],
+        references: [{ path: "./tsconfig.app.json" }],
+      }),
+    )
+
+    const appTsconfigPath = join(testDir, "tsconfig.app.json")
+    writeFileSync(
+      appTsconfigPath,
+      JSON.stringify({
+        compilerOptions: {
+          paths: { "@/*": ["./src/*"] },
+        },
+        include: ["src"],
+      }),
+    )
+
+    writeFileSync(join(testDir, "src/index.ts"), "export default {}")
+
+    const result = await resolveTsconfig(join(testDir, "src/index.ts"))
+    expect(result).toBe(appTsconfigPath)
+  })
+
+  it("tolerates circular and missing references", async () => {
+    writeFileSync(
+      join(testDir, "tsconfig.json"),
+      JSON.stringify({
+        files: [],
+        references: [
+          // circular: points back to the root config
+          { path: "./tsconfig.json" },
+          // missing: file does not exist
+          { path: "./tsconfig.missing.json" },
+          { path: "./tsconfig.app.json" },
+        ],
+      }),
+    )
+
+    const appTsconfigPath = join(testDir, "tsconfig.app.json")
+    writeFileSync(
+      appTsconfigPath,
+      JSON.stringify({
+        compilerOptions: {
+          paths: { "@/*": ["./src/*"] },
+        },
         include: ["src"],
       }),
     )

--- a/packages/cli/__tests__/resolve-tsconfig.test.ts
+++ b/packages/cli/__tests__/resolve-tsconfig.test.ts
@@ -229,12 +229,12 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(testDir, "src/index.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
-    // tsconfck merges extends into the parsed tsconfig, so paths should be visible
+    // get-tsconfig merges extends into the parsed tsconfig, so paths should be visible
     expect(result).toBe(appTsconfigPath)
   })
 
   it("picks non-first reference with inherited paths over first reference without", async () => {
-    // This test disambiguates: does tsconfck merge `extends` in referenced
+    // This test disambiguates: does get-tsconfig merge `extends` in referenced
     // configs so our `paths` check finds inherited paths? If not, the fallback
     // would wrongly pick tsconfig.node.json (listed first).
     writeFileSync(

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,7 @@
     "debug": "^4.4.3",
     "dotenv": "^17.2.3",
     "esbuild": "^0.27.3",
+    "get-tsconfig": "^4.14.0",
     "globby": "16.1.1",
     "https-proxy-agent": "^7.0.6",
     "look-it-up": "2.1.0",
@@ -69,7 +70,6 @@
     "prettier": "3.8.1",
     "recast": "^0.23.0",
     "scule": "1.3.0",
-    "tsconfck": "^3.1.6",
     "zod": "^3.25.76"
   },
   "peerDependencies": {

--- a/packages/cli/src/utils/resolve-tsconfig.ts
+++ b/packages/cli/src/utils/resolve-tsconfig.ts
@@ -10,7 +10,6 @@ type ConfigNode = {
   path: string
   config: TsConfigJsonResolved
   references?: ConfigNode[]
-  parent?: ConfigNode
 }
 
 // resolve relative path to referenced tsconfig
@@ -41,7 +40,6 @@ function loadReference(
   const node: ConfigNode = {
     path: configPath,
     config,
-    parent,
   }
 
   // follow nested references
@@ -61,10 +59,19 @@ function resolveReferences(
   if (!references?.length) return node
 
   debug("solution-style tsconfig detected, checking references...")
-  node.references = references.map((ref) => {
-    if (!ref?.path)
-      throw new Error(`Invalid tsconfig reference in ${node.path}`)
-    return loadReference(node, ref.path, seen)
+  node.references = references.flatMap((ref) => {
+    // Skip references that are missing, malformed, or circular so a single
+    // broken entry doesn't fail resolution for the whole project
+    if (!ref?.path) {
+      debug("invalid tsconfig reference in", node.path)
+      return []
+    }
+    try {
+      return [loadReference(node, ref.path, seen)]
+    } catch (error) {
+      debug("skipping unresolvable reference:", ref.path, error)
+      return []
+    }
   })
 
   return node

--- a/packages/cli/src/utils/resolve-tsconfig.ts
+++ b/packages/cli/src/utils/resolve-tsconfig.ts
@@ -1,8 +1,104 @@
 import createDebug from "debug"
-import { resolve } from "node:path"
-import { parse } from "tsconfck"
+import { createFilesMatcher, getTsconfig, parseTsconfig } from "get-tsconfig"
+import type { TsConfigJsonResolved } from "get-tsconfig"
+import { realpathSync, statSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
 
 const debug = createDebug("chakra:tsconfig")
+
+type ConfigNode = {
+  path: string
+  config: TsConfigJsonResolved
+  references?: ConfigNode[]
+  parent?: ConfigNode
+}
+
+// resolve relative path to referenced tsconfig
+function resolveReferencePath(configPath: string, refPath: string): string {
+  const base = resolve(dirname(configPath), refPath)
+
+  try {
+    if (statSync(base).isFile()) return base
+  } catch {}
+
+  return join(base, "tsconfig.json")
+}
+
+// recursively load referenced tsconfigs
+function loadReference(
+  parent: ConfigNode,
+  refPath: string,
+  seen: Set<string>,
+): ConfigNode {
+  const configPath = resolveReferencePath(parent.path, refPath)
+
+  const real = realpathSync(configPath)
+  if (seen.has(real)) {
+    throw new Error(`Circular tsconfig reference: ${configPath}`)
+  }
+
+  const config = parseTsconfig(configPath)
+  const node: ConfigNode = {
+    path: configPath,
+    config,
+    parent,
+  }
+
+  // follow nested references
+  seen.add(real)
+  resolveReferences(node, seen)
+  seen.delete(real)
+
+  return node
+}
+
+// recursively resolve referenced tsconfigs
+function resolveReferences(
+  node: ConfigNode,
+  seen = new Set<string>(),
+): ConfigNode {
+  const { references } = node.config
+  if (!references?.length) return node
+
+  debug("solution-style tsconfig detected, checking references...")
+  node.references = references.map((ref) => {
+    if (!ref?.path)
+      throw new Error(`Invalid tsconfig reference in ${node.path}`)
+    return loadReference(node, ref.path, seen)
+  })
+
+  return node
+}
+
+function findConfigForFile(root: ConfigNode, sourceFile: string): ConfigNode {
+  function visit(node: ConfigNode): ConfigNode | undefined {
+    // Explore children first so the first matching descendant wins.
+    for (const ref of node.references ?? []) {
+      const match = visit(ref)
+      if (match) return match
+    }
+
+    const matcher = createFilesMatcher(node)
+    return matcher(sourceFile) ? node : undefined
+  }
+
+  return visit(root) ?? root
+}
+
+function loadResolvedConfig(sourceFile: string): ConfigNode | undefined {
+  const root = getTsconfig(sourceFile)
+  if (!root) return undefined
+
+  const real = realpathSync(root.path)
+  const node: ConfigNode = {
+    path: root.path,
+    config: root.config,
+  }
+
+  const seen = new Set([real])
+  const resolved = resolveReferences(node, seen)
+  return findConfigForFile(resolved, sourceFile)
+}
 
 /**
  * Resolves the correct tsconfig file for a given source file.
@@ -22,33 +118,15 @@ export async function resolveTsconfig(
   }
 
   try {
-    const result = await parse(sourceFile)
+    const nearest = loadResolvedConfig(sourceFile)
 
-    if (!result.tsconfigFile) {
+    if (!nearest) {
       debug("no tsconfig found for", sourceFile)
       return undefined
     }
 
-    debug("found tsconfig:", result.tsconfigFile)
-
-    // If this is a solution-style tsconfig (has references, no real files),
-    // find the referenced config that contains `paths`
-    if (result.referenced && result.referenced.length > 0) {
-      debug("solution-style tsconfig detected, checking references...")
-
-      for (const ref of result.referenced) {
-        if (ref.tsconfig?.compilerOptions?.paths) {
-          debug("found paths in referenced tsconfig:", ref.tsconfigFile)
-          return ref.tsconfigFile
-        }
-      }
-
-      // Fall back to the first referenced tsconfig
-      debug("no paths found in references, using first reference")
-      return result.referenced[0].tsconfigFile
-    }
-
-    return result.tsconfigFile
+    debug("found tsconfig:", nearest.path)
+    return nearest.path
   } catch (error) {
     debug("tsconfig resolution failed:", error)
     return undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,6 +598,9 @@ importers:
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
+      get-tsconfig:
+        specifier: ^4.14.0
+        version: 4.14.0
       globby:
         specifier: 16.1.1
         version: 16.1.1
@@ -622,9 +625,6 @@ importers:
       scule:
         specifier: 1.3.0
         version: 1.3.0
-      tsconfck:
-        specifier: ^3.1.6
-        version: 3.1.6(typescript@5.9.3)
       zod:
         specifier: ^3.25.76
         version: 3.25.76


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #10787 

## 📝 Description

Remove dependency of the CLI to [`tsconfck`](https://github.com/dominikg/tsconfck) due to deprecation (see https://github.com/dominikg/tsconfck/issues/240). As suggested, migrate to [`get-tsconfig`](https://github.com/privatenumber/get-tsconfig).

## ⛳️ Current behavior (updates)

The CLI command `typegen` relies on `tsconfck` to find the tsconfig-file that declares `paths` aliases for resolution of import path.

`tsconfck` has a peer dependency on `typescript: ^5.0.0`. Installing `@chakra-ui/cli` together with `typescript: >=6.0.0` results in an "unmet dependency" error. As `tsconfck` is discontinued it (most likely) won't receive an update for typescript 6 compatibility.

## 🚀 New behavior

No user-facing changes should be visible. As `get-tsconfig` does not depend on `typescript` directly, no error occurs when installing `@chakra-ui/cli` and `typescript: >=5.0.0 || >=6.0.0` side-by-side.

## 💣 Is this a breaking change (Yes/No):

No, it should not, as long as resolution of `reference` entries is handled transparently.

## 📝 Additional Information

The current behavior of `resolveTsconfig()` is to find the tsconfig-file that declares the `paths` aliases. `tsconfck` did return the file that is actually responsible for the queried source file, following `references` if neccessary. `get-tsconfig` does *not* automatically follow `references`. ~~The new behaviour only follows references (one level deep) if the root file (the nearest `tsconfig.json`) does not declare any `paths`.~~

~~The new behaviour should yield identical results in the vite-project case, but might differ in more complex cases using `references`. For a true 1:1 migration `reference` resolution has to be expanded.~~

The new behaviour follows `references` recursively until it finds a config that is valid for the source file (according to `include`, `files`, `exclude`). This handles the vite-project case as intended without extra logic to find `compilerOptions.paths` and should match behaviour of `tsc`.

Generative AI has been utilized to aid in the preparation and review of this PR. :robot: 