### PR TITLE
docs(collapsible): demonstrate activity hide mode

### DIFF
--- a/apps/compositions/src/examples/collapsible-with-hide-mode.tsx
+++ b/apps/compositions/src/examples/collapsible-with-hide-mode.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import {
+  Box,
+  Button,
+  Collapsible,
+  SimpleGrid,
+  Stack,
+  Text,
+} from "@chakra-ui/react"
+import { useEffect, useState } from "react"
+
+export const CollapsibleWithHideMode = () => {
+  return (
+    <Stack gap="4" width="full">
+      <Text color="fg.muted" textStyle="sm">
+        Collapse both panels for a few seconds, then reopen them to compare the
+        effect counters.
+      </Text>
+      <SimpleGrid columns={{ base: 1, md: 2 }} gap="6">
+        <HideModeDemo mode="display-none" />
+        <HideModeDemo mode="activity" />
+      </SimpleGrid>
+    </Stack>
+  )
+}
+
+const HideModeDemo = (props: { mode: "display-none" | "activity" }) => (
+  <Collapsible.Root defaultOpen hideMode={props.mode}>
+    <Stack align="flex-start" gap="3">
+      <Text fontWeight="medium">hideMode=&quot;{props.mode}&quot;</Text>
+      <Collapsible.Trigger asChild>
+        <Button size="sm" variant="outline">
+          Toggle content
+        </Button>
+      </Collapsible.Trigger>
+      <Collapsible.Content width="full">
+        <Box borderWidth="1px" borderRadius="md" p="4">
+          <EffectCounter />
+        </Box>
+      </Collapsible.Content>
+    </Stack>
+  </Collapsible.Root>
+)
+
+const EffectCounter = () => {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setCount((current) => current + 1)
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [])
+
+  return <Text>Effect ticks: {count}</Text>
+}

--- a/apps/www/content/docs/components/collapsible.mdx
+++ b/apps/www/content/docs/components/collapsible.mdx
@@ -65,6 +65,17 @@ Use the `unmountOnExit` prop to make the content unmount when collapsed.
 
 <ExampleTabs name="collapsible-lazy-mounted" />
 
+### Hide Mode
+
+Use `hideMode="activity"` to keep collapsed content mounted while React 19
+pauses effects in its subtree. The default `display-none` mode hides the content
+with the `hidden` attribute and keeps effects running.
+
+`hideMode` does not apply when `unmountOnExit` is enabled because the subtree is
+removed instead of hidden.
+
+<ExampleTabs name="collapsible-with-hide-mode" />
+
 ## Guides
 
 ### Accessing collapsible context


### PR DESCRIPTION
## 📝 Description

Adds an interactive example explaining the `hideMode` prop in the Collapsible documentation.

The example compares the default `display-none` behavior with React 19's `activity` behavior.

## ⛳️ Current behavior (updates)

The `hideMode` prop is available in the component API, but the documentation does not provide a practical example showing how its two modes affect React effects while content is collapsed.

The interaction between `hideMode` and `unmountOnExit` is also not demonstrated.

## 🚀 New behavior

Adds two Collapsible components with effect counters:

- `hideMode="display-none"` keeps effects running while content is hidden.
- `hideMode="activity"` pauses effects while preserving component state.

The documentation also clarifies that `hideMode` does not apply when `unmountOnExit` is enabled because the subtree is removed instead of hidden.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The `activity` mode requires React 19. This is a documentation-only change with no new external dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62757244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable issues identified.

<details><summary><h3>Summary</h3></summary>

- Adds two collapsible panels with interval-driven effect counters.
- Documents that activity mode pauses effects while preserving state.
- Clarifies that `unmountOnExit` removes the subtree instead of applying a hide mode.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(collapsible): demonstrate activity ..."](https://github.com/chakra-ui/chakra-ui/commit/1445492952925192a661baa7926202b0f849295d)</sub>

<!-- /greptile_comment -->