### PR TITLE
fix: correct css prop usage in Checkmark component

### DIFF
--- a/.changeset/checkmark-css-prop.md
+++ b/.changeset/checkmark-css-prop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Checkmark: Fix incorrect css prop application

--- a/packages/react/src/components/checkmark/checkmark.tsx
+++ b/packages/react/src/components/checkmark/checkmark.tsx
@@ -32,8 +32,15 @@ export const Checkmark = forwardRef<SVGSVGElement, CheckmarkProps>(
     const recipe = useRecipe({ key: "checkmark", recipe: props.recipe })
     const [variantProps, restProps] = recipe.splitVariantProps(props)
 
-    const { checked, indeterminate, disabled, unstyled, children, ...rest } =
-      restProps
+    const {
+      checked,
+      indeterminate,
+      disabled,
+      unstyled,
+      children,
+      css,
+      ...rest
+    } = restProps
 
     const styles = unstyled ? EMPTY_STYLES : recipe(variantProps)
 
@@ -50,7 +57,7 @@ export const Checkmark = forwardRef<SVGSVGElement, CheckmarkProps>(
           indeterminate ? "indeterminate" : checked ? "checked" : "unchecked"
         }
         data-disabled={dataAttr(disabled)}
-        css={[styles, props.css]}
+        css={[styles, css]}
         {...rest}
       >
         {indeterminate ? (


### PR DESCRIPTION
## 📝 Description

Destructure the `css` prop so it isn't re-applied by the prop spread.

## ⛳️ Current behavior (updates)

`<Checkmark css={...} />` overrides the component's recipe styles. `css` falls through `{...rest}`, which is spread after `css={[styles, props.css]}`, so the raw `css` replaces the merged styles.

## 🚀 New behavior

The user `css` is merged with the recipe styles (`css={[styles, css]}`) instead of replacing them.

## 💣 Is this a breaking change (Yes/No):

No
