### PR TITLE
Rename TanStackRouterVite to tanstackRouter

### DIFF
--- a/apps/www/content/docs/get-started/frameworks/tanstack-router.mdx
+++ b/apps/www/content/docs/get-started/frameworks/tanstack-router.mdx
@@ -73,12 +73,12 @@ If you're using TypeScript, in the `tsconfig.app.json` file, make sure the
 Add the TanStack Router Vite plugin and enable tsconfig path resolution.
 
 ```ts title="vite.config.ts"
-import { TanStackRouterVite } from "@tanstack/router-plugin/vite"
+import { tanstackRouter } from "@tanstack/router-plugin/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [TanStackRouterVite({ autoCodeSplitting: true }), react()],
+  plugins: [tanstackRouter({ autoCodeSplitting: true }), react()],
   resolve: {
     tsconfigPaths: true,
   },
@@ -97,7 +97,7 @@ import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig({
   plugins: [
-    TanStackRouterVite({ autoCodeSplitting: true }),
+    tanstackRouter({ autoCodeSplitting: true }),
     react(),
     tsconfigPaths(),
   ],

--- a/sandbox/tanstack-router/vite.config.ts
+++ b/sandbox/tanstack-router/vite.config.ts
@@ -1,11 +1,11 @@
-import { TanStackRouterVite } from "@tanstack/router-plugin/vite"
+import { tanstackRouter } from "@tanstack/router-plugin/vite"
 import react from "@vitejs/plugin-react"
 import { resolve } from "path"
 import { defineConfig } from "vite"
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [TanStackRouterVite({ autoCodeSplitting: true }), react()],
+  plugins: [tanstackRouter({ autoCodeSplitting: true }), react()],
   resolve: {
     alias: {
       "@chakra-ui/react": resolve("..", "..", "packages/react/src"),


### PR DESCRIPTION
The exported function `TanStackRouterVite` is marked as deprecated in the latest documentation. 

As suggested in the documentation, `tanstackRouter` must be used instead.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description
The exported function `TanStackRouterVite` is marked as deprecated in the latest documentation. 

As suggested in the documentation, `tanstackRouter` must be used instead.

## ⛳️ Current behavior (updates)
Currently the documentation guiding user to use chakra-ui with tanstack/react-router is suggesting to use a deprecated function from the tanstack router vite plugin. 

[Current Docs](https://chakra-ui.com/docs/get-started/frameworks/tanstack-router)

## 🚀 New behavior
This PR only updates the tanstack router framework installation guide. There is no new behavior.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
