### PR TITLE
feat(codemod): faster in-process upgrade with a real dry-run preview

### DIFF
--- a/.changeset/codemod-fast-upgrade-preview.md
+++ b/.changeset/codemod-fast-upgrade-preview.md
@@ -2,15 +2,15 @@
 "@chakra-ui/codemod": minor
 ---
 
-Make `upgrade` faster and its dry run actually useful.
+Speed up the `upgrade` command and add a readable dry-run preview.
 
-- Transforms now run in-process instead of spawning a Node process each. A full
-  run drops from ~30s to a few seconds on a small project.
-- `upgrade --dry` lists the files that would change and, per file, the
-  components and props it would touch (e.g. `Button, color palette`).
-- Projects with many changed files get a `chakra-codemod-report.md` with the
-  full breakdown; smaller ones print inline.
-- The `color-mode` transform no longer installs a snippet during a dry run, and
-  uses the current CLI flag instead of the removed `--yes`.
-- The `steps` transform no longer injects a stray `Steps` import into files that
+- Run transforms in-process instead of spawning a Node process per transform,
+  taking a full run from ~30s to a few seconds.
+- `upgrade --dry` now lists the files that would change and, per file, the
+  components and props it touches (e.g. `Button, color palette`).
+- Large projects write the full breakdown to `chakra-codemod-report.md`; smaller
+  ones print it inline.
+- Stop the `color-mode` transform from installing a snippet during a dry run,
+  and use the current CLI flag instead of the removed `--yes`.
+- Stop the `steps` transform from adding a stray `Steps` import to files that
   don't use a stepper.

--- a/.changeset/codemod-fast-upgrade-preview.md
+++ b/.changeset/codemod-fast-upgrade-preview.md
@@ -1,0 +1,16 @@
+---
+"@chakra-ui/codemod": minor
+---
+
+Make `upgrade` faster and its dry run actually useful.
+
+- Transforms now run in-process instead of spawning a Node process each. A full
+  run drops from ~30s to a few seconds on a small project.
+- `upgrade --dry` lists the files that would change and, per file, the
+  components and props it would touch (e.g. `Button, color palette`).
+- Projects with many changed files get a `chakra-codemod-report.md` with the
+  full breakdown; smaller ones print inline.
+- The `color-mode` transform no longer installs a snippet during a dry run, and
+  uses the current CLI flag instead of the removed `--yes`.
+- The `steps` transform no longer injects a stray `Steps` import into files that
+  don't use a stepper.

