### PR TITLE
fix(docs): replace Stack.Separator with standalone Separator in migration guide (#10881)

### DIFF
--- a/.changeset/fix-migration-stack-separator.md
+++ b/.changeset/fix-migration-stack-separator.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Docs: fix `Stack.Separator` references in the v3 migration guide. The standalone `Separator` component is now used in both the `StackDivider` and `Stack Props` examples.

--- a/apps/www/content/docs/get-started/migration.mdx
+++ b/apps/www/content/docs/get-started/migration.mdx
@@ -439,7 +439,7 @@ For indeterminate progress:
 ### StackDivider
 
 - No longer available as a separate component
-- Use explicit `Stack.Separator` components between stack items
+- Use explicit `Separator` components between stack items
 
 Before:
 
@@ -454,11 +454,13 @@ Before:
 After:
 
 ```tsx
+import { Separator, VStack, Box } from "@chakra-ui/react";
+
 <VStack gap={4}>
   <Box>Item 1</Box>
-  <Stack.Separator borderColor="gray.200" />
+  <Separator borderColor="gray.200" />
   <Box>Item 2</Box>
-  <Stack.Separator borderColor="gray.200" />
+  <Separator borderColor="gray.200" />
   <Box>Item 3</Box>
 </VStack>
 ```
@@ -3112,7 +3114,7 @@ const Demo = () => (
 // After
 <Stack
   gap="4"
-  separator={<Stack.Separator />}
+  separator={<Separator />}
 >
   <Box>Item 1</Box>
   <Box>Item 2</Box>


### PR DESCRIPTION
Fixes #10881.

The **StackDivider** section and the **Stack Props** example in the v2-to-v3 migration guide both told users to migrate to \`Stack.Separator\`. That is not a valid export from \`@chakra-ui/react\` - \`Stack\` is not a compound/namespaced component in v3 and never exposed \`Separator\` as a property. Users following the guide hit:

- Runtime: \`Cannot read properties of undefined (reading 'Separator')\`
- TypeScript: \`Property 'Separator' does not exist on type 'StackProps'\`

Replaced both references with the standalone \`Separator\` component documented at https://chakra-ui.com/docs/components/separator. Added an explicit \`import { Separator }\` statement in the StackDivider example to match the Separator docs style. The Stack Props example stays inline so the diff stays scoped to the property rename.

Diff is 2 hunks in 1 file (1 net line). No code change, no API change - the migration guide is the only thing this fixes.