### PR TITLE
docs(react): remove redundant "render" in For children prop

### DIFF
--- a/packages/react/src/components/for/for.tsx
+++ b/packages/react/src/components/for/for.tsx
@@ -10,7 +10,7 @@ export interface ForProps<T> {
    */
   fallback?: React.ReactNode | undefined
   /**
-   * The render function to render each item in the array
+   * The function to render each item in the array
    */
   children: (item: Exclude<T, undefined>, index: number) => React.ReactNode
 }


### PR DESCRIPTION
## 📝 Description

The `For` component's `children` prop JSDoc duplicates "render" ("The render function to render each item").

## ⛳️ Current behavior (updates)

The JSDoc reads: "The render function to render each item in the array".

## 🚀 New behavior

Simplified to "The function to render each item in the array", dropping the duplicated "render". Matches the sibling `fallback` prop's "...content to render..." phrasing.

## 💣 Is this a breaking change (Yes/No):

No.
