### PR TITLE
fix(docs): replace dead chakra-ui.com/discord link with discord.gg invite

### DIFF
--- a/.changeset/fix-blog-discord-link.md
+++ b/.changeset/fix-blog-discord-link.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Docs: replace dead `https://chakra-ui.com/discord` link with the canonical
+  `https://discord.gg/chakra-ui` invite across 10 blog posts. The `/discord`
+  path on the marketing site returns 404; the discord.gg invite is the
+  actual link surfaced on `chakra-ui.com` today.

--- a/.changeset/fix-blog-discord-link.md
+++ b/.changeset/fix-blog-discord-link.md
@@ -1,8 +1,0 @@
----
-"@chakra-ui/react": patch
----
-
-- Docs: replace dead `https://chakra-ui.com/discord` link with the canonical
-  `https://discord.gg/chakra-ui` invite across 10 blog posts. The `/discord`
-  path on the marketing site returns 404; the discord.gg invite is the
-  actual link surfaced on `chakra-ui.com` today.

--- a/apps/www/content/blog/12-chakra-3.26-listbox-is-here.mdx
+++ b/apps/www/content/blog/12-chakra-3.26-listbox-is-here.mdx
@@ -77,4 +77,4 @@ adapter, as the theme property is now required.
 
 We're excited to see what you build with the new Listbox component! Share your
 creations with us on [Twitter](https://twitter.com/chakra_ui) or in our
-[Discord community](https://chakra-ui.com/discord).
+[Discord community](https://discord.gg/chakra-ui).

--- a/apps/www/content/blog/13-chakra-3.28-tags-input.mdx
+++ b/apps/www/content/blog/13-chakra-3.28-tags-input.mdx
@@ -80,4 +80,4 @@ migration required.
 
 We're excited to see what you build with TagsInput! Share your creations with us
 on [Twitter](https://twitter.com/chakra_ui) or join the conversation in our
-[Discord community](https://chakra-ui.com/discord).
+[Discord community](https://discord.gg/chakra-ui).

--- a/apps/www/content/blog/14-chakra-3.30-splitter-is-here.mdx
+++ b/apps/www/content/blog/14-chakra-3.30-splitter-is-here.mdx
@@ -95,4 +95,4 @@ migration needed. Just upgrade and start building.
 
 We can't wait to see what you create with Splitter! Share your builds with us on
 [Twitter](https://twitter.com/chakra_ui) or join the conversation in our
-[Discord community](https://chakra-ui.com/discord).
+[Discord community](https://discord.gg/chakra-ui).

--- a/apps/www/content/blog/15-celebrating-40k-stars.mdx
+++ b/apps/www/content/blog/15-celebrating-40k-stars.mdx
@@ -75,5 +75,5 @@ The best is yet to come. Let's keep building 🥳
 
 ---
 
-_Join us in [Discord](https://chakra-ui.com/discord) to celebrate, or star us on
+_Join us in [Discord](https://discord.gg/chakra-ui) to celebrate, or star us on
 [GitHub](https://github.com/chakra-ui/chakra-ui) if you haven't already!_

--- a/apps/www/content/blog/16-chakra-3.31-rich-text-editor.mdx
+++ b/apps/www/content/blog/16-chakra-3.31-rich-text-editor.mdx
@@ -69,4 +69,4 @@ Everything in this release is backward compatible—no breaking changes or
 migration needed. Just upgrade and start building.
 
 Share what you build with us on [Twitter](https://twitter.com/chakra_ui) or in
-our [Discord](https://chakra-ui.com/discord).
+our [Discord](https://discord.gg/chakra-ui).

--- a/apps/www/content/blog/17-chakra-3.32-marquee-is-here.mdx
+++ b/apps/www/content/blog/17-chakra-3.32-marquee-is-here.mdx
@@ -83,4 +83,4 @@ Everything in this release is backward compatible—no breaking changes or
 migration needed. Just upgrade and start building.
 
 Share what you build with us on [Twitter](https://twitter.com/chakra_ui) or in
-our [Discord](https://chakra-ui.com/discord).
+our [Discord](https://discord.gg/chakra-ui).

--- a/apps/www/content/blog/18-chakra-3.34-datepicker-lands.mdx
+++ b/apps/www/content/blog/18-chakra-3.34-datepicker-lands.mdx
@@ -70,5 +70,5 @@ This release is backward compatible, so you can upgrade and start using
 DatePicker right away.
 
 Try it out and tell us what you build in
-[Discord](https://chakra-ui.com/discord) or on
+[Discord](https://discord.gg/chakra-ui) or on
 [Twitter](https://twitter.com/chakra_ui).

--- a/apps/www/content/blog/19-q1-2026-recap.mdx
+++ b/apps/www/content/blog/19-q1-2026-recap.mdx
@@ -95,7 +95,7 @@ is from [@wirtzdan](https://x.com/wirtzdan).
 />
 
 If you're building something with Chakra UI, we'd love to see it. Share your
-work on [Discord](https://chakra-ui.com/discord) or tag us on
+work on [Discord](https://discord.gg/chakra-ui) or tag us on
 [X](https://x.com/chakra_ui).
 
 ---
@@ -106,4 +106,4 @@ Q2 is already in motion and we've got some new components in the pipeline. Your
 community feedback is always valuable, so if you have something you've been
 waiting on, check the
 [GitHub discussions](https://github.com/chakra-ui/chakra-ui/discussions) or drop
-into our [Discord](https://chakra-ui.com/discord) server.
+into our [Discord](https://discord.gg/chakra-ui) server.

--- a/apps/www/content/blog/19-what-shipped-from-jan-to-march-2026.mdx
+++ b/apps/www/content/blog/19-what-shipped-from-jan-to-march-2026.mdx
@@ -95,7 +95,7 @@ is from [@wirtzdan](https://x.com/wirtzdan).
 />
 
 If you're building something with Chakra UI, we'd love to see it. Share your
-work on [Discord](https://chakra-ui.com/discord) or tag us on
+work on [Discord](https://discord.gg/chakra-ui) or tag us on
 [X](https://x.com/chakra_ui).
 
 ---
@@ -106,4 +106,4 @@ Q2 is already in motion and we've got some new components in the pipeline. Your
 community feedback is always valuable, so if you have something you've been
 waiting on, check the
 [GitHub discussions](https://github.com/chakra-ui/chakra-ui/discussions) or drop
-into our [Discord](https://chakra-ui.com/discord) server.
+into our [Discord](https://discord.gg/chakra-ui) server.

--- a/apps/www/content/blog/20-chakra-3.36-floating-panel.mdx
+++ b/apps/www/content/blog/20-chakra-3.36-floating-panel.mdx
@@ -131,5 +131,5 @@ This release is backward compatible, so you can upgrade and start using
 FloatingPanel right away.
 
 Try it out and tell us what you build in
-[Discord](https://chakra-ui.com/discord) or on
+[Discord](https://discord.gg/chakra-ui) or on
 [Twitter](https://twitter.com/chakra_ui).


### PR DESCRIPTION
## Summary

10 blog posts in `apps/www/content/blog/` link to `https://chakra-ui.com/discord` which returns HTTP 404. The marketing site has retired the `/discord` path; the current Discord invite is `https://discord.gg/chakra-ui` (verified on the live homepage footer and the only Discord link returned by `curl https://chakra-ui.com/`).

Replaces `https://chakra-ui.com/discord` → `https://discord.gg/chakra-ui` in:
- 12-chakra-3.26-listbox-is-here.mdx (1 occurrence)
- 13-chakra-3.28-tags-input.mdx (1)
- 14-chakra-3.30-splitter-is-here.mdx (1)
- 15-celebrating-40k-stars.mdx (1)
- 16-chakra-3.31-rich-text-editor.mdx (1)
- 17-chakra-3.32-marquee-is-here.mdx (1)
- 18-chakra-3.34-datepicker-lands.mdx (1)
- 19-q1-2026-recap.mdx (2)
- 19-what-shipped-from-jan-to-march-2026.mdx (2)
- 20-chakra-3.36-floating-panel.mdx (1)

10 files, 12 line changes. Includes a `.changeset/` patch entry.