### PR TITLE
fix(react): preserve cva variant keys that collide with CSS shorthands

### DIFF
--- a/.changeset/cva-variant-shorthand-keys.md
+++ b/.changeset/cva-variant-shorthand-keys.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/react": patch
+---
+
+- **System / CVA**: Fix recipe variants whose names collide with CSS shorthands
+  (`rounded`, `bg`, `p`, etc.) being silently dropped. Variant selections were
+  run through style `normalize`, which rewrote those keys (`rounded` →
+  `borderRadius`) before lookup. Selections now only convert array → breakpoint
+  values and leave variant keys intact. Slot recipes (`sva`) are fixed too.

--- a/packages/react/__tests__/cva.test.ts
+++ b/packages/react/__tests__/cva.test.ts
@@ -162,4 +162,56 @@ describe("cva", () => {
       "@layer recipes": { marginTop: "20px" },
     })
   })
+
+  test("keeps variant keys that collide with CSS shorthands", () => {
+    const { cva: cvaWithShorthand } = createSystem({
+      theme: {
+        breakpoints: { sm: "30em" },
+      },
+      utilities: {
+        borderRadius: { shorthand: "rounded" },
+        background: { shorthand: "bg" },
+        padding: { shorthand: "p" },
+      },
+    })
+
+    const recipe = cvaWithShorthand({
+      base: { color: "red" },
+      variants: {
+        rounded: {
+          true: {
+            borderWidth: "2px",
+            borderStyle: "solid",
+          },
+        },
+        bg: {
+          solid: { background: "blue" },
+        },
+        p: {
+          sm: { padding: "4px" },
+        },
+      },
+      compoundVariants: [
+        {
+          rounded: true,
+          bg: "solid",
+          css: { borderColor: "green" },
+        },
+      ],
+      defaultVariants: {
+        rounded: true,
+      },
+    })
+
+    expect(recipe({ bg: "solid", p: "sm" })).toMatchObject({
+      "@layer recipes": {
+        color: "red",
+        borderWidth: "2px",
+        borderStyle: "solid",
+        background: "blue",
+        padding: "4px",
+        borderColor: "green",
+      },
+    })
+  })
 })

--- a/packages/react/src/styled-system/cva.ts
+++ b/packages/react/src/styled-system/cva.ts
@@ -24,13 +24,15 @@ const defaults = (conf: any): Required<RecipeDefinition> => ({
 
 interface Options {
   normalize: (styles: Dict) => Dict
+  /** Array → breakpoint only; must not rewrite CSS shorthand keys. */
+  normalizeProps: (props: Dict) => Dict
   css: CssFn
   conditions: Condition
   layers: Layers
 }
 
 export function createRecipeFn(options: Options): RecipeCreatorFn {
-  const { css, conditions, normalize, layers } = options
+  const { css, conditions, normalize, normalizeProps, layers } = options
 
   function cva(config: Dict = {}) {
     const defaultsConfig = defaults(config)
@@ -43,14 +45,14 @@ export function createRecipeFn(options: Options): RecipeCreatorFn {
 
     const getVariantCss = createCssFn({
       conditions,
-      normalize,
+      normalize: normalizeProps,
       transform(prop, value) {
         return variants[prop]?.[value]
       },
     })
 
     const resolve = memo(function resolve(props: Dict = {}) {
-      const variantSelections: Dict = normalize({
+      const variantSelections: Dict = normalizeProps({
         ...defaultVariants,
         ...compact(props),
       })

--- a/packages/react/src/styled-system/normalize.ts
+++ b/packages/react/src/styled-system/normalize.ts
@@ -15,3 +15,16 @@ export function createNormalizeFn(context: {
     })
   }
 }
+
+/** Normalize recipe props (array → breakpoint) without rewriting CSS shorthand keys. */
+export function createNormalizePropsFn(context: {
+  normalize: SystemContext["normalizeValue"]
+}) {
+  const { normalize } = context
+
+  return function (props: Dict) {
+    return walkObject(props, normalize, {
+      stop: (value) => Array.isArray(value),
+    })
+  }
+}

--- a/packages/react/src/styled-system/system.ts
+++ b/packages/react/src/styled-system/system.ts
@@ -15,7 +15,7 @@ import { mergeConfigs } from "./config"
 import { createCssFn } from "./css"
 import { createRecipeFn } from "./cva"
 import { createLayers } from "./layers"
-import { createNormalizeFn } from "./normalize"
+import { createNormalizeFn, createNormalizePropsFn } from "./normalize"
 import { createPreflight } from "./preflight"
 import { createSerializeFn } from "./serialize"
 import { EMPTY_OBJECT, createEmptyObject } from "./singleton"
@@ -117,6 +117,10 @@ export function createSystem(...configs: SystemConfig[]): SystemContext {
     normalize: normalizeValue,
   })
 
+  const normalizeProps = createNormalizePropsFn({
+    normalize: normalizeValue,
+  })
+
   const serialize = createSerializeFn({
     conditions,
     isValidProperty,
@@ -132,6 +136,7 @@ export function createSystem(...configs: SystemConfig[]): SystemContext {
     css: css as any,
     conditions,
     normalize: normalizeFn,
+    normalizeProps,
     layers,
   })
 


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/10972

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR separates recipe-prop normalization from CSS style normalization so CVA and SVA variant names that collide with CSS shorthands remain intact.
- Adds property-preserving array-to-breakpoint normalization for recipe selections.
- Wires the new normalizer into variant resolution while retaining ordinary CSS normalization for recipe styles.
- Adds regression coverage for shorthand-colliding variants, defaults, and compound variants.
- Documents the fix as a patch release.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new normalization path preserving shorthand-colliding variant keys while retaining responsive array handling.

The sole recipe-factory caller supplies the new normalizer, responsive values retain their expected breakpoint shape, and no changed path was found to introduce a concrete behavioral, build, or security failure.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/styled-system/cva.ts | Uses the property-preserving normalizer for recipe selections and responsive variant lookup while leaving style normalization unchanged. |
| packages/react/src/styled-system/normalize.ts | Adds a focused normalizer that converts responsive arrays without rewriting property keys. |
| packages/react/src/styled-system/system.ts | Constructs and supplies the new recipe-prop normalizer to the sole createRecipeFn call site. |
| packages/react/__tests__/cva.test.ts | Covers shorthand-colliding explicit, default, and compound variant selections. |
| .changeset/cva-variant-shorthand-keys.md | Accurately records the CVA and SVA shorthand-collision fix as a patch. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Recipe props] --> B[normalizeProps]
  B --> C[Preserve variant keys]
  B --> D[Convert arrays to breakpoint objects]
  C --> E[Variant lookup]
  D --> E
  E --> F[Selected recipe styles]
  F --> G[CSS normalization]
  G --> H[Generated recipe CSS]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react): preserve cva variant keys th..."](https://github.com/chakra-ui/chakra-ui/commit/560b2be9ed4ea202490ca6e882872de02656faff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61419120)</sub>

<!-- /greptile_comment -->