### PR TITLE
docs(field): target control

### DIFF
--- a/apps/compositions/src/examples/field-with-multiple-controls.tsx
+++ b/apps/compositions/src/examples/field-with-multiple-controls.tsx
@@ -6,7 +6,7 @@ export const FieldWithMultipleControls = () => {
       <Field.Label>Price</Field.Label>
       <HStack gap="2">
         <Field.Item value="currency">
-          <NativeSelect.Root width="100px">
+          <NativeSelect.Root width="150px">
             <NativeSelect.Field aria-label="Currency" defaultValue="USD">
               <option value="USD">USD</option>
               <option value="EUR">EUR</option>

--- a/apps/compositions/src/examples/field-with-multiple-controls.tsx
+++ b/apps/compositions/src/examples/field-with-multiple-controls.tsx
@@ -1,0 +1,27 @@
+import { Field, HStack, Input, NativeSelect } from "@chakra-ui/react"
+
+export const FieldWithMultipleControls = () => {
+  return (
+    <Field.Root target="amount" maxW="sm">
+      <Field.Label>Price</Field.Label>
+      <HStack gap="2">
+        <Field.Item value="currency">
+          <NativeSelect.Root width="100px">
+            <NativeSelect.Field aria-label="Currency" defaultValue="USD">
+              <option value="USD">USD</option>
+              <option value="EUR">EUR</option>
+              <option value="GBP">GBP</option>
+            </NativeSelect.Field>
+            <NativeSelect.Indicator />
+          </NativeSelect.Root>
+        </Field.Item>
+        <Field.Item value="amount">
+          <Input type="number" placeholder="0.00" />
+        </Field.Item>
+      </HStack>
+      <Field.HelperText>
+        Enter the price and select a currency.
+      </Field.HelperText>
+    </Field.Root>
+  )
+}

--- a/apps/compositions/src/examples/field-with-target-control.tsx
+++ b/apps/compositions/src/examples/field-with-target-control.tsx
@@ -1,6 +1,6 @@
 import { Field, HStack, Input, NativeSelect } from "@chakra-ui/react"
 
-export const FieldWithMultipleControls = () => {
+export const FieldWithTargetControl = () => {
   return (
     <Field.Root target="amount" maxW="sm">
       <Field.Label>Price</Field.Label>
@@ -19,9 +19,6 @@ export const FieldWithMultipleControls = () => {
           <Input type="number" placeholder="0.00" />
         </Field.Item>
       </HStack>
-      <Field.HelperText>
-        Enter the price and select a currency.
-      </Field.HelperText>
     </Field.Root>
   )
 }

--- a/apps/www/content/docs/components/field.mdx
+++ b/apps/www/content/docs/components/field.mdx
@@ -81,10 +81,9 @@ Here's how to use the field component with a native select.
 
 <ExampleTabs name="field-with-native-select" />
 
-### Multiple Controls
+### Target Controls
 
-Use `Field.Item` to associate multiple controls with a field. Set the `target`
-prop on `Field.Root` to the item the label should point to.
+Set the `target` prop on `Field.Root` to the item the label should point to.
 
 <ExampleTabs name="field-with-multiple-controls" />
 

--- a/apps/www/content/docs/components/field.mdx
+++ b/apps/www/content/docs/components/field.mdx
@@ -81,6 +81,13 @@ Here's how to use the field component with a native select.
 
 <ExampleTabs name="field-with-native-select" />
 
+### Multiple Controls
+
+Use `Field.Item` to associate multiple controls with a field. Set the `target`
+prop on `Field.Root` to the item the label should point to.
+
+<ExampleTabs name="field-with-multiple-controls" />
+
 ### Required
 
 Pass the `required` prop to `Field.Root` and use the `Field.RequiredIndicator`

--- a/apps/www/content/docs/components/field.mdx
+++ b/apps/www/content/docs/components/field.mdx
@@ -81,7 +81,7 @@ Here's how to use the field component with a native select.
 
 <ExampleTabs name="field-with-native-select" />
 
-### Target Controls
+### Target Control
 
 Set the `target` prop on `Field.Root` to the item the label should point to.
 

--- a/apps/www/content/docs/components/field.mdx
+++ b/apps/www/content/docs/components/field.mdx
@@ -85,7 +85,7 @@ Here's how to use the field component with a native select.
 
 Set the `target` prop on `Field.Root` to the item the label should point to.
 
-<ExampleTabs name="field-with-multiple-controls" />
+<ExampleTabs name="field-with-target-control" />
 
 ### Required
 


### PR DESCRIPTION
## 📝 Description

Adds a Target Control example to the Field documentation.

The example demonstrates how to use `Field.Item` and the `target` prop when a field contains multiple controls, such as a currency selector and an amount input.

## ⛳️ Current behavior (updates)

The Field documentation does not demonstrate how labels are associated with a specific control when multiple controls are rendered inside the same field.

The purpose of `Field.Item` and `Field.Root`'s `target` prop is therefore not immediately clear from the existing examples.

## 🚀 New behavior

Adds a price field containing a currency selector and an amount input.

The example uses `target="amount"` on `Field.Root` and matching `value` props on `Field.Item` to associate the field label with the amount input.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.