### PR TITLE
fix(react): settle overlay promises when an overlay is removed

### DIFF
--- a/.changeset/settle-overlay-promises.md
+++ b/.changeset/settle-overlay-promises.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix `createOverlay` leaving promises pending forever when an overlay is removed.
+`remove` and `removeAll` deleted the overlay without settling the promises
+handed out by `open`, `close` and `waitForExit`, so any code awaiting them was
+stuck. They now resolve with `undefined`.

--- a/packages/react/__tests__/use-overlay.test.tsx
+++ b/packages/react/__tests__/use-overlay.test.tsx
@@ -16,6 +16,14 @@ const { Viewport, open, close, removeAll, getSnapshot } = createOverlay(
   },
 )
 
+const settled = <T,>(promise: Promise<T>) =>
+  Promise.race([
+    promise.then((value) => ({ status: "settled", value })),
+    new Promise<{ status: string; value?: T }>((resolve) =>
+      setTimeout(() => resolve({ status: "pending" }), 50),
+    ),
+  ])
+
 describe("createOverlay", () => {
   beforeEach(() => {
     opens.length = 0
@@ -116,5 +124,56 @@ describe("createOverlay", () => {
     // explicitly remove the overlay
     overlay.remove("my-modal")
     expect(overlay.has("my-modal")).toBe(false)
+  })
+
+  it("resolves the pending open() promise when the overlay is removed", async () => {
+    const overlay = createOverlay(() => <div />)
+
+    const result = overlay.open("my-modal", {})
+    overlay.remove("my-modal")
+
+    expect(await settled(result)).toEqual({
+      status: "settled",
+      value: undefined,
+    })
+  })
+
+  it("resolves the pending open() promise when all overlays are removed", async () => {
+    const overlay = createOverlay(() => <div />)
+
+    const result = overlay.open("my-modal", {})
+    overlay.removeAll()
+
+    expect(await settled(result)).toEqual({
+      status: "settled",
+      value: undefined,
+    })
+  })
+
+  it("resolves the pending close() promise when the overlay is removed", async () => {
+    const overlay = createOverlay(() => <div />)
+
+    overlay.open("my-modal", {})
+    const closed = overlay.close("my-modal")
+    overlay.remove("my-modal")
+
+    expect(await settled(closed)).toEqual({
+      status: "settled",
+      value: undefined,
+    })
+  })
+
+  it("resolves a pending waitForExit() when all overlays are removed", async () => {
+    const overlay = createOverlay(() => <div />)
+
+    overlay.open("my-modal", {})
+    void overlay.close("my-modal")
+    const exited = overlay.waitForExit("my-modal")
+    overlay.removeAll()
+
+    expect(await settled(exited)).toEqual({
+      status: "settled",
+      value: undefined,
+    })
   })
 })

--- a/packages/react/src/hooks/use-overlay.tsx
+++ b/packages/react/src/hooks/use-overlay.tsx
@@ -169,7 +169,21 @@ export function createOverlay<TProps extends Dict, TReturn = unknown>(
     return exitPromise
   }
 
+  // a removed overlay never reaches close or exit, so settle the promises
+  // handed out by `open` and `close` instead of leaving callers awaiting forever
+  const settlePending = (id: string) => {
+    const overlay = map.get(id) as
+      | (CreateOverlayProps<TReturn> & TProps)
+      | undefined
+    if (!overlay) return
+    overlay.setReturnValue?.(undefined as TReturn)
+    overlay.setExitComplete?.()
+    overlay.setReturnValue = undefined
+    overlay.setExitComplete = undefined
+  }
+
   const remove = (id: string) => {
+    settlePending(id)
     map.delete(id)
     exitPromises.delete(id)
     publish()
@@ -197,6 +211,7 @@ export function createOverlay<TProps extends Dict, TReturn = unknown>(
   }
 
   const removeAll = () => {
+    for (const id of map.keys()) settlePending(id)
     map.clear()
     exitPromises.clear()
     publish()

--- a/packages/react/src/hooks/use-overlay.tsx
+++ b/packages/react/src/hooks/use-overlay.tsx
@@ -178,8 +178,6 @@ export function createOverlay<TProps extends Dict, TReturn = unknown>(
     if (!overlay) return
     overlay.setReturnValue?.(undefined as TReturn)
     overlay.setExitComplete?.()
-    overlay.setReturnValue = undefined
-    overlay.setExitComplete = undefined
   }
 
   const remove = (id: string) => {


### PR DESCRIPTION
## 📝 Description

`createOverlay` hands out three promises: `open(id, props)` resolves with the
value passed to `close`, `close(id, value)` resolves when the exit animation
finishes, and `waitForExit(id)` resolves on the same signal. All three are
resolved from callbacks (`setReturnValue`, `setExitComplete`) stored on the
overlay entry in the internal map.

`remove(id)` and `removeAll()` delete that entry without ever invoking those
callbacks, so every promise still awaiting the overlay stays pending for the
lifetime of the page.

## ⛳️ Current behavior (updates)

```tsx
const dialog = createOverlay(MyDialog)

const result = dialog.open("confirm", {})
dialog.remove("confirm") // or dialog.removeAll() on route change / logout

await result // never settles
```

The same happens to `await dialog.close("confirm")` and to
`await dialog.waitForExit("confirm")` when the overlay is removed before its
exit animation completes. `removeAll()` is the common trigger, since it is the
natural thing to call on navigation or teardown, and it silently strands every
in-flight `open()` awaiter.

## 🚀 New behavior

`remove` and `removeAll` now settle the pending `setReturnValue` and
`setExitComplete` callbacks with `undefined` before dropping the entry. This
matches the declared return type of `open`, which is already
`Promise<TReturn | undefined>`, and mirrors `close(id)` called without a value.

The normal lifecycle is unchanged: on the `close` then `onExitComplete` path
both callbacks have already been invoked and cleared by the time `remove` runs,
so the added calls are no-ops there.

Four regression tests were added to `packages/react/__tests__/use-overlay.test.tsx`.
Reverting the source change turns exactly those four red with
`expected { status: 'pending' } to deeply equal { status: 'settled', value: undefined }`,
and the other 1013 tests in the repo stay green.

## 💣 Is this a breaking change (Yes/No):

No. Promises that previously hung forever now resolve with `undefined`.

## 📝 Additional Information

A changeset is included (`patch` for `@chakra-ui/react`).
