### PR TITLE
fix: add default size to the basic example

### DIFF
--- a/apps/compositions/src/examples/floating-panel-basic.tsx
+++ b/apps/compositions/src/examples/floating-panel-basic.tsx
@@ -11,7 +11,10 @@ import {
 
 export const FloatingPanelBasic = () => {
   return (
-    <FloatingPanel.Root>
+    <FloatingPanel.Root
+      defaultSize={{ width: 320, height: 180 }}
+      minSize={{ width: 240, height: 100 }}
+    >
       <FloatingPanel.Trigger asChild>
         <Button variant="outline" size="sm">
           Open Panel


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Added a default size to the basic floating panel example

## ⛳️ Current behavior (updates)

The basic floating panel example in the compositions didn't have a default size configured, which could result in unexpected sizing behavior or a less polished initial appearance.

## 🚀 New behavior

The floating panel basic example now includes a default size property, ensuring it displays properly out of the box and serves as a better reference for developers implementing this component.

## 💣 Is this a breaking change (Yes/No):

No

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Chakra users. -->

## 📝 Additional Information
