### PR TITLE
fix(dialog): stop click event propagation in DialogActionTrigger

### DIFF
--- a/.changeset/violet-buttons-write.md
+++ b/.changeset/violet-buttons-write.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+fix(dialog): stop event propagation in DialogActionTrigger to prevent closing
+nested parent dialogs

--- a/packages/react/src/components/dialog/dialog.tsx
+++ b/packages/react/src/components/dialog/dialog.tsx
@@ -135,9 +135,27 @@ export const DialogActionTrigger = forwardRef<
   HTMLButtonElement,
   DialogActionTriggerProps
 >(function DialogActionTrigger(props, ref) {
+  const { onClick, ...rest } = props
   const dialog = useDialogContext()
+
   return (
-    <chakra.button {...props} ref={ref} onClick={() => dialog.setOpen(false)} />
+    <chakra.button
+      {...rest}
+      ref={ref}
+      onClick={(e) => {
+        // 1. Call the user's custom onClick if they provided one
+        onClick?.(e)
+
+        // 2. If the user explicitly called e.preventDefault(), don't close the dialog
+        if (e.defaultPrevented) return
+
+        // 3. Stop the click event from bubbling up to parent dialog layers
+        e.stopPropagation()
+
+        // 4. Safely close the current dialog context
+        dialog.setOpen(false)
+      }}
+    />
   )
 })
 


### PR DESCRIPTION
Closes #10902

## 📝 Description

Stops click event propagation inside the `DialogActionTrigger` component. This prevents the click event from bubbling up the React/DOM tree when closing a nested child dialog, which previously caused the parent dialog to unexpectedly close as well.

## ⛳️ Current behavior (updates)

When a nested child dialog is open (especially if rendered as initially open via `defaultOpen`), clicking the close button (`DialogActionTrigger`) inside the child dialog bubbles the click event up to the parent dialog's elements. This causes the parent dialog layer to interpret the click incorrectly, unexpectedly closing both the child and the parent dialog at the same time.

## 🚀 New behavior

Clicking a `DialogActionTrigger` inside a nested child dialog safely halts the event propagation via `e.stopPropagation()`. The child dialog closes seamlessly while its parent dialog remains completely unaffected and open on the screen.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Tested the fix locally inside the `Nested` Storybook environment to ensure proper event isolation and verified that the parent container remains open after the child dialog is dismissed.