### PR TITLE
fix(codemod): report dry-run output and fix parser/package-scan bugs

### DIFF
--- a/.changeset/codemod-dry-run-output.md
+++ b/.changeset/codemod-dry-run-output.md
@@ -1,0 +1,13 @@
+---
+"@chakra-ui/codemod": patch
+---
+
+Fix three bugs in the `upgrade` command:
+
+- `--dry` now prints a summary of which transforms would change files. Before,
+  it silenced jscodeshift and showed nothing.
+- `.ts` files now use the `ts` parser instead of `tsx`, so type assertions and
+  generic arrows no longer throw and get skipped.
+- The unused-package check no longer scans `node_modules`, so it stops flagging
+  `framer-motion` and `@emotion/styled` as used when only a dependency imports
+  them (and runs much faster).

--- a/packages/codemod/src/run-transform.ts
+++ b/packages/codemod/src/run-transform.ts
@@ -14,6 +14,18 @@ interface RunTransformOptions {
   ignorePattern?: string[]
 }
 
+export interface TransformResult {
+  changed: number
+  errors: number
+}
+
+function parseStats(output: string): TransformResult {
+  const num = (label: string) =>
+    Number(new RegExp(`(\\d+)\\s+${label}`).exec(output)?.[1] ?? 0)
+  // jscodeshift reports transformed files as "ok"
+  return { changed: num("ok"), errors: num("errors") }
+}
+
 process.once("SIGINT", () => {
   p.cancel("Upgrade cancelled.")
   process.exit(0)
@@ -58,7 +70,7 @@ export async function runTransform(
 
   if (dry) args.push("--dry")
   if (print) args.push("--print")
-  if (upgrade) args.push("--silent")
+  if (upgrade && !dry) args.push("--silent")
 
   let s: ReturnType<typeof p.spinner> | undefined
 
@@ -70,7 +82,7 @@ export async function runTransform(
     if (dry) p.log.info(color.yellow("[dry-run] No changes will be applied"))
   }
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<TransformResult>((resolve, reject) => {
     try {
       if (!upgrade) {
         s = p.spinner()
@@ -82,8 +94,10 @@ export async function runTransform(
         env: process.env,
       })
 
+      let stdoutBuffer = ""
       let stderrBuffer = ""
       child.stdout.on("data", (data) => {
+        stdoutBuffer += data.toString()
         if (upgrade) return
         const lines = data.toString().split("\n")
         for (const line of lines) {
@@ -112,7 +126,7 @@ export async function runTransform(
             s.stop(color.green("Transformations complete"))
             p.outro(`${color.cyan("Done!")} Your theme/code has been migrated.`)
           }
-          resolve()
+          resolve(parseStats(stdoutBuffer))
         } else {
           s?.stop(color.red("Transformation failed"))
           // Extract concise error line (first meaningful line)

--- a/packages/codemod/src/upgrade.ts
+++ b/packages/codemod/src/upgrade.ts
@@ -215,21 +215,42 @@ export async function upgrade(
 
     const { componentsDir } = getProjectInfo(process.cwd())
 
+    const changed: string[] = []
+    let failed = 0
+
     for (const name of transformsToRun) {
       s.message(`Transforming: ${name}`)
       try {
-        await runTransform(name, process.cwd(), {
+        const { changed: count } = await runTransform(name, process.cwd(), {
           dry,
           upgrade: true,
           ignorePattern: ["node_modules", componentsDir],
         })
+        if (count > 0)
+          changed.push(`${name} (${count} file${count > 1 ? "s" : ""})`)
       } catch (err) {
+        failed++
         const msg = err instanceof Error ? err.message : String(err)
         p.log.error(`Failed transform ${name}: ${msg}`)
       }
     }
 
-    s.stop("All transforms completed")
+    s.stop(
+      dry
+        ? "Dry run complete — no files were changed"
+        : "All transforms completed",
+    )
+
+    if (changed.length > 0) {
+      p.note(
+        changed.join("\n"),
+        dry
+          ? "Transforms that would change files"
+          : "Transforms that changed files",
+      )
+    } else if (failed === 0) {
+      p.log.info("No files matched any transform.")
+    }
   }
 
   p.outro(

--- a/packages/codemod/src/utils/is-package-used.ts
+++ b/packages/codemod/src/utils/is-package-used.ts
@@ -1,6 +1,14 @@
 import fs from "fs"
 import path from "path"
 
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+])
+
 export async function isPackageUsed(
   pkgName: string,
   targetPath: string,
@@ -9,6 +17,7 @@ export async function isPackageUsed(
   for (const file of files) {
     const fullPath = path.join(targetPath, file.name)
     if (file.isDirectory()) {
+      if (IGNORE_DIRS.has(file.name) || file.name.startsWith(".")) continue
       if (await isPackageUsed(pkgName, fullPath)) return true
     } else if (file.isFile() && /\.(ts|tsx|js|jsx)$/.test(file.name)) {
       const content = fs.readFileSync(fullPath, "utf8")

--- a/packages/codemod/src/utils/parser.ts
+++ b/packages/codemod/src/utils/parser.ts
@@ -25,7 +25,7 @@ function createParserFromPath(filePath: string): j.JSCodeshift {
   // jsx is allowed in .js files, feed them into the tsx parser.
   // tsx parser :.js, .jsx, .tsx
   // ts parser: .ts, .mts, .cts
-  const isTsFile = /\.(m|c)?.ts$/.test(filePath)
+  const isTsFile = /\.(m|c)?ts$/.test(filePath)
   return isTsFile ? j.withParser("ts") : j.withParser("tsx")
 }
 


### PR DESCRIPTION
## 📝 Description

Fixes three bugs in the codemod `upgrade` command.

## ⛳️ Current behavior (updates)

- `upgrade --dry` silences jscodeshift and drops its stdout, so it finishes without telling you anything about what would change.
- `parser.ts` sends `.ts` files to the `tsx` parser. Files using type assertions (`<Foo>bar`) or generic arrows throw a syntax error and get skipped.
- The unused-package check walks `node_modules`, so `framer-motion` and `@emotion/styled` almost always look "used" and never get removed. It's also slow, especially from a monorepo root.

## 🚀 New behavior

- `--dry` prints a summary of which transforms would change files, and how many.
- `.ts` files use the `ts` parser; `.mts`/`.cts` still match, `.tsx` still uses `tsx`.
- The package check skips `node_modules`, `dist`, `build`, `out`, `coverage`, and dot-dirs.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
