### PR TITLE
docs(select): select virtualized example

### DIFF
--- a/apps/compositions/src/examples/select-virtualized.tsx
+++ b/apps/compositions/src/examples/select-virtualized.tsx
@@ -52,38 +52,35 @@ export const SelectVirtualized = () => {
         </Select.Trigger>
       </Select.Control>
       <Select.Positioner>
-        <Select.Content ref={contentRef}>
-          <div
-            style={{
-              height: `${virtualizer.getTotalSize()}px`,
-              width: "100%",
-              position: "relative",
-            }}
-          >
-            {virtualizer.getVirtualItems().map((virtualItem) => {
-              const item = items[virtualItem.index]
-              return (
-                <Select.Item
-                  key={item.value}
-                  item={item}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    height: `${virtualItem.size}px`,
-                    transform: `translateY(${virtualItem.start}px)`,
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                  }}
-                >
-                  <Select.ItemText>{item.label}</Select.ItemText>
-                  <Select.ItemIndicator />
-                </Select.Item>
-              )
-            })}
-          </div>
+        <Select.Content
+          ref={contentRef}
+          height={`${virtualizer.getTotalSize()}px`}
+          width={"100%"}
+          position={"relative"}
+        >
+          {virtualizer.getVirtualItems().map((virtualItem) => {
+            const item = items[virtualItem.index]
+            return (
+              <Select.Item
+                key={item.value}
+                item={item}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: `${virtualItem.size}px`,
+                  transform: `translateY(${virtualItem.start}px)`,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                <Select.ItemText>{item.label}</Select.ItemText>
+                <Select.ItemIndicator />
+              </Select.Item>
+            )
+          })}
         </Select.Content>
       </Select.Positioner>
       <Select.HiddenSelect />

--- a/apps/compositions/src/examples/select-virtualized.tsx
+++ b/apps/compositions/src/examples/select-virtualized.tsx
@@ -52,35 +52,38 @@ export const SelectVirtualized = () => {
         </Select.Trigger>
       </Select.Control>
       <Select.Positioner>
-        <Select.Content
-          ref={contentRef}
-          height={`${virtualizer.getTotalSize()}px`}
-          width={"100%"}
-          position={"relative"}
-        >
-          {virtualizer.getVirtualItems().map((virtualItem) => {
-            const item = items[virtualItem.index]
-            return (
-              <Select.Item
-                key={item.value}
-                item={item}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  height: `${virtualItem.size}px`,
-                  transform: `translateY(${virtualItem.start}px)`,
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
-              >
-                <Select.ItemText>{item.label}</Select.ItemText>
-                <Select.ItemIndicator />
-              </Select.Item>
-            )
-          })}
+        <Select.Content ref={contentRef}>
+          <div
+            style={{
+              height: `${virtualizer.getTotalSize()}px`,
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualItem) => {
+              const item = items[virtualItem.index]
+              return (
+                <Select.Item
+                  key={item.value}
+                  item={item}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: `${virtualItem.size}px`,
+                    transform: `translateY(${virtualItem.start}px)`,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  <Select.ItemText>{item.label}</Select.ItemText>
+                  <Select.ItemIndicator />
+                </Select.Item>
+              )
+            })}
+          </div>
         </Select.Content>
       </Select.Positioner>
       <Select.HiddenSelect />

--- a/apps/www/content/docs/components/select.mdx
+++ b/apps/www/content/docs/components/select.mdx
@@ -134,6 +134,13 @@ the `maxHeight` set.
 
 <ExampleTabs name="select-with-overflow" />
 
+### Virtualized
+
+For large collections, combine the Select with `@tanstack/react-virtual` to
+render only the visible items and keep scrolling responsive.
+
+<ExampleTabs name="select-virtualized" />
+
 ### Item Description
 
 Here's an example of how to render a description for each item.


### PR DESCRIPTION
## 📝 Description

Expose the existing virtualized Select example in the Select documentation.

## ⛳️ Current behavior (updates)

A `select-virtualized` composition already exists in the repository, but it is not referenced from the Select documentation. Users looking for an efficient way to render large collections cannot discover the example from the component page.

## 🚀 New behavior

The Select documentation now includes a Virtualized section explaining how to combine Select with `@tanstack/react-virtual` to render only visible options and keep large collections responsive.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The existing composition is reused without modification. No new dependency is introduced because `@tanstack/react-virtual` is already used by the project.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63150303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until the virtualized example retains an in-flow total-height spacer so its entire option collection remains scrollable.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fcompositions%2Fsrc%2Fexamples%2Fselect-virtualized.tsx%3A57%0AMoving%20the%20virtualizer%E2%80%99s%20total%20height%20onto%20%60Select.Content%60%20removes%20the%20in-flow%20spacer%20that%20establishes%20the%20scroll%20range.%20The%20Select%20content%20recipe%20limits%20this%20element%20to%20%6024rem%60%2C%20while%20the%20absolutely%20positioned%20items%20do%20not%20reserve%20the%20collection%E2%80%99s%20full%20height.%20As%20a%20result%2C%20users%20cannot%20reliably%20scroll%20to%20later%20options.%20Keep%20the%20total-size%20height%20on%20an%20inner%20positioned%20element%2C%20as%20the%20other%20virtualized%20examples%20do.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fchakra-ui&pr=10996&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Scroll range is truncated** <a href="https://github.com/chakra-ui/chakra-ui/pull/10996#discussion_r3991369350">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/compositions/src/examples/select-virtualized.tsx:57
Moving the virtualizer’s total height onto `Select.Content` removes the in-flow spacer that establishes the scroll range. The Select content recipe limits this element to `24rem`, while the absolutely positioned items do not reserve the collection’s full height. As a result, users cannot reliably scroll to later options. Keep the total-size height on an inner positioned element, as the other virtualized examples do.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds a Virtualized section and example tab to the Select documentation.
- Moves the virtualizer sizing and positioning from an inner spacer onto `Select.Content`.
- The container restructuring removes the full-height scroll spacer and breaks the virtualized scroll geometry.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(select): remove additional div tag"](https://github.com/chakra-ui/chakra-ui/commit/48a2aa9358ad64439582b28610cea6a457619e2d)</sub>

<!-- /greptile_comment -->