### PR TITLE
perf(react): cache recipe resolution

### DIFF
--- a/.changeset/recipe-cache-performance.md
+++ b/.changeset/recipe-cache-performance.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Improve recipe component performance by caching compiled keyed recipes and
+  memoizing resolved recipe styles for repeated variant selections

--- a/packages/react/__tests__/recipe-cache.test.tsx
+++ b/packages/react/__tests__/recipe-cache.test.tsx
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react"
+import {
+  ChakraProvider,
+  createSystem,
+  defaultConfig,
+  defaultSystem,
+  useRecipe,
+  useSlotRecipe,
+} from "../src"
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+)
+
+describe("recipe caching", () => {
+  test("reuses compiled recipes for the same system and key", () => {
+    const first = renderHook(() => useRecipe({ key: "button" }), { wrapper })
+    const second = renderHook(() => useRecipe({ key: "button" }), { wrapper })
+
+    expect(first.result.current).toBe(second.result.current)
+  })
+
+  test("reuses compiled slot recipes for the same system and key", () => {
+    const first = renderHook(() => useSlotRecipe({ key: "tag" }), { wrapper })
+    const second = renderHook(() => useSlotRecipe({ key: "tag" }), { wrapper })
+
+    expect(first.result.current).toBe(second.result.current)
+  })
+
+  test("does not share custom recipe props through the keyed recipe cache", () => {
+    const recipe = {
+      variants: {
+        size: {
+          sm: { fontSize: "12px" },
+        },
+      },
+    }
+
+    const first = renderHook(() => useRecipe({ recipe }), { wrapper })
+    const second = renderHook(() => useRecipe({ recipe }), { wrapper })
+
+    expect(first.result.current).not.toBe(second.result.current)
+  })
+
+  test("memoizes recipe style resolution by variant selection", () => {
+    const system = createSystem(defaultConfig)
+    const recipe = system.cva({
+      base: {
+        borderRadius: "4px",
+      },
+      variants: {
+        size: {
+          sm: { fontSize: "12px" },
+          md: { fontSize: "16px" },
+        },
+      },
+    })
+
+    const first = recipe({ size: "sm" })
+    const second = recipe({ size: "sm" })
+    const third = recipe({ size: "md" })
+
+    expect(second).toBe(first)
+    expect(third).not.toBe(first)
+    expect(third).toMatchObject({
+      "@layer recipes": {
+        fontSize: "16px",
+      },
+    })
+  })
+
+  test("memoizes slot recipe style resolution by variant selection", () => {
+    const system = createSystem(defaultConfig)
+    const recipe = system.sva({
+      slots: ["root", "label"],
+      base: {
+        root: { display: "flex" },
+        label: { fontWeight: "medium" },
+      },
+      variants: {
+        size: {
+          sm: {
+            root: { gap: "4px" },
+            label: { fontSize: "12px" },
+          },
+          md: {
+            root: { gap: "8px" },
+            label: { fontSize: "16px" },
+          },
+        },
+      },
+    })
+
+    const first = recipe({ size: "sm" })
+    const second = recipe({ size: "sm" })
+    const third = recipe({ size: "md" })
+
+    expect(second).toBe(first)
+    expect(second.root).toBe(first.root)
+    expect(third).not.toBe(first)
+    expect(third.label).toMatchObject({
+      "@layer recipes": {
+        fontSize: "16px",
+      },
+    })
+  })
+})

--- a/packages/react/src/styled-system/cva.ts
+++ b/packages/react/src/styled-system/cva.ts
@@ -3,6 +3,7 @@ import {
   compact,
   cx,
   mapEntries,
+  memo,
   mergeWith,
   omit,
   splitProps,
@@ -48,7 +49,7 @@ export function createRecipeFn(options: Options): RecipeCreatorFn {
       },
     })
 
