### PR TITLE
fix(RadioCard): preserve outline border-width when disabled and checked

### DIFF
--- a/.changeset/radio-card-outline-disabled.md
+++ b/.changeset/radio-card-outline-disabled.md
@@ -1,0 +1,10 @@
+---
+"@chakra-ui/react": patch
+---
+
+- **RadioCard**: Fix `outline` variant border-width appearing reduced when
+  disabled and checked. The `itemControl`'s disabled background
+  (`bg.muted`) was covering the `item`'s checked inset box-shadow ring,
+  making the visual border appear thinner. Override the disabled
+  background in the `outline` variant to prevent the shadow from being
+  hidden.

--- a/packages/panda-preset/src/slot-recipes/radio-card.ts
+++ b/packages/panda-preset/src/slot-recipes/radio-card.ts
@@ -217,6 +217,11 @@ export const radioCardSlotRecipe = defineSlotRecipe({
             borderColor: "colorPalette.solid",
           },
         },
+        itemControl: {
+          _disabled: {
+            bg: "unset",
+          },
+        },
         itemIndicator: {
           borderWidth: "1px",
           borderColor: "border.emphasized",


### PR DESCRIPTION
## Summary

Fixes #10930: the RadioCard outline variant visually loses its
border-width when disabled and checked.

### Root cause

In the outline variant, the checked `item` renders a 2px visual border
composed of a real `borderWidth: 1px` plus an inner ring simulated with
`boxShadow: inset 0 0 0 1px var(--shadow-color)`.

When the RadioCard is disabled, the `itemControl` (which fills the
`item` via `flex: 1` and `rounded: inherit`) gets a `bg: bg.muted`
background from the base recipe. That opaque background paints over the
`item`'s inset box-shadow ring, so the checked border appears as thin as
1px instead of 2px — the visual border-width change described in the
issue.

### Fix

Override the disabled `itemControl` background in the outline variant
with `bg: unset` (matching the existing pattern already used by the
solid variant). The disabled state remains clearly visible through the
`item`'s existing `opacity: 0.5`, while the checked 2px outline is
preserved.

## Changes

- `packages/panda-preset/src/slot-recipes/radio-card.ts`
- Add `.changeset/radio-card-outline-disabled.md`

> Pure contribution, no bounty (chakra-ui is not a bounty project).
