### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #10890)

### DIFF
--- a/.claude/commands/ark.md
+++ b/.claude/commands/ark.md
@@ -1,6 +1,6 @@
 ---
 description: Implement a new Ark UI component
-argument-hint: [componentName]
+argument-hint: "[componentName]"
 ---
 
 ## Context

--- a/.claude/commands/github-reviewer.md
+++ b/.claude/commands/github-reviewer.md
@@ -1,6 +1,6 @@
 ---
 description: Draft a response for a GitHub issue
-argument-hint: [issue-url]
+argument-hint: "[issue-url]"
 ---
 
 ## Context


### PR DESCRIPTION
Closes #10890.

## Summary

Purely mechanical single-character transform to 2 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (2)

- `.claude/commands/github-reviewer.md`
- `.claude/commands/ark.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- Regression sweep: no unquoted-bracket `argument-hint:` lines remain in these files
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
