### PR TITLE
docs(pagination): add custom page text document

### DIFF
--- a/apps/compositions/src/examples/pagination-with-custom-format.tsx
+++ b/apps/compositions/src/examples/pagination-with-custom-format.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { ButtonGroup, IconButton, Pagination } from "@chakra-ui/react"
 import { LuChevronLeft, LuChevronRight } from "react-icons/lu"
 
@@ -7,7 +9,7 @@ export const PaginationWithCustomFormat = () => {
       <ButtonGroup variant="ghost" size="sm" w="full">
         <Pagination.PageText
           flex="1"
-          format={({ page, totalPages }) => `Page ${page} de ${totalPages}`}
+          format={({ page, totalPages }) => `صفحه ${page} از ${totalPages}`}
         />
         <Pagination.PrevTrigger asChild>
           <IconButton>

--- a/apps/www/content/docs/components/pagination.mdx
+++ b/apps/www/content/docs/components/pagination.mdx
@@ -120,6 +120,13 @@ text.
 
 <ExampleTabs name="pagination-with-count-text" />
 
+### Custom Page Text
+
+Pass a function to the `format` prop of `Pagination.PageText` to customize or
+localize the page text.
+
+<ExampleTabs name="pagination-with-custom-format" />
+
 ### Data Driven
 
 Here's an example of controlling the pagination state and using the state to


### PR DESCRIPTION
## 📝 Description

Exposes the existing custom page-text example in the Pagination documentation.

## ⛳️ Current behavior (updates)

The Pagination documentation only demonstrates the predefined `format="long"` value for `Pagination.PageText`.

An existing example showing the function form of `format` is present in the compositions directory but is not referenced by the documentation page.

## 🚀 New behavior

Adds a Custom Page Text section that renders the existing custom-format example.

The example demonstrates how a formatter function can access `page` and `totalPages` to customize or localize the displayed page text.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This change only connects an existing example to the documentation page. It does not add runtime code or external dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62739931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking localization-quality issue in the Persian example.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fcompositions%2Fsrc%2Fexamples%2Fpagination-with-custom-format.tsx%3A12%0AThe%20new%20formatter%20renders%20Persian%20text%20and%20interpolated%20numbers%20inside%20the%20documentation%20site's%20default%20LTR%2C%20language-unspecified%20context.%20This%20presents%20incomplete%20localization%20guidance%20and%20omits%20the%20bidi%20and%20language%20semantics%20used%20by%20RTL%20examples%20elsewhere%20in%20the%20repository.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fchakra-ui&pr=10990&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Persian text lacks RTL context** <a href="https://github.com/chakra-ui/chakra-ui/pull/10990#discussion_r3982530982">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/compositions/src/examples/pagination-with-custom-format.tsx:12
The new formatter renders Persian text and interpolated numbers inside the documentation site's default LTR, language-unspecified context. This presents incomplete localization guidance and omits the bidi and language semantics used by RTL examples elsewhere in the repository.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds a Custom Page Text section referencing `pagination-with-custom-format`.
- Marks the composition as a client component.
- Uses a formatter function that displays the current and total page counts in Persian.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(pagination): resolve error &#39;functio..."](https://github.com/chakra-ui/chakra-ui/commit/f28abf419b37be343279a02e37f98e4eafb1217a)</sub>

<!-- /greptile_comment -->