### PR TITLE
fix(file-upload): style disabled delete triggers

### DIFF
--- a/.changeset/soft-files-rest.md
+++ b/.changeset/soft-files-rest.md
@@ -1,0 +1,6 @@
+---
+"@chakra-ui/react": patch
+"@chakra-ui/panda-preset": patch
+---
+
+Fix disabled file upload delete triggers showing an active cursor and full-strength icon.

--- a/packages/panda-preset/src/slot-recipes/file-upload.ts
+++ b/packages/panda-preset/src/slot-recipes/file-upload.ts
@@ -110,6 +110,9 @@ export const fileUploadSlotRecipe = defineSlotRecipe({
       p: "2px",
       color: "fg.muted",
       cursor: "button",
+      _disabled: {
+        layerStyle: "disabled",
+      },
     },
     itemPreview: {
       color: "fg.muted",

--- a/packages/react/src/theme/recipes/file-upload.ts
+++ b/packages/react/src/theme/recipes/file-upload.ts
@@ -95,6 +95,9 @@ export const fileUploadSlotRecipe = defineSlotRecipe({
       p: "2px",
       color: "fg.muted",
       cursor: "button",
+      _disabled: {
+        layerStyle: "disabled",
+      },
     },
     itemPreview: {
       color: "fg.muted",


### PR DESCRIPTION
Closes #10977

## 📝 Description

Apply Chakra's existing `disabled` layer style to file upload item delete
triggers in both the React theme and the Panda preset. A changeset covers both
published packages.

## ⛳️ Current behavior (updates)

For a disabled `FileUpload` with pre-existing files, the delete trigger is
disabled in the DOM, but its recipe still applies the active `button` cursor
and full opacity, so the X icon looks interactive.

## 🚀 New behavior

Disabled item delete triggers use the shared disabled layer, which applies the
themeable `cursor.disabled` token and reduced opacity. Enabled triggers are
unchanged, and the React and Panda recipes stay aligned.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

- Reproduced with the issue's StackBlitz in Chromium: the button has both
  `disabled` and `data-disabled`, but currently computes to `cursor: pointer`
  and `opacity: 1`.
- Verified the shared disabled layer computes to `cursor: not-allowed` and
  `opacity: 0.5` with the default theme.
- `prettier --check` passes for all three changed files.
- TypeScript 5.9.3 reports no syntax diagnostics for either recipe file.

AI assistance was used during implementation; I reviewed the complete diff and
verified the reported behavior in Chromium.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61925590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/chakra-ui/10979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable defects identified in the changed styling or release metadata.

<details><summary><h3>Summary</h3></summary>

- Adds disabled cursor and reduced-opacity styling to the React file-upload recipe.
- Keeps the Panda preset recipe aligned with the React theme.
- Adds a changeset for `@chakra-ui/react` and `@chakra-ui/panda-preset`.
</details>

<!-- /greptile_comment -->