### PR TITLE
fix(listbox): prevent crash when filter empties collection in explorer demo

### DIFF
--- a/apps/compositions/src/examples/listbox-explorer-demo.tsx
+++ b/apps/compositions/src/examples/listbox-explorer-demo.tsx
@@ -22,7 +22,9 @@ export const ListboxExplorerDemo = () => {
     <Listbox.Root
       maxW="320px"
       collection={collection}
-      defaultValue={[collection.items[0].value]}
+      defaultValue={
+        collection.items[0] ? [collection.items[0].value] : undefined
+      }
     >
       <Listbox.Label>Select item</Listbox.Label>
 


### PR DESCRIPTION
In the Listbox explorer demo (`listbox-explorer-demo.tsx`), the `defaultValue` prop accesses `collection.items[0].value` without a null guard. When the user types a filter query (e.g. "ab") that matches no items, the filtered collection becomes empty, causing:

TypeError: Cannot read properties of undefined (reading 'value')

## Reproduce

1. Open the Listbox explorer in the www docs
2. Type "ab" in the filter input
3. Observe the crash

## Fix

Add a null guard: only set `defaultValue` when `collection.items[0]` exists.