### PR TITLE
fix: correct css prop usage in WrapItem component

### DIFF
--- a/.changeset/wrap-item-css-prop.md
+++ b/.changeset/wrap-item-css-prop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+- WrapItem: Fix incorrect css prop application

--- a/packages/react/src/components/wrap/wrap.tsx
+++ b/packages/react/src/components/wrap/wrap.tsx
@@ -48,11 +48,12 @@ const itemStyle = defineStyle({
 
 export const WrapItem = forwardRef<HTMLDivElement, WrapItemProps>(
   function WrapItem(props, ref) {
+    const { css, ...rest } = props
     return (
       <chakra.div
         ref={ref}
-        css={[itemStyle, props.css]}
-        {...props}
+        css={[itemStyle, css]}
+        {...rest}
         className={cx("chakra-wrap__listitem", props.className)}
       />
     )


### PR DESCRIPTION
## 📝 Description

Destructure the `css` prop so it isn't re-applied by the prop spread.

## ⛳️ Current behavior (updates)

`<WrapItem css={...} />` overrides the component's item styles. `props` is spread via `{...props}` after `css={[itemStyle, props.css]}`, so the raw `css` replaces the merged styles.

## 🚀 New behavior

The user `css` is merged with the item styles (`css={[itemStyle, css]}`) instead of replacing them.

## 💣 Is this a breaking change (Yes/No):

No
