### PR TITLE
fix: preserve italic styles in preflight

### DIFF
--- a/.changeset/fix-preflight-italics.md
+++ b/.changeset/fix-preflight-italics.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix semantic `i` and `em` elements not rendering in italics when preflight is
+enabled.

--- a/packages/react/__tests__/preflight.test.ts
+++ b/packages/react/__tests__/preflight.test.ts
@@ -1,0 +1,11 @@
+import { createPreflight } from "../src/styled-system/preflight"
+
+describe("preflight", () => {
+  test("preserves semantic italic styles", () => {
+    const result = createPreflight({ preflight: true })
+
+    expect(result["i, em"]).toEqual({
+      fontStyle: "italic",
+    })
+  })
+})

--- a/packages/react/src/styled-system/preflight.ts
+++ b/packages/react/src/styled-system/preflight.ts
@@ -102,6 +102,9 @@ export function createPreflight(options: PreflightConfig) {
     "b, strong": {
       fontWeight: "bolder",
     },
+    "i, em": {
+      fontStyle: "italic",
+    },
     "code, kbd, samp, pre": {
       fontSize: "1em",
       "--font-mono-fallback":


### PR DESCRIPTION
## Summary

- restore default italic styling for semantic `i` and `em` elements when preflight is enabled
- add focused regression coverage for `createPreflight`
- add a patch changeset for `@chakra-ui/react`

## Why

The universal preflight rule applies `font: inherit`, which removes the browser's
default italic styling. Preflight restores the semantic styling for `b` and
`strong`, but did not do the equivalent for `i` and `em`.

This caused raw semantic italic markup from content such as Markdown editors to
render without emphasis.

## Impact

Raw `i` and `em` elements preserve their expected italic styling when Chakra
preflight is enabled. There are no API changes.

## Testing

- `pnpm test packages/react/__tests__/preflight.test.ts --run`
- `pnpm --filter @chakra-ui/react typecheck`
- `pnpm exec prettier --check packages/react/src/styled-system/preflight.ts packages/react/__tests__/preflight.test.ts .changeset/fix-preflight-italics.md`

Fixes #10910
