### PR TITLE
fix(docs): remove dead Codeium/Windsurf memories link, fix web.dev/image-loading

### DIFF
--- a/apps/www/content/docs/get-started/ai/llms.mdx
+++ b/apps/www/content/docs/get-started/ai/llms.mdx
@@ -46,5 +46,3 @@ Use `@Docs` feature in Cursor to include the LLMs.txt files in your project.
 ### Windstatic
 
 Reference the LLMs.txt files using `@` or in your `.windsurfrules` files.
-
-[Read more](https://docs.codeium.com/windsurf/memories#memories-and-rules)

--- a/packages/codemod/docs/IMAGE_MIGRATION.md
+++ b/packages/codemod/docs/IMAGE_MIGRATION.md
@@ -543,4 +543,4 @@ If you encounter issues during migration:
 
 - [Image Component Documentation](https://chakra-ui.com/docs/components/image)
 - [Chakra UI v3 Migration Guide](https://chakra-ui.com/docs/get-started/migration)
-- [React Image Loading Best Practices](https://web.dev/image-loading/)
+- [React Image Loading Best Practices](https://web.dev/learn/images/)


### PR DESCRIPTION
Two dead link fixes in v3 docs:

1. `apps/www/content/docs/get-started/ai/llms.mdx`: The "Read more" link to `https://docs.codeium.com/windsurf/memories#memories-and-rules` is dead. The Codeium product was renamed to Windsurf, the docs moved to `docs.windsurf.com`, and the memories feature is no longer documented (the redirect chain ends at `docs.devin.ai/desktop/memories` which 404s). The Windsurf memories feature has been deprecated. Removed the dead "Read more" link; the section header and description stand on their own.

2. `packages/codemod/docs/IMAGE_MIGRATION.md`: The "React Image Loading Best Practices" link to `https://web.dev/image-loading/` 404s (web.dev restructured its image content into learning paths). Replaced with `https://web.dev/learn/images/` (200), the new "Image Performance" learning path that covers responsive images, formats, lazy loading, and LCP.

No semantic content change beyond updating link targets.