### PR TITLE
docs(slider): add custom marker labels example

### DIFF
--- a/apps/compositions/src/examples/slider-with-custom-marker-labels.tsx
+++ b/apps/compositions/src/examples/slider-with-custom-marker-labels.tsx
@@ -1,0 +1,30 @@
+import { Slider } from "@chakra-ui/react"
+
+const marks = [
+  { value: 20, label: "Low", color: "green.fg" },
+  { value: 50, label: "Medium", color: "orange.fg" },
+  { value: 80, label: "High", color: "red.fg" },
+]
+
+export const SliderWithCustomMarkerLabels = () => {
+  return (
+    <Slider.Root width="xs" defaultValue={[50]}>
+      <Slider.Control>
+        <Slider.Track>
+          <Slider.Range />
+        </Slider.Track>
+        <Slider.Thumbs />
+        <Slider.MarkerGroup>
+          {marks.map((mark) => (
+            <Slider.Marker key={mark.value} value={mark.value}>
+              <Slider.MarkerIndicator />
+              <Slider.MarkerLabel color={mark.color} fontWeight="medium">
+                {mark.label}
+              </Slider.MarkerLabel>
+            </Slider.Marker>
+          ))}
+        </Slider.MarkerGroup>
+      </Slider.Control>
+    </Slider.Root>
+  )
+}

--- a/apps/www/content/docs/components/slider.mdx
+++ b/apps/www/content/docs/components/slider.mdx
@@ -196,6 +196,13 @@ You can also add labels to the marks using the `marks` prop.
 
 <ExampleTabs name="slider-with-marks-and-label" />
 
+### Custom Marker Labels
+
+Compose `Slider.Marker`, `Slider.MarkerIndicator`, and `Slider.MarkerLabel` to
+customize each marker independently.
+
+<ExampleTabs name="slider-with-custom-marker-labels" />
+
 ### Vertical
 
 Use the `orientation` prop to change the orientation of the slider.


### PR DESCRIPTION
## 📝 Description

Add an example demonstrating direct composition and customization of `Slider.MarkerLabel`.

## ⛳️ Current behavior (updates)

The Slider documentation demonstrates the `Slider.Marks` shortcut, but it does not show how to compose marker parts directly when each marker requires individual styling.

## 🚀 New behavior

A new Custom Marker Labels example composes:

- `Slider.MarkerGroup`
- `Slider.Marker`
- `Slider.MarkerIndicator`
- `Slider.MarkerLabel`

Each marker label is styled independently to represent low, medium, and high threshold values.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The existing `Slider.Marks` examples remain unchanged. This example documents the lower-level composition API without adding dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63471591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness or quality issues identified.

<details><summary><h3>Summary</h3></summary>

- Introduces individually colored Low, Medium, and High marker labels.
- Links the new composition from the Slider documentation.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(slider): add custom marker labels e..."](https://github.com/chakra-ui/chakra-ui/commit/0dc021888bc6cef77e152dd80d25802142ca41d8)</sub>

<!-- /greptile_comment -->