### PR TITLE
docs(pin-input): add sanitize value example

### DIFF
--- a/apps/compositions/src/examples/pin-input-with-sanitized-value.tsx
+++ b/apps/compositions/src/examples/pin-input-with-sanitized-value.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { Clipboard, Field, IconButton, PinInput, Stack } from "@chakra-ui/react"
 
 export const PinInputWithSanitizedValue = () => {

--- a/apps/compositions/src/examples/pin-input-with-sanitized-value.tsx
+++ b/apps/compositions/src/examples/pin-input-with-sanitized-value.tsx
@@ -1,0 +1,32 @@
+import { Clipboard, Field, IconButton, PinInput, Stack } from "@chakra-ui/react"
+
+export const PinInputWithSanitizedValue = () => {
+  return (
+    <Stack gap="4">
+      <Clipboard.Root value="1-2-3-4">
+        <Clipboard.ValueText fontFamily="mono" />
+        <Clipboard.Trigger asChild>
+          <IconButton size="xs" variant="outline">
+            <Clipboard.Indicator />
+          </IconButton>
+        </Clipboard.Trigger>
+      </Clipboard.Root>
+
+      <Field.Root>
+        <Field.Label>Paste the copied code</Field.Label>
+        <PinInput.Root sanitizeValue={(value) => value.replace(/\D/g, "")}>
+          <PinInput.HiddenInput />
+          <PinInput.Control>
+            <PinInput.Input index={0} />
+            <PinInput.Input index={1} />
+            <PinInput.Input index={2} />
+            <PinInput.Input index={3} />
+          </PinInput.Control>
+        </PinInput.Root>
+        <Field.HelperText>
+          Dashes are removed before validation.
+        </Field.HelperText>
+      </Field.Root>
+    </Stack>
+  )
+}

--- a/apps/www/content/docs/components/pin-input.mdx
+++ b/apps/www/content/docs/components/pin-input.mdx
@@ -49,6 +49,13 @@ experience when entering OTP codes
 
 <ExampleTabs name="pin-input-with-otp" />
 
+### Sanitize Pasted Values
+
+Use the `sanitizeValue` prop to remove formatting such as dashes or spaces from
+pasted values before validation.
+
+<ExampleTabs name="pin-input-with-sanitized-value" />
+
 ### Mask
 
 Pass the `mask` prop to the `PinInput.Root` component to obscure the entered pin


### PR DESCRIPTION
## 📝 Description

Adds a practical `sanitizeValue` example to the PinInput documentation.

## ⛳️ Current behavior (updates)

The PinInput API supports sanitizing pasted values before validation, but the documentation does not demonstrate this behavior.

Users copying formatted one-time codes containing spaces or dashes do not have an example showing how to normalize those values.

## 🚀 New behavior

Adds an example containing a copyable `1-2-3-4` code and a four-digit PinInput.

The example uses `sanitizeValue` to remove non-numeric characters before validation, converting the pasted value to `1234`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is a documentation-only change and does not add any external dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62750380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Adds a copyable `1-2-3-4` value and a four-slot PinInput that removes non-digit characters.
- Adds a “Sanitize Pasted Values” section to the PinInput documentation.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(pin-input): resolve error &#39;function..."](https://github.com/chakra-ui/chakra-ui/commit/e2a91601fbe47fb393857531eba4db3e3e7a1603)</sub>

<!-- /greptile_comment -->