### PR TITLE
fix(docs): replace dead lucide.dev/react link with canonical package docs URL

### DIFF
--- a/apps/www/content/docs/components/icon.mdx
+++ b/apps/www/content/docs/components/icon.mdx
@@ -22,7 +22,7 @@ import { Icon } from "@chakra-ui/react"
 
 Chakra doesn't provide any icons out of the box. Use popular icon libraries like
 [react-icons](https://react-icons.github.io/react-icons/) or
-[lucide-react](https://lucide.dev/react/)
+[lucide-react](https://lucide.dev/guide/packages/lucide-react)
 
 :::
 


### PR DESCRIPTION
## Summary

The Icon component guide links to `https://lucide.dev/react/` which returns HTTP 404. The current canonical URL for the lucide-react package documentation is `https://lucide.dev/guide/packages/lucide-react` (verified 200). This 1-line fix updates the link so users following the guide land on the actual lucide-react package docs.

## Changes

- `apps/www/content/docs/components/icon.mdx:25` — replace `https://lucide.dev/react/` (404) with `https://lucide.dev/guide/packages/lucide-react` (200).

## Verification

- `curl -sL -A 'Mozilla/5.0' https://lucide.dev/react` → 404
- `curl -sL -A 'Mozilla/5.0' https://lucide.dev/guide/packages/lucide-react` → 200

No changeset needed (docs-only change that does not affect the published package).