### PR TITLE
docs(slider): add large step example

### DIFF
--- a/apps/compositions/src/examples/slider-with-large-step.tsx
+++ b/apps/compositions/src/examples/slider-with-large-step.tsx
@@ -1,0 +1,22 @@
+import { HStack, Slider, Text } from "@chakra-ui/react"
+
+export const SliderWithLargeStep = () => {
+  return (
+    <Slider.Root maxW="sm" defaultValue={[40]} step={1} largeStep={20}>
+      <HStack justify="space-between">
+        <Slider.Label>Volume</Slider.Label>
+        <Slider.ValueText />
+      </HStack>
+      <Slider.Control>
+        <Slider.Track>
+          <Slider.Range />
+        </Slider.Track>
+        <Slider.Thumbs />
+      </Slider.Control>
+      <Text color="fg.muted" textStyle="xs">
+        Hold Shift and press an arrow key, or use Page Up and Page Down, to
+        change the value by 20.
+      </Text>
+    </Slider.Root>
+  )
+}

--- a/apps/www/content/docs/components/slider.mdx
+++ b/apps/www/content/docs/components/slider.mdx
@@ -179,6 +179,13 @@ Use the `step` prop to set the step value of the slider.
 
 <ExampleTabs name="slider-with-step" />
 
+### Large Step
+
+Use the `largeStep` prop to set the increment used with `Shift` + Arrow,
+`PageUp`, and `PageDown`.
+
+<ExampleTabs name="slider-with-large-step" />
+
 ### Thumb Alignment
 
 Use the `thumbAlignment` and `thumbSize` prop to align the thumb within the


### PR DESCRIPTION
## 📝 Description

Adds a `largeStep` example to the Slider documentation.

## ⛳️ Current behavior (updates)

The Slider documentation demonstrates the regular `step` prop but does not show how to configure larger keyboard increments.

Users must rely on the prop table to discover the behavior of `largeStep`.

## 🚀 New behavior

Adds an interactive Slider configured with `step={1}` and `largeStep={20}`.

The example explains that the value changes by the larger increment when users press Shift + Arrow, Page Up, or Page Down.

It also renders `Slider.ValueText` so the keyboard-driven value changes are immediately visible.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62700204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable defects identified.

<details><summary><h3>Summary</h3></summary>

- Configures `largeStep={20}` alongside `step={1}` and displays the current value.
- Documents Shift + Arrow, Page Up, and Page Down behavior in the Slider guide.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(slider): add large step example"](https://github.com/chakra-ui/chakra-ui/commit/02950e3b725a6b96c199cbc5fe4f81f80debfdd9)</sub>

<!-- /greptile_comment -->