### PR TITLE
fix(react): return zero-valued tokens from system.token

### DIFF
--- a/.changeset/token-zero-value.md
+++ b/.changeset/token-zero-value.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix `system.token()` and `useToken()` returning the fallback for tokens whose
+value is `0`. The lookup used `||` instead of `??`, so
+`useToken("zIndex", "base")` returned the string `"base"` instead of `0`, while
+`tokens.getVar()` already used `??`.

--- a/packages/react/__tests__/system.test.ts
+++ b/packages/react/__tests__/system.test.ts
@@ -289,6 +289,24 @@ describe("system", () => {
     expect(sys.token("colors.teal.200")).toBe("#light")
   })
 
+  test("system.token resolves tokens whose value is zero", () => {
+    const sys = createSystem({
+      theme: {
+        tokens: {
+          zIndex: {
+            base: { value: 0 },
+            docked: { value: 10 },
+          },
+        },
+      },
+    })
+
+    expect(sys.token("zIndex.base")).toBe(0)
+    expect(sys.token("zIndex.base", "base")).toBe(0)
+    expect(sys.token("zIndex.docked")).toBe(10)
+    expect(sys.token("zIndex.unknown", "fallback")).toBe("fallback")
+  })
+
   test("system.css preserves property order in memo cache keys (#10952)", () => {
     const sys = createSystem({})
     const widthThenHeight = sys.css({ width: "100px", height: "200px" })

--- a/packages/react/src/styled-system/system.ts
+++ b/packages/react/src/styled-system/system.ts
@@ -177,7 +177,7 @@ export function createSystem(...configs: SystemConfig[]): SystemContext {
   const tokenMap = getTokenMap(tokens)
 
   const tokenFn: TokenFn = (path: string, fallback?: any) => {
-    return tokenMap.get(path)?.value || fallback
+    return tokenMap.get(path)?.value ?? fallback
   }
 
   tokenFn.var = (path: string, fallback?: any) => {


### PR DESCRIPTION
## 📝 Description

`system.token()` uses `||` to fall back, so any token whose value is `0` is
reported as missing.

```ts
const sys = createSystem(defaultConfig)
sys.token("zIndex.base") // undefined, expected 0
```

`useToken` passes the token name as the fallback, so the same call through the
hook returns a string that is not a valid `z-index`:

```ts
useToken("zIndex", "base") // ["base"], expected [0]
```

`zIndex.base` ships in the default theme as `{ value: 0 }`. `zIndex.hide`
(`-1`) and `zIndex.docked` (`10`) are unaffected, only `0` is.

## ⛳️ Current behavior (updates)

`tokenFn` in `packages/react/src/styled-system/system.ts` returns
`tokenMap.get(path)?.value || fallback`. A stored value of `0` is falsy, so the
fallback wins even though the token exists in the map.

## 🚀 New behavior

Use `??` so the fallback only applies when the token is absent. This matches
`tokens.getVar()` in `token-dictionary.ts`, which already uses `??`.

The added test asserts `sys.token("zIndex.base")` is `0`, that an explicit
fallback does not override it, that a non-zero token is unchanged, and that an
unknown path still returns the fallback.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

`token.var` is left alone: it reads `cssVar.ref`, which is never falsy.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects token lookup fallback semantics so valid zero-valued tokens are returned instead of treated as missing.
- Replaces truthy fallback selection with nullish fallback selection in `system.token()`.
- Adds coverage for zero-valued, non-zero, missing, and explicitly-fallbacked token lookups.
- Adds a patch changeset documenting the corrected `system.token()` and `useToken()` behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The implementation aligns token lookup with nullish fallback semantics, preserves valid zero values, and retains fallback behavior for absent tokens with direct regression coverage.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/styled-system/system.ts | Uses nullish coalescing so stored falsy values such as numeric zero are preserved while absent values still use the fallback. |
| packages/react/__tests__/system.test.ts | Adds focused regression coverage for zero-valued tokens and confirms existing fallback behavior. |
| .changeset/token-zero-value.md | Accurately documents the user-visible patch and its effect on `system.token()` and `useToken()`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react): return zero-valued tokens fr..."](https://github.com/chakra-ui/chakra-ui/commit/6d0ae77c90d89df650eeb5ef3080f06f6d29139f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60887541)</sub>

<!-- /greptile_comment -->