### PR TITLE
fix(build): resolve windows path and import issues across scripts and tests

### DIFF
--- a/packages/cli/__tests__/resolve-tsconfig.test.ts
+++ b/packages/cli/__tests__/resolve-tsconfig.test.ts
@@ -25,7 +25,9 @@ describe("resolveTsconfig", () => {
       join(testDir, "src/index.ts"),
       tsconfigPath,
     )
-    expect(result).toBe(tsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      tsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("finds tsconfig.json for a source file", async () => {
@@ -42,7 +44,9 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(testDir, "src/index.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
-    expect(result).toBe(tsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      tsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("resolves solution-style tsconfig with references", async () => {
@@ -82,7 +86,9 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(testDir, "src/index.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
-    expect(result).toBe(appTsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      appTsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("falls back to first reference when no paths found", async () => {
@@ -117,7 +123,9 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(testDir, "src/index.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
-    expect(result).toBe(appTsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      appTsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("returns undefined when no tsconfig exists", async () => {
@@ -154,7 +162,9 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(testDir, "src/index.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
-    expect(result).toBe(tsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      tsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("picks the reference with paths when it is not the first one", async () => {
@@ -193,7 +203,9 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(testDir, "src/index.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
-    expect(result).toBe(appTsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      appTsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("handles reference that itself extends another config with paths", async () => {
@@ -230,7 +242,9 @@ describe("resolveTsconfig", () => {
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
     // tsconfck merges extends into the parsed tsconfig, so paths should be visible
-    expect(result).toBe(appTsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      appTsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("picks non-first reference with inherited paths over first reference without", async () => {
@@ -281,7 +295,9 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(testDir, "src/index.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(testDir, "src/index.ts"))
-    expect(result).toBe(appTsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      appTsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 
   it("finds tsconfig from deeply nested source file", async () => {
@@ -300,6 +316,8 @@ describe("resolveTsconfig", () => {
     writeFileSync(join(deepDir, "login.ts"), "export default {}")
 
     const result = await resolveTsconfig(join(deepDir, "login.ts"))
-    expect(result).toBe(tsconfigPath)
+    expect(result?.replaceAll("\\", "/")).toBe(
+      tsconfigPath?.replaceAll("\\", "/"),
+    )
   })
 })

--- a/packages/panda-preset/scripts/sync.ts
+++ b/packages/panda-preset/scripts/sync.ts
@@ -56,7 +56,7 @@ async function main() {
   const promises = files.map(async (file) => {
     const content = await readFile(file, "utf8")
 
-    let relativePath = relative(dirname(file), defFile)
+    let relativePath = relative(dirname(file), defFile).replaceAll("\\", "/")
     relativePath = relativePath === "def.ts" ? "./def.ts" : relativePath
 
     const fileFromSrc = relative("src", file)

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -3,6 +3,7 @@ import commonjs from "@rollup/plugin-commonjs"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
 import replace from "@rollup/plugin-replace"
 import glob from "fast-glob"
+import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { Plugin, RollupOptions } from "rollup"
 import esbuild from "rollup-plugin-esbuild"
@@ -16,7 +17,9 @@ interface Options {
 export async function getConfig(options: Options): Promise<RollupOptions> {
   const { dir, aliases } = options
 
-  const packageJson = await import(resolve(dir, "package.json"))
+  const packageJson = JSON.parse(
+    readFileSync(resolve(dir, "package.json"), "utf8"),
+  )
 
   const isCli =
     packageJson.bin !== undefined || packageJson.name.includes("docgen")
@@ -31,6 +34,7 @@ export async function getConfig(options: Options): Promise<RollupOptions> {
     esbuild({
       sourceMap: true,
       tsconfig: resolve(dir, "tsconfig.json"),
+      jsx: "automatic",
       platform: isCli ? "node" : "browser",
     }),
     replace({ preventAssignment: true }),

--- a/scripts/build/main.ts
+++ b/scripts/build/main.ts
@@ -1,4 +1,5 @@
-import { resolve } from "path/posix"
+import { readFileSync } from "fs"
+import { resolve } from "path"
 import { buildProject } from "./build.js"
 
 async function main() {
@@ -8,7 +9,9 @@ async function main() {
   const clean = flags.includes("--clean")
   const dts = flags.includes("--dts")
 
-  const packageJson = await import(resolve(cwd, "package.json"))
+  const packageJson = JSON.parse(
+    readFileSync(resolve(cwd, "package.json"), "utf8"),
+  )
 
   await buildProject({
     dir: cwd,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes #10840 

## 📝 Description

This PR fixes multiple Windows-specific path resolution issues that cause  `pnpm build` ,  `pnpm theme:eject` , and `pnpm test`  to crash immediately for Windows developers.

## ⛳️ Current behavior (updates)

1. `scripts/build/main.ts`  and  `scripts/build/config.ts`  fail with an  `ERR\_UNSUPPORTED\_ESM\_URL\_SCHEME`  because dynamic  `import(resolve("package.json"))`  does not handle Windows absolute drive paths (e.g.,  `C:...` ) correctly.
2. `packages/panda-preset/scripts/sync.ts`  generates invalid TypeScript imports (like  `import { defineSlotRecipe } from "..\def"` ) because  `node:path` 's  `relative()`  returns backslashes on Windows.
3. `packages/cli/**tests**/resolve-tsconfig.test.ts`  fails 5 assertions on Windows because the expected paths use backslashes ( `\` ) while  tsconfck  returns forward slashes ( `/` ).

## 🚀 New behavior

1. Changed dynamic  `import`  to  `JSON.parse(readFileSync(...))`  in build scripts, which is cross-platform safe and guarantees  `dependencies`  are extracted properly for rollup.
2. Added  `jsx: "automatic"`  to  `esbuild`  config so it correctly transpiles JSX without falling back to classic mode.
3. Normalizes all backslashes to forward slashes ( `.replaceAll("\\", "/")` ) during code generation in  `sync.ts` and inside the CLI test assertions.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
With these fixes, all 972 automated tests in the repository now pass perfectly on Windows.