### PR TITLE
docs(splitter): note SSR caveat for CSS-unit panel sizes

### DIFF
--- a/apps/www/content/docs/components/splitter.mdx
+++ b/apps/www/content/docs/components/splitter.mdx
@@ -141,10 +141,8 @@ should keep a fixed width, such as a navigation sidebar.
 
 :::warning
 
-CSS-unit sizes are resolved on the client because they require measuring the
-container. During server rendering, panels using these units fall back to an
-even split and adjust to their final size after hydration, which can cause a
-brief layout shift. Use percentage sizes if you need a stable initial render.
+CSS-unit sizes are measured on the client, so panels using them can shift after
+hydration. Use percentage sizes for a stable server-rendered layout.
 
 :::
 

--- a/apps/www/content/docs/components/splitter.mdx
+++ b/apps/www/content/docs/components/splitter.mdx
@@ -139,6 +139,15 @@ In addition to percentages, `defaultSize`, `minSize`, and `maxSize` accept CSS
 units like `px`, `em`, `rem`, `vh`, and `vw`. This is useful for panels that
 should keep a fixed width, such as a navigation sidebar.
 
+:::warning
+
+CSS-unit sizes are resolved on the client because they require measuring the
+container. During server rendering, panels using these units fall back to an
+even split and adjust to their final size after hydration, which can cause a
+brief layout shift. Use percentage sizes if you need a stable initial render.
+
+:::
+
 <ExampleTabs name="splitter-css-units" />
 
 ### Resize Behavior


### PR DESCRIPTION
## 📝 Description

Adds a warning callout to the Splitter **CSS Unit Sizes** docs about the SSR side effect of using CSS-unit (e.g. pixel) panel sizes.

## ⛳️ Current behavior (updates)

The CSS Unit Sizes section (added in #10848) doesn't mention that CSS-unit sizes behave differently during SSR.

## 🚀 New behavior

Documents that CSS-unit sizes (`px`, `em`, `rem`, `vw`, `vh`) require measuring the container, so they resolve on the client — during SSR the panels fall back to an even split and adjust after hydration, which can cause a brief layout shift. Percentages render stably on the server.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Behavior confirmed in `@zag-js/splitter` (`utils/size.mjs` → `parsePanelSize` requires the root element for non-percentage units).

## Screenshot
<img width="890" height="620" alt="Screenshot 2026-06-10 at 10 44 29" src="https://github.com/user-attachments/assets/bf3b7f34-987b-4638-b681-76072d32556d" />