-    const resolve = (props = {}) => {
+    const resolve = memo((props = {}) => {
       const variantSelections: Dict = normalize({
         ...defaultVariants,
         ...compact(props),
@@ -64,7 +65,7 @@ export function createRecipeFn(options: Options): RecipeCreatorFn {
       )
 
       return layers.wrap("recipes", css(variantCss, compoundVariantCss))
-    }
+    })
 
     const variantKeys = Object.keys(variants)
 
@@ -92,7 +93,7 @@ export function createRecipeFn(options: Options): RecipeCreatorFn {
       Object.keys(value as any),
     ])
 
-    const cvaFn = (props: any) => css(resolve(props))
+    const cvaFn = memo((props: any) => css(resolve(props)))
     return Object.assign(cvaFn, {
       className: config.className,
       __cva__: true,

--- a/packages/react/src/styled-system/sva.ts
+++ b/packages/react/src/styled-system/sva.ts
@@ -1,4 +1,4 @@
-import { type Dict, mapEntries, omit, splitProps } from "../utils"
+import { type Dict, mapEntries, memo, omit, splitProps } from "../utils"
 import type { RecipeCreatorFn, SlotRecipeCreatorFn } from "./recipe.types"
 import { EMPTY_ARRAY, EMPTY_OBJECT, createEmptyObject } from "./singleton"
 
@@ -56,11 +56,11 @@ export function createSlotRecipeFn(options: Options): SlotRecipeCreatorFn {
       ([slot, slotCva]) => [slot, cva(slotCva)],
     )
 
-    function svaFn(props: Dict) {
+    const svaFn = memo((props: Dict) => {
       //@ts-ignore
       const result = slots.map(([slot, cvaFn]) => [slot, cvaFn(props)])
       return Object.fromEntries(result)
-    }
+    })
 
     const variants = (config.variants ?? EMPTY_OBJECT) as Dict
     const variantKeys = Object.keys(variants)

--- a/packages/react/src/styled-system/use-recipe.ts
+++ b/packages/react/src/styled-system/use-recipe.ts
@@ -18,10 +18,7 @@ export interface UseRecipeOptions<K extends RecipeKey> {
   recipe?: RecipeDefinition | undefined
 }
 
-const recipeCache = new WeakMap<
-  SystemContext,
-  Map<string, SystemRecipeFn<any, any>>
->()
+const recipeCache = new WeakMap<SystemContext, Map<string, any>>()
 
 function getCachedRecipe(sys: SystemContext, key: string) {
   let cache = recipeCache.get(sys)
@@ -35,7 +32,7 @@ function getCachedRecipe(sys: SystemContext, key: string) {
 
   if (!recipe) {
     const config = sys.getRecipe(key, {})
-    recipe = sys.cva(structuredClone(config)) as SystemRecipeFn<any, any>
+    recipe = sys.cva(structuredClone(config))
     cache.set(key, recipe)
   }
 

--- a/packages/react/src/styled-system/use-recipe.ts
+++ b/packages/react/src/styled-system/use-recipe.ts
@@ -9,12 +9,37 @@ import type {
   RecipeVariantProps,
   SystemRecipeFn,
 } from "./recipe.types"
+import type { SystemContext } from "./types"
 
 export type RecipeKey = keyof ConfigRecipes | (string & {})
 
 export interface UseRecipeOptions<K extends RecipeKey> {
   key?: K | undefined
   recipe?: RecipeDefinition | undefined
+}
+
+const recipeCache = new WeakMap<
+  SystemContext,
+  Map<string, SystemRecipeFn<any, any>>
+>()
+
+function getCachedRecipe(sys: SystemContext, key: string) {
+  let cache = recipeCache.get(sys)
+
+  if (!cache) {
+    cache = new Map()
+    recipeCache.set(sys, cache)
+  }
+
+  let recipe = cache.get(key)
+
+  if (!recipe) {
+    const config = sys.getRecipe(key, {})
+    recipe = sys.cva(structuredClone(config)) as SystemRecipeFn<any, any>
+    cache.set(key, recipe)
+  }
+
+  return recipe
 }
 
 export function useRecipe<
@@ -35,7 +60,8 @@ export function useRecipe(options: any): any {
   const { key, recipe: recipeProp } = options
   const sys = useChakraContext()
   return useMemo((): any => {
-    const recipe = recipeProp || (key != null ? sys.getRecipe(key) : {})
-    return sys.cva(structuredClone(recipe))
+    if (recipeProp) return sys.cva(structuredClone(recipeProp))
+    if (key != null) return getCachedRecipe(sys, key)
+    return sys.cva({})
   }, [key, recipeProp, sys])
 }

--- a/packages/react/src/styled-system/use-slot-recipe.ts
+++ b/packages/react/src/styled-system/use-slot-recipe.ts
@@ -9,6 +9,7 @@ import type {
   SlotRecipeConfig,
   SystemSlotRecipeFn,
 } from "./recipe.types"
+import type { SystemContext } from "./types"
 
 export type SlotRecipeKey = keyof ConfigSlotRecipes | (string & {})
 
@@ -20,6 +21,34 @@ export type SlotRecipeFn<K extends SlotRecipeKey> =
 export interface UseSlotRecipeOptions<K extends SlotRecipeKey> {
   key?: K | undefined
   recipe?: SlotRecipeConfig | undefined
+}
+
+const slotRecipeCache = new WeakMap<
+  SystemContext,
+  Map<string, SystemSlotRecipeFn<string, any, any>>
+>()
+
+function getCachedSlotRecipe(sys: SystemContext, key: string) {
+  let cache = slotRecipeCache.get(sys)
+
+  if (!cache) {
+    cache = new Map()
+    slotRecipeCache.set(sys, cache)
+  }
+
+  let recipe = cache.get(key)
+
+  if (!recipe) {
+    const config = sys.getSlotRecipe(key, {})
+    recipe = sys.sva(structuredClone(config)) as SystemSlotRecipeFn<
+      string,
+      any,
+      any
+    >
+    cache.set(key, recipe)
+  }
+
+  return recipe
 }
 
 export function useSlotRecipe<
@@ -44,7 +73,8 @@ export function useSlotRecipe(options: any): any {
   const { key, recipe: recipeProp } = options
   const sys = useChakraContext()
   return useMemo((): any => {
-    const recipe = recipeProp || (key != null ? sys.getSlotRecipe(key) : {})
-    return sys.sva(structuredClone(recipe))
+    if (recipeProp) return sys.sva(structuredClone(recipeProp))
+    if (key != null) return getCachedSlotRecipe(sys, key)
+    return sys.sva({ slots: [] })
   }, [key, recipeProp, sys])
 }

--- a/packages/react/src/styled-system/use-slot-recipe.ts
+++ b/packages/react/src/styled-system/use-slot-recipe.ts
@@ -23,10 +23,7 @@ export interface UseSlotRecipeOptions<K extends SlotRecipeKey> {
   recipe?: SlotRecipeConfig | undefined
 }
 
-const slotRecipeCache = new WeakMap<
-  SystemContext,
-  Map<string, SystemSlotRecipeFn<string, any, any>>
->()
+const slotRecipeCache = new WeakMap<SystemContext, Map<string, any>>()
 
 function getCachedSlotRecipe(sys: SystemContext, key: string) {
   let cache = slotRecipeCache.get(sys)
@@ -40,11 +37,7 @@ function getCachedSlotRecipe(sys: SystemContext, key: string) {
 
   if (!recipe) {
     const config = sys.getSlotRecipe(key, {})
-    recipe = sys.sva(structuredClone(config)) as SystemSlotRecipeFn<
-      string,
-      any,
-      any
-    >
+    recipe = sys.sva(structuredClone(config))
     cache.set(key, recipe)
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #10878

## 📝 Description

Cache compiled keyed recipes per Chakra system and memoize recipe style resolution by variant selection.

## ⛳️ Current behavior (updates)

Recipe components compile the same keyed recipe per component instance and produce fresh resolved style object identities for repeated variant selections.

## 🚀 New behavior

Keyed recipes and slot recipes share compiled functions for the same Chakra system, while repeated recipe and slot recipe variant selections reuse resolved style objects.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- Adds focused regression tests for keyed hook caching and referentially stable recipe/slot recipe style resolution.
- Verified with `pnpm vitest run "packages/react/__tests__/recipe-cache.test.tsx" "packages/react/__tests__/recipe.test.ts"`.
- Verified with `pnpm react typecheck`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70ee62a0-6865-47d9-9fbf-66e971594015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70ee62a0-6865-47d9-9fbf-66e971594015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

