### PR TITLE
docs(listbox): add keyboard priority example

### DIFF
--- a/apps/compositions/src/examples/listbox-with-keyboard-priority.tsx
+++ b/apps/compositions/src/examples/listbox-with-keyboard-priority.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { Input, Listbox, Text, createListCollection } from "@chakra-ui/react"
+
+export const ListboxWithKeyboardPriority = () => {
+  return (
+    <Listbox.Root collection={frameworks} maxW="320px">
+      <Listbox.Label>Select framework</Listbox.Label>
+      <Listbox.Input
+        as={Input}
+        keyboardPriority="navigate"
+        placeholder="Use Home, End, or Arrow keys"
+      />
+      <Text color="fg.muted" textStyle="xs">
+        The navigation keys highlight listbox items instead of moving the text
+        caret.
+      </Text>
+      <Listbox.Content>
+        {frameworks.items.map((framework) => (
+          <Listbox.Item item={framework} key={framework.value}>
+            <Listbox.ItemText>{framework.label}</Listbox.ItemText>
+            <Listbox.ItemIndicator />
+          </Listbox.Item>
+        ))}
+      </Listbox.Content>
+    </Listbox.Root>
+  )
+}
+
+const frameworks = createListCollection({
+  items: [
+    { label: "React.js", value: "react" },
+    { label: "Vue.js", value: "vue" },
+    { label: "Angular", value: "angular" },
+    { label: "Svelte", value: "svelte" },
+  ],
+})

--- a/apps/www/content/docs/components/listbox.mdx
+++ b/apps/www/content/docs/components/listbox.mdx
@@ -121,6 +121,14 @@ easy to find specific items in long lists.
 
 <ExampleTabs name="listbox-with-input" />
 
+### Keyboard Priority
+
+Set `keyboardPriority="navigate"` on `Listbox.Input` to use Home, End, and arrow
+keys for listbox navigation. The default `caret` mode preserves native text
+editing behavior.
+
+<ExampleTabs name="listbox-with-keyboard-priority" />
+
 ### With Popover
 
 Use the listbox within a popover to create dropdown-like selection menus that


### PR DESCRIPTION
## 📝 Description

Adds an example for the `keyboardPriority` prop on `Listbox.Input`.

## ⛳️ Current behavior (updates)

The Listbox documentation includes an input example but does not explain how keyboard conflicts between native text editing and Listbox navigation are resolved.

The difference between the `caret` and `navigate` modes is only available through the API description.

## 🚀 New behavior

Adds a Listbox input configured with `keyboardPriority="navigate"`.

The example demonstrates that Home, End, and supported arrow keys can navigate and highlight Listbox items instead of moving the text input caret.

The accompanying documentation also clarifies that the default `caret` mode preserves native text-editing behavior.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62718502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only PR appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Adds a `keyboardPriority="navigate"` Listbox composition.
- Documents navigation mode and the default caret-preserving behavior.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(listbox): add keyboard priority exa..."](https://github.com/chakra-ui/chakra-ui/commit/3ab47291e4585ebef686190d300a034f1d35e0e7)</sub>

<!-- /greptile_comment -->