### PR TITLE
docs(pin-input): add auto submit example

### DIFF
--- a/apps/compositions/src/examples/pin-input-with-auto-submit.tsx
+++ b/apps/compositions/src/examples/pin-input-with-auto-submit.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { PinInput, Stack, Text } from "@chakra-ui/react"
+import { useState } from "react"
+
+export const PinInputWithAutoSubmit = () => {
+  const [submitted, setSubmitted] = useState(false)
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        setSubmitted(true)
+      }}
+    >
+      <Stack gap="3">
+        <PinInput.Root autoSubmit onValueChange={() => setSubmitted(false)}>
+          <PinInput.HiddenInput name="pin" />
+          <PinInput.Control>
+            <PinInput.Input index={0} />
+            <PinInput.Input index={1} />
+            <PinInput.Input index={2} />
+            <PinInput.Input index={3} />
+          </PinInput.Control>
+        </PinInput.Root>
+        <Text textStyle="sm" color={submitted ? "fg.success" : "fg.muted"}>
+          {submitted
+            ? "The form was submitted."
+            : "The form submits when all digits are entered."}
+        </Text>
+      </Stack>
+    </form>
+  )
+}

--- a/apps/www/content/docs/components/pin-input.mdx
+++ b/apps/www/content/docs/components/pin-input.mdx
@@ -49,6 +49,13 @@ experience when entering OTP codes
 
 <ExampleTabs name="pin-input-with-otp" />
 
+### Auto Submit
+
+Use the `autoSubmit` prop to submit the owning form automatically when every
+input has been filled.
+
+<ExampleTabs name="pin-input-with-auto-submit" />
+
 ### Mask
 
 Pass the `mask` prop to the `PinInput.Root` component to obscure the entered pin


### PR DESCRIPTION
## 📝 Description

Adds an `autoSubmit` example to the PinInput documentation.

## ⛳️ Current behavior (updates)

The `autoSubmit` prop is available in the PinInput API, but the documentation does not show how it behaves inside a form.

## 🚀 New behavior

Adds a four-digit PinInput inside a form with `autoSubmit` enabled.

When all inputs are filled, the owning form is submitted automatically. The example includes visible status text so users can observe when submission occurs.

The hidden input is also assigned a name to demonstrate how the PIN value participates in form submission.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62730356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Adds a four-digit PinInput with `autoSubmit`, a named hidden input, and status feedback.
- Adds an Auto Submit section to the PinInput documentation referencing the new example.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(pin-input): add auto submit example"](https://github.com/chakra-ui/chakra-ui/commit/21b5cb265f03c23507074e7fddcab07e1cb1127b)</sub>

<!-- /greptile_comment -->