--- a/packages/codemod/__tests__/codemod-integration.test.ts
+++ b/packages/codemod/__tests__/codemod-integration.test.ts
@@ -100,7 +100,7 @@ export default function App() {
 
     const result = await runAllTransforms(input)
     expect(result).toMatchInlineSnapshot(`
-      "import { Steps, ChakraProvider, defaultSystem } from '@chakra-ui/react'
+      "import { ChakraProvider, defaultSystem } from '@chakra-ui/react'
 
       export default function App() {
         return (

--- a/packages/codemod/src/run-transform.ts
+++ b/packages/codemod/src/run-transform.ts
@@ -1,11 +1,16 @@
 import * as p from "@clack/prompts"
-import { spawn } from "child_process"
+import { EventEmitter } from "events"
 import fs from "fs"
 import { createRequire } from "node:module"
+import path from "path"
 import color from "picocolors"
 import { transforms } from "./transforms.js"
 
 const require = createRequire(import.meta.url)
+const Runner = require("jscodeshift/src/Runner")
+
+process.setMaxListeners(Infinity)
+EventEmitter.defaultMaxListeners = 0
 
 interface RunTransformOptions {
   dry?: boolean
@@ -17,13 +22,21 @@ interface RunTransformOptions {
 export interface TransformResult {
   changed: number
   errors: number
+  files: string[]
+  errorFiles: string[]
 }
 
-function parseStats(output: string): TransformResult {
-  const num = (label: string) =>
-    Number(new RegExp(`(\\d+)\\s+${label}`).exec(output)?.[1] ?? 0)
-  // jscodeshift reports transformed files as "ok"
-  return { changed: num("ok"), errors: num("errors") }
+const ANSI = /\x1b\[[0-9;]*m/g
+
+function extractPaths(output: string, tag: "OKK" | "ERR"): string[] {
+  const marker = ` ${tag} `
+  return output
+    .replace(ANSI, "")
+    .split("\n")
+    .filter((line) => line.includes(marker))
+    .map((line) => line.slice(line.lastIndexOf(marker) + marker.length).trim())
+    .filter(Boolean)
+    .map((file) => path.relative(process.cwd(), file))
 }
 
 process.once("SIGINT", () => {
@@ -35,7 +48,7 @@ export async function runTransform(
   transformName: string,
   targetPath: string,
   options: RunTransformOptions = {},
-) {
+): Promise<TransformResult> {
   const { dry = false, print = false, upgrade = false } = options
   const defaultIgnore = [
     "node_modules",
@@ -57,93 +70,61 @@ export async function runTransform(
   if (!fs.existsSync(targetPath))
     throw new Error(color.red(`Target path "${targetPath}" not found.`))
 
-  const jscodeshiftBin = require.resolve("jscodeshift/bin/jscodeshift.js")
-  const args = [
-    "-t",
-    transform.path,
-    targetPath,
-    "--extensions=tsx,ts,jsx,js",
-    "--parser=tsx",
-    "--jobs=1",
-    ...ignorePattern.map((pattern) => `--ignore-pattern=${pattern}`),
-  ]
-
-  if (dry) args.push("--dry")
-  if (print) args.push("--print")
-  if (upgrade && !dry) args.push("--silent")
-
   let s: ReturnType<typeof p.spinner> | undefined
-
   if (!upgrade) {
     p.intro(color.bgCyan(color.black(" ✨ Chakra Codemod ")))
     p.note(
       `Preparing to run ${color.cyan(transformName)} on ${color.dim(targetPath)}`,
     )
     if (dry) p.log.info(color.yellow("[dry-run] No changes will be applied"))
+    s = p.spinner()
+    s.start(`Running codemod: ${transformName}`)
   }
 
-  return new Promise<TransformResult>((resolve, reject) => {
-    try {
-      if (!upgrade) {
-        s = p.spinner()
-        s.start(`Running codemod: ${transformName}`)
-      }
+  const capturing = !print
+  const chunks: string[] = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  if (capturing) {
+    process.stdout.write = ((chunk: any) => {
+      chunks.push(chunk.toString())
+      return true
+    }) as typeof process.stdout.write
+  }
 
-      const child = spawn(process.execPath, [jscodeshiftBin, ...args], {
-        stdio: ["ignore", "pipe", "pipe"],
-        env: process.env,
-      })
+  try {
+    const result = await Runner.run(transform.path, [targetPath], {
+      extensions: "tsx,ts,jsx,js",
+      parser: "tsx",
+      runInBand: true,
+      babel: true,
+      silent: false,
+      verbose: capturing ? 2 : 0,
+      dry,
+      print,
+      ignorePattern,
+    })
 
-      let stdoutBuffer = ""
-      let stderrBuffer = ""
-      child.stdout.on("data", (data) => {
-        stdoutBuffer += data.toString()
-        if (upgrade) return
-        const lines = data.toString().split("\n")
-        for (const line of lines) {
-          // Filter verbose lines
-          if (
-            !/Sending \d+ files to free worker/.test(line) &&
-            line.trim() !== ""
-          ) {
-            s?.message(line)
-          }
-        }
-      })
+    const output = chunks.join("")
+    if (capturing) process.stdout.write = originalWrite
 
-      child.stderr.on("data", (data) => {
-        stderrBuffer += data.toString()
-      })
-
-      child.on("error", (err) => {
-        s?.stop(color.red("Failed to start process"))
-        reject(err)
-      })
-
-      child.on("close", (code) => {
-        if (code === 0) {
-          if (!upgrade && s) {
-            s.stop(color.green("Transformations complete"))
-            p.outro(`${color.cyan("Done!")} Your theme/code has been migrated.`)
-          }
-          resolve(parseStats(stdoutBuffer))
-        } else {
-          s?.stop(color.red("Transformation failed"))
-          // Extract concise error line (first meaningful line)
-          const firstLine = stderrBuffer
-            .split("\n")
-            .find((l) => l.includes("SyntaxError") || l.includes("Error"))
-          reject(
-            new Error(
-              firstLine ||
-                `Transform "${transformName}" failed with code ${code}`,
-            ),
-          )
-        }
-      })
-    } catch (err) {
-      s?.stop(color.red("Unexpected error during transformation"))
-      reject(err)
+    if (!upgrade && s) {
+      s.stop(
+        dry
+          ? color.green("Dry run complete")
+          : color.green("Transformations complete"),
+      )
+      p.outro(`${color.cyan("Done!")} Your theme/code has been migrated.`)
     }
-  })
+
+    return {
+      changed: result?.ok ?? 0,
+      errors: result?.error ?? 0,
+      files: capturing ? extractPaths(output, "OKK") : [],
+      errorFiles: capturing ? extractPaths(output, "ERR") : [],
+    }
+  } catch (err) {
+    if (capturing) process.stdout.write = originalWrite
+    s?.stop(color.red("Transformation failed"))
+    throw err instanceof Error ? err : new Error(String(err))
+  }
 }

--- a/packages/codemod/src/transforms/components/steps.ts
+++ b/packages/codemod/src/transforms/components/steps.ts
@@ -21,6 +21,31 @@ export default function transformer(
   const { chakraLocalNames } = collectChakraLocalNames(j, root)
   if (chakraLocalNames.size === 0) return file.source
 
+  const oldStepsComponents = [
+    "Stepper",
+    "Step",
+    "StepDescription",
+    "StepIcon",
+    "StepIndicator",
+    "StepNumber",
+    "StepSeparator",
+    "StepStatus",
+    "StepTitle",
+  ]
+
+  const stepsNames = new Set([...oldStepsComponents, "Steps", "useSteps"])
+  const usesSteps = root
+    .find(j.ImportDeclaration, { source: { value: "@chakra-ui/react" } })
+    .paths()
+    .some((path) =>
+      (path.node.specifiers || []).some(
+        (spec) =>
+          spec.type === "ImportSpecifier" &&
+          stepsNames.has(spec.imported.name as string),
+      ),
+    )
+  if (!usesSteps) return file.source
+
   // Track if we're using useSteps (for Steps.RootProvider)
   let usesStepsHook = false
   let stepsVariableName = "stepsApi"
@@ -61,19 +86,6 @@ export default function transformer(
 
   // Track if StepIcon was imported (to add LuCheck from react-icons/lu)
   let hadStepIcon = false
-
-  // Remove old Steps component imports except Steps and useSteps
-  const oldStepsComponents = [
-    "Stepper",
-    "Step",
-    "StepDescription",
-    "StepIcon",
-    "StepIndicator",
-    "StepNumber",
-    "StepSeparator",
-    "StepStatus",
-    "StepTitle",
-  ]
 
   // Track if we've added Steps to avoid adding to every import when file has multiple @chakra-ui/react imports
   let stepsAddedToFile = false

--- a/packages/codemod/src/transforms/removed/color-mode.ts
+++ b/packages/codemod/src/transforms/removed/color-mode.ts
@@ -7,7 +7,7 @@ import { getProjectInfo } from "../../utils/get-project-info"
 export default function transformer(
   file: FileInfo,
   api: API,
-  _options: Options,
+  options: Options,
 ) {
   const j = api.jscodeshift
   const root = j(file.source)
@@ -75,14 +75,15 @@ export default function transformer(
       fs.existsSync(path.join(componentsDir, `${componentName}${ext}`)),
     )
 
-    if (!snippetExists) {
+    if (!snippetExists && !options.dry) {
       try {
-        // Install snippet
-        execSync("npx @chakra-ui/cli snippet add color-mode --yes", {
-          stdio: "inherit",
+        execSync("npx --yes @chakra-ui/cli snippet add color-mode", {
+          stdio: "ignore",
         })
-      } catch (e) {
-        console.error("Failed to install color-mode snippet", e)
+      } catch {
+        console.error(
+          "Could not auto-install the color-mode snippet. Run `npx @chakra-ui/cli snippet add color-mode` manually.",
+        )
       }
     }
 

--- a/packages/codemod/src/upgrade.ts
+++ b/packages/codemod/src/upgrade.ts
@@ -1,6 +1,7 @@
 import * as p from "@clack/prompts"
 import { spawn } from "child_process"
 import fs from "fs"
+import path from "path"
 import picocolors from "picocolors"
 import semver from "semver"
 import { runTransform } from "./run-transform.js"
@@ -215,19 +216,26 @@ export async function upgrade(
 
     const { componentsDir } = getProjectInfo(process.cwd())
 
-    const changed: string[] = []
+    // file -> transforms that touch it
+    const byFile = new Map<string, Set<string>>()
+    const errorsByFile = new Map<string, Set<string>>()
     let failed = 0
+
+    const add = (map: Map<string, Set<string>>, file: string, name: string) => {
+      if (!map.has(file)) map.set(file, new Set())
+      map.get(file)!.add(name)
+    }
 
     for (const name of transformsToRun) {
       s.message(`Transforming: ${name}`)
       try {
-        const { changed: count } = await runTransform(name, process.cwd(), {
+        const res = await runTransform(name, process.cwd(), {
           dry,
           upgrade: true,
           ignorePattern: ["node_modules", componentsDir],
         })
-        if (count > 0)
-          changed.push(`${name} (${count} file${count > 1 ? "s" : ""})`)
+        res.files.forEach((f) => add(byFile, f, name))
+        res.errorFiles.forEach((f) => add(errorsByFile, f, name))
       } catch (err) {
         failed++
         const msg = err instanceof Error ? err.message : String(err)
@@ -241,21 +249,22 @@ export async function upgrade(
         : "All transforms completed",
     )
 
-    if (changed.length > 0) {
-      p.note(
-        changed.join("\n"),
-        dry
-          ? "Transforms that would change files"
-          : "Transforms that changed files",
-      )
-    } else if (failed === 0) {
-      p.log.info("No files matched any transform.")
-    }
+    reportChanges(byFile, errorsByFile, dry, failed)
   }
 
-  p.outro(
-    picocolors.green("🎉 Upgrade complete! Review your changes and run tests."),
-  )
+  if (dry) {
+    p.outro(
+      picocolors.green(
+        "Dry run done. To see exact changes, run the upgrade on a clean branch and use `git diff`.",
+      ),
+    )
+  } else {
+    p.outro(
+      picocolors.green(
+        "🎉 Upgrade complete! Review the diff and run your tests.",
+      ),
+    )
+  }
 }
 
 async function runCommand(cmd: string, silent = false) {
@@ -280,4 +289,99 @@ async function runCommand(cmd: string, silent = false) {
 
 function section(title: string) {
   p.log.message(`\n${picocolors.bold(picocolors.cyan(`▸ ${title}`))}`)
+}
+
+const INLINE_THRESHOLD = 25
+
+function humanize(name: string): string {
+  const isComponent = transforms[name]?.path
+    .split(path.sep)
+    .includes("components")
+  if (isComponent) {
+    return name
+      .split("-")
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join("")
+  }
+  return name.replace(/-/g, " ")
+}
+
+function labelsFor(names: Set<string>): string {
+  return [...new Set([...names].map(humanize))].sort().join(", ")
+}
+
+function reportChanges(
+  byFile: Map<string, Set<string>>,
+  errorsByFile: Map<string, Set<string>>,
+  dry: boolean,
+  failed: number,
+) {
+  if (byFile.size === 0 && errorsByFile.size === 0) {
+    if (failed === 0) p.log.info("No files matched any transform.")
+    return
+  }
+
+  const verb = dry ? "would change" : "changed"
+  const entries = [...byFile.entries()].sort(([a], [b]) => a.localeCompare(b))
+
+  if (entries.length > 0) {
+    if (entries.length > INLINE_THRESHOLD) {
+      const reportPath = writeReport(entries, errorsByFile, dry)
+      p.note(
+        `${entries.length} files ${verb}.\nFull breakdown: ${picocolors.cyan(reportPath)}`,
+        dry ? "Preview" : "Summary",
+      )
+    } else {
+      const body = entries
+        .map(
+          ([file, names]) =>
+            `${picocolors.cyan(file)}\n  ${picocolors.dim(labelsFor(names))}`,
+        )
+        .join("\n")
+      p.note(body, `Files that ${verb} (${entries.length})`)
+    }
+  }
+
+  if (errorsByFile.size > 0) {
+    const body = [...errorsByFile.entries()]
+      .map(([file, names]) => `${file} (${labelsFor(names)})`)
+      .join("\n")
+    p.note(
+      picocolors.yellow(body),
+      `${errorsByFile.size} file(s) need manual attention`,
+    )
+  }
+}
+
+function writeReport(
+  entries: [string, Set<string>][],
+  errorsByFile: Map<string, Set<string>>,
+  dry: boolean,
+): string {
+  const verb = dry ? "would change" : "changed"
+  const lines = [
+    `# Chakra UI v3 upgrade${dry ? " (dry run)" : ""}`,
+    "",
+    `${entries.length} files ${verb}.`,
+    "",
+    "## Files",
+    "",
+  ]
+
+  for (const [file, names] of entries) {
+    lines.push(`- \`${file}\` — ${labelsFor(names)}`)
+  }
+  lines.push("")
+
+  if (errorsByFile.size > 0) {
+    lines.push("## Needs manual attention", "")
+    for (const [file, names] of errorsByFile) {
+      lines.push(`- \`${file}\` — ${labelsFor(names)}`)
+    }
+    lines.push("")
+  }
+
+  const reportPath = path.join(process.cwd(), "chakra-codemod-report.md")
+  fs.writeFileSync(reportPath, lines.join("\n"))
+  return path.relative(process.cwd(), reportPath)
 }


