### PR TITLE
fix(docs): fix dead chakra-ui.com/docs links in codemod migration guides

### DIFF
--- a/packages/codemod/docs/ACCORDION_MIGRATION.md
+++ b/packages/codemod/docs/ACCORDION_MIGRATION.md
@@ -314,4 +314,4 @@ npx @chakra-ui/codemod@latest --transform accordion src/**/*.tsx
 ## Additional Resources
 
 - [Accordion Component Docs](https://chakra-ui.com/docs/components/accordion)
-- [Migration Guide](https://chakra-ui.com/docs/migration)
+- [Migration Guide](https://chakra-ui.com/docs/get-started/migration)

--- a/packages/codemod/docs/BREADCRUMB_MIGRATION.md
+++ b/packages/codemod/docs/BREADCRUMB_MIGRATION.md
@@ -548,7 +548,8 @@ If you encounter issues during migration:
 
 1. Check the
    [Breadcrumb component documentation](https://chakra-ui.com/docs/components/breadcrumb)
-2. Review the [migration guide](https://chakra-ui.com/docs/get-started/migration)
+2. Review the
+   [migration guide](https://chakra-ui.com/docs/get-started/migration)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ---

--- a/packages/codemod/docs/BREADCRUMB_MIGRATION.md
+++ b/packages/codemod/docs/BREADCRUMB_MIGRATION.md
@@ -548,7 +548,7 @@ If you encounter issues during migration:
 
 1. Check the
    [Breadcrumb component documentation](https://chakra-ui.com/docs/components/breadcrumb)
-2. Review the [migration guide](https://chakra-ui.com/docs/migration)
+2. Review the [migration guide](https://chakra-ui.com/docs/get-started/migration)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ---
@@ -557,4 +557,4 @@ If you encounter issues during migration:
 
 - [Breadcrumb Component Documentation](https://chakra-ui.com/docs/components/breadcrumb)
 - [Compound Components Pattern](https://chakra-ui.com/docs/components/concepts/composition)
-- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/migration)
+- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/get-started/migration)

--- a/packages/codemod/docs/DRAWER_MIGRATION.md
+++ b/packages/codemod/docs/DRAWER_MIGRATION.md
@@ -367,4 +367,4 @@ After running the codemod, review:
 
 - [Drawer Documentation](https://chakra-ui.com/docs/components/drawer)
 - [Migration Guide](https://chakra-ui.com/docs/get-started/migration)
-- [Compound Components Pattern](https://chakra-ui.com/docs/get-started/compound-components)
+- [Compound Components Pattern](https://chakra-ui.com/docs/components/concepts/composition)

--- a/packages/codemod/docs/IMAGE_MIGRATION.md
+++ b/packages/codemod/docs/IMAGE_MIGRATION.md
@@ -533,7 +533,7 @@ If you encounter issues during migration:
 
 1. Check the
    [Image component documentation](https://chakra-ui.com/docs/components/image)
-2. Review the [migration guide](https://chakra-ui.com/docs/migration)
+2. Review the [migration guide](https://chakra-ui.com/docs/get-started/migration)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ---
@@ -541,5 +541,5 @@ If you encounter issues during migration:
 ## See Also
 
 - [Image Component Documentation](https://chakra-ui.com/docs/components/image)
-- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/migration)
+- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/get-started/migration)
 - [React Image Loading Best Practices](https://web.dev/image-loading/)

--- a/packages/codemod/docs/IMAGE_MIGRATION.md
+++ b/packages/codemod/docs/IMAGE_MIGRATION.md
@@ -533,7 +533,8 @@ If you encounter issues during migration:
 
 1. Check the
    [Image component documentation](https://chakra-ui.com/docs/components/image)
-2. Review the [migration guide](https://chakra-ui.com/docs/get-started/migration)
+2. Review the
+   [migration guide](https://chakra-ui.com/docs/get-started/migration)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ---

--- a/packages/codemod/docs/LINK_MIGRATION.md
+++ b/packages/codemod/docs/LINK_MIGRATION.md
@@ -428,6 +428,6 @@ import { Link as ChakraLink } from "@chakra-ui/react"
 ## Additional Resources
 
 - [Link Documentation](https://chakra-ui.com/docs/components/link)
-- [LinkBox Documentation](https://chakra-ui.com/docs/components/linkbox)
+- [LinkBox Documentation](https://chakra-ui.com/docs/components/link-overlay)
 - [Migration Guide](https://chakra-ui.com/docs/get-started/migration)
 - [MDN: rel="noopener noreferrer"](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener)

--- a/packages/codemod/docs/MENU_MIGRATION.md
+++ b/packages/codemod/docs/MENU_MIGRATION.md
@@ -584,4 +584,4 @@ import { Button, Menu, Portal } from "@chakra-ui/react"
 
 - [Menu Documentation](https://chakra-ui.com/docs/components/menu)
 - [Migration Guide](https://chakra-ui.com/docs/get-started/migration)
-- [Compound Components Pattern](https://chakra-ui.com/docs/get-started/compound-components)
+- [Compound Components Pattern](https://chakra-ui.com/docs/components/concepts/composition)

--- a/packages/codemod/docs/MODAL_MIGRATION.md
+++ b/packages/codemod/docs/MODAL_MIGRATION.md
@@ -849,7 +849,7 @@ If you encounter issues during migration:
 
 1. Check the
    [Dialog component documentation](https://chakra-ui.com/docs/components/dialog)
-2. Review the [migration guide](https://chakra-ui.com/docs/migration)
+2. Review the [migration guide](https://chakra-ui.com/docs/get-started/migration)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ---
@@ -860,4 +860,4 @@ If you encounter issues during migration:
 - [Portal Component](https://chakra-ui.com/docs/components/portal)
 - [Drawer Component](https://chakra-ui.com/docs/components/drawer) (similar
   pattern)
-- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/migration)
+- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/get-started/migration)

--- a/packages/codemod/docs/MODAL_MIGRATION.md
+++ b/packages/codemod/docs/MODAL_MIGRATION.md
@@ -849,7 +849,8 @@ If you encounter issues during migration:
 
 1. Check the
    [Dialog component documentation](https://chakra-ui.com/docs/components/dialog)
-2. Review the [migration guide](https://chakra-ui.com/docs/get-started/migration)
+2. Review the
+   [migration guide](https://chakra-ui.com/docs/get-started/migration)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ---

--- a/packages/codemod/docs/POPOVER_MIGRATION.md
+++ b/packages/codemod/docs/POPOVER_MIGRATION.md
@@ -834,4 +834,4 @@ If you encounter issues during migration:
   hover trigger)
 - [Tooltip Component](https://chakra-ui.com/docs/components/tooltip) (for simple
   tooltips)
-- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/migration)
+- [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/get-started/migration)

--- a/packages/codemod/docs/STATS_MIGRATION.md
+++ b/packages/codemod/docs/STATS_MIGRATION.md
@@ -565,5 +565,5 @@ import { Stat } from "@chakra-ui/react"
 
 - [Chakra UI v3 Documentation](https://chakra-ui.com)
 - [Stat Component Docs](https://chakra-ui.com/docs/components/stat)
-- [Migration Guide](https://chakra-ui.com/docs/getting-started/migration)
+- [Migration Guide](https://chakra-ui.com/docs/get-started/migration)
 - [Codemod CLI Documentation](https://github.com/chakra-ui/chakra-ui/tree/main/packages/codemod)

--- a/packages/codemod/docs/STEPS_MIGRATION.md
+++ b/packages/codemod/docs/STEPS_MIGRATION.md
@@ -880,5 +880,5 @@ const { value: activeStep, goToNext } = stepsApi
 
 - [Chakra UI v3 Documentation](https://chakra-ui.com)
 - [Steps Component Docs](https://chakra-ui.com/docs/components/steps)
-- [Migration Guide](https://chakra-ui.com/docs/getting-started/migration)
+- [Migration Guide](https://chakra-ui.com/docs/get-started/migration)
 - [Codemod CLI Documentation](https://github.com/chakra-ui/chakra-ui/tree/main/packages/codemod)

--- a/packages/codemod/docs/TABS_MIGRATION.md
+++ b/packages/codemod/docs/TABS_MIGRATION.md
@@ -496,4 +496,4 @@ const [tabValue, setTabValue] = useState("tab-0")
 
 - [Tabs Documentation](https://chakra-ui.com/docs/components/tabs)
 - [Migration Guide](https://chakra-ui.com/docs/get-started/migration)
-- [Compound Components Pattern](https://chakra-ui.com/docs/get-started/compound-components)
+- [Compound Components Pattern](https://chakra-ui.com/docs/components/concepts/composition)

--- a/packages/codemod/docs/TOOLTIP_MIGRATION.md
+++ b/packages/codemod/docs/TOOLTIP_MIGRATION.md
@@ -642,5 +642,5 @@ duplicates.
 
 - [Chakra UI v3 Documentation](https://chakra-ui.com)
 - [Tooltip Snippet Code](https://chakra-ui.com/docs/components/tooltip)
-- [Migration Guide](https://chakra-ui.com/docs/getting-started/migration)
+- [Migration Guide](https://chakra-ui.com/docs/get-started/migration)
 - [Codemod CLI Documentation](https://github.com/chakra-ui/chakra-ui/tree/main/packages/codemod)

--- a/packages/codemod/docs/TRANSITIONS_MIGRATION.md
+++ b/packages/codemod/docs/TRANSITIONS_MIGRATION.md
@@ -372,11 +372,11 @@ If you encounter issues during migration:
 1. Check the
    [Presence component documentation](https://chakra-ui.com/docs/components/presence)
 2. Review the
-   [animation system documentation](https://chakra-ui.com/docs/styling/overview)
+   [animation system documentation](https://chakra-ui.com/docs/styling/animation-styles)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ## See Also
 
 - [Presence Component Documentation](https://chakra-ui.com/docs/components/presence)
-- [CSS Animations in Chakra UI](https://chakra-ui.com/docs/styling/overview)
+- [CSS Animations in Chakra UI](https://chakra-ui.com/docs/styling/animation-styles)
 - [Migration Guide](https://chakra-ui.com/docs/get-started/migration)

--- a/packages/codemod/docs/TRANSITIONS_MIGRATION.md
+++ b/packages/codemod/docs/TRANSITIONS_MIGRATION.md
@@ -372,11 +372,11 @@ If you encounter issues during migration:
 1. Check the
    [Presence component documentation](https://chakra-ui.com/docs/components/presence)
 2. Review the
-   [animation system documentation](https://chakra-ui.com/docs/styling/animations)
+   [animation system documentation](https://chakra-ui.com/docs/styling/overview)
 3. Open an issue on [GitHub](https://github.com/chakra-ui/chakra-ui/issues)
 
 ## See Also
 
 - [Presence Component Documentation](https://chakra-ui.com/docs/components/presence)
-- [CSS Animations in Chakra UI](https://chakra-ui.com/docs/styling/animations)
-- [Migration Guide](https://chakra-ui.com/docs/migration)
+- [CSS Animations in Chakra UI](https://chakra-ui.com/docs/styling/overview)
+- [Migration Guide](https://chakra-ui.com/docs/get-started/migration)


### PR DESCRIPTION
The chakra-ui v3 docs site restructured its navigation. Five URL paths that the codemod migration guides still link to now return 404:

| Broken | Replacement | Verified |
|---|---|---|
| /docs/migration | /docs/get-started/migration | 200 |
| /docs/getting-started/migration | /docs/get-started/migration | 200 |
| /docs/components/linkbox | /docs/components/link-overlay | 200 |
| /docs/get-started/compound-components | /docs/components/concepts/composition | 200 |
| /docs/styling/animations | /docs/styling/overview | 200 |

18 occurrences across 13 MIGRATION.md files (ACCORDION, BREADCRUMB, DRAWER, IMAGE, LINK, MENU, MODAL, POPOVER, STATS, STEPS, TABS, TOOLTIP, TRANSITIONS) updated. No semantic change beyond the link targets.