### PR TITLE
fix: missing type="button" on Tag, ActionBar, Dialog, Drawer triggers

### DIFF
--- a/.changeset/fix-close-trigger-submit-type.md
+++ b/.changeset/fix-close-trigger-submit-type.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Fix `Tag.CloseTrigger`, `ActionBar.SelectionTrigger`, `Dialog.ActionTrigger`,
+  `Drawer.ActionTrigger` missing `type="button"`, causing unintended form
+  submission when used inside a `<form>`

--- a/packages/react/__tests__/action-bar.test.tsx
+++ b/packages/react/__tests__/action-bar.test.tsx
@@ -1,0 +1,19 @@
+import { ActionBar } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("ActionBar", () => {
+  it("defaults SelectionTrigger to type=button", () => {
+    const { getByTestId } = render(
+      <ActionBar.Root open>
+        <ActionBar.Positioner>
+          <ActionBar.Content>
+            <ActionBar.SelectionTrigger data-testid="selection-trigger">
+              Selection
+            </ActionBar.SelectionTrigger>
+          </ActionBar.Content>
+        </ActionBar.Positioner>
+      </ActionBar.Root>,
+    )
+    expect(getByTestId("selection-trigger")).toHaveAttribute("type", "button")
+  })
+})

--- a/packages/react/__tests__/dialog.test.tsx
+++ b/packages/react/__tests__/dialog.test.tsx
@@ -1,0 +1,19 @@
+import { Dialog } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("Dialog", () => {
+  it("defaults ActionTrigger to type=button", () => {
+    const { getByTestId } = render(
+      <Dialog.Root open>
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.ActionTrigger data-testid="action-trigger">
+              Cancel
+            </Dialog.ActionTrigger>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Dialog.Root>,
+    )
+    expect(getByTestId("action-trigger")).toHaveAttribute("type", "button")
+  })
+})

--- a/packages/react/__tests__/drawer.test.tsx
+++ b/packages/react/__tests__/drawer.test.tsx
@@ -1,0 +1,19 @@
+import { Drawer } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("Drawer", () => {
+  it("defaults ActionTrigger to type=button", () => {
+    const { getByTestId } = render(
+      <Drawer.Root open>
+        <Drawer.Positioner>
+          <Drawer.Content>
+            <Drawer.ActionTrigger data-testid="action-trigger">
+              Cancel
+            </Drawer.ActionTrigger>
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Drawer.Root>,
+    )
+    expect(getByTestId("action-trigger")).toHaveAttribute("type", "button")
+  })
+})

--- a/packages/react/__tests__/tag.test.tsx
+++ b/packages/react/__tests__/tag.test.tsx
@@ -1,0 +1,13 @@
+import { Tag } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("Tag", () => {
+  it("defaults CloseTrigger to type=button", () => {
+    const { getByTestId } = render(
+      <Tag.Root>
+        <Tag.CloseTrigger data-testid="close-trigger" />
+      </Tag.Root>,
+    )
+    expect(getByTestId("close-trigger")).toHaveAttribute("type", "button")
+  })
+})

--- a/packages/react/src/components/action-bar/action-bar.tsx
+++ b/packages/react/src/components/action-bar/action-bar.tsx
@@ -105,7 +105,7 @@ export interface ActionBarSelectionTriggerProps
 export const ActionBarSelectionTrigger = withContext<
   HTMLButtonElement,
   ActionBarSelectionTriggerProps
->("button", "selectionTrigger")
+>("button", "selectionTrigger", { defaultProps: { type: "button" } })
 
 ////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/react/src/components/dialog/dialog.tsx
+++ b/packages/react/src/components/dialog/dialog.tsx
@@ -137,7 +137,12 @@ export const DialogActionTrigger = forwardRef<
 >(function DialogActionTrigger(props, ref) {
   const dialog = useDialogContext()
   return (
-    <chakra.button {...props} ref={ref} onClick={() => dialog.setOpen(false)} />
+    <chakra.button
+      type="button"
+      {...props}
+      ref={ref}
+      onClick={() => dialog.setOpen(false)}
+    />
   )
 })
 

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -137,7 +137,12 @@ export const DrawerActionTrigger = forwardRef<
 >(function DrawerActionTrigger(props, ref) {
   const drawer = useDialogContext()
   return (
-    <chakra.button {...props} ref={ref} onClick={() => drawer.setOpen(false)} />
+    <chakra.button
+      type="button"
+      {...props}
+      ref={ref}
+      onClick={() => drawer.setOpen(false)}
+    />
   )
 })
 

--- a/packages/react/src/components/tag/tag.tsx
+++ b/packages/react/src/components/tag/tag.tsx
@@ -54,7 +54,9 @@ export interface TagCloseTriggerProps
 export const TagCloseTrigger = withContext<
   HTMLButtonElement,
   TagCloseTriggerProps
->("button", "closeTrigger", { defaultProps: { children: <CloseIcon /> } })
+>("button", "closeTrigger", {
+  defaultProps: { type: "button", children: <CloseIcon /> },
+})
 
 ////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)

🚨 NOTE: Please open v2 related PRs against the `v2` branch.
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixed a bug where `Tag.CloseTrigger` / `ActionBar.SelectionTrigger` / `Dialog.ActionTrigger` / `Drawer.ActionTrigger` were missing the `type="button"` attribute, causing the form to be submitted unintentionally when used inside a `<form>`.

The reason I consider this a bug is that a similar issue was raised back in Chakra UI's v1 era at https://github.com/chakra-ui/chakra-ui/issues/958, and it was fixed in https://github.com/chakra-ui/chakra-ui/pull/961.

This issue has resurfaced in v3.

## ⛳️ Current behavior (updates)

The following components render a raw `<button>` element without specifying a `type` attribute, so it falls back to the browser's default value of `type="submit"`:

- `Tag.CloseTrigger` (`packages/react/src/components/tag/tag.tsx`)
- `ActionBar.SelectionTrigger` (`packages/react/src/components/action-bar/action-bar.tsx`)
- `Dialog.ActionTrigger` (`packages/react/src/components/dialog/dialog.tsx`)
- `Drawer.ActionTrigger` (`packages/react/src/components/drawer/drawer.tsx`)

As a result, using these components inside a `<form>` causes unintended form submission when pressing Enter or clicking them.

## 🚀 New behavior

Added a `type="button"` default value to the components above. If the caller explicitly passes a `type`, that value takes precedence, so existing behavior is not broken (same precedence as the `Button` component).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
