### PR TITLE
docs(tags-input): add sanitize value example

### DIFF
--- a/apps/compositions/src/examples/tags-input-with-sanitized-value.tsx
+++ b/apps/compositions/src/examples/tags-input-with-sanitized-value.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { Span, TagsInput } from "@chakra-ui/react"
+
+export const TagsInputWithSanitizedValue = () => {
+  return (
+    <TagsInput.Root sanitizeValue={(value) => value.trim().toLowerCase()}>
+      <TagsInput.Label>Frameworks</TagsInput.Label>
+      <TagsInput.Control>
+        <TagsInput.Items />
+        <TagsInput.Input placeholder={'Try " React "'} />
+      </TagsInput.Control>
+      <Span color="fg.muted" textStyle="xs" ms="auto">
+        Tags are trimmed and converted to lowercase.
+      </Span>
+      <TagsInput.HiddenInput />
+    </TagsInput.Root>
+  )
+}

--- a/apps/www/content/docs/components/tags-input.mdx
+++ b/apps/www/content/docs/components/tags-input.mdx
@@ -163,6 +163,13 @@ based on a delimiter.
 
 <ExampleTabs name="tags-input-with-paste" />
 
+### Sanitize Values
+
+Use the `sanitizeValue` prop to normalize a value before it is added, such as
+trimming whitespace or converting text to lowercase.
+
+<ExampleTabs name="tags-input-with-sanitized-value" />
+
 ### Blur Behavior
 
 Use the `blurBehavior` prop to configure how the input behaves when it loses


### PR DESCRIPTION
## 📝 Description

Adds a `sanitizeValue` example to the TagsInput documentation.

## ⛳️ Current behavior (updates)

The TagsInput API supports sanitizing values before they are added, but the documentation does not provide an example of this behavior.

Users must rely on the prop table to understand how normalization can be applied.

## 🚀 New behavior

Adds an interactive TagsInput that trims whitespace and converts new values to lowercase:

`"React"` becomes `"react"`.

The example demonstrates how `sanitizeValue` can normalize user input before creating a tag.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62720459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable defects identified.

<details><summary><h3>Summary</h3></summary>

- Trims leading and trailing whitespace and converts entered values to lowercase.
- Adds a “Sanitize Values” section to the Tags Input documentation.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(tags-input): add sanitize value exa..."](https://github.com/chakra-ui/chakra-ui/commit/a3cd1aa129f4536eff9faf8c6de6349387f94882)</sub>

<!-- /greptile_comment -->