### PR TITLE
fix(react): match all breakpoints when useBreakpoint gets no list

### DIFF
--- a/.changeset/use-breakpoint-default-breakpoints.md
+++ b/.changeset/use-breakpoint-default-breakpoints.md
@@ -1,0 +1,8 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix `useBreakpoint` returning `"base"` on every viewport when the `breakpoints`
+option is omitted. The filter that narrows the evaluated breakpoints read an
+absent option as "match nothing" rather than "match all", so no media query was
+registered and the `fallback` was always returned.

--- a/packages/react/__tests__/use-breakpoint.test.tsx
+++ b/packages/react/__tests__/use-breakpoint.test.tsx
@@ -1,0 +1,76 @@
+import { renderHook } from "@testing-library/react"
+import { ChakraProvider, defaultSystem, useBreakpoint } from "../src"
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+)
+
+// the viewport is wide enough for `base`, `sm` and `md`, but not `lg` and up
+const matching = [
+  "(min-width: 0px)",
+  "(min-width: 30rem)",
+  "(min-width: 48rem)",
+]
+
+const mockMatchMedia = () =>
+  vi.fn().mockImplementation((query: string) => ({
+    matches: matching.includes(query),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }))
+
+describe("useBreakpoint", () => {
+  let originalMatchMedia: typeof window.matchMedia
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia
+    window.matchMedia = mockMatchMedia() as any
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  test("should return the highest matching breakpoint when no breakpoints are listed", () => {
+    const { result } = renderHook(() => useBreakpoint({ ssr: false }), {
+      wrapper,
+    })
+
+    expect(result.current).toBe("md")
+  })
+
+  test("should return the highest matching breakpoint from the listed breakpoints", () => {
+    const { result } = renderHook(
+      () => useBreakpoint({ ssr: false, breakpoints: ["base", "sm", "md"] }),
+      { wrapper },
+    )
+
+    expect(result.current).toBe("md")
+  })
+
+  test("should not return a listed breakpoint that does not match", () => {
+    const { result } = renderHook(
+      () => useBreakpoint({ ssr: false, breakpoints: ["base", "lg"] }),
+      { wrapper },
+    )
+
+    expect(result.current).toBe("base")
+  })
+
+  test("should return the fallback when no breakpoint matches", () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })) as any
+
+    const { result } = renderHook(
+      () => useBreakpoint({ ssr: false, fallback: "sm" }),
+      { wrapper },
+    )
+
+    expect(result.current).toBe("sm")
+  })
+})

--- a/packages/react/src/hooks/use-breakpoint.ts
+++ b/packages/react/src/hooks/use-breakpoint.ts
@@ -62,7 +62,7 @@ export function useBreakpoint(options: UseBreakpointOptions = {}) {
     })
     .filter(
       ({ breakpoint }) =>
-        !!options.breakpoints?.includes(breakpoint as BreakpointName),
+        options.breakpoints?.includes(breakpoint as BreakpointName) ?? true,
     )
 
   const fallback = breakpoints.map(({ fallback }) => fallback)


### PR DESCRIPTION
## 📝 Description

`useBreakpoint` narrows the breakpoints it will evaluate with `!!options.breakpoints?.includes(breakpoint)` (`use-breakpoint.ts:63-66`). When the `breakpoints` option is not passed, `undefined?.includes(...)` is `undefined` and `!!undefined` is `false`, so the filter drops every breakpoint including `base`. The hook then registers no media query at all, `lastIndexOf(true)` on the empty result returns `-1`, and it falls through to `fallback`.

`breakpoints` is optional in `UseBreakpointOptions`, and its JSDoc describes it as the set to match against rather than a required argument, so it reads as a narrowing filter.

`useBreakpointValue` is unaffected. It always passes `breakpoints: Object.keys(normalized)`, so the filter always has a list to work with.

## ⛳️ Current behavior (updates)

`useBreakpoint({ ssr: false })` returns `"base"` on every viewport, silently.

## 🚀 New behavior

An absent `breakpoints` option means every breakpoint in the theme. Passing a list narrows exactly as it did before.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Added `packages/react/__tests__/use-breakpoint.test.tsx` with four cases. One fails on `main` with `expected 'base' to be 'md'`. The other three pass before and after, and they are the ones I actually wanted, since they pin what this change must not alter: an explicit list still narrows, a listed breakpoint that does not match is still excluded, and `fallback` is still returned when nothing matches. Full suite 80 files / 1023 tests green with the change; changeset included.

I also checked the other eleven optional-chained predicates in `packages/react/src` (`?.includes`, `?.some`, `?.every`, `?.has`). This is the only site where an absent option has to mean "everything" - in the rest, including `factory.tsx` and the code-block adapters, the falsy default is the intended reading, so there is nothing else to change here.

One thing worth weighing: `useBreakpoint` is not in the migration guide's list of the hooks v3 ships, so you may simply prefer people use `useBreakpointValue`. I fixed it rather than assuming it is on the way out, because it is exported from the package root with its own documented options and both #10961 and #10721 improved it in the last few weeks. Happy to close this if the hook is being retired.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `useBreakpoint` so omitting the optional breakpoint list evaluates every theme breakpoint instead of filtering all of them out.
- Changes the breakpoint predicate to default to `true` only when the option is absent.
- Adds coverage for omitted lists, explicit narrowing, unmatched listed breakpoints, and fallback behavior.
- Adds a patch changeset for `@chakra-ui/react`.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the implementation, tests, and changeset consistently addressing the omitted-breakpoint-list regression.

The updated predicate only broadens matching when the optional list is absent; explicit lists retain their previous narrowing behavior, and normalized breakpoints provide valid ordered media queries.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/hooks/use-breakpoint.ts | Correctly preserves explicit-list filtering while treating an omitted list as matching all normalized theme breakpoints. |
| packages/react/__tests__/use-breakpoint.test.tsx | Adds focused tests covering the regression and preserving existing explicit-list and fallback semantics. |
| .changeset/use-breakpoint-default-breakpoints.md | Accurately documents the user-visible hook fix as a patch change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react): match all breakpoints when u..."](https://github.com/chakra-ui/chakra-ui/commit/5ad9f7964fc2fe080ea32f3f62e95b9ce61ef88f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61548378)</sub>

<!-- /greptile_comment -->