### PR TITLE
fix(compositions): support addons in InputGroup snippet

### DIFF
--- a/apps/compositions/src/ui/input-group.tsx
+++ b/apps/compositions/src/ui/input-group.tsx
@@ -1,12 +1,24 @@
-import type { BoxProps, InputElementProps } from "@chakra-ui/react"
-import { Group, InputElement } from "@chakra-ui/react"
+import {
+  type BoxProps,
+  Group,
+  InputAddon,
+  type InputAddonProps,
+  InputElement,
+  type InputElementProps,
+} from "@chakra-ui/react"
 import * as React from "react"
 
 export interface InputGroupProps extends BoxProps {
-  startElementProps?: InputElementProps
-  endElementProps?: InputElementProps
   startElement?: React.ReactNode
+  startElementProps?: InputElementProps
   endElement?: React.ReactNode
+  endElementProps?: InputElementProps
+
+  startAddon?: React.ReactNode
+  startAddonProps?: InputAddonProps
+  endAddon?: React.ReactNode
+  endAddonProps?: InputAddonProps
+
   children: React.ReactElement<InputElementProps>
   startOffset?: InputElementProps["paddingStart"]
   endOffset?: InputElementProps["paddingEnd"]
@@ -20,6 +32,10 @@ export const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
       endElement,
       endElementProps,
       children,
+      startAddon,
+      startAddonProps,
+      endAddon,
+      endAddonProps,
       startOffset = "6px",
       endOffset = "6px",
       ...rest
@@ -30,16 +46,23 @@ export const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
 
     return (
       <Group ref={ref} {...rest}>
+        {startAddon && (
+          <InputAddon {...startAddonProps}>{startAddon}</InputAddon>
+        )}
         {startElement && (
           <InputElement pointerEvents="none" {...startElementProps}>
             {startElement}
           </InputElement>
         )}
         {React.cloneElement(child, {
-          ...(startElement && {
-            ps: `calc(var(--input-height) - ${startOffset})`,
-          }),
-          ...(endElement && { pe: `calc(var(--input-height) - ${endOffset})` }),
+          ...(startElement &&
+            !startAddon && {
+              ps: `calc(var(--input-height) - ${startOffset})`,
+            }),
+          ...(endElement &&
+            !endAddon && {
+              pe: `calc(var(--input-height) - ${endOffset})`,
+            }),
           ...children.props,
         })}
         {endElement && (
@@ -47,6 +70,7 @@ export const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
             {endElement}
           </InputElement>
         )}
+        {endAddon && <InputAddon {...endAddonProps}>{endAddon}</InputAddon>}
       </Group>
     )
   },


### PR DESCRIPTION
Closes #10914 

## 📝 Description

Fixes the InputGroup composition snippet not supporting `startAddon` and `endAddon` props even though they are available in the InputGroup documentation.

## ⛳️ Current behavior (updates)

The generated InputGroup snippet does not include `startAddon`, `endAddon`, `startAddonProps`, or `endAddonProps` in its type definitions.

Using documented props like:

```tsx
<InputGroup startAddon="https://">
  <Input />
</InputGroup>