### PR TITLE
feat(Button): add accessibleWhenDisabled prop for accessible disabled state (Closes #10929)

### DIFF
--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -38,7 +38,19 @@ export interface ButtonLoadingProps {
 }
 
 export interface ButtonBaseProps
-  extends RecipeProps<"button">, UnstyledProp, ButtonLoadingProps {}
+  extends RecipeProps<"button">, UnstyledProp, ButtonLoadingProps {
+  /**
+   * When `true`, the button will use `aria-disabled` instead of the native
+   * `disabled` attribute, keeping the button focusable and accessible to
+   * assistive technologies.
+   *
+   * When enabled, the button's click handler will be suppressed to prevent
+   * action triggers while the button is in a disabled state.
+   *
+   * @default false
+   */
+  accessibleWhenDisabled?: boolean | undefined
+}
 
 export interface ButtonProps extends HTMLChakraProps<
   "button",
@@ -59,15 +71,31 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       spinner,
       spinnerPlacement,
+      accessibleWhenDisabled,
       ...rest
     } = result.props
+
+    const isDisabled = loading || rest.disabled
+
     return (
       <chakra.button
         type="button"
         ref={ref}
         {...rest}
         data-loading={dataAttr(loading)}
-        disabled={loading || rest.disabled}
+        disabled={accessibleWhenDisabled ? undefined : isDisabled}
+        aria-disabled={
+          accessibleWhenDisabled && isDisabled ? true : undefined
+        }
+        data-disabled={dataAttr(isDisabled)}
+        onClick={
+          accessibleWhenDisabled && isDisabled
+            ? (e: React.MouseEvent) => {
+                e.preventDefault()
+                e.stopPropagation()
+              }
+            : rest.onClick
+        }
         className={cx(result.className, props.className)}
         css={[result.styles, props.css]}
       >


### PR DESCRIPTION
## Summary

Adds an `accessibleWhenDisabled` prop to the `Button` component. When enabled, the button uses `aria-disabled` instead of the native `disabled` attribute, keeping the button focusable and accessible to assistive technologies.

## Problem

When a button becomes disabled (e.g., during a loading state), it loses focus because the native `disabled` attribute removes it from the focus order. After clicking the button, focus should ideally remain on the same control while the action is in progress.

## Solution

- Added `accessibleWhenDisabled` prop to `ButtonBaseProps`
- When `true` and the button is disabled:
  - Uses `aria-disabled="true"` instead of the native `disabled` attribute
  - Sets `data-disabled` for CSS styling (Panda CSS `_disabled` selector matches `[data-disabled]`)
  - Suppresses click events to prevent action triggers
- IconButton and CloseButton inherit the feature via `ButtonProps`

## Usage

```tsx
<Button disabled accessibleWhenDisabled>Submit</Button>
<Button loading accessibleWhenDisabled>Submit</Button>
```

Closes #10929