### PR TITLE
fix: forward the rel attribute on LinkOverlay

### DIFF
--- a/.changeset/link-overlay-rel.md
+++ b/.changeset/link-overlay-rel.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix issue where `LinkOverlay` dropped the `rel` attribute instead of forwarding
+it to the rendered anchor.

--- a/packages/react/__tests__/link-box.test.tsx
+++ b/packages/react/__tests__/link-box.test.tsx
@@ -1,0 +1,13 @@
+import { LinkOverlay } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("LinkOverlay", () => {
+  it("forwards the rel attribute to the anchor", () => {
+    const { getByRole } = render(
+      <LinkOverlay href="https://example.com" rel="noopener noreferrer">
+        link
+      </LinkOverlay>,
+    )
+    expect(getByRole("link")).toHaveAttribute("rel", "noopener noreferrer")
+  })
+})

--- a/packages/react/src/components/link/link-box.tsx
+++ b/packages/react/src/components/link/link-box.tsx
@@ -8,7 +8,7 @@ export interface LinkOverlayProps extends HTMLChakraProps<"a"> {}
 
 export const LinkOverlay = forwardRef<HTMLAnchorElement, LinkOverlayProps>(
   function LinkOverlay(props, ref) {
-    const { rel, className, ...rest } = props
+    const { className, ...rest } = props
     return (
       <chakra.a
         {...rest}


### PR DESCRIPTION
## Description

`LinkOverlay` accepts `HTMLChakraProps<"a">` (which includes `rel`), but it destructured `rel` out of its props and never applied it, so the attribute was dropped from the rendered anchor.

## Current behavior (updates)

Passing `rel` to `LinkOverlay` (e.g. `rel="noopener noreferrer"`) had no effect; the rendered `<a>` carried no `rel` attribute.

## New behavior

`rel` is forwarded to the rendered anchor like any other anchor attribute.

## Is this a breaking change (Yes/No):

No
