### PR TITLE
fix(react): remove obsolete TypeScript suppressions

### DIFF
--- a/packages/react/src/components/alert/alert.tsx
+++ b/packages/react/src/components/alert/alert.tsx
@@ -50,11 +50,9 @@ export const AlertRoot = withProvider<HTMLDivElement, AlertRootProps>(
   {
     forwardAsChild: true,
     wrapElement(element, props) {
+      const status = (props.status || "info") as StatusProps["status"]
       return (
-        // @ts-ignore fix later
-        <AlertStatusProvider value={{ status: props.status || "info" }}>
-          {element}
-        </AlertStatusProvider>
+        <AlertStatusProvider value={{ status }}>{element}</AlertStatusProvider>
       )
     },
   },

--- a/packages/react/src/hooks/use-const.ts
+++ b/packages/react/src/hooks/use-const.ts
@@ -5,10 +5,9 @@ import { useRef } from "react"
 type InitFn<T> = () => T
 
 export function useConst<T extends any>(init: T | InitFn<T>): T {
-  const ref = useRef(null)
+  const ref = useRef<T | null>(null)
   if (ref.current === null) {
-    // @ts-ignore
-    ref.current = typeof init === "function" ? init() : init
+    ref.current = typeof init === "function" ? (init as InitFn<T>)() : init
   }
-  return ref.current as T
+  return ref.current
 }

--- a/packages/react/src/styled-system/create-recipe-context.tsx
+++ b/packages/react/src/styled-system/create-recipe-context.tsx
@@ -34,7 +34,6 @@ export function createRecipeContext<K extends RecipeKey>(
       recipe: restProps.recipe || recipeConfig,
     }) as SystemRecipeFn<{}, {}>
 
-    // @ts-ignore
     const [variantProps, otherProps] = useMemo(
       () => recipe.splitVariantProps(restProps),
       [recipe, restProps],

--- a/packages/react/src/styled-system/create-slot-recipe-context.tsx
+++ b/packages/react/src/styled-system/create-slot-recipe-context.tsx
@@ -75,7 +75,6 @@ export const createSlotRecipeContext = <R extends SlotRecipeKey>(
       recipe: restProps.recipe || recipeConfig,
     }) as SystemSlotRecipeFn<string, {}, {}>
 
-    // @ts-ignore
     const [variantProps, otherProps] = useMemo(
       () => slotRecipe.splitVariantProps(restProps),
       [restProps, slotRecipe],


### PR DESCRIPTION
Closes #10892

## 📝 Description

Removes four obsolete or incorrect TypeScript suppression comments from the React package and replaces the two real type mismatches with explicit, narrow typing.

## ⛳️ Current behavior (updates)

- `AlertRoot` suppresses the mismatch between its responsive `status` prop and the alert status context.
- `useConst` initializes an untyped null ref and suppresses assignment of its generic value.
- The recipe and slot recipe context helpers retain suppressions even though their input props are now typed as `any` and compile without them.

## 🚀 New behavior

- Narrows the alert context value to `StatusProps["status"]`.
- Types the `useConst` ref as `T | null` and narrows function initializers before invoking them.
- Removes the two obsolete recipe context suppressions.
- Keeps runtime behavior and the public API unchanged.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Validation:

- `pnpm --filter=@chakra-ui/react typecheck`
- `pnpm exec vitest run packages/react/__tests__/recipe.test.ts packages/react/__tests__/recipe-types.test.ts packages/react/__tests__/display-name.test.ts` (29 tests passed)
- `pnpm --filter=@chakra-ui/react build:fast`
- `pnpm exec prettier --check` for all four changed files
- `pnpm lint` (0 errors; two unrelated existing warnings)
- `git diff --check`

No changeset is included because this is an internal type-safety refactor with no runtime or public API change.
