### PR TITLE
docs(number-input): add keyboard steps example

### DIFF
--- a/apps/compositions/src/examples/number-input-with-keyboard-steps.tsx
+++ b/apps/compositions/src/examples/number-input-with-keyboard-steps.tsx
@@ -1,0 +1,21 @@
+import { Field, NumberInput } from "@chakra-ui/react"
+
+export const NumberInputWithKeyboardSteps = () => {
+  return (
+    <Field.Root maxW="240px">
+      <Field.Label>Quantity</Field.Label>
+      <NumberInput.Root
+        defaultValue="10"
+        step={1}
+        largeStep={20}
+        smallStep={0.5}
+      >
+        <NumberInput.Control />
+        <NumberInput.Input />
+      </NumberInput.Root>
+      <Field.HelperText>
+        Use Shift + Arrow for 20 and Alt + Arrow for 0.5.
+      </Field.HelperText>
+    </Field.Root>
+  )
+}

--- a/apps/www/content/docs/components/number-input.mdx
+++ b/apps/www/content/docs/components/number-input.mdx
@@ -96,6 +96,13 @@ or decrement interval of the number input.
 
 <ExampleTabs name="number-input-with-step" />
 
+### Keyboard Steps
+
+Use `largeStep` to set the increment when holding `Shift`, and `smallStep` to
+set the increment when holding `Alt` while pressing an arrow key.
+
+<ExampleTabs name="number-input-with-keyboard-steps" />
+
 ### Controlled
 
 Pass the `value` and `onValueChange` props to the `NumberInput.Root` component


### PR DESCRIPTION
## 📝 Description

Adds a keyboard-steps example to the NumberInput documentation.

The example demonstrates the `largeStep` and `smallStep` props introduced for modifier-assisted keyboard stepping.

## ⛳️ Current behavior (updates)

The NumberInput documentation explains the regular `step` prop but does not demonstrate how Shift and Alt modify keyboard increments.

Users must rely on the prop table to discover `largeStep` and `smallStep`.

## 🚀 New behavior

Adds a NumberInput configured with:

- `step={1}`
- `largeStep={20}`
- `smallStep={0.5}`

The example explains that Shift + Arrow uses the large step and Alt + Arrow uses the small step.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62735321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge, with no concrete defects identified.

<details><summary><h3>Summary</h3></summary>

- Adds a composed NumberInput example using regular, large, and small step values.
- Documents the Shift and Alt keyboard modifiers and embeds the example in the NumberInput guide.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(number-input): add keyboard steps e..."](https://github.com/chakra-ui/chakra-ui/commit/ceff97bc421cd4c0e6e8dc950768503e4c640b83)</sub>

<!-- /greptile_comment -->