### PR TITLE
fix(cli): clarify invalid typegen system exports

### DIFF
--- a/.changeset/fix-cli-typegen-system-export-error.md
+++ b/.changeset/fix-cli-typegen-system-export-error.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/cli": patch
+---
+
+Improve the `chakra typegen` error when the input file does not export a Chakra
+system, including the discovered exports and a `createSystem(...)` example for
+files that export `defineConfig(...)` configs.

--- a/packages/cli/__tests__/io.test.ts
+++ b/packages/cli/__tests__/io.test.ts
@@ -1,0 +1,75 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { TextEncoder } from "node:util"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+const nodeUint8Array = new TextEncoder().encode("").constructor
+
+const readInput = async (file: string, cwd: string) => {
+  Object.defineProperties(globalThis, {
+    TextEncoder: {
+      configurable: true,
+      value: TextEncoder,
+    },
+    Uint8Array: {
+      configurable: true,
+      value: nodeUint8Array,
+    },
+  })
+
+  const { read } = await import("../src/utils/io")
+  return read(file, { cwd })
+}
+
+describe("io.read", () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `chakra-cli-io-test-${Date.now()}`)
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it("accepts a default Chakra system export", async () => {
+    const source = join(testDir, "system.ts")
+    writeFileSync(source, "export default { $$chakra: true }")
+
+    const result = await readInput(source, testDir)
+
+    expect(result.mod).toMatchObject({ $$chakra: true })
+  })
+
+  it("explains when the default export is not a Chakra system", async () => {
+    const source = join(testDir, "config.ts")
+    writeFileSync(source, "export default { theme: { tokens: {} } }")
+
+    await expect(readInput(source, testDir)).rejects.toThrow(
+      /No Chakra system export found/,
+    )
+    await expect(readInput(source, testDir)).rejects.toThrow(
+      'Found export: "default".',
+    )
+    await expect(readInput(source, testDir)).rejects.toThrow(
+      "defineConfig(...)",
+    )
+    await expect(readInput(source, testDir)).rejects.toThrow(
+      "createSystem(defaultConfig, config)",
+    )
+  })
+
+  it("lists named exports when no Chakra system export is found", async () => {
+    const source = join(testDir, "theme.ts")
+    writeFileSync(source, "export const theme = { tokens: {} }")
+
+    await expect(readInput(source, testDir)).rejects.toThrow(
+      'Found export: "theme".',
+    )
+    await expect(readInput(source, testDir)).rejects.toThrow(
+      'expects "default", "preset", "system"',
+    )
+  })
+})

--- a/packages/cli/src/utils/io.ts
+++ b/packages/cli/src/utils/io.ts
@@ -73,12 +73,12 @@ function loadViaRequire(file: string, code: string): any {
     }
   }
 
-  delete require.cache[require.resolve(file)]
-  const raw = require(file)
-  const result = raw.default ?? raw
-
-  require.extensions[ext] = defaultLoader
-  return result
+  try {
+    delete require.cache[require.resolve(file)]
+    return require(file)
+  } finally {
+    require.extensions[ext] = defaultLoader
+  }
 }
 
 function loadViaVm(code: string): any {
@@ -89,12 +89,55 @@ function loadViaVm(code: string): any {
     require,
   })
   vm.runInContext(code, ctx)
-  const raw = mod.exports as any
-  return raw.default ?? raw
+  return mod.exports
+}
+
+const systemExports = ["default", "preset", "system"] as const
+
+const isRecord = (mod: unknown): mod is Record<string, unknown> => {
+  return typeof mod === "object" && mod !== null
 }
 
 const isValidSystem = (mod: unknown): mod is SystemContext => {
-  return Object.hasOwnProperty.call(mod, "$$chakra")
+  return isRecord(mod) && Object.hasOwnProperty.call(mod, "$$chakra")
+}
+
+function resolveSystemExport(mod: unknown) {
+  const candidate = isRecord(mod) && mod.default != null ? mod.default : mod
+
+  if (!isRecord(candidate) || isValidSystem(candidate)) return candidate
+
+  const exports = candidate as Record<string, unknown>
+  return exports.default || exports.preset || exports.system || candidate
+}
+
+function formatExportName(name: string) {
+  return `"${name}"`
+}
+
+function getExportNames(mod: unknown) {
+  if (!isRecord(mod) || isValidSystem(mod)) return []
+  return Object.keys(mod).filter((name) => name !== "__esModule")
+}
+
+function formatInvalidSystemError(file: string, mod: unknown) {
+  const exportNames = getExportNames(mod)
+  const foundExports = exportNames.length
+    ? `Found export${exportNames.length === 1 ? "" : "s"}: ${exportNames
+        .map(formatExportName)
+        .join(", ")}.`
+    : "Found no named exports."
+
+  return [
+    `No Chakra system export found in ${file}.`,
+    `The chakra typegen command expects ${systemExports
+      .map(formatExportName)
+      .join(
+        ", ",
+      )}, or a CommonJS export to be a Chakra system created with createSystem(...).`,
+    foundExports,
+    "If this file exports a config from defineConfig(...), wrap it first: export default createSystem(defaultConfig, config).",
+  ].join(" ")
 }
 
 export const read = async (
@@ -106,13 +149,10 @@ export const read = async (
 
   const bundle = await bundleFile(filePath, cwd, tsconfig)
   const mod = loadBundledCode(filePath, bundle.code)
-
-  const resolvedMod = mod.default || mod.preset || mod.system || mod
+  const resolvedMod = resolveSystemExport(mod)
 
   if (!isValidSystem(resolvedMod)) {
-    throw new Error(
-      `No default export found in ${file}. Did you forget to provide an export default?`,
-    )
+    throw new Error(formatInvalidSystemError(file, mod))
   }
 
   return { mod: resolvedMod, dependencies: bundle.dependencies }


### PR DESCRIPTION
Closes #10824

## 📝 Description

Improves the `chakra typegen` error when the input file does not export a Chakra system. The error now names the accepted export shapes and lists the exports that were actually found.

## ⛳️ Current behavior (updates)

A file that exports a `defineConfig(...)` config or other non-system value reports `No default export found`, even when a default export exists.

## 🚀 New behavior

The CLI reports that no Chakra system export was found, mentions `default`, `preset`, and `system`, lists discovered exports, and points config files toward `createSystem(defaultConfig, config)`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Tested with:

- `pnpm exec vitest run --config packages/cli/vitest.config.ts packages/cli/__tests__/io.test.ts`
- `pnpm --filter @chakra-ui/cli typecheck`
- `pnpm exec prettier --check packages/cli/src/utils/io.ts packages/cli/__tests__/io.test.ts .changeset/fix-cli-typegen-system-export-error.md`
- `git diff --check`

AI assistance was used to prepare this PR.
