### PR TITLE
docs(steps): add skippable step example

### DIFF
--- a/apps/compositions/src/examples/steps-with-skippable-step.tsx
+++ b/apps/compositions/src/examples/steps-with-skippable-step.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { Button, ButtonGroup, Input, Steps, Text } from "@chakra-ui/react"
+import { useState } from "react"
+
+const steps = ["Account", "Company", "Review"]
+
+export const StepsWithSkippableStep = () => {
+  const [email, setEmail] = useState("")
+  const [company, setCompany] = useState("")
+  const [error, setError] = useState("")
+
+  return (
+    <Steps.Root
+      count={steps.length}
+      linear
+      isStepValid={(index) => index !== 0 || email.includes("@")}
+      isStepSkippable={(index) => index === 1}
+      onStepInvalid={() => setError("Enter a valid email to continue.")}
+    >
+      <Steps.List>
+        {steps.map((title, index) => (
+          <Steps.Item key={title} index={index}>
+            <Steps.Trigger>
+              <Steps.Indicator />
+              <Steps.Title>{title}</Steps.Title>
+            </Steps.Trigger>
+            <Steps.Separator />
+          </Steps.Item>
+        ))}
+      </Steps.List>
+
+      <Steps.Content index={0} spaceY="2">
+        <Text textStyle="sm">Enter your account email.</Text>
+        <Input
+          type="email"
+          value={email}
+          placeholder="email@example.com"
+          onChange={(event) => {
+            setEmail(event.target.value)
+            setError("")
+          }}
+        />
+        {error && (
+          <Text role="alert" color="fg.error" textStyle="sm">
+            {error}
+          </Text>
+        )}
+      </Steps.Content>
+
+      <Steps.Content index={1} spaceY="2">
+        <Text textStyle="sm">
+          Company details are optional, so this step can be skipped.
+        </Text>
+        <Input
+          value={company}
+          placeholder="Company name (optional)"
+          onChange={(event) => setCompany(event.target.value)}
+        />
+      </Steps.Content>
+
+      <Steps.Content index={2} spaceY="2">
+        <Text>Email: {email}</Text>
+        <Text>Company: {company || "Not provided"}</Text>
+      </Steps.Content>
+
+      <Steps.CompletedContent>Setup complete.</Steps.CompletedContent>
+
+      <ButtonGroup size="sm" variant="outline" mt="4">
+        <Steps.PrevTrigger asChild>
+          <Button>Back</Button>
+        </Steps.PrevTrigger>
+        <Steps.NextTrigger asChild>
+          <Button>Next</Button>
+        </Steps.NextTrigger>
+      </ButtonGroup>
+    </Steps.Root>
+  )
+}

--- a/apps/www/content/docs/components/steps.mdx
+++ b/apps/www/content/docs/components/steps.mdx
@@ -81,6 +81,13 @@ the `onStepInvalid` prop to handle invalid step transitions.
 
 <ExampleTabs name="steps-with-validation" />
 
+### Skippable Step
+
+Use the `isStepSkippable` prop to allow optional steps to bypass validation in
+a linear flow.
+
+<ExampleTabs name="steps-with-skippable-step" />
+
 ### Store
 
 An alternative way to control the steps is to use the `RootProvider` component


### PR DESCRIPTION
## 📝 Description

Add an example demonstrating how to create an optional step using `isStepSkippable`.

## ⛳️ Current behavior (updates)

The Steps documentation demonstrates `isStepValid` and `onStepInvalid`, but it does not show how `isStepSkippable` interacts with validation in a linear flow.

## 🚀 New behavior

A new Skippable Step example demonstrates a three-step setup flow where:

- The account step requires a valid email address.
- The company step is optional and can be skipped.
- `isStepSkippable` allows navigation past the optional step.
- Invalid required-step navigation displays an accessible error message.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This example documents an existing Steps API and does not add any dependencies.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63476564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge after non-blocking improvements to the example’s email validation and accessible field markup.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fcompositions%2Fsrc%2Fexamples%2Fsteps-with-skippable-step.tsx%3A17%0AThe%20email%20step%20treats%20any%20value%20containing%20%60%40%60%2C%20including%20malformed%20values%20such%20as%20%60%40%60%2C%20as%20valid.%20Users%20can%20therefore%20advance%20to%20the%20review%20step%20even%20though%20the%20UI%20says%20that%20a%20valid%20email%20is%20required.%20Use%20the%20email%20input%E2%80%99s%20native%20validity%20or%20equivalent%20email%20validation%20instead%20of%20%60includes%28%22%40%22%29%60.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fcompositions%2Fsrc%2Fexamples%2Fsteps-with-skippable-step.tsx%3A34-35%0ABoth%20new%20inputs%20rely%20on%20placeholders%20and%20unassociated%20text%20instead%20of%20programmatic%20labels%2C%20and%20the%20validation%20error%20is%20not%20associated%20with%20the%20email%20field.%20Assistive%20technology%20therefore%20cannot%20reliably%20connect%20each%20instruction%20and%20error%20to%20its%20input.%20Wrap%20each%20input%20in%20%60Field.Root%60%20with%20%60Field.Label%60%2C%20and%20expose%20the%20email%20error%20through%20%60Field.ErrorText%60.%20This%20also%20applies%20to%20the%20company%20input%20and%20the%20error%20message%20later%20in%20this%20example.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fchakra-ui&pr=10998&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Email validation is too permissive** <a href="https://github.com/chakra-ui/chakra-ui/pull/10998#discussion_r3997327670">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Inputs lack accessible labels** <a href="https://github.com/chakra-ui/chakra-ui/pull/10998#discussion_r3997327671">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/compositions/src/examples/steps-with-skippable-step.tsx:17
The email step treats any value containing `@`, including malformed values such as `@`, as valid. Users can therefore advance to the review step even though the UI says that a valid email is required. Use the email input’s native validity or equivalent email validation instead of `includes("@")`.

### Issue 2
apps/compositions/src/examples/steps-with-skippable-step.tsx:34-35
Both new inputs rely on placeholders and unassociated text instead of programmatic labels, and the validation error is not associated with the email field. Assistive technology therefore cannot reliably connect each instruction and error to its input. Wrap each input in `Field.Root` with `Field.Label`, and expose the email error through `Field.ErrorText`. This also applies to the company input and the error message later in this example.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Validates the required account step before forward navigation.
- Marks the company step as skippable.
- Displays entered data in a review step and announces validation failures.
- The example should improve its email validation and field accessibility associations.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(steps): add skippable step example"](https://github.com/chakra-ui/chakra-ui/commit/0554745a7cf810b515396770626ec433e3e9e57f)</sub>

<!-- /greptile_comment -->