### PR TITLE
docs: fix Node.js version formatting in installation guide

### DIFF
--- a/apps/www/content/docs/get-started/installation.mdx
+++ b/apps/www/content/docs/get-started/installation.mdx
@@ -30,7 +30,7 @@ Try Chakra UI in Stackblitz sandbox
 
 :::
 
-> The minimum node version required is Node.20.x
+> The minimum Node.js version required is 20.x
 
 ## Styling roadmap
 


### PR DESCRIPTION
## Summary
Small documentation fix in `apps/www/content/docs/get-started/installation.mdx`.

## Change
- Before: `The minimum node version required is Node.20.x`
- After: `The minimum Node.js version required is 20.x`

## Why
- "Node.20.x" has a stray period between "Node" and the version number
- "Node.js" is the proper name of the runtime (lowercase "node" usually refers to the CLI binary)

No code or behavior changes — docs only.