### PR TITLE
fix: preserve user onClick on Dialog and Drawer ActionTrigger

### DIFF
--- a/.changeset/action-trigger-onclick.md
+++ b/.changeset/action-trigger-onclick.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react": patch
+---
+
+- Fix `Dialog.ActionTrigger` and `Drawer.ActionTrigger` discarding a caller's
+  `onClick`. The internal close handler was declared after the props spread, so
+  it replaced the user handler instead of running alongside it

--- a/.changeset/action-trigger-onclick.md
+++ b/.changeset/action-trigger-onclick.md
@@ -2,6 +2,6 @@
 "@chakra-ui/react": patch
 ---
 
-- Fix `Dialog.ActionTrigger` and `Drawer.ActionTrigger` discarding a caller's
-  `onClick`. The internal close handler was declared after the props spread, so
-  it replaced the user handler instead of running alongside it
+- Fix `Dialog.ActionTrigger` and `Drawer.ActionTrigger` ignoring the `onClick`
+  handler passed to them. The handler now runs before the dialog closes, and
+  calling `event.preventDefault()` in it keeps the dialog open

--- a/packages/react/__tests__/dialog.test.tsx
+++ b/packages/react/__tests__/dialog.test.tsx
@@ -36,4 +36,24 @@ describe("Dialog", () => {
     await user.click(getByTestId("action-trigger"))
     expect(onClick).toHaveBeenCalledTimes(1)
   })
+
+  it("does not close when the user calls preventDefault", async () => {
+    const onOpenChange = vi.fn()
+    const { getByTestId, user } = render(
+      <Dialog.Root open onOpenChange={onOpenChange}>
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.ActionTrigger
+              data-testid="action-trigger"
+              onClick={(event) => event.preventDefault()}
+            >
+              Cancel
+            </Dialog.ActionTrigger>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Dialog.Root>,
+    )
+    await user.click(getByTestId("action-trigger"))
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
 })

--- a/packages/react/__tests__/dialog.test.tsx
+++ b/packages/react/__tests__/dialog.test.tsx
@@ -16,4 +16,24 @@ describe("Dialog", () => {
     )
     expect(getByTestId("action-trigger")).toHaveAttribute("type", "button")
   })
+
+  it("calls the user's onClick on ActionTrigger", async () => {
+    const onClick = vi.fn()
+    const { getByTestId, user } = render(
+      <Dialog.Root open>
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.ActionTrigger
+              data-testid="action-trigger"
+              onClick={onClick}
+            >
+              Cancel
+            </Dialog.ActionTrigger>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Dialog.Root>,
+    )
+    await user.click(getByTestId("action-trigger"))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/react/__tests__/drawer.test.tsx
+++ b/packages/react/__tests__/drawer.test.tsx
@@ -16,4 +16,24 @@ describe("Drawer", () => {
     )
     expect(getByTestId("action-trigger")).toHaveAttribute("type", "button")
   })
+
+  it("calls the user's onClick on ActionTrigger", async () => {
+    const onClick = vi.fn()
+    const { getByTestId, user } = render(
+      <Drawer.Root open>
+        <Drawer.Positioner>
+          <Drawer.Content>
+            <Drawer.ActionTrigger
+              data-testid="action-trigger"
+              onClick={onClick}
+            >
+              Cancel
+            </Drawer.ActionTrigger>
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Drawer.Root>,
+    )
+    await user.click(getByTestId("action-trigger"))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/react/__tests__/drawer.test.tsx
+++ b/packages/react/__tests__/drawer.test.tsx
@@ -36,4 +36,24 @@ describe("Drawer", () => {
     await user.click(getByTestId("action-trigger"))
     expect(onClick).toHaveBeenCalledTimes(1)
   })
+
+  it("does not close when the user calls preventDefault", async () => {
+    const onOpenChange = vi.fn()
+    const { getByTestId, user } = render(
+      <Drawer.Root open onOpenChange={onOpenChange}>
+        <Drawer.Positioner>
+          <Drawer.Content>
+            <Drawer.ActionTrigger
+              data-testid="action-trigger"
+              onClick={(event) => event.preventDefault()}
+            >
+              Cancel
+            </Drawer.ActionTrigger>
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Drawer.Root>,
+    )
+    await user.click(getByTestId("action-trigger"))
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
 })

--- a/packages/react/src/components/dialog/dialog.tsx
+++ b/packages/react/src/components/dialog/dialog.tsx
@@ -141,7 +141,10 @@ export const DialogActionTrigger = forwardRef<
       type="button"
       {...props}
       ref={ref}
-      onClick={() => dialog.setOpen(false)}
+      onClick={(event) => {
+        props.onClick?.(event)
+        dialog.setOpen(false)
+      }}
     />
   )
 })

--- a/packages/react/src/components/dialog/dialog.tsx
+++ b/packages/react/src/components/dialog/dialog.tsx
@@ -143,6 +143,7 @@ export const DialogActionTrigger = forwardRef<
       ref={ref}
       onClick={(event) => {
         props.onClick?.(event)
+        if (event.defaultPrevented) return
         dialog.setOpen(false)
       }}
     />

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -141,7 +141,10 @@ export const DrawerActionTrigger = forwardRef<
       type="button"
       {...props}
       ref={ref}
-      onClick={() => drawer.setOpen(false)}
+      onClick={(event) => {
+        props.onClick?.(event)
+        drawer.setOpen(false)
+      }}
     />
   )
 })

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -143,6 +143,7 @@ export const DrawerActionTrigger = forwardRef<
       ref={ref}
       onClick={(event) => {
         props.onClick?.(event)
+        if (event.defaultPrevented) return
         drawer.setOpen(false)
       }}
     />


### PR DESCRIPTION
### Description

`Dialog.ActionTrigger` and `Drawer.ActionTrigger` accept `onClick` in their public props type, but silently discard it.

Both render `<chakra.button type="button" {...props} ref={ref} onClick={() => dialog.setOpen(false)} />`, declaring the internal close handler *after* the props spread, so a caller's `onClick` is replaced rather than chained (`dialog.tsx:144`, `drawer.tsx:144`). The dialog closes, the handler never runs, and nothing warns: `<Dialog.ActionTrigger onClick={handleSave}>Save</Dialog.ActionTrigger>` is a silent no-op for `handleSave`.

### Fix

`CodeBlockCollapseTrigger` in this package already does this correctly, calling `restProps.onClick?.(e)` before its own action (`code-block.tsx:355`). The change makes both triggers follow that existing convention rather than introducing a new one.

Passing the handler to a child through `asChild` is unaffected, because `mergeProps` chains `on[A-Z]` handlers. Only a handler passed directly to `ActionTrigger` is lost today.

### Changes

One regression test per component, and a patch changeset. The full package suite is 1001 passing.
