### PR TITLE
docs(drawer): document autofocus data attributes

### DIFF
--- a/apps/compositions/src/examples/drawer-with-initial-focus.tsx
+++ b/apps/compositions/src/examples/drawer-with-initial-focus.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import {
   Button,
   CloseButton,
@@ -8,12 +6,10 @@ import {
   Portal,
   Stack,
 } from "@chakra-ui/react"
-import { useRef } from "react"
 
 export const DrawerWithInitialFocus = () => {
-  const ref = useRef<HTMLInputElement | null>(null)
   return (
-    <Drawer.Root initialFocusEl={() => ref.current}>
+    <Drawer.Root>
       <Drawer.Trigger asChild>
         <Button variant="outline" size="sm">
           Open Drawer
@@ -33,14 +29,14 @@ export const DrawerWithInitialFocus = () => {
               </p>
               <Stack mt="5">
                 <Input defaultValue="Naruto" placeholder="First name" />
-                <Input ref={ref} placeholder="Email" />
+                <Input data-autofocus placeholder="Email" />
               </Stack>
             </Drawer.Body>
             <Drawer.Footer>
               <Button variant="outline">Cancel</Button>
               <Button>Save</Button>
             </Drawer.Footer>
-            <Drawer.CloseTrigger asChild>
+            <Drawer.CloseTrigger data-no-autofocus asChild>
               <CloseButton size="sm" />
             </Drawer.CloseTrigger>
           </Drawer.Content>

--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -70,7 +70,9 @@ Use the `placement` prop to change the placement of the drawer component.
 
 ### Initial Focus
 
-Use the `initialFocusEl` prop to set the initial focus of the drawer component.
+Add `data-autofocus` to the element that should receive focus when the drawer
+opens. Use `data-no-autofocus` to exclude an element from the automatic focus
+order.
 
 <ExampleTabs name="drawer-with-initial-focus" />
 


### PR DESCRIPTION
## 📝 Description

Updates the Drawer initial-focus example to demonstrate the new autofocus data attributes.

## ⛳️ Current behavior (updates)

The current Drawer example uses `initialFocusEl` together with `useRef` to select the element that should receive focus.

It does not demonstrate the simpler `data-autofocus` and `data-no-autofocus` attributes.

## 🚀 New behavior

Updates the example to:

- Apply `data-autofocus` directly to the Email input.
- Apply `data-no-autofocus` to the close trigger.
- Remove the unnecessary ref and client-side hook.
- Update the documentation text to explain both attributes.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The existing `initialFocusEl` API remains supported. This PR only modernizes the documentation example and does not add external dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62732587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable defects identified.

<details><summary><h3>Summary</h3></summary>

- Replaces `initialFocusEl` and its React ref with `data-autofocus` on the Email input.
- Adds `data-no-autofocus` to the close trigger.
- Documents how both attributes affect automatic focus selection.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(drawer): document autofocus data at..."](https://github.com/chakra-ui/chakra-ui/commit/7b0ae0c7cfaeff1527b9e5512e2d8d1889963933)</sub>

<!-- /greptile_comment -->