### PR TITLE
docs(dialog): document autofocus data attributes

### DIFF
--- a/apps/compositions/src/examples/dialog-with-initial-focus.tsx
+++ b/apps/compositions/src/examples/dialog-with-initial-focus.tsx
@@ -1,12 +1,16 @@
-"use client"
-
-import { Button, Dialog, Field, Input, Portal, Stack } from "@chakra-ui/react"
-import { useRef } from "react"
+import {
+  Button,
+  CloseButton,
+  Dialog,
+  Field,
+  Input,
+  Portal,
+  Stack,
+} from "@chakra-ui/react"
 
 export const DialogWithInitialFocus = () => {
-  const ref = useRef<HTMLInputElement | null>(null)
   return (
-    <Dialog.Root initialFocusEl={() => ref.current}>
+    <Dialog.Root>
       <Dialog.Trigger asChild>
         <Button variant="outline">Open</Button>
       </Dialog.Trigger>
@@ -25,7 +29,7 @@ export const DialogWithInitialFocus = () => {
                 </Field.Root>
                 <Field.Root>
                   <Field.Label>Last Name</Field.Label>
-                  <Input ref={ref} placeholder="Focus First" />
+                  <Input data-autofocus placeholder="Focus First" />
                 </Field.Root>
               </Stack>
             </Dialog.Body>
@@ -35,6 +39,9 @@ export const DialogWithInitialFocus = () => {
               </Dialog.ActionTrigger>
               <Button>Save</Button>
             </Dialog.Footer>
+            <Dialog.CloseTrigger data-no-autofocus asChild>
+              <CloseButton size="sm" />
+            </Dialog.CloseTrigger>
           </Dialog.Content>
         </Dialog.Positioner>
       </Portal>

--- a/apps/www/content/docs/components/dialog.mdx
+++ b/apps/www/content/docs/components/dialog.mdx
@@ -132,7 +132,9 @@ confirmation.
 
 ### Initial Focus
 
-Use the `initialFocusEl` prop to set the initial focus of the dialog component.
+Add `data-autofocus` to the element that should receive focus when the dialog
+opens. Use `data-no-autofocus` to exclude an element from the automatic focus
+order.
 
 <ExampleTabs name="dialog-with-initial-focus" />
 


### PR DESCRIPTION
## 📝 Description

Updates the Dialog initial-focus example to demonstrate the new autofocus data attributes.

## ⛳️ Current behavior (updates)

The current Dialog example uses `initialFocusEl` and `useRef` to select the initially focused element.

It does not show how initial focus can be configured declaratively with `data-autofocus` or how elements can be excluded with `data-no-autofocus`.

## 🚀 New behavior

Updates the example to:

- Apply `data-autofocus` directly to the intended input.
- Add a close trigger marked with `data-no-autofocus`.
- Remove the unnecessary ref and client-side hook.
- Update the documentation text to describe the automatic focus order.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The existing `initialFocusEl` API remains supported. This is a documentation-only change with no new external dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62734111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable defects identified.

<details><summary><h3>Summary</h3></summary>

- Marks the intended input with `data-autofocus`.
- Adds a close trigger excluded from automatic focus selection with `data-no-autofocus`.
- Revises the Dialog documentation to explain the attribute-based focus behavior.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(dialog): document autofocus data at..."](https://github.com/chakra-ui/chakra-ui/commit/9f34ea6962f2a7ee4d02611bfc4dbc7f038631a9)</sub>

<!-- /greptile_comment -->