### PR TITLE
fix: correct css prop usage in Float component

### DIFF
--- a/.changeset/float-css-prop.md
+++ b/.changeset/float-css-prop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Float: Fix incorrect css prop application

--- a/packages/react/__tests__/float.test.tsx
+++ b/packages/react/__tests__/float.test.tsx
@@ -1,0 +1,11 @@
+import { Float } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("Float", () => {
+  it("keeps its base positioning styles when a css prop is passed", () => {
+    const { getByTestId } = render(
+      <Float data-testid="float" css={{ color: "red" }} />,
+    )
+    expect(getByTestId("float")).toHaveStyle({ position: "absolute" })
+  })
+})

--- a/packages/react/src/components/float/float.tsx
+++ b/packages/react/src/components/float/float.tsx
@@ -53,6 +53,7 @@ export const Float = forwardRef<HTMLDivElement, FloatProps>(
       offsetY,
       offset = "0",
       placement = "top-end",
+      css: cssProp,
       ...rest
     } = props
 
@@ -108,7 +109,7 @@ export const Float = forwardRef<HTMLDivElement, FloatProps>(
       [offset, offsetX, offsetY, placement],
     )
 
-    return <chakra.div ref={ref} css={styles} {...rest} />
+    return <chakra.div ref={ref} css={[styles, cssProp]} {...rest} />
   },
 )
 


### PR DESCRIPTION
## Description

Destructure the `css` prop so it isn't re-applied by the prop spread.

## Current behavior (updates)

`<Float css={...} />` overrides the component's positioning styles. `css` falls through `{...rest}`, which is spread after `css={styles}`, so the raw `css` replaces the base styles (`position`, insets, `translate`).

## New behavior

The user `css` is merged with the base styles (`css={[styles, css]}`) instead of replacing them.

## Is this a breaking change (Yes/No):

No
