### PR TITLE
fix: correct css prop usage in Bleed component

### DIFF
--- a/.changeset/bleed-css-prop.md
+++ b/.changeset/bleed-css-prop.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Bleed: Fix incorrect css prop application

--- a/packages/react/__tests__/bleed.test.tsx
+++ b/packages/react/__tests__/bleed.test.tsx
@@ -1,0 +1,11 @@
+import { Bleed } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("Bleed", () => {
+  it("keeps a custom css prop alongside its negative-margin styles", () => {
+    const { getByTestId } = render(
+      <Bleed data-testid="bleed" inline="4" css={{ position: "fixed" }} />,
+    )
+    expect(getByTestId("bleed")).toHaveStyle({ position: "fixed" })
+  })
+})

--- a/packages/react/src/components/bleed/bleed.tsx
+++ b/packages/react/src/components/bleed/bleed.tsx
@@ -47,23 +47,27 @@ export const Bleed = forwardRef<HTMLDivElement, BleedProps>(
       block,
       blockStart,
       blockEnd,
+      css: cssProp,
       ...rest
     } = props
 
     return (
       <chakra.div
         ref={ref}
+        css={[
+          {
+            "--bleed-inline-start": mapObject(inline ?? inlineStart, valueFn),
+            "--bleed-inline-end": mapObject(inline ?? inlineEnd, valueFn),
+            "--bleed-block-start": mapObject(block ?? blockStart, valueFn),
+            "--bleed-block-end": mapObject(block ?? blockEnd, valueFn),
+            marginInlineStart: "calc(var(--bleed-inline-start, 0) * -1)",
+            marginInlineEnd: "calc(var(--bleed-inline-end, 0) * -1)",
+            marginBlockStart: "calc(var(--bleed-block-start, 0) * -1)",
+            marginBlockEnd: "calc(var(--bleed-block-end, 0) * -1)",
+          },
+          cssProp,
+        ]}
         {...rest}
-        css={{
-          "--bleed-inline-start": mapObject(inline ?? inlineStart, valueFn),
-          "--bleed-inline-end": mapObject(inline ?? inlineEnd, valueFn),
-          "--bleed-block-start": mapObject(block ?? blockStart, valueFn),
-          "--bleed-block-end": mapObject(block ?? blockEnd, valueFn),
-          marginInlineStart: "calc(var(--bleed-inline-start, 0) * -1)",
-          marginInlineEnd: "calc(var(--bleed-inline-end, 0) * -1)",
-          marginBlockStart: "calc(var(--bleed-block-start, 0) * -1)",
-          marginBlockEnd: "calc(var(--bleed-block-end, 0) * -1)",
-        }}
       />
     )
   },


### PR DESCRIPTION
## Description

Destructure the `css` prop so it isn't dropped by the prop spread.

## Current behavior (updates)

`<Bleed css={...} />` has its `css` dropped. `css` falls through `{...rest}`, which is spread before the explicit `css={...}` object, so the component's own negative-margin styles replace the user `css`.

## New behavior

The user `css` is merged with the base styles (`css={[styles, css]}`) instead of being dropped.

## Is this a breaking change (Yes/No):

No
