### PR TITLE
fix(react): normalize nested semantic token overrides

### DIFF
--- a/.changeset/nested-semantic-token-overrides.md
+++ b/.changeset/nested-semantic-token-overrides.md
@@ -1,0 +1,9 @@
+---
+"@chakra-ui/react": patch
+---
+
+Fix a nested `theme.semanticTokens` override silently deleting the sibling
+semantic tokens it nests under. Setting `semanticTokens.colors.red` to a single
+value dropped `red.solid`, `red.fg`, `red.subtle` and the rest of the palette,
+which broke `colorPalette="red"` for every component. `theme.tokens` already
+handled this shape, and `theme.semanticTokens` now does too.

--- a/packages/react/__tests__/merge-config.test.ts
+++ b/packages/react/__tests__/merge-config.test.ts
@@ -139,6 +139,100 @@ describe("mergeConfig", () => {
     `)
   })
 
+  test("should handle nested semantic token overrides", () => {
+    const baseConfig = {
+      theme: {
+        semanticTokens: {
+          colors: {
+            accent: {
+              solid: { value: { base: "#2563eb", _dark: "#60a5fa" } },
+              fg: { value: { base: "#1d4ed8", _dark: "#93c5fd" } },
+            },
+          },
+        },
+      },
+    }
+
+    const customConfig = {
+      theme: {
+        semanticTokens: {
+          colors: {
+            accent: { value: { base: "#ef4444", _dark: "#f87171" } },
+          },
+        },
+      },
+    }
+
+    const mergedConfig = mergeConfigs(baseConfig, customConfig)
+    const system = createSystem(mergedConfig)
+
+    const conditionsOf = (name: string) =>
+      system.tokens.getByName(name)?.extensions.conditions
+
+    expect(conditionsOf("colors.accent.solid")).toEqual({
+      base: "#2563eb",
+      _dark: "#60a5fa",
+    })
+    expect(conditionsOf("colors.accent.fg")).toEqual({
+      base: "#1d4ed8",
+      _dark: "#93c5fd",
+    })
+    expect(conditionsOf("colors.accent")).toEqual({
+      base: "#ef4444",
+      _dark: "#f87171",
+    })
+
+    expect(mergedConfig.theme?.semanticTokens).toMatchInlineSnapshot(`
+      {
+        "colors": {
+          "accent": {
+            "DEFAULT": {
+              "value": {
+                "_dark": "#f87171",
+                "base": "#ef4444",
+              },
+            },
+            "fg": {
+              "value": {
+                "_dark": "#93c5fd",
+                "base": "#1d4ed8",
+              },
+            },
+            "solid": {
+              "value": {
+                "_dark": "#60a5fa",
+                "base": "#2563eb",
+              },
+            },
+          },
+        },
+      }
+    `)
+  })
+
+  test("nested semantic token override should keep the default palette", () => {
+    const system = createSystem(defaultConfig, {
+      theme: {
+        semanticTokens: {
+          colors: {
+            red: { value: { _light: "tomato", _dark: "firebrick" } },
+          },
+        },
+      },
+    })
+
+    expect(system.token("colors.red.solid")).toBe(
+      "var(--chakra-colors-red-solid)",
+    )
+    expect(system.token("colors.red.fg")).toBe("var(--chakra-colors-red-fg)")
+    expect(system.token("colors.red.subtle")).toBe(
+      "var(--chakra-colors-red-subtle)",
+    )
+    expect(
+      system.tokens.getByName("colors.red")?.extensions.conditions,
+    ).toEqual({ _light: "tomato", _dark: "firebrick" })
+  })
+
   test("should handle nested token overrides with mixed-case sibling keys", () => {
     const baseConfig = {
       theme: {

--- a/packages/react/src/styled-system/merge-config.ts
+++ b/packages/react/src/styled-system/merge-config.ts
@@ -9,43 +9,53 @@ const isValidToken = (token: any): boolean => {
   return token && typeof token === "object" && !Array.isArray(token)
 }
 
+const normalizeNestedTokens = (target: Record<string, any>) => {
+  walkObject(
+    target,
+    (value) => {
+      const keys = Object.keys(value)
+      const nestedKeys = keys.filter((k) => !tokenKeys.includes(k))
+      const hasNested = nestedKeys.length > 0
+      const hasTokenProps = tokenKeys.some((k) => value[k] != null)
+
+      // If this token has both token properties and nested tokens,
+      // move token properties to DEFAULT
+      if (hasNested && hasTokenProps) {
+        value.DEFAULT ||= {}
+        tokenKeys.forEach((key) => {
+          if (value[key] == null) return
+          value.DEFAULT[key] ||= value[key]
+          delete value[key]
+        })
+      }
+
+      return value
+    },
+    {
+      stop(value) {
+        // Stop traversal only for actual token entries.
+        // Mixed-case token names like `whiteAlpha` live at the category level
+        // and should not prevent us from reaching sibling tokens like `black`.
+        return (
+          isValidToken(value) && tokenKeys.some((key) => value[key] != null)
+        )
+      },
+    },
+  )
+}
+
 export const mergeConfigs = (...configs: SystemConfig[]): SystemConfig => {
   const merged = mergeWith({}, ...configs.map(clone))
 
   // Normalize tokens to handle nested token structures
   if (merged.theme?.tokens) {
-    walkObject(
-      merged.theme.tokens,
-      (value) => {
-        const keys = Object.keys(value)
-        const nestedKeys = keys.filter((k) => !tokenKeys.includes(k))
-        const hasNested = nestedKeys.length > 0
-        const hasTokenProps = tokenKeys.some((k) => value[k] != null)
+    normalizeNestedTokens(merged.theme.tokens)
+  }
 
-        // If this token has both token properties and nested tokens,
-        // move token properties to DEFAULT
-        if (hasNested && hasTokenProps) {
-          value.DEFAULT ||= {}
-          tokenKeys.forEach((key) => {
-            if (value[key] == null) return
-            value.DEFAULT[key] ||= value[key]
-            delete value[key]
-          })
-        }
-
-        return value
-      },
-      {
-        stop(value) {
-          // Stop traversal only for actual token entries.
-          // Mixed-case token names like `whiteAlpha` live at the category level
-          // and should not prevent us from reaching sibling tokens like `black`.
-          return (
-            isValidToken(value) && tokenKeys.some((key) => value[key] != null)
-          )
-        },
-      },
-    )
+  // Semantic tokens are walked with the same `stop` predicate, so they need the
+  // same normalization or a nested override hides its sibling tokens.
+  if (merged.theme?.semanticTokens) {
+    normalizeNestedTokens(merged.theme.semanticTokens)
   }
 
   return merged


### PR DESCRIPTION
## The bug

`mergeConfigs` normalizes nested overrides in `theme.tokens` but not in
`theme.semanticTokens`. Both end up in `createTokenDictionary`, which walks them
with the *same* `{ stop: isToken }` predicate (`token-dictionary.ts:148` and
`:187`, where `isToken` is `hasOwnProperty("value")`).

So when a user override adds a `value` key to a node that already holds nested
semantic tokens, the walk stops at that node and every sibling under it is never
registered. The whole palette disappears, with no warning.

## Reproduction

```ts
const system = createSystem(defaultConfig, {
  theme: {
    semanticTokens: {
      colors: {
        red: { value: { _light: "tomato", _dark: "firebrick" } },
      },
    },
  },
})

system.token("colors.red.solid") // undefined  (was var(--chakra-colors-red-solid))
system.token("colors.red.fg") // undefined
system.token("colors.red.subtle") // undefined
```

`red.contrast`, `red.muted`, `red.emphasized`, `red.focusRing` and `red.border`
go the same way, so `colorPalette="red"` silently breaks for every component.

## The asymmetry

The exact same shape on `theme.tokens` works, because #10801 added a
`walkObject` normalization for it:

```ts
createSystem(defaultConfig, {
  theme: { tokens: { colors: { red: { value: "tomato" } } } },
})
// colors.red     -> "tomato"   (the override)
// colors.red.500 -> "#ef4444"  (palette intact)
```

`theme.semanticTokens` is the direct twin and never got that treatment.

## The fix

Extract the existing normalization into `normalizeNestedTokens(target)` and call
it for `theme.semanticTokens` as well as `theme.tokens`. The moved block is
unchanged; only the call site is new.

The normalization moves the override into `DEFAULT`, which is exactly how the
built-in semantic tokens already spell this shape (`bg`, `fg`, `border` and
`colorPalette` all use an explicit `DEFAULT: { value: ... }`). Because it moves
the whole `value` object rather than reaching inside it, conditional values
(`base`, `_light`, `_dark`) travel intact.

I checked that running the normalizer over the shipped `defaultConfig`
`semanticTokens` tree is a no-op, byte for byte, since none of the defaults mix
a `value` with nested siblings.

## Tests

Two tests in `packages/react/__tests__/merge-config.test.ts`, next to the
existing `theme.tokens` ones:

- `should handle nested semantic token overrides` uses a two-entry palette with
  conditional values, and asserts the resolved conditions of both the surviving
  siblings and the override itself, plus the merged config shape.
- `nested semantic token override should keep the default palette` covers the
  real `defaultConfig` case above.

Reverting only `merge-config.ts` turns both red with
`expected undefined to deeply equal { base: '#2563eb', _dark: '#60a5fa' }` and
`expected undefined to be 'var(--chakra-colors-red-solid)'`, which is the
missing-sibling symptom rather than a shape mismatch.

Full suite: 79 files, 1019 tests before, 1021 after, no regressions. Typecheck
and prettier clean.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63604207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

This PR is not safe to merge because common semantic token overrides can still be ignored.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Freact%2Fsrc%2Fstyled-system%2Fmerge-config.ts%3A27%0AWhen%20an%20earlier%20config%20already%20has%20%60DEFAULT%60%2C%20%60%7C%7C%3D%60%20keeps%20its%20old%20property%20and%20then%20deletes%20the%20later%20override.%20The%20shipped%20%60colors.bg%60%2C%20%60colors.fg%60%2C%20and%20%60colors.border%60%20tokens%20have%20%60DEFAULT%60%2C%20so%20a%20later%20top-level%20%60value%60%20for%20any%20of%20them%20is%20ignored.%20Copy%20the%20later%20property%20into%20%60DEFAULT%60%20instead%2C%20and%20add%20a%20test%20for%20this%20merge%20shape.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fchakra-ui&pr=10999&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Existing defaults beat overrides** <a href="https://github.com/chakra-ui/chakra-ui/pull/10999#discussion_r3999482771">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/react/src/styled-system/merge-config.ts:27
When an earlier config already has `DEFAULT`, `||=` keeps its old property and then deletes the later override. The shipped `colors.bg`, `colors.fg`, and `colors.border` tokens have `DEFAULT`, so a later top-level `value` for any of them is ignored. Copy the later property into `DEFAULT` instead, and add a test for this merge shape.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Nested semantic token overrides now keep their sibling tokens while preserving the override's conditional values. The existing token normalizer is reused for semantic tokens so custom palette values no longer hide the rest of the palette.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant createSystem
    participant mergeConfigs
    participant normalizeNestedTokens
    participant TokenDictionary
    User->>createSystem: Pass defaultConfig and semantic token override
    createSystem->>mergeConfigs: Merge configs in argument order
    mergeConfigs->>normalizeNestedTokens: Normalize merged semanticTokens
    alt Parent has no DEFAULT
        normalizeNestedTokens->>normalizeNestedTokens: Move value into DEFAULT
    else Parent already has DEFAULT
        normalizeNestedTokens->>normalizeNestedTokens: Keep old DEFAULT.value and delete new value
    end
    normalizeNestedTokens-->>mergeConfigs: Return normalized tree
    mergeConfigs-->>createSystem: Return merged config
    createSystem->>TokenDictionary: Register semantic tokens
    TokenDictionary-->>User: Resolve siblings and the selected DEFAULT value
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(react): normalize nested semantic to..."](https://github.com/chakra-ui/chakra-ui/commit/7a3e6a680dd19a2365c6011923a91ba83b59e836)</sub>

<!-- /greptile_comment -->