### PR TITLE
docs(blog): fix dead chakra-ui.com/llms-migration.txt link

### DIFF
--- a/apps/www/content/blog/06-making-docs-ai-friendly.mdx
+++ b/apps/www/content/blog/06-making-docs-ai-friendly.mdx
@@ -46,7 +46,7 @@ file that fits your needs.
   documentation
 - **[llms-theming.txt](https://chakra-ui.com/llms-theming.txt)**: Only theming
   documentation
-- **[llms-migration.txt](https://chakra-ui.com/llms-migration.txt)**: Migration
+- **[llms-v3-migration.txt](https://chakra-ui.com/llms-v3-migration.txt)**: Migration
   guide for v2 to v3
 
 ### Add it to your LLM
@@ -67,7 +67,7 @@ answers.
 
 ## (Pro Tip) Migration
 
-If you're migrating from v2 to v3, you can load up the **llms-migration.txt**
+If you're migrating from v2 to v3, you can load up the **llms-v3-migration.txt**
 file to get help with migrating your Chakra project much faster.
 
 ## Conclusion


### PR DESCRIPTION
docs(blog): fix dead `chakra-ui.com/llms-migration.txt` link

The "Making the Chakra docs AI-friendly" blog post points at
`https://chakra-ui.com/llms-migration.txt` (twice), which returns
HTTP 404. The actual file is hosted at
`https://chakra-ui.com/llms-v3-migration.txt` (HTTP 200, same content
sized to the v2 -> v3 migration). The post predates the v3 file
rename; the docs site dropped the v2-named slug and now serves
v3 by name.

Both occurrences in the post are now updated; no other text
changes.

## Diff

```
 apps/www/content/blog/06-making-docs-ai-friendly.mdx | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Verification

```
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://chakra-ui.com/llms-migration.txt"
404
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://chakra-ui.com/llms-v3-migration.txt"
200
```
