### PR TITLE
fix(www): drop numeric prefix from blog links

### DIFF
--- a/apps/www/app/launch-week/data.ts
+++ b/apps/www/app/launch-week/data.ts
@@ -55,7 +55,7 @@ export const LAUNCH_DATA: LaunchItem[] = [
     cards: [
       {
         title: "Blog Post",
-        url: "/blog/10-announcing-chakra-ui-mcp-server",
+        url: "/blog/announcing-chakra-ui-mcp-server",
         icon: LuFileText,
       },
       {
@@ -89,7 +89,7 @@ export const LAUNCH_DATA: LaunchItem[] = [
     cards: [
       {
         title: "Announcement",
-        url: "/blog/11-improved-developer-experience",
+        url: "/blog/improved-developer-experience",
         icon: LuFileText,
       },
       {

--- a/apps/www/components/site/hero.section.tsx
+++ b/apps/www/components/site/hero.section.tsx
@@ -147,7 +147,7 @@ export const HeroSection = () => (
     <Container>
       <Stack gap={{ base: "5", md: "10" }} mb="20">
         <Announcement alignSelf="flex-start" asChild>
-          <Link href="/blog/21-chakra-3.37-date-input">
+          <Link href="/blog/chakra-3.37-date-input">
             <LuPartyPopper />
             Meet DateInput
             <HiArrowRight />


### PR DESCRIPTION
## 📝 Description

Blog slugs strip the numeric prefix from the MDX filename, so links that include it 404.

## ⛳️ Current behavior (updates)

- The homepage hero pill points to `/blog/21-chakra-3.37-date-input` → 404
- Launch week links point to `/blog/10-announcing-chakra-ui-mcp-server` and `/blog/11-improved-developer-experience` → 404

## 🚀 New behavior

Links use the real slugs (`/blog/chakra-3.37-date-input`, etc.).

## 💣 Is this a breaking change (Yes/No):

No
