### PR TITLE
docs(table): fix migration guide mapping for Td

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -2102,7 +2102,8 @@ const Demo = () => (
 ### Table
 
 - `TableContainer` is now `Table.ScrollArea`
-- `Td`(now called `Table.ColumnHeader`) `isNumeric` is now `textAlign="end"`
+- `Td`(now called `Table.Cell`) `isNumeric` is now `textAlign="end"`
+- `Th` is now `Table.ColumnHeader`
 
 The compound component have been renamed slightly.
 


### PR DESCRIPTION
Closes # N/A

## 📝 Description

Fix incorrect migration mapping for `Td` in the Table migration guide.

`Td` should map to `Table.Cell` in Chakra UI v3, not `Table.ColumnHeader`.

## ⛳️ Current behavior (updates)

The migration guide incorrectly states:

`Td` → `Table.ColumnHeader`

## 🚀 New behavior

Updated the migration guide to correctly map:

`Td` → `Table.Cell`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This is a documentation-only fix.
