### PR TITLE
fix: correct className usage in Image component

### DIFF
--- a/.changeset/image-classname-override.md
+++ b/.changeset/image-classname-override.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Image: Fix custom `className` removing the base `chakra-image` class

--- a/packages/react/__tests__/image.test.tsx
+++ b/packages/react/__tests__/image.test.tsx
@@ -1,0 +1,13 @@
+import { Image } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("Image", () => {
+  it("keeps the chakra-image class when a className is passed", () => {
+    const { getByRole } = render(
+      <Image className="custom-image" alt="example" />,
+    )
+    const img = getByRole("img")
+    expect(img).toHaveClass("chakra-image")
+    expect(img).toHaveClass("custom-image")
+  })
+})

--- a/packages/react/src/components/image/image.tsx
+++ b/packages/react/src/components/image/image.tsx
@@ -38,8 +38,8 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(
         ref={ref}
         objectFit={fit}
         objectPosition={align}
-        className={cx("chakra-image", props.className)}
         {...rest}
+        className={cx("chakra-image", props.className)}
       />
     )
   },


### PR DESCRIPTION
## 📝 Description

Keep the base `chakra-image` class when a custom `className` is passed to `Image`.

## ⛳️ Current behavior (updates)

Passing a `className` to `Image` overrode the base class, so the rendered element lost `chakra-image`.

## 🚀 New behavior

The custom `className` is merged with `chakra-image` via `cx`, so both classes are applied.

## 💣 Is this a breaking change (Yes/No):

No
