### PR TITLE
refactor(react): clean up obsolete and incorrect ts-ignore comments

### DIFF
--- a/.changeset/fix-react-ts-ignore-cleanups.md
+++ b/.changeset/fix-react-ts-ignore-cleanups.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/react": patch
+---
+
+refactor(react): clean up obsolete and incorrect type-bypass `@ts-ignore`
+comments, and resolve compiler errors in `AlertRoot` context provider,
+`useConst` hook ref initialization, `createRecipeContext`, and
+`createSlotRecipeContext`.

--- a/packages/react/src/components/alert/alert.tsx
+++ b/packages/react/src/components/alert/alert.tsx
@@ -51,8 +51,9 @@ export const AlertRoot = withProvider<HTMLDivElement, AlertRootProps>(
     forwardAsChild: true,
     wrapElement(element, props) {
       return (
-        // @ts-ignore fix later
-        <AlertStatusProvider value={{ status: props.status || "info" }}>
+        <AlertStatusProvider
+          value={{ status: (props.status || "info") as StatusProps["status"] }}
+        >
           {element}
         </AlertStatusProvider>
       )

--- a/packages/react/src/hooks/use-const.ts
+++ b/packages/react/src/hooks/use-const.ts
@@ -4,11 +4,10 @@ import { useRef } from "react"
 
 type InitFn<T> = () => T
 
-export function useConst<T extends any>(init: T | InitFn<T>): T {
-  const ref = useRef(null)
+export function useConst<T>(init: T | InitFn<T>): T {
+  const ref = useRef<T | null>(null)
   if (ref.current === null) {
-    // @ts-ignore
-    ref.current = typeof init === "function" ? init() : init
+    ref.current = typeof init === "function" ? (init as InitFn<T>)() : init
   }
   return ref.current as T
 }

--- a/packages/react/src/styled-system/create-recipe-context.tsx
+++ b/packages/react/src/styled-system/create-recipe-context.tsx
@@ -34,7 +34,6 @@ export function createRecipeContext<K extends RecipeKey>(
       recipe: restProps.recipe || recipeConfig,
     }) as SystemRecipeFn<{}, {}>
 
-    // @ts-ignore
     const [variantProps, otherProps] = useMemo(
       () => recipe.splitVariantProps(restProps),
       [recipe, restProps],

--- a/packages/react/src/styled-system/create-slot-recipe-context.tsx
+++ b/packages/react/src/styled-system/create-slot-recipe-context.tsx
@@ -75,7 +75,6 @@ export const createSlotRecipeContext = <R extends SlotRecipeKey>(
       recipe: restProps.recipe || recipeConfig,
     }) as SystemSlotRecipeFn<string, {}, {}>
 
-    // @ts-ignore
     const [variantProps, otherProps] = useMemo(
       () => slotRecipe.splitVariantProps(restProps),
       [restProps, slotRecipe],


### PR DESCRIPTION
Closes #10892

## 📝 Description

This PR refactors type safety in the `react` package by resolving compiler bypasses and removing obsolete `@ts-ignore` comments.

## ⛳️ Current behavior (updates)

- `alert.tsx`: Bypasses a context status provider type-mismatch with `// @ts-ignore fix later`.
- `use-const.ts`: Uses typed `useRef(null)` (typed as null-only), forcing a `@ts-ignore` when assigning init values.
- `create-recipe-context.tsx` & `create-slot-recipe-context.tsx`: Uses `@ts-ignore` to bypass `splitVariantProps` calls, which is no longer needed since `props` has `any` type now.

## 🚀 New behavior

- `alert.tsx`: Uses a proper type-assertion (`as StatusProps["status"]`) to safely resolve context types.
- `use-const.ts`: Types `useRef<T | null>(null)` and asserts `init as InitFn<T>` to make ref assignment safe.
- Obsolete `@ts-ignore` comments are removed.
- Includes a standard changeset file in `.changeset/fix-react-ts-ignore-cleanups.md`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Tests and typecheck compile cleanly.
