### PR TITLE
fix(flex, square): apply the array form of the css prop

### DIFF
--- a/.changeset/fix-flex-square-css-array.md
+++ b/.changeset/fix-flex-square-css-array.md
@@ -1,0 +1,10 @@
+---
+"@chakra-ui/react": patch
+---
+
+- **Flex, Square**: Fix the array form of the `css` prop being silently dropped.
+  Both components merged the incoming `css` into their base styles with an
+  object spread, which turns an array into index keys instead of merging its
+  entries. They now pass `css={[baseStyles, props.css]}`, matching
+  `AspectRatio`, `Bleed` and `Float`. `Circle` renders through `Square`, so it
+  is fixed too

--- a/packages/react/__tests__/css-prop.test.tsx
+++ b/packages/react/__tests__/css-prop.test.tsx
@@ -1,0 +1,77 @@
+import { Box, Circle, Flex, Square } from "@chakra-ui/react"
+import { render } from "./core/render"
+
+describe("css prop", () => {
+  it("applies an array css prop on Box", () => {
+    const { getByTestId } = render(
+      <Box data-testid="box" css={[{ position: "fixed" }]} />,
+    )
+    expect(getByTestId("box")).toHaveStyle({ position: "fixed" })
+  })
+
+  it("applies an array css prop on Flex alongside its layout styles", () => {
+    const { getByTestId } = render(
+      <Flex
+        data-testid="flex"
+        direction="column"
+        css={[{ position: "fixed" }]}
+      />,
+    )
+    expect(getByTestId("flex")).toHaveStyle({ position: "fixed" })
+    expect(getByTestId("flex")).toHaveStyle({ flexDirection: "column" })
+  })
+
+  it("applies an array css prop on Square alongside its centering styles", () => {
+    const { getByTestId } = render(
+      <Square data-testid="square" size="10" css={[{ position: "fixed" }]} />,
+    )
+    expect(getByTestId("square")).toHaveStyle({ position: "fixed" })
+    expect(getByTestId("square")).toHaveStyle({ alignItems: "center" })
+  })
+
+  it("applies an array css prop on Circle, which renders through Square", () => {
+    const { getByTestId } = render(
+      <Circle data-testid="circle" size="10" css={[{ position: "fixed" }]} />,
+    )
+    expect(getByTestId("circle")).toHaveStyle({ position: "fixed" })
+    expect(getByTestId("circle")).toHaveStyle({ borderRadius: "9999px" })
+  })
+
+  it("applies an object css prop on Flex alongside its layout styles", () => {
+    const { getByTestId } = render(
+      <Flex
+        data-testid="flex"
+        direction="column"
+        css={{ position: "fixed" }}
+      />,
+    )
+    expect(getByTestId("flex")).toHaveStyle({ position: "fixed" })
+    expect(getByTestId("flex")).toHaveStyle({ flexDirection: "column" })
+  })
+
+  it("applies an object css prop on Square alongside its centering styles", () => {
+    const { getByTestId } = render(
+      <Square data-testid="square" size="10" css={{ position: "fixed" }} />,
+    )
+    expect(getByTestId("square")).toHaveStyle({ position: "fixed" })
+    expect(getByTestId("square")).toHaveStyle({ alignItems: "center" })
+  })
+
+  it("lets the css prop win over a base style it collides with on Flex", () => {
+    const { getByTestId } = render(
+      <Flex
+        data-testid="flex"
+        direction="column"
+        css={{ flexDirection: "row" }}
+      />,
+    )
+    expect(getByTestId("flex")).toHaveStyle({ flexDirection: "row" })
+  })
+
+  it("lets the css prop win over a base style it collides with on Square", () => {
+    const { getByTestId } = render(
+      <Square data-testid="square" size="10" css={{ alignItems: "start" }} />,
+    )
+    expect(getByTestId("square")).toHaveStyle({ alignItems: "start" })
+  })
+})

--- a/packages/react/src/components/flex/flex.tsx
+++ b/packages/react/src/components/flex/flex.tsx
@@ -38,17 +38,19 @@ export const Flex = forwardRef<HTMLDivElement, FlexProps>(
       <chakra.div
         ref={ref}
         {...rest}
-        css={{
-          display: inline ? "inline-flex" : "flex",
-          flexDirection: direction,
-          alignItems: align,
-          justifyContent: justify,
-          flexWrap: wrap,
-          flexBasis: basis,
-          flexGrow: grow,
-          flexShrink: shrink,
-          ...props.css,
-        }}
+        css={[
+          {
+            display: inline ? "inline-flex" : "flex",
+            flexDirection: direction,
+            alignItems: align,
+            justifyContent: justify,
+            flexWrap: wrap,
+            flexBasis: basis,
+            flexGrow: grow,
+            flexShrink: shrink,
+          },
+          props.css,
+        ]}
       />
     )
   },

--- a/packages/react/src/components/square/index.tsx
+++ b/packages/react/src/components/square/index.tsx
@@ -19,14 +19,16 @@ export const Square = forwardRef<HTMLDivElement, SquareProps>(
         {...rest}
         ref={ref}
         boxSize={size}
-        css={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          flexShrink: 0,
-          flexGrow: 0,
-          ...props.css,
-        }}
+        css={[
+          {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+            flexGrow: 0,
+          },
+          props.css,
+        ]}
       />
     )
   },


### PR DESCRIPTION
## 📝 Description

`Flex` and `Square` merge the incoming `css` prop into their base styles with an object spread. The `css` prop is typed to accept an array of style objects, and object-spreading an array produces index keys, so nothing in the array reaches the style output.

`AspectRatio`, `Bleed` and `Float` already pass `css={[baseStyles, props.css]}`, and `toArray` in `use-resolved-props.ts` exists to support exactly this. `Flex` and `Square` are the two remaining `...props.css` sites in the package, so this closes the class rather than sampling it.

`Circle` renders through `Square`, so it is fixed by the same change and needs no edit of its own.

## ⛳️ Current behavior (updates)

`<Flex css={[{ position: "fixed" }]}>` applies nothing, while the same array on `<Box>` applies it.

## 🚀 New behavior

Both components pass `css={[baseStyles, props.css]}`. Precedence is unchanged for the object form: base styles first, the caller's `css` second.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Added `packages/react/__tests__/css-prop.test.tsx` with eight cases. Three fail on `main` - the array form on `Flex`, `Square` and `Circle`. The other five pass before and after: the array form on `Box` as a control, the object form on `Flex` and `Square`, and two checking that a `css` value still wins over a base style it collides with. That last pair is the one I most wanted, since switching to the array form changes how precedence is resolved and nothing in the repo covered it. Full suite 1005/1005 with the change; changeset included.