### PR DESCRIPTION
## 📝 Description

Follow-up to #10933. Makes `upgrade` fast and turns the dry run into something you can actually read before committing to the migration.

## ⛳️ Current behavior (updates)

- Each transform spawns its own Node/jscodeshift process, run one after another. A full run is ~30s even on a tiny project.
- `--dry` tells you which files would change, but not what would change in them.
- The `color-mode` transform runs `npx @chakra-ui/cli snippet add --yes` mid-transform — even in a dry run — and `--yes` is no longer a valid CLI flag.
- The `steps` transform adds a `Steps` import to every file that imports from `@chakra-ui/react`, whether or not the file uses a stepper.

## 🚀 New behavior

- Transforms run in-process via jscodeshift's `Runner`. A full run drops from ~30s to a few seconds.
- `--dry` lists the files that would change and, per file, the components and props it would touch (e.g. `Button, color palette`).
- Many changed files → a `chakra-codemod-report.md` with the full breakdown; few → printed inline.
- `color-mode` skips the snippet install during a dry run and uses the current CLI flag.
- `steps` only touches files that actually import a Steps API.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

**Why `Runner` instead of spawning the CLI:** this isn't a new dependency or engine. jscodeshift's CLI binary (`bin/jscodeshift.js`) is a thin wrapper that parses argv and calls `Runner.run(...)`. The old code spawned that binary once per transform, so every transform paid a full Node boot (~0.5s × 62 transforms ≈ the 30s). We now call the same `Runner.run(...)` directly, in the process we're already in — same engine, same transforms, minus 62 process spawns.

`Runner` is loaded with `createRequire(...)` because it's a non-exported CommonJS internal that ESM `import` can't resolve; this matches the `require.resolve("jscodeshift/bin/jscodeshift.js")` the file used before.
