### PR TITLE
fix(dialog, drawer): drop preventDefault guard on ActionTrigger

### DIFF
--- a/.changeset/action-trigger-onclick.md
+++ b/.changeset/action-trigger-onclick.md
@@ -3,5 +3,4 @@
 ---
 
 - Fix `Dialog.ActionTrigger` and `Drawer.ActionTrigger` ignoring the `onClick`
-  handler passed to them. The handler now runs before the dialog closes, and
-  calling `event.preventDefault()` in it keeps the dialog open
+  handler passed to them. The handler now runs before the dialog closes

--- a/packages/react/__tests__/dialog.test.tsx
+++ b/packages/react/__tests__/dialog.test.tsx
@@ -36,24 +36,4 @@ describe("Dialog", () => {
     await user.click(getByTestId("action-trigger"))
     expect(onClick).toHaveBeenCalledTimes(1)
   })
-
-  it("does not close when the user calls preventDefault", async () => {
-    const onOpenChange = vi.fn()
-    const { getByTestId, user } = render(
-      <Dialog.Root open onOpenChange={onOpenChange}>
-        <Dialog.Positioner>
-          <Dialog.Content>
-            <Dialog.ActionTrigger
-              data-testid="action-trigger"
-              onClick={(event) => event.preventDefault()}
-            >
-              Cancel
-            </Dialog.ActionTrigger>
-          </Dialog.Content>
-        </Dialog.Positioner>
-      </Dialog.Root>,
-    )
-    await user.click(getByTestId("action-trigger"))
-    expect(onOpenChange).not.toHaveBeenCalled()
-  })
 })

--- a/packages/react/__tests__/drawer.test.tsx
+++ b/packages/react/__tests__/drawer.test.tsx
@@ -36,24 +36,4 @@ describe("Drawer", () => {
     await user.click(getByTestId("action-trigger"))
     expect(onClick).toHaveBeenCalledTimes(1)
   })
-
-  it("does not close when the user calls preventDefault", async () => {
-    const onOpenChange = vi.fn()
-    const { getByTestId, user } = render(
-      <Drawer.Root open onOpenChange={onOpenChange}>
-        <Drawer.Positioner>
-          <Drawer.Content>
-            <Drawer.ActionTrigger
-              data-testid="action-trigger"
-              onClick={(event) => event.preventDefault()}
-            >
-              Cancel
-            </Drawer.ActionTrigger>
-          </Drawer.Content>
-        </Drawer.Positioner>
-      </Drawer.Root>,
-    )
-    await user.click(getByTestId("action-trigger"))
-    expect(onOpenChange).not.toHaveBeenCalled()
-  })
 })

--- a/packages/react/src/components/dialog/dialog.tsx
+++ b/packages/react/src/components/dialog/dialog.tsx
@@ -143,7 +143,6 @@ export const DialogActionTrigger = forwardRef<
       ref={ref}
       onClick={(event) => {
         props.onClick?.(event)
-        if (event.defaultPrevented) return
         dialog.setOpen(false)
       }}
     />

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -143,7 +143,6 @@ export const DrawerActionTrigger = forwardRef<
       ref={ref}
       onClick={(event) => {
         props.onClick?.(event)
-        if (event.defaultPrevented) return
         drawer.setOpen(false)
       }}
     />


### PR DESCRIPTION
## 📝 Description

Partial revert of #10951. That PR landed two things: the `onClick` fix
(correct, kept) and a `if (event.defaultPrevented) return` guard before the
close (removed here).

## ⛳️ Current behavior (updates)

`Dialog.ActionTrigger` / `Drawer.ActionTrigger` bail out of closing whenever the
click event has `defaultPrevented` set. `defaultPrevented` is not specific to
the handler passed to `ActionTrigger` — it is also true for an event that
bubbled up from a child element that called `preventDefault()`:

```tsx
<Dialog.ActionTrigger>
  <span onClick={(e) => e.preventDefault()}>Cancel</span>
</Dialog.ActionTrigger>
```

That dialog closed before #10951 and does not close on `main` today, with
nothing in the markup hinting at why.

## 🚀 New behavior

The user's `onClick` runs, then the dialog closes — unconditionally, as it did
before #10951:

```tsx
onClick={(event) => {
  props.onClick?.(event)
  dialog.setOpen(false)
}}
```

The four files touched are byte-identical to the state the original PR was
approved in. The changeset sentence about `preventDefault` is dropped too, since
that release note has not shipped yet.

Opting out of the close is worth revisiting as its own change if someone asks
for it, but it needs to distinguish a handler that prevented the event from one
that merely received a prevented event.

## 💣 Is this a breaking change (Yes/No):

No. `preventDefault` support was never released — #10951 has not shipped.

## 📝 Additional Information

`ActionTrigger` tests pass, `typecheck` and `prettier --check` clean.
