### PR TITLE
refactor: use zag attribute utilities

### DIFF
--- a/.changeset/use-zag-attr-utils.md
+++ b/.changeset/use-zag-attr-utils.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+---
+
+Use `@zag-js/dom-query` as the source of the `dataAttr` and `ariaAttr`
+utilities.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,6 +44,7 @@
     "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
     "@emotion/utils": "^1.4.2",
     "@pandacss/is-valid-prop": "^1.4.2",
+    "@zag-js/dom-query": "1.41.2",
     "csstype": "^3.2.3"
   },
   "peerDependencies": {

--- a/packages/react/src/utils/attr.ts
+++ b/packages/react/src/utils/attr.ts
@@ -1,4 +1,1 @@
-type Booleanish = boolean | "true" | "false"
-
-export const dataAttr = (condition: boolean | undefined) =>
-  (condition ? "" : undefined) as Booleanish
+export { ariaAttr, dataAttr } from "@zag-js/dom-query"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,9 @@ importers:
       '@pandacss/is-valid-prop':
         specifier: ^1.4.2
         version: 1.11.1
+      '@zag-js/dom-query':
+        specifier: 1.41.2
+        version: 1.41.2
       csstype:
         specifier: ^3.2.3
         version: 3.2.3


### PR DESCRIPTION
Closes #

## 📝 Description

Re-export `dataAttr` and `ariaAttr` from `@zag-js/dom-query` instead of maintaining a local implementation.

## ⛳️ Current behavior (updates)

Chakra maintains its own `dataAttr` utility and does not expose `ariaAttr`.

## 🚀 New behavior

Both utilities are re-exported from `@zag-js/dom-query`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Ideally, Ark UI would expose these utilities so Chakra would not need to install `@zag-js/dom-query` directly and keep its version aligned with Ark UI.