### PR TITLE
fix: correct misspelled "permuations" variable in breakpoints

### DIFF
--- a/packages/react/src/styled-system/breakpoints.ts
+++ b/packages/react/src/styled-system/breakpoints.ts
@@ -20,7 +20,7 @@ export function createBreakpoints(
 
   function getRanges() {
     const breakpoints: string[] = Object.keys(values)
-    const permuations = getPermutations(breakpoints)
+    const permutations = getPermutations(breakpoints)
 
     const results = breakpoints
       .flatMap((name) => {
@@ -38,7 +38,7 @@ export function createBreakpoints(
       })
       .filter(([, value]) => value !== "")
       .concat(
-        permuations.map(([min, max]) => {
+        permutations.map(([min, max]) => {
           const minValue = get(min)
           const maxValue = get(max)
           return [


### PR DESCRIPTION
## What

Renames the local variable `permuations` → `permutations` in
`packages/react/src/styled-system/breakpoints.ts`.

## Why

The variable holds the return value of `getPermutations(...)`, which is
spelled correctly. The local binding was misspelled, making it harder to read
and grep (`getPermutations` → `permuations` was an inconsistent pair).

## Scope & risk

- Two occurrences, both inside the `getRanges()` closure (lines 23 and 41).
- Pure rename — no logic, types, or runtime behavior change.
- Variable is local to `getRanges()`, so there is no public API impact.