### PR TITLE
fix(docs): use standalone Separator component in migration guide

### DIFF
--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -439,7 +439,7 @@ For indeterminate progress:
 ### StackDivider
 
 - No longer available as a separate component
-- Use explicit `Stack.Separator` components between stack items
+- Use explicit `Separator` components between stack items
 
 Before:
 
@@ -454,11 +454,13 @@ Before:
 After:
 
 ```tsx
+import { Separator, VStack, Box } from "@chakra-ui/react"
+
 <VStack gap={4}>
   <Box>Item 1</Box>
-  <Stack.Separator borderColor="gray.200" />
+  <Separator borderColor="gray.200" />
   <Box>Item 2</Box>
-  <Stack.Separator borderColor="gray.200" />
+  <Separator borderColor="gray.200" />
   <Box>Item 3</Box>
 </VStack>
 ```
@@ -3100,6 +3102,8 @@ const Demo = () => (
 **Example:**
 
 ```tsx
+import { Stack, Separator, Box } from "@chakra-ui/react"
+
 // Before
 <Stack
   spacing="4"
@@ -3112,7 +3116,7 @@ const Demo = () => (
 // After
 <Stack
   gap="4"
-  separator={<Stack.Separator />}
+  separator={<Separator />}
 >
   <Box>Item 1</Box>
   <Box>Item 2</Box>


### PR DESCRIPTION
📝 Description
Fix incorrect Stack.Separator references in the migration guide. The guide incorrectly tells users to use Stack.Separator which doesn't exist in v3 — the actual standalone Separator component should be used instead.
⛳️ Current behavior (updates)
The migration guide at apps/www/content/docs/get-started/migration.mdx references Stack.Separator in two places:
1. The StackDivider section (lines 439-466)
2. The Stack Props section (lines 3096-3123)
Stack.Separator is not a valid export from @chakra-ui/react. Users following the guide encounter runtime/type errors.
🚀 New behavior
Replaced all Stack.Separator references with the standalone Separator component, which is the actual export from @chakra-ui/react. Added proper import statements to code examples for consistency with the Separator component documentation (https://chakra-ui.com/docs/components/separator).
💣 Is this a breaking change (Yes/No):
No
📝 Additional Information
- Fixes #10881
- The Stack component in v3 does not use compound/namespaced patterns (unlike Accordion, Dialog, etc.), so Stack.Separator was never a valid API