### PR TITLE
fix(radio-card): outline variant preserves border-width when disabled

### DIFF
--- a/.changeset/radio-card-outline-disabled.md
+++ b/.changeset/radio-card-outline-disabled.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/react": patch
+---
+
+- **RadioCard**: Fix the `outline` variant losing its border width when a card
+  is both checked and disabled. The checked ring is an inset box-shadow on
+  `item`, and inset shadows paint below child content, so `itemControl`'s
+  disabled `bg.muted` background covered it. The `outline` variant now clears
+  that background when disabled, matching what `solid` already did

--- a/.changeset/radio-card-outline-disabled.md
+++ b/.changeset/radio-card-outline-disabled.md
@@ -3,7 +3,5 @@
 ---
 
 - **RadioCard**: Fix the `outline` variant losing its border width when a card
-  is both checked and disabled. The checked ring is an inset box-shadow on
-  `item`, and inset shadows paint below child content, so `itemControl`'s
-  disabled `bg.muted` background covered it. The `outline` variant now clears
-  that background when disabled, matching what `solid` already did
+  is both checked and disabled. The checked ring is an inset box-shadow, which
+  `itemControl`'s disabled background painted over

--- a/packages/panda-preset/src/slot-recipes/radio-card.ts
+++ b/packages/panda-preset/src/slot-recipes/radio-card.ts
@@ -217,6 +217,11 @@ export const radioCardSlotRecipe = defineSlotRecipe({
             borderColor: "colorPalette.solid",
           },
         },
+        itemControl: {
+          _disabled: {
+            bg: "unset",
+          },
+        },
         itemIndicator: {
           borderWidth: "1px",
           borderColor: "border.emphasized",

--- a/packages/react/src/theme/recipes/radio-card.ts
+++ b/packages/react/src/theme/recipes/radio-card.ts
@@ -157,6 +157,11 @@ export const radioCardSlotRecipe = defineSlotRecipe({
             borderColor: "colorPalette.solid",
           },
         },
+        itemControl: {
+          _disabled: {
+            bg: "unset",
+          },
+        },
         itemIndicator: radiomarkRecipe.variants?.variant.solid,
       },
 


### PR DESCRIPTION
### Description

When the `RadioCard` outline variant is both checked and disabled, the `inset box-shadow` that simulates the inner border is hidden by the `itemControl`'s `bg.muted` background (set in the base recipe, line `itemControl._disabled: { bg: "bg.muted" }`).

The outline variant's checked state uses `boxShadow: "inset 0 0 0 1px var(--shadow-color)"` on the item element, which should provide a visible border. However, the `itemControl` child element's background color covers this shadow, making the border appear to lose its width.

### Fix

Override `itemControl._disabled: { bg: "unset" }` in the outline variant, matching the existing pattern already used by the solid variant. This prevents the background from covering the inset box-shadow.

### Changes

- `packages/react/src/theme/recipes/radio-card.ts` — add `itemControl._disabled: { bg: "unset" }` to outline variant
- `packages/panda-preset/src/slot-recipes/radio-card.ts` — same change

### Related issue

Closes #10930