### PR TITLE
docs: fix Next.js Link import in breadcrumb example

### DIFF
--- a/apps/www/content/docs/components/breadcrumb.mdx
+++ b/apps/www/content/docs/components/breadcrumb.mdx
@@ -80,7 +80,7 @@ Use the `asChild` prop to change the underlying breadcrumb link
 
 ```tsx
 import { Breadcrumb } from "@chakra-ui/react"
-import { Link } from "next/link"
+import Link from "next/link"
 
 export const Example = () => {
   return (


### PR DESCRIPTION
## 📝 Description

Correct the Next.js Link import in the Breadcrumb routing example.

## ⛳️ Current behavior (updates)

The example uses a named import from next/link, which is not exported and causes an error when the snippet is copied into a Next.js project.

## 🚀 New behavior

The example uses the supported default import from next/link.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Documentation-only change. Verified with git diff --check.