### PR TITLE
docs(tags-input): add allow duplicates example

### DIFF
--- a/apps/compositions/src/examples/tags-input-with-duplicates.tsx
+++ b/apps/compositions/src/examples/tags-input-with-duplicates.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { TagsInput } from "@chakra-ui/react"
+
+export const TagsInputWithDuplicates = () => {
+  return (
+    <TagsInput.Root allowDuplicates defaultValue={["React"]}>
+      <TagsInput.Label>Favorite frameworks</TagsInput.Label>
+      <TagsInput.Control>
+        <TagsInput.Items />
+        <TagsInput.Input placeholder={'Add "React" again'} />
+      </TagsInput.Control>
+      <TagsInput.HiddenInput />
+    </TagsInput.Root>
+  )
+}

--- a/apps/www/content/docs/components/tags-input.mdx
+++ b/apps/www/content/docs/components/tags-input.mdx
@@ -106,6 +106,13 @@ tags that can be added.
 
 <ExampleTabs name="tags-input-with-max" />
 
+### Allow Duplicates
+
+Use the `allowDuplicates` prop to allow the same value to be added more than
+once.
+
+<ExampleTabs name="tags-input-with-duplicates" />
+
 ### Editable Tags
 
 Use the `editable` prop to enable inline editing of existing tags by double


### PR DESCRIPTION
## 📝 Description

Adds an `allowDuplicates` example to the TagsInput documentation.

## ⛳️ Current behavior (updates)

The TagsInput API supports duplicate values, but the existing examples do not demonstrate how to enable or use this behavior.

## 🚀 New behavior

Adds an interactive TagsInput configured with `allowDuplicates`.

The example starts with a `React` tag and allows users to add the same value again, making the behavior of the prop immediately visible.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62721780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Adds an interactive `TagsInputWithDuplicates` composition initialized with a React tag.
- Adds an “Allow Duplicates” section referencing the new example from the Tags Input documentation.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(tags-input): add allow duplicates e..."](https://github.com/chakra-ui/chakra-ui/commit/c69cfaa1506f8894348ee554f390ec2b364a9aa5)</sub>

<!-- /greptile_comment -->