### PR TITLE
fix(number-input): prevent control overflow when Label is used

### DIFF
--- a/.changeset/fix-number-input-label-overflow.md
+++ b/.changeset/fix-number-input-label-overflow.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Fix `NumberInput.Control` overflow when `NumberInput.Label` is used inside
+  `NumberInput.Root`
+- The control is now anchored to the input height via `--input-height` instead
+  of spanning the full root height

--- a/apps/compositions/src/examples/number-input-with-label.tsx
+++ b/apps/compositions/src/examples/number-input-with-label.tsx
@@ -1,0 +1,11 @@
+import { NumberInput } from "@chakra-ui/react"
+
+export const NumberInputWithLabel = () => {
+  return (
+    <NumberInput.Root defaultValue="10" width="200px">
+      <NumberInput.Label>Label</NumberInput.Label>
+      <NumberInput.Control />
+      <NumberInput.Input />
+    </NumberInput.Root>
+  )
+}

--- a/packages/react/__stories__/number-input.stories.tsx
+++ b/packages/react/__stories__/number-input.stories.tsx
@@ -19,6 +19,7 @@ export { NumberInputWithField as Field } from "compositions/examples/number-inpu
 export { NumberInputWithFormatOptions as FormatOptions } from "compositions/examples/number-input-with-format-options"
 export { NumberInputWithHookForm as HookForm } from "compositions/examples/number-input-with-hook-form"
 export { NumberInputWithInvalid as Invalid } from "compositions/examples/number-input-with-invalid"
+export { NumberInputWithLabel as Label } from "compositions/examples/number-input-with-label"
 export { NumberInputWithMinMax as MinMax } from "compositions/examples/number-input-with-min-max"
 export { NumberInputWithMouseWheel as MouseWheel } from "compositions/examples/number-input-with-mouse-wheel"
 export { NumberInputWithScrubber as Scrubber } from "compositions/examples/number-input-with-scrubber"

--- a/packages/react/src/theme/recipes/number-input.ts
+++ b/packages/react/src/theme/recipes/number-input.ts
@@ -46,11 +46,10 @@ export const numberInputSlotRecipe = defineSlotRecipe({
       display: "flex",
       flexDirection: "column",
       position: "absolute",
-      top: "0",
       insetEnd: "0px",
       margin: "1px",
       width: "var(--stepper-width)",
-      height: "calc(100% - 2px)",
+      height: "var(--input-height)",
       zIndex: "1",
       borderStartWidth: "1px",
       divideY: "1px",
@@ -72,6 +71,9 @@ export const numberInputSlotRecipe = defineSlotRecipe({
   variants: {
     size: {
       xs: {
+        root: {
+          "--input-height": "sizes.7",
+        },
         input: inputRecipe.variants!.size.xs,
         control: {
           fontSize: "2xs",
@@ -79,6 +81,9 @@ export const numberInputSlotRecipe = defineSlotRecipe({
         },
       },
       sm: {
+        root: {
+          "--input-height": "sizes.8",
+        },
         input: inputRecipe.variants!.size.sm,
         control: {
           fontSize: "xs",
@@ -86,6 +91,9 @@ export const numberInputSlotRecipe = defineSlotRecipe({
         },
       },
       md: {
+        root: {
+          "--input-height": "sizes.9",
+        },
         input: inputRecipe.variants!.size.md,
         control: {
           fontSize: "sm",
@@ -93,6 +101,9 @@ export const numberInputSlotRecipe = defineSlotRecipe({
         },
       },
       lg: {
+        root: {
+          "--input-height": "sizes.10",
+        },
         input: inputRecipe.variants!.size.lg,
         control: {
           fontSize: "sm",


### PR DESCRIPTION
## Summary

Fixes the layout issue where `NumberInput.Control` overflows when `NumberInput.Label` is used inside `NumberInput.Root`.

## Before

The `NumberInput.Control` was:
- Positioned at `top: "0"` of the root
- Spanned the full root height via `height: "calc(100% - 2px)"`

When a `NumberInput.Label` was added as a child of the root, the root's height increased to accommodate the label, causing the control to extend upward into the label area.

## After

- Removed the explicit `top: "0"` so the control uses its static position (right after the input in the normal flow)
- Changed the control's height from `calc(100% - 2px)` to `var(--input-height)` — the control now matches the input height instead of the full root height
- Added `--input-height` to the `root` slot in the size variants so the control can inherit this CSS variable

## Verification

- `pnpm --filter=@chakra-ui/react typecheck` passes
- `pnpm --filter=@chakra-ui/react test run` passes
- Added a `number-input-with-label` story that reproduces the original issue

Closes #10889