### PR TITLE
fix(react): honor getWindow option in useBreakpoint

### DIFF
--- a/.changeset/quiet-hooks-forward-window.md
+++ b/.changeset/quiet-hooks-forward-window.md
@@ -1,0 +1,7 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix `useBreakpoint` and `useBreakpointValue` ignoring the `getWindow` option, so
+media queries were always evaluated against the ambient `window` instead of the
+provided one (iframes, Shadow DOM, tests).

--- a/packages/react/__tests__/use-breakpoint-value.test.tsx
+++ b/packages/react/__tests__/use-breakpoint-value.test.tsx
@@ -51,4 +51,43 @@ describe("useBreakpointValue", () => {
       window.matchMedia = originalMatchMedia
     }
   })
+
+  test("should evaluate media queries against the window from getWindow", () => {
+    const createMatchMedia = (matching: string[]) => (query: string) => ({
+      matches: matching.includes(query),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })
+
+    // the ambient window reports `md`, the injected one only reports `sm`
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi
+      .fn()
+      .mockImplementation(
+        createMatchMedia([
+          "(min-width: 0px)",
+          "(min-width: 30rem)",
+          "(min-width: 48rem)",
+        ]),
+      ) as any
+
+    const iframeWindow = {
+      matchMedia: createMatchMedia(["(min-width: 0px)", "(min-width: 30rem)"]),
+    } as unknown as typeof window
+
+    try {
+      const { result } = renderHook(
+        () =>
+          useBreakpointValue(
+            { base: 1, sm: 2, md: 3 },
+            { ssr: false, getWindow: () => iframeWindow },
+          ),
+        { wrapper },
+      )
+      expect(result.current).toBe(2)
+    } finally {
+      window.matchMedia = originalMatchMedia
+    }
+  })
 })

--- a/packages/react/src/hooks/use-breakpoint.ts
+++ b/packages/react/src/hooks/use-breakpoint.ts
@@ -69,7 +69,7 @@ export function useBreakpoint(options: UseBreakpointOptions = {}) {
 
   const values = useMediaQuery(
     breakpoints.map((bp) => bp.query),
-    { fallback, ssr: options.ssr },
+    { fallback, ssr: options.ssr, getWindow: options.getWindow },
   )
 
   // find highest matched breakpoint

--- a/packages/react/src/hooks/use-media-query.ts
+++ b/packages/react/src/hooks/use-media-query.ts
@@ -18,7 +18,7 @@ function listen(query: MediaQueryList, callback: MediaQueryCallback) {
 export interface UseMediaQueryOptions {
   fallback?: boolean[] | undefined
   ssr?: boolean | undefined
-  getWindow?(): typeof window
+  getWindow?: (() => typeof window | undefined) | undefined
 }
 
 export function useMediaQuery(


### PR DESCRIPTION
## 📝 Description

`UseBreakpointOptions` declares and documents a `getWindow` option (`packages/react/src/hooks/use-breakpoint.ts:23-27`):

```ts
/**
 * Custom function to retrieve the `window` object. Useful in environments
 * where `window` may not be the global (e.g. iframes, Shadow DOM, tests).
 */
getWindow?: () => typeof window | undefined
```

But `useBreakpoint` never reads it. It forwards only `fallback` and `ssr` to `useMediaQuery` (`packages/react/src/hooks/use-breakpoint.ts:70-73`):

```ts
const values = useMediaQuery(
  breakpoints.map((bp) => bp.query),
  { fallback, ssr: options.ssr },
)
```

`useMediaQuery` does support the option and already falls back to the global when it is absent or returns nothing (`use-media-query.ts:38` and `:46`), so the value simply never arrives. The option has been inert since the v3 hooks were introduced in #8815.

Because `useBreakpointValue` spreads its options into `useBreakpoint`, it is affected the same way.

## ⛳️ Current behavior (updates)

`useBreakpoint({ getWindow })` and `useBreakpointValue(value, { getWindow })` evaluate their media queries against the ambient `window`, ignoring the provided one. Inside an iframe or a Shadow DOM host, the returned breakpoint tracks the outer document instead of the intended one, and the option cannot be used to inject a window in tests.

## 🚀 New behavior

`getWindow` is forwarded to `useMediaQuery`, so breakpoints are resolved against the window it returns.

The type of `UseMediaQueryOptions["getWindow"]` is widened to `(() => typeof window | undefined) | undefined` so it matches `UseBreakpointOptions["getWindow"]` and the other options in the same interface, which already carry the explicit `| undefined`. This only relaxes what a caller may return; the implementation has always handled a nullish result via `?? window`.

Added a regression test in `packages/react/__tests__/use-breakpoint-value.test.tsx`: the ambient `window` reports `md` while the injected one reports only `sm`. It returns `3` on `main` and `2` with this change.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

`pnpm exec vitest run packages/react` passes (32 files, 186 tests) and `pnpm typecheck` is clean.
