### PR TITLE
docs(spinner): add custom indicator example

### DIFF
--- a/apps/compositions/src/examples/spinner-with-custom-indicator.tsx
+++ b/apps/compositions/src/examples/spinner-with-custom-indicator.tsx
@@ -1,28 +1,8 @@
-import { For, HStack, Spinner, Stack } from "@chakra-ui/react"
-import { ImSpinner6, ImSpinner9 } from "react-icons/im"
-import { PiSpinnerGapLight } from "react-icons/pi"
+import { Spinner } from "@chakra-ui/react"
+import { LuLoader } from "react-icons/lu"
 
 export const SpinnerWithCustomIndicator = () => (
-  <Stack>
-    <For each={[ImSpinner6, PiSpinnerGapLight, ImSpinner9]}>
-      {(Icon, i) => (
-        <HStack key={i}>
-          <For each={["xs", "sm", "md", "lg", "xl"]}>
-            {(size, j) => (
-              <Spinner
-                asChild
-                key={`${i}-${j}`}
-                borderWidth="0"
-                color="cyan.800"
-                size={size}
-                animationDuration="1s"
-              >
-                <Icon />
-              </Spinner>
-            )}
-          </For>
-        </HStack>
-      )}
-    </For>
-  </Stack>
+  <Spinner asChild borderWidth="0">
+    <LuLoader />
+  </Spinner>
 )

--- a/apps/compositions/src/examples/spinner-with-custom-indicator.tsx
+++ b/apps/compositions/src/examples/spinner-with-custom-indicator.tsx
@@ -1,0 +1,28 @@
+import { For, HStack, Spinner, Stack } from "@chakra-ui/react"
+import { ImSpinner6, ImSpinner9 } from "react-icons/im"
+import { PiSpinnerGapLight } from "react-icons/pi"
+
+export const SpinnerWithCustomIndicator = () => (
+  <Stack>
+    <For each={[ImSpinner6, PiSpinnerGapLight, ImSpinner9]}>
+      {(Icon, i) => (
+        <HStack key={i}>
+          <For each={["xs", "sm", "md", "lg", "xl"]}>
+            {(size, j) => (
+              <Spinner
+                asChild
+                key={`${i}-${j}`}
+                borderWidth="0"
+                color="cyan.800"
+                size={size}
+                animationDuration="1s"
+              >
+                <Icon />
+              </Spinner>
+            )}
+          </For>
+        </HStack>
+      )}
+    </For>
+  </Stack>
+)

--- a/apps/www/content/docs/components/spinner.mdx
+++ b/apps/www/content/docs/components/spinner.mdx
@@ -58,6 +58,12 @@ Use the `borderWidth` prop to change the thickness of the spinner.
 
 <ExampleTabs name="spinner-with-custom-thickness" />
 
+### Custom Indicator
+
+Use the `asChild` prop to render a custom icon as the spinner.
+
+<ExampleTabs name="spinner-with-custom-indicator" />
+
 ### Label
 
 Compose the spinner with a label to provide additional context.

--- a/packages/react/__stories__/spinner.stories.tsx
+++ b/packages/react/__stories__/spinner.stories.tsx
@@ -17,6 +17,7 @@ export { SpinnerCustomColor as CustomColor } from "compositions/examples/spinner
 export { SpinnerSizeTable as Sizes } from "compositions/examples/spinner-size-table"
 export { SpinnerWithCustomSpeed as CustomSpeed } from "compositions/examples/spinner-with-custom-speed"
 export { SpinnerWithCustomThickness as CustomThickness } from "compositions/examples/spinner-with-custom-thickness"
+export { SpinnerWithCustomIndicator as CustomIndicator } from "compositions/examples/spinner-with-custom-indicator"
 export { SpinnerWithTrackColor as TrackColor } from "compositions/examples/spinner-with-track-color"
 export { SpinnerWithLabel as Label } from "compositions/examples/spinner-with-label"
 export { SpinnerWithOverlay as Overlay } from "compositions/examples/spinner-with-overlay"


### PR DESCRIPTION
## 📝 Description

Adds a custom indicator example to the Spinner documentation.

The example demonstrates how to use the `asChild` prop to render a custom icon as the spinner indicator while preserving the Spinner's animation and sizing behavior.

This PR only adds a documentation example and does not introduce any new dependencies or changes to the Spinner API.

## ⛳️ Current behavior (updates)

The Spinner documentation currently includes examples for sizes, colors, custom colors, track colors, animation speed, labels, and overlays.

However, it does not demonstrate how the `asChild` prop can be used to replace the default spinner indicator with a custom icon.

## 🚀 New behavior

Adds a new `Custom Indicator` example that demonstrates:

* Rendering custom icons as Spinner indicators using `asChild`
* Reusing the Spinner animation with custom SVG icons
* Removing the default spinner border when rendering a custom indicator
* Using existing Spinner sizing and animation props with custom icons

The example is added to:

`apps/compositions/src/examples/spinner-with-custom-indicator.tsx`

and referenced from:

`apps/www/content/docs/components/spinner.mdx`

## 💣 Is this a breaking change (Yes/No):

No.

This PR only adds a new documentation example and does not modify any existing APIs or component behavior.

## 📝 Additional Information

The example was tested locally on the Spinner documentation page and verified for:

* Custom indicator rendering
* Spinner animation
* Different custom icon shapes
* Light and dark mode rendering
* Type checking and linting

No new external dependencies are